### PR TITLE
Fix runtime settings sync for notifications and fleet polling

### DIFF
--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -99,6 +99,8 @@ func main() {
 	}
 	defer store.Close()
 
+	persistedSettings := loadPersistedSettings(store, logger)
+
 	// Create Prometheus metrics
 	metrics := notifier.NewMetrics()
 
@@ -174,30 +176,28 @@ func main() {
 	} else {
 		// Production mode: real collectors
 		col := collector.New(cfg.HostPaths, logger)
+		interval = intervalFromSettings(persistedSettings, interval, logger)
 
-		var notif *notifier.Notifier
-		if len(cfg.Notifications.Webhooks) > 0 {
-			notif = notifier.New(cfg.Notifications.Webhooks, logger)
+		webhooks := cfg.Notifications.Webhooks
+		if persistedSettings != nil && persistedSettings.Notifications.Webhooks != nil {
+			webhooks = persistedSettings.Notifications.Webhooks
 		}
+		notif := buildNotifier(webhooks, logger, store)
 
 		sched = scheduler.New(col, store, notif, metrics, logger, interval)
+		applySchedulerSettingsFromStore(sched, persistedSettings)
 		sched.Start()
 		defer sched.Stop()
 	}
 
 	// Fleet manager (multi-server monitoring)
 	fleetMgr := fleet.New(logger)
-	// Load fleet servers from settings
-	if raw, err := store.GetConfig("settings"); err == nil && raw != "" {
-		var settingsData struct {
-			Fleet []internal.RemoteServer `json:"fleet"`
-		}
-		if json.Unmarshal([]byte(raw), &settingsData) == nil && len(settingsData.Fleet) > 0 {
-			fleetMgr.SetServers(settingsData.Fleet)
-			fleetMgr.Start(60 * time.Second) // poll every 60s
-			logger.Info("fleet monitoring started", "servers", len(settingsData.Fleet))
-		}
+	if persistedSettings != nil && len(persistedSettings.Fleet) > 0 {
+		fleetMgr.SetServers(persistedSettings.Fleet)
+		logger.Info("fleet monitoring loaded", "servers", len(persistedSettings.Fleet))
 	}
+	fleetMgr.Start(60 * time.Second)
+	defer fleetMgr.Stop()
 
 	// Create API server
 	apiServer := api.New(store, sched, metrics, fleetMgr, logger, version)
@@ -311,4 +311,81 @@ func countSev(findings []internal.Finding, sev internal.Severity) int {
 		}
 	}
 	return n
+}
+
+func loadPersistedSettings(store *storage.DB, logger *slog.Logger) *api.Settings {
+	raw, err := store.GetConfig("settings")
+	if err != nil || raw == "" {
+		return nil
+	}
+	var settings api.Settings
+	if err := json.Unmarshal([]byte(raw), &settings); err != nil {
+		logger.Warn("failed to parse stored settings", "error", err)
+		return nil
+	}
+	return &settings
+}
+
+func intervalFromSettings(settings *api.Settings, fallback time.Duration, logger *slog.Logger) time.Duration {
+	if settings == nil || settings.ScanInterval == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(settings.ScanInterval)
+	if err != nil {
+		logger.Warn("ignoring invalid stored scan interval", "scan_interval", settings.ScanInterval, "error", err)
+		return fallback
+	}
+	return d
+}
+
+func buildNotifier(webhooks []internal.WebhookConfig, logger *slog.Logger, store *storage.DB) *notifier.Notifier {
+	if len(webhooks) == 0 {
+		return nil
+	}
+	n := notifier.New(webhooks, logger)
+	n.SetResultHook(func(name, webhookType, status string, findingsCount int, errMsg string) {
+		if err := store.SaveNotificationLog(name, webhookType, status, findingsCount, errMsg); err != nil {
+			logger.Warn("failed to save notification log", "error", err)
+		}
+	})
+	return n
+}
+
+func applySchedulerSettingsFromStore(sched *scheduler.Scheduler, settings *api.Settings) {
+	if sched == nil || settings == nil {
+		return
+	}
+
+	snapshotDays := settings.Retention.SnapshotDays
+	if snapshotDays < 7 {
+		snapshotDays = 90
+	}
+	maxDBSizeMB := settings.Retention.MaxDBSizeMB
+	if maxDBSizeMB < 50 {
+		maxDBSizeMB = 500
+	}
+	notifyLogDays := settings.Retention.NotifyLogDays
+	if notifyLogDays < 1 {
+		notifyLogDays = 30
+	}
+	sched.UpdateRetention(scheduler.RetentionConfig{
+		SnapshotDays:  snapshotDays,
+		MaxDBSizeMB:   maxDBSizeMB,
+		NotifyLogDays: notifyLogDays,
+	})
+
+	keepCount := settings.Backup.KeepCount
+	if keepCount <= 0 {
+		keepCount = 4
+	}
+	intervalH := settings.Backup.IntervalH
+	if intervalH <= 0 {
+		intervalH = 168
+	}
+	sched.UpdateBackup(scheduler.BackupConfig{
+		Enabled:   settings.Backup.Enabled,
+		Path:      settings.Backup.Path,
+		KeepCount: keepCount,
+		IntervalH: intervalH,
+	})
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -64,7 +64,7 @@ func (s *Server) Router() http.Handler {
 	r.Use(middleware.Timeout(30 * time.Second))
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   []string{"*"},
-		AllowedMethods:   []string{"GET", "POST", "OPTIONS"},
+		AllowedMethods:   []string{"GET", "POST", "PUT", "OPTIONS"},
 		AllowedHeaders:   []string{"Accept", "Content-Type"},
 		ExposedHeaders:   []string{"Link"},
 		AllowCredentials: false,
@@ -159,6 +159,12 @@ type statusResponse struct {
 
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	resp := statusResponse{}
+	settings := s.getSettings()
+	dismissed := make(map[string]struct{}, len(settings.DismissedFindings))
+	for _, title := range settings.DismissedFindings {
+		dismissed[title] = struct{}{}
+	}
+
 	if s.scheduler != nil {
 		resp.ScanRunning = s.scheduler.IsRunning()
 		resp.ScanIntervalSecs = int(s.scheduler.Interval().Seconds())
@@ -178,6 +184,9 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		resp.LastScan = snap.Timestamp.Format(time.RFC3339)
 
 		for _, f := range snap.Findings {
+			if _, ok := dismissed[f.Title]; ok {
+				continue
+			}
 			switch f.Severity {
 			case "critical":
 				resp.CriticalCount++
@@ -198,7 +207,6 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Include section visibility and dismissed findings from settings
-	settings := s.getSettings()
 	resp.Sections = &settings.Sections
 	resp.DismissedFindings = settings.DismissedFindings
 

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -290,6 +290,9 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 			KeepCount: keepCount,
 			IntervalH: intervalH,
 		})
+
+		// Update notifier webhooks at runtime.
+		s.scheduler.UpdateNotifier(s.buildNotifier(settings.Notifications.Webhooks))
 	}
 
 	writeJSON(w, http.StatusOK, settings)
@@ -487,6 +490,19 @@ func (s *Server) getSettings() Settings {
 	return settings
 }
 
+func (s *Server) buildNotifier(webhooks []internal.WebhookConfig) *notifier.Notifier {
+	if len(webhooks) == 0 {
+		return nil
+	}
+	n := notifier.New(webhooks, s.logger)
+	n.SetResultHook(func(name, webhookType, status string, findingsCount int, errMsg string) {
+		if err := s.store.SaveNotificationLog(name, webhookType, status, findingsCount, errMsg); err != nil {
+			s.logger.Warn("failed to save notification log", "error", err)
+		}
+	})
+	return n
+}
+
 // handleDBStats returns database size and row count statistics.
 // GET /api/v1/db/stats
 func (s *Server) handleDBStats(w http.ResponseWriter, r *http.Request) {
@@ -542,6 +558,11 @@ func (s *Server) handleTestWebhook(w http.ResponseWriter, r *http.Request) {
 	// Create a temporary notifier with just this webhook.
 	testLogger := s.logger.With("handler", "test-webhook")
 	n := notifier.New([]internal.WebhookConfig{wh}, testLogger)
+	n.SetResultHook(func(name, webhookType, status string, findingsCount int, errMsg string) {
+		if err := s.store.SaveNotificationLog(name, webhookType, status, findingsCount, errMsg); err != nil {
+			s.logger.Warn("failed to save notification log", "error", err)
+		}
+	})
 	n.NotifyFindings(testFindings, "nas-doctor-test")
 
 	// NotifyFindings does not return an error (it logs internally).

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -22,6 +22,7 @@ type Notifier struct {
 	webhooks []internal.WebhookConfig
 	client   *http.Client
 	logger   *slog.Logger
+	resultFn func(name, webhookType, status string, findingsCount int, errMsg string)
 }
 
 // New creates a Notifier with the given webhook configurations.
@@ -33,6 +34,11 @@ func New(webhooks []internal.WebhookConfig, logger *slog.Logger) *Notifier {
 		},
 		logger: logger,
 	}
+}
+
+// SetResultHook registers a callback invoked for each webhook delivery result.
+func (n *Notifier) SetResultHook(fn func(name, webhookType, status string, findingsCount int, errMsg string)) {
+	n.resultFn = fn
 }
 
 // NotifyFindings sends alerts for the given findings to all configured webhooks.
@@ -63,10 +69,19 @@ func (n *Notifier) NotifyFindings(findings []internal.Finding, hostname string) 
 
 		if err != nil {
 			n.logger.Error("webhook notification failed", "name", wh.Name, "type", wh.Type, "error", err)
+			n.logResult(wh, "failed", len(filtered), err.Error())
 		} else {
 			n.logger.Info("webhook notification sent", "name", wh.Name, "type", wh.Type, "findings", len(filtered))
+			n.logResult(wh, "sent", len(filtered), "")
 		}
 	}
+}
+
+func (n *Notifier) logResult(wh internal.WebhookConfig, status string, findingsCount int, errMsg string) {
+	if n.resultFn == nil {
+		return
+	}
+	n.resultFn(wh.Name, wh.Type, status, findingsCount, errMsg)
 }
 
 // ---------- Discord ----------

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -176,12 +176,15 @@ func (s *Scheduler) RunOnce() {
 	s.mu.Unlock()
 
 	// Notify
-	if s.notifier != nil {
+	s.mu.RLock()
+	notif := s.notifier
+	s.mu.RUnlock()
+	if notif != nil {
 		hostname := snap.System.Hostname
 		if hostname == "" {
 			hostname = "Unknown"
 		}
-		s.notifier.NotifyFindings(snap.Findings, hostname)
+		notif.NotifyFindings(snap.Findings, hostname)
 	}
 
 	// Data lifecycle: prune old data
@@ -311,6 +314,18 @@ func (s *Scheduler) UpdateBackup(cfg BackupConfig) {
 		"keep", cfg.KeepCount,
 		"interval_h", cfg.IntervalH,
 	)
+}
+
+// UpdateNotifier swaps the notifier used for delivery.
+func (s *Scheduler) UpdateNotifier(notif *notifier.Notifier) {
+	s.mu.Lock()
+	s.notifier = notif
+	s.mu.Unlock()
+	if notif == nil {
+		s.logger.Info("notifier updated", "enabled", false)
+		return
+	}
+	s.logger.Info("notifier updated", "enabled", true)
 }
 
 // checkBackup runs a backup if enough time has elapsed since the last one.


### PR DESCRIPTION
## Summary
- load persisted settings at startup so scan interval, retention, backup, fleet, and webhook behavior are consistent after restart
- update the scheduler notifier at runtime when settings change, and wire webhook delivery results into `notification_log`
- keep fleet polling active regardless of whether servers are configured at boot, align status counters with dismissed findings, and allow CORS preflight for `PUT`

## Testing
- go test ./...
- go vet ./...
- manual runtime validation for webhook delivery + notification log, persisted interval across restart, continuous fleet polling, dismissed findings counter behavior, and CORS `PUT` preflight