### PR TITLE
Add TrueNAS SCALE support and fix CPU/chart bugs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.25'
 
       - name: Build Linux binary
         run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o nas-doctor-linux-amd64 ./cmd/nas-doctor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,11 @@ services:
       - nas-doctor-data:/data
       # Host system access (read-only)
       - /var/run/docker.sock:/var/run/docker.sock:ro  # Docker monitoring
-      - /boot:/host/boot:ro                            # Unraid config, parity logs
       - /var/log:/host/log:ro                          # System logs (syslog, messages)
       - /mnt:/host/mnt:ro                              # Host disk mounts (per-disk space)
-      - /etc/unraid-version:/etc/unraid-version:ro     # Unraid OS version
+      # Unraid-specific (comment out on non-Unraid systems):
+      # - /boot:/host/boot:ro                          # Unraid config, parity logs
+      # - /etc/unraid-version:/etc/unraid-version:ro   # Unraid OS version detection
     environment:
       - TZ=${TZ:-UTC}
       - NAS_DOCTOR_LISTEN=:8060

--- a/internal/api/stats_page.go
+++ b/internal/api/stats_page.go
@@ -317,10 +317,10 @@ body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--t
       // Duplicate single point so charts can draw a line
       if (sys.length === 1) sys = [sys[0], sys[0]];
       var lb = sys.map(function(p,i){return i});
-      try { NasChart.area("chart-cpu",{data:sys.map(function(p){return p.cpu_usage}),labels:lb,color:"#5e6ad2",fillAlpha:0.12,yMin:0}); } catch(e){}
-      try { NasChart.area("chart-mem",{data:sys.map(function(p){return p.mem_percent}),labels:lb,color:"#7170ff",fillAlpha:0.12,yMin:0}); } catch(e){}
-      try { NasChart.area("chart-io",{data:sys.map(function(p){return p.io_wait}),labels:lb,color:"#f59e0b",fillAlpha:0.12,yMin:0}); } catch(e){}
-      try { NasChart.line("chart-load",{data:sys.map(function(p){return p.load_1}),labels:lb,color:"#22c55e"}); } catch(e){}
+      try { NasChart.area("chart-cpu",{datasets:[{data:sys.map(function(p){return p.cpu_usage}),color:"#5e6ad2",label:"CPU"}],labels:lb,yLabel:"%"}); } catch(e){}
+      try { NasChart.area("chart-mem",{datasets:[{data:sys.map(function(p){return p.mem_percent}),color:"#7170ff",label:"Memory"}],labels:lb,yLabel:"%"}); } catch(e){}
+      try { NasChart.area("chart-io",{datasets:[{data:sys.map(function(p){return p.io_wait}),color:"#f59e0b",label:"I/O Wait"}],labels:lb,yLabel:"%"}); } catch(e){}
+      try { NasChart.line("chart-load",{datasets:[{data:sys.map(function(p){return p.load_avg_1}),color:"#22c55e",label:"Load 1m"}],labels:lb}); } catch(e){}
     }
     for (var i = 0; i < smart.length; i++) {
       var el = document.getElementById("temp-chart-"+i);
@@ -331,7 +331,7 @@ body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--t
           var temps = disks[d].temps.map(function(p){return p.temp});
           var mx = Math.max.apply(null,temps);
           var clr = mx>=55?"#ef4444":mx>=45?"#f59e0b":"#22c55e";
-          try { NasChart.area("temp-chart-"+i,{data:temps,labels:temps.map(function(v,k){return k}),color:clr,fillAlpha:0.1}); } catch(e){}
+          try { NasChart.area("temp-chart-"+i,{datasets:[{data:temps,color:clr,label:"Temp"}],labels:temps.map(function(v,k){return k}),yLabel:"\u00B0C"}); } catch(e){}
           break;
         }
       }

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -56,7 +56,7 @@ func (c *Collector) Collect() (*internal.Snapshot, error) {
 		c.logger.Warn("SMART collection partial failure", "error", err)
 	}
 	// Enrich SMART data with Unraid array slot mapping (md -> physical device)
-	if smart != nil {
+	if smart != nil && sys.Platform == "unraid" {
 		mdMap := buildMDToPhysicalMap() // "sdb" -> "1" (for /mnt/disk1)
 		for i := range smart {
 			devName := strings.TrimPrefix(smart[i].Device, "/dev/")

--- a/internal/collector/disk.go
+++ b/internal/collector/disk.go
@@ -29,7 +29,8 @@ func collectDisks() ([]internal.DiskInfo, error) {
 }
 
 // collectHostMountDisks reads disk info from the host's /mnt via the bind mount at /host/mnt.
-// This is the primary method for Unraid where disks are at /mnt/disk1, /mnt/disk2, etc.
+// On Unraid, disks are at /mnt/disk1, /mnt/disk2, etc.
+// On TrueNAS, ZFS datasets are at /mnt/poolname/dataset (e.g. /mnt/apps, /mnt/media).
 func collectHostMountDisks() []internal.DiskInfo {
 	// Check if /host/mnt exists (bind-mounted from host)
 	out, err := execCmd("df", "-h", "--output=source,fstype,size,used,avail,pcent,target")
@@ -49,12 +50,21 @@ func collectHostMountDisks() []internal.DiskInfo {
 		}
 		mount := fields[6]
 
-		// Only include /host/mnt/disk*, /host/mnt/cache*, /host/mnt/user
+		// Include host-mounted paths under /host/mnt/
+		// Unraid: /host/mnt/disk1, /host/mnt/cache, /host/mnt/user
+		// TrueNAS: /host/mnt/apps, /host/mnt/media, /host/mnt/poolname/dataset
 		if !strings.HasPrefix(mount, "/host/mnt/") {
 			continue
 		}
 
 		device := fields[0]
+		fstype := fields[1]
+
+		// Skip ZFS boot-pool system datasets (TrueNAS internal — not user data)
+		if strings.HasPrefix(device, "boot-pool/") {
+			continue
+		}
+
 		total := parseSize(fields[2])
 		used := parseSize(fields[3])
 		free := parseSize(fields[4])
@@ -68,7 +78,7 @@ func collectHostMountDisks() []internal.DiskInfo {
 			Device:     device,
 			MountPoint: displayMount,
 			Label:      guessLabel(displayMount, device),
-			FSType:     fields[1],
+			FSType:     fstype,
 			TotalGB:    total,
 			UsedGB:     used,
 			FreeGB:     free,
@@ -254,6 +264,16 @@ func guessLabel(mount, device string) string {
 	}
 	if mount == "/mnt/user" || mount == "/mnt/user0" {
 		return "User Share"
+	}
+	// ZFS dataset patterns (TrueNAS, Proxmox, generic ZFS)
+	// Device looks like "pool/dataset" or "tank/media/movies"
+	if strings.Contains(device, "/") && !strings.HasPrefix(device, "/dev/") {
+		// Use the last path component as the label, capitalized
+		parts := strings.Split(device, "/")
+		label := parts[len(parts)-1]
+		if label != "" {
+			return strings.ToUpper(label[:1]) + label[1:]
+		}
 	}
 	// Read label from filesystem if available
 	if strings.HasPrefix(device, "/dev/") {

--- a/internal/collector/smart.go
+++ b/internal/collector/smart.go
@@ -53,9 +53,21 @@ func collectSMART() ([]internal.SMARTInfo, error) {
 func discoverDrives() []string {
 	var drives []string
 
-	// Discover /dev/sd* drives
+	// Discover /dev/sd* drives (Linux SCSI/SATA)
 	matches, _ := filepath.Glob("/dev/sd[a-z]")
 	drives = append(drives, matches...)
+
+	// Discover /dev/da* drives (FreeBSD SCSI/SAS — TrueNAS CORE)
+	daMatches, _ := filepath.Glob("/dev/da[0-9]")
+	drives = append(drives, daMatches...)
+	daMatches2, _ := filepath.Glob("/dev/da[0-9][0-9]")
+	drives = append(drives, daMatches2...)
+
+	// Discover /dev/ada* drives (FreeBSD ATA — TrueNAS CORE)
+	adaMatches, _ := filepath.Glob("/dev/ada[0-9]")
+	drives = append(drives, adaMatches...)
+	adaMatches2, _ := filepath.Glob("/dev/ada[0-9][0-9]")
+	drives = append(drives, adaMatches2...)
 
 	// Discover NVMe drives
 	nvmeMatches, _ := filepath.Glob("/dev/nvme[0-9]n1")

--- a/internal/collector/system.go
+++ b/internal/collector/system.go
@@ -122,51 +122,74 @@ func collectSystem(hp internal.HostPaths) (internal.SystemInfo, error) {
 	return info, nil
 }
 
-// readCPUStats reads /proc/stat twice with a short delay to compute
-// instantaneous CPU usage and I/O wait percentages.
+// readCPUStats samples /proc/stat multiple times over a few seconds to compute
+// a smoothed CPU usage and I/O wait percentage. Multiple samples reduce the
+// impact of short-lived spikes (including our own collection overhead).
 func readCPUStats() (cpuUsage, ioWait float64) {
-	parse := func() (idle, iowait, total float64, ok bool) {
+	type cpuSample struct {
+		idle, iowait, total float64
+	}
+
+	parse := func() (cpuSample, bool) {
 		data, err := os.ReadFile("/proc/stat")
 		if err != nil {
-			return 0, 0, 0, false
+			return cpuSample{}, false
 		}
 		for _, line := range strings.Split(string(data), "\n") {
 			if strings.HasPrefix(line, "cpu ") {
 				fields := strings.Fields(line)
 				if len(fields) >= 6 {
 					// fields: cpu user nice system idle iowait irq softirq steal ...
-					idle, _ = strconv.ParseFloat(fields[4], 64)
-					iowait, _ = strconv.ParseFloat(fields[5], 64)
+					var s cpuSample
+					s.idle, _ = strconv.ParseFloat(fields[4], 64)
+					s.iowait, _ = strconv.ParseFloat(fields[5], 64)
 					for _, f := range fields[1:] {
 						v, _ := strconv.ParseFloat(f, 64)
-						total += v
+						s.total += v
 					}
-					return idle, iowait, total, true
+					return s, true
 				}
 			}
 		}
-		return 0, 0, 0, false
+		return cpuSample{}, false
 	}
 
-	idle1, iowait1, total1, ok1 := parse()
-	time.Sleep(500 * time.Millisecond)
-	idle2, iowait2, total2, ok2 := parse()
+	// Take 4 samples over 3 seconds (1s apart) and average the 3 intervals.
+	// This gives a representative ~3s window that smooths out short spikes.
+	const numSamples = 4
+	const sampleInterval = time.Second
+	samples := make([]cpuSample, 0, numSamples)
 
-	if !ok1 || !ok2 {
+	for i := 0; i < numSamples; i++ {
+		s, ok := parse()
+		if !ok {
+			return 0, 0
+		}
+		samples = append(samples, s)
+		if i < numSamples-1 {
+			time.Sleep(sampleInterval)
+		}
+	}
+
+	var totalCPU, totalIOWait float64
+	intervals := 0
+	for i := 1; i < len(samples); i++ {
+		totalDelta := samples[i].total - samples[i-1].total
+		if totalDelta <= 0 {
+			continue
+		}
+		idleDelta := samples[i].idle - samples[i-1].idle
+		iowaitDelta := samples[i].iowait - samples[i-1].iowait
+
+		totalCPU += (1.0 - idleDelta/totalDelta) * 100
+		totalIOWait += (iowaitDelta / totalDelta) * 100
+		intervals++
+	}
+
+	if intervals == 0 {
 		return 0, 0
 	}
-
-	totalDelta := total2 - total1
-	if totalDelta <= 0 {
-		return 0, 0
-	}
-
-	idleDelta := idle2 - idle1
-	iowaitDelta := iowait2 - iowait1
-
-	cpuUsage = (1.0 - idleDelta/totalDelta) * 100
-	ioWait = (iowaitDelta / totalDelta) * 100
-	return cpuUsage, ioWait
+	return totalCPU / float64(intervals), totalIOWait / float64(intervals)
 }
 
 func detectPlatform(hp internal.HostPaths) (platform, version string) {

--- a/internal/collector/system.go
+++ b/internal/collector/system.go
@@ -2,7 +2,9 @@ package collector
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"runtime"
@@ -201,6 +203,32 @@ func detectPlatform(hp internal.HostPaths) (platform, version string) {
 		return
 	}
 
+	// Check TrueNAS SCALE — the host kernel contains "+truenas" in /proc/version
+	// (e.g. "Linux version 6.12.15-production+truenas"). /proc is shared from the
+	// host even inside a container, making this the most reliable detection method.
+	if procVer, err := os.ReadFile("/proc/version"); err == nil {
+		if strings.Contains(string(procVer), "+truenas") {
+			platform = "truenas"
+			// Try to read the TrueNAS version from /etc/version (host-mounted paths).
+			// Inside a Docker container, this requires a bind mount like:
+			//   -v /etc/version:/host/etc/version:ro
+			for _, path := range []string{"/host/etc/version", "/etc/version"} {
+				if data, err := os.ReadFile(path); err == nil {
+					ver := strings.TrimSpace(string(data))
+					if ver != "" {
+						version = ver
+						break
+					}
+				}
+			}
+			// Fallback: try the TrueNAS local API (available with --network host)
+			if version == "" {
+				version = fetchTrueNASVersion()
+			}
+			return
+		}
+	}
+
 	// Check /etc/os-release for others
 	if f, err := os.Open("/etc/os-release"); err == nil {
 		defer f.Close()
@@ -222,10 +250,35 @@ func detectPlatform(hp internal.HostPaths) (platform, version string) {
 	return
 }
 
+// fetchTrueNASVersion queries the TrueNAS local API to get the system version.
+// This works when the container runs with --network host.
+func fetchTrueNASVersion() string {
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get("http://localhost/api/v2.0/system/version")
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return ""
+	}
+	var ver string
+	if err := json.NewDecoder(resp.Body).Decode(&ver); err != nil {
+		return ""
+	}
+	// Response is like "TrueNAS-25.04.2.1" — strip the prefix
+	ver = strings.TrimPrefix(ver, "TrueNAS-")
+	return ver
+}
+
 func collectTopProcesses(n int) []internal.ProcessInfo {
+	// Try GNU ps first (--sort flag), fall back to POSIX ps without sorting
 	out, err := execCmd("ps", "aux", "--sort=-%cpu")
 	if err != nil {
-		return nil
+		out, err = execCmd("ps", "aux")
+		if err != nil {
+			return nil
+		}
 	}
 	var procs []internal.ProcessInfo
 	lines := strings.Split(out, "\n")

--- a/internal/collector/system.go
+++ b/internal/collector/system.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mcdays94/nas-doctor/internal"
 )
@@ -90,8 +91,8 @@ func collectSystem(hp internal.HostPaths) (internal.SystemInfo, error) {
 		}
 	}
 
-	// I/O wait from /proc/stat (simple snapshot)
-	info.IOWait = readIOWait()
+	// CPU usage and I/O wait from /proc/stat (two samples, 500ms apart)
+	info.CPUUsage, info.IOWait = readCPUStats()
 
 	// Detect platform
 	info.Platform, info.PlatformVer = detectPlatform(hp)
@@ -119,31 +120,51 @@ func collectSystem(hp internal.HostPaths) (internal.SystemInfo, error) {
 	return info, nil
 }
 
-func readIOWait() float64 {
-	data, err := os.ReadFile("/proc/stat")
-	if err != nil {
-		return 0
-	}
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.HasPrefix(line, "cpu ") {
-			fields := strings.Fields(line)
-			if len(fields) >= 6 {
-				// fields: cpu user nice system idle iowait ...
-				idle, _ := strconv.ParseFloat(fields[4], 64)
-				iowait, _ := strconv.ParseFloat(fields[5], 64)
-				total := 0.0
-				for _, f := range fields[1:] {
-					v, _ := strconv.ParseFloat(f, 64)
-					total += v
-				}
-				if total > 0 {
-					_ = idle // used in total
-					return iowait / total * 100
+// readCPUStats reads /proc/stat twice with a short delay to compute
+// instantaneous CPU usage and I/O wait percentages.
+func readCPUStats() (cpuUsage, ioWait float64) {
+	parse := func() (idle, iowait, total float64, ok bool) {
+		data, err := os.ReadFile("/proc/stat")
+		if err != nil {
+			return 0, 0, 0, false
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			if strings.HasPrefix(line, "cpu ") {
+				fields := strings.Fields(line)
+				if len(fields) >= 6 {
+					// fields: cpu user nice system idle iowait irq softirq steal ...
+					idle, _ = strconv.ParseFloat(fields[4], 64)
+					iowait, _ = strconv.ParseFloat(fields[5], 64)
+					for _, f := range fields[1:] {
+						v, _ := strconv.ParseFloat(f, 64)
+						total += v
+					}
+					return idle, iowait, total, true
 				}
 			}
 		}
+		return 0, 0, 0, false
 	}
-	return 0
+
+	idle1, iowait1, total1, ok1 := parse()
+	time.Sleep(500 * time.Millisecond)
+	idle2, iowait2, total2, ok2 := parse()
+
+	if !ok1 || !ok2 {
+		return 0, 0
+	}
+
+	totalDelta := total2 - total1
+	if totalDelta <= 0 {
+		return 0, 0
+	}
+
+	idleDelta := idle2 - idle1
+	iowaitDelta := iowait2 - iowait1
+
+	cpuUsage = (1.0 - idleDelta/totalDelta) * 100
+	ioWait = (iowaitDelta / totalDelta) * 100
+	return cpuUsage, ioWait
 }
 
 func detectPlatform(hp internal.HostPaths) (platform, version string) {

--- a/internal/collector/update_check.go
+++ b/internal/collector/update_check.go
@@ -78,7 +78,7 @@ func getLatestVersion(platform string) (*cachedVersion, error) {
 	case "unraid":
 		latest, err = fetchUnraidLatest()
 	case "truenas":
-		latest, err = fetchGitHubLatestRelease("truenas/middleware")
+		latest, err = fetchTrueNASLatest()
 	default:
 		return nil, fmt.Errorf("update checks not supported for %s", platform)
 	}
@@ -141,7 +141,61 @@ func fetchUnraidLatest() (*cachedVersion, error) {
 	}, nil
 }
 
-// ── GitHub: for TrueNAS and other platforms ─────────────────────────
+// ── TrueNAS SCALE: query local API (container runs with --network host) ─
+
+func fetchTrueNASLatest() (*cachedVersion, error) {
+	// TrueNAS SCALE exposes a local WebSocket/HTTP API.
+	// From a container with --network host, we can query it at localhost.
+	// The /api/v2.0/update/check_available endpoint returns available updates.
+	client := &http.Client{Timeout: 15 * time.Second}
+	req, err := http.NewRequest("POST", "http://localhost/api/v2.0/update/check_available", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create TrueNAS API request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("TrueNAS API unavailable: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 403 || resp.StatusCode == 401 {
+		// API requires authentication — can't check updates without API key.
+		return nil, fmt.Errorf("TrueNAS API requires authentication (HTTP %d)", resp.StatusCode)
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("TrueNAS API returned HTTP %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Status  string `json:"status"`
+		Version string `json:"version"`
+		Notes   string `json:"release_notes_url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode TrueNAS update response: %w", err)
+	}
+
+	if result.Status != "AVAILABLE" {
+		// No update available — current version is latest
+		return &cachedVersion{
+			version:   "", // empty signals no update
+			name:      "TrueNAS SCALE (up to date)",
+			url:       "",
+			checkedAt: time.Now(),
+		}, nil
+	}
+
+	return &cachedVersion{
+		version:   normalizeVersion(result.Version),
+		name:      "TrueNAS SCALE " + result.Version,
+		url:       result.Notes,
+		checkedAt: time.Now(),
+	}, nil
+}
+
+// ── GitHub: for other platforms ──────────────────────────────────────
 
 type githubRelease struct {
 	TagName string `json:"tag_name"`


### PR DESCRIPTION
## Summary

- Add TrueNAS SCALE platform detection, drive discovery, ZFS disk labeling, and update checking
- Fix CPU usage always showing 0% in production mode (was never populated)
- Fix stats page System Metrics charts rendering blank

Tested on **TrueNAS SCALE 25.04.2.1** with 5 drives (3 HDD + 2 NVMe), 32 Docker containers, and ZFS datasets.

## Changes

### TrueNAS SCALE compatibility
- **Platform detection** via `+truenas` kernel tag in `/proc/version` (works inside Docker containers). Version extracted from bind-mounted `/etc/version` or TrueNAS local API fallback.
- **Drive discovery** adds `/dev/da*` and `/dev/ada*` glob patterns for FreeBSD SCSI/SAS/ATA drives (TrueNAS CORE).
- **ZFS disk labeling** derives friendly labels from dataset names (e.g. `apps/configs/jellyfin` → "Jellyfin"). Filters out `boot-pool` system datasets.
- **Update check** replaces the broken `truenas/middleware` GitHub repo lookup (which has no releases) with a call to the TrueNAS local API (`/api/v2.0/update/check_available`).
- **docker-compose.yml** comments out Unraid-only volume mounts (`/boot`, `/etc/unraid-version`) that create empty directories on non-Unraid systems and break version detection.
- Gates Unraid MD-to-physical device mapping on `platform == "unraid"`.
- Adds POSIX `ps` fallback when GNU `--sort` flag is unavailable.

### Bug fixes
- **CPU usage 0%**: `CPUUsage` was never set in production — `readIOWait()` only computed I/O wait. Replaced with `readCPUStats()` that samples `/proc/stat` 4 times over 3 seconds and averages the intervals, giving accurate real-time CPU and I/O wait that matches host monitoring dashboards.
- **Stats page charts blank**: `stats_page.go` called `NasChart.area()` / `NasChart.line()` with `{data: [...]}` but these functions expect `{datasets: [{data: [...]}]}`. Also fixed load average chart reading `p.load_1` instead of `p.load_avg_1`.
- **CI Go version**: Updated from `1.22` to `1.25` to match `go.mod`.

## Test results

On TrueNAS SCALE 25.04.2.1 (Intel i3-14100, 64GB RAM, ZFS):

| Metric | NAS Doctor | Host (`free -m` / `iostat`) |
|--------|-----------|---------------------------|
| CPU Usage | 8.04% | 9.17% (iostat) |
| Memory | 44,731 / 64,075 MB (69.81%) | 44,734 / 64,075 MB (69.81%) |
| I/O Wait | 0.13% | 0.00% (iostat) |
| Platform | `truenas` | ✓ |
| Version | `25.04.2.1` | ✓ |
| SMART | 5 drives (3 HDD + 2 NVMe) | ✓ |
| Docker | 32 containers | ✓ |
| ZFS datasets | 17 with correct labels | ✓ |

All existing tests pass.