### PR TITLE
Fix panic on double-call to fleet Manager.Stop()

### DIFF
--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -20,6 +20,7 @@ type Manager struct {
 	logger   *slog.Logger
 	client   *http.Client
 	stop     chan struct{}
+	stopOnce sync.Once
 }
 
 // New creates a new fleet manager.
@@ -71,9 +72,9 @@ func (m *Manager) Start(interval time.Duration) {
 	}()
 }
 
-// Stop halts the polling loop.
+// Stop halts the polling loop. Safe to call multiple times.
 func (m *Manager) Stop() {
-	close(m.stop)
+	m.stopOnce.Do(func() { close(m.stop) })
 }
 
 // PollAll polls all enabled remote servers concurrently.


### PR DESCRIPTION
## Summary

- `fleet.Manager.Stop()` calls `close(m.stop)` unconditionally, which panics if called twice

## Problem

In Go, closing an already-closed channel is a runtime panic. If `Stop()` is called more than once (e.g. during graceful shutdown when multiple signal handlers fire, or if a settings-restart path calls Stop then Start), the application crashes with `panic: close of closed channel`.

## Fix

Wrap the close in `sync.Once` so it's safe for repeated calls:

```go
func (m *Manager) Stop() {
    m.stopOnce.Do(func() { close(m.stop) })
}
```

One line change, no behavior difference for the normal single-call path.