### PR TITLE
Fix stale Prometheus metrics when disks/containers are removed

### DIFF
--- a/internal/notifier/prometheus.go
+++ b/internal/notifier/prometheus.go
@@ -212,6 +212,20 @@ func (m *Metrics) Update(snap *internal.Snapshot) {
 	m.ioWait.Set(snap.System.IOWait)
 	m.uptime.Set(float64(snap.System.UptimeSecs))
 
+	// Reset label-based metrics to clear stale entries from removed
+	// disks, drives, or containers that no longer appear in the snapshot.
+	m.diskUsedBytes.Reset()
+	m.diskTotalBytes.Reset()
+	m.diskUsedPct.Reset()
+	m.smartHealthy.Reset()
+	m.smartTemp.Reset()
+	m.smartReallocated.Reset()
+	m.smartPending.Reset()
+	m.smartUDMACRC.Reset()
+	m.smartPowerOnHours.Reset()
+	m.containerCPU.Reset()
+	m.containerMem.Reset()
+
 	// Disks
 	for _, d := range snap.Disks {
 		labels := prometheus.Labels{


### PR DESCRIPTION
## Summary

- Reset all label-based Prometheus GaugeVecs before each update cycle to clear stale entries

## Problem

When a disk is removed, a container deleted, or a drive replaced, the old Prometheus time series persists indefinitely with its last-known value. This is because `GaugeVec.With(labels).Set(value)` creates persistent entries that are never cleaned up.

For example, if a container named `test-app` is stopped and removed, `/metrics` continues reporting:
```
nasdoctor_docker_container_cpu_percent{name="test-app",image="..."} 12.5
```

This causes stale data in dashboards and incorrect alerting.

## Fix

Add `Reset()` calls on all 11 label-based GaugeVecs at the start of `Update()`, before iterating over the current snapshot. This ensures only entities present in the latest scan are reported:

- 3 disk GaugeVecs (used bytes, total bytes, used percent)
- 6 SMART GaugeVecs (healthy, temp, reallocated, pending, UDMA CRC, power-on hours)
- 2 Docker GaugeVecs (CPU, memory)

Scalar gauges (CPU usage, memory, load average, etc.) are unaffected since they don't use labels.

Tested on TrueNAS SCALE 25.04.2.1 — all 5 SMART drives, 17 disk mounts, and 32 Docker containers report correctly via `/metrics`.