### PR TITLE
v0.5.8 — Prometheus exporter, log forwarding, notification rules, Synology fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 > **Alpha** — NAS Doctor is in alpha. Features may be incomplete, bugs are expected, and breaking changes can occur between releases. Only tested on Unraid. [Report issues here.](https://github.com/mcdays94/nas-doctor/issues)
 
 <p align="center">
+  <em>Sleep tight. Your server never does.</em><br><br>
   <a href="https://buymeacoffee.com/miguelcaetanodias"><img src="https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-yellow.svg?style=flat-square&logo=buy-me-a-coffee" alt="Buy Me A Coffee"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 
 > **Alpha** — NAS Doctor is in alpha. Features may be incomplete, bugs are expected, and breaking changes can occur between releases. Only tested on Unraid. [Report issues here.](https://github.com/mcdays94/nas-doctor/issues)
 
+<p align="center">
+  <a href="https://buymeacoffee.com/miguelcaetanodias"><img src="https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-yellow.svg?style=flat-square&logo=buy-me-a-coffee" alt="Buy Me A Coffee"></a>
+</p>
+
 ---
 
 ![NAS Doctor Dashboard](screenshots/midnight-top.jpg)
@@ -468,10 +472,3 @@ Demo includes: 7 SMART drives (with Backblaze-informed findings), 14 Docker cont
 ## License
 
 MIT
-
----
-
-<p align="center">
-  If NAS Doctor helps you sleep better knowing your server is healthy:<br><br>
-  <a href="https://buymeacoffee.com/miguelcaetanodias"><img src="https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-yellow.svg?style=flat-square&logo=buy-me-a-coffee" alt="Buy Me A Coffee"></a>
-</p>

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ All configurable from the web UI at `/settings`, organized with a sticky section
 - **Dashboard Sections**: Toggle visibility of individual sections (SMART, Docker, ZFS, UPS, Parity, Network, Tunnels, etc.)
 - **Data & Retention**: Snapshot retention days, max DB size cap, notification log retention
 - **Backup**: Scheduled DB backups with configurable location, interval, and retention count
-- **Log Forwarding**: Forward scan results to external logging endpoints (coming soon)
+- **Log Forwarding**: Forward scan results to **Loki**, **syslog** (UDP/TCP), or any **HTTP JSON** endpoint after each scan — with custom headers, labels, and payload format (full, findings only, summary)
 
 ### Environment Variables
 
@@ -391,38 +391,64 @@ All configurable from the web UI at `/settings`, organized with a sticky section
 All metrics prefixed with `nasdoctor_`. Full list:
 
 <details>
-<summary>Expand metric list</summary>
+<summary>Expand metric list (80+ metrics)</summary>
 
 ```
-# System
-nasdoctor_system_cpu_usage_percent
-nasdoctor_system_memory_used_bytes / _total_bytes
+# System (12 gauges)
+nasdoctor_system_cpu_usage_percent / _cpu_cores
+nasdoctor_system_memory_used_bytes / _total_bytes / _used_percent
+nasdoctor_system_swap_used_bytes / _total_bytes
 nasdoctor_system_load_avg_1 / _5 / _15
-nasdoctor_system_io_wait_percent
-nasdoctor_system_uptime_seconds
+nasdoctor_system_io_wait_percent / _uptime_seconds
 
 # Disks (labels: device, mountpoint, label)
 nasdoctor_disk_used_bytes / _total_bytes / _used_percent
 
-# SMART (labels: device, model, serial)
-nasdoctor_smart_healthy  (1=passed, 0=failed)
-nasdoctor_smart_temperature_celsius
-nasdoctor_smart_reallocated_sectors / _pending_sectors
-nasdoctor_smart_udma_crc_errors / _power_on_hours
+# SMART (labels: device, model, serial) — 11 gauges per drive
+nasdoctor_smart_healthy / _temperature_celsius / _temperature_max_celsius
+nasdoctor_smart_reallocated_sectors / _pending_sectors / _offline_uncorrectable
+nasdoctor_smart_udma_crc_errors / _command_timeout / _spin_retry_count
+nasdoctor_smart_power_on_hours / _size_bytes
 
 # Docker (labels: name, image)
-nasdoctor_docker_container_cpu_percent / _memory_bytes
+nasdoctor_docker_container_cpu_percent / _memory_bytes / _running
+nasdoctor_docker_container_count
+
+# Network (labels: interface)
+nasdoctor_network_interface_up / _mtu
+
+# UPS (10 gauges)
+nasdoctor_ups_battery_percent / _battery_voltage
+nasdoctor_ups_input_voltage / _output_voltage / _load_percent
+nasdoctor_ups_runtime_minutes / _wattage_watts / _temperature_celsius
+nasdoctor_ups_on_battery / _low_battery
+
+# ZFS (labels: pool for pools, dataset+pool for datasets)
+nasdoctor_zfs_pool_healthy / _used_bytes / _total_bytes / _used_percent
+nasdoctor_zfs_pool_fragmentation_percent / _scan_percent / _scan_errors
+nasdoctor_zfs_pool_read_errors / _write_errors / _checksum_errors
+nasdoctor_zfs_arc_size_bytes / _max_size_bytes / _hit_rate_percent
+nasdoctor_zfs_arc_hits_total / _misses_total
+nasdoctor_zfs_l2arc_size_bytes / _hit_rate_percent
+nasdoctor_zfs_dataset_used_bytes / _avail_bytes / _compression_ratio
+
+# Service Checks (labels: name, type, target)
+nasdoctor_service_up / _response_ms / _consecutive_failures
+
+# Parity (Unraid)
+nasdoctor_parity_speed_mb_per_sec / _duration_seconds / _errors / _running
+
+# Tunnels
+nasdoctor_tunnel_cloudflared_up / _connections (labels: name)
+nasdoctor_tunnel_tailscale_node_online / _tx_bytes / _rx_bytes (labels: name, ip)
 
 # Findings
 nasdoctor_findings_critical_count / _warning_count
 nasdoctor_findings_total{severity="critical|warning|info"}
 
-# Parity (Unraid)
-nasdoctor_parity_speed_mb_per_sec / _duration_seconds
-
-# Collection
-nasdoctor_collection_duration_seconds
-nasdoctor_last_collection_timestamp
+# Other
+nasdoctor_update_available
+nasdoctor_collection_duration_seconds / _last_collection_timestamp
 ```
 
 </details>

--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -313,11 +313,10 @@ func loadConfig(path string, cfg *internal.Config) error {
 func applyEnvOverrides(cfg *internal.Config) {
 	if url := os.Getenv("NAS_DOCTOR_WEBHOOK_URL"); url != "" {
 		wh := internal.WebhookConfig{
-			Name:     "env-webhook",
-			URL:      url,
-			Type:     envOr("NAS_DOCTOR_WEBHOOK_TYPE", "generic"),
-			Enabled:  true,
-			MinLevel: internal.Severity(envOr("NAS_DOCTOR_WEBHOOK_MIN_LEVEL", "warning")),
+			Name:    "env-webhook",
+			URL:     url,
+			Type:    envOr("NAS_DOCTOR_WEBHOOK_TYPE", "generic"),
+			Enabled: true,
 		}
 		cfg.Notifications.Webhooks = append(cfg.Notifications.Webhooks, wh)
 	}

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -58,6 +58,23 @@ func Analyze(snap *internal.Snapshot) []internal.Finding {
 func analyzeSMART(drives []internal.SMARTInfo) []internal.Finding {
 	var findings []internal.Finding
 	for _, d := range drives {
+		// SMART data unavailable (drive detected but no attributes)
+		if !d.DataAvailable {
+			findings = append(findings, internal.Finding{
+				Severity:    internal.SeverityWarning,
+				Category:    internal.CategorySMART,
+				Title:       fmt.Sprintf("SMART data unavailable: %s", d.Device),
+				Description: fmt.Sprintf("Drive %s (%s) was detected but smartctl could not read SMART attributes. The drive may be behind an HBA, USB bridge, or unsupported controller.", d.Device, d.Model),
+				Evidence:    []string{"Temperature: 0°C", "Power-on hours: 0", "No SMART attributes in smartctl output"},
+				Impact:      "Drive health cannot be monitored — failures may go undetected",
+				Action:      "Check if the drive supports SMART passthrough. For USB drives, try enabling SAT passthrough. For HBA controllers, verify smartctl can access the drive directly.",
+				Priority:    "short-term",
+				Cost:        "Free",
+				RelatedDisk: d.Serial,
+			})
+			continue
+		}
+
 		// SMART health self-assessment failed
 		if !d.HealthPassed {
 			findings = append(findings, internal.Finding{

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 
 	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/logfwd"
 	"github.com/mcdays94/nas-doctor/internal/notifier"
 	"github.com/mcdays94/nas-doctor/internal/scheduler"
 	"github.com/mcdays94/nas-doctor/internal/storage"
@@ -93,10 +94,13 @@ type SettingsLogForward struct {
 
 // LogForwardDestination represents a single log-forwarding target.
 type LogForwardDestination struct {
-	Name    string `json:"name"`
-	Type    string `json:"type"`
-	URL     string `json:"url"`
-	Enabled bool   `json:"enabled"`
+	Name    string            `json:"name"`
+	Type    string            `json:"type"` // loki, http_json, syslog
+	URL     string            `json:"url"`  // endpoint URL (Loki push, HTTP endpoint, syslog host:port)
+	Enabled bool              `json:"enabled"`
+	Headers map[string]string `json:"headers,omitempty"` // custom HTTP headers (auth tokens, etc.)
+	Labels  map[string]string `json:"labels,omitempty"`  // Loki labels / metadata tags
+	Format  string            `json:"format,omitempty"`  // full (default), findings_only, summary
 }
 
 const settingsConfigKey = "settings"
@@ -513,6 +517,25 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 			DefaultCooldownSec: settings.Notifications.DefaultCooldownSec,
 		})
 		s.scheduler.UpdateServiceChecks(settings.ServiceChecks.Checks)
+
+		// Update log forwarding
+		if settings.LogPush.Enabled && len(settings.LogPush.Destinations) > 0 {
+			var dests []logfwd.Destination
+			for _, d := range settings.LogPush.Destinations {
+				dests = append(dests, logfwd.Destination{
+					Name:    d.Name,
+					Type:    d.Type,
+					URL:     d.URL,
+					Enabled: d.Enabled,
+					Headers: d.Headers,
+					Labels:  d.Labels,
+					Format:  d.Format,
+				})
+			}
+			s.scheduler.UpdateLogForwarder(dests)
+		} else {
+			s.scheduler.UpdateLogForwarder(nil)
+		}
 	}
 
 	writeJSON(w, http.StatusOK, settings)

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -72,10 +72,11 @@ type RetentionSettings struct {
 	NotifyLogDays int `json:"notify_log_days"` // Keep notification log entries for N days (0 = default 30)
 }
 
-// SettingsNotifications holds the webhook list within settings.
+// SettingsNotifications holds the webhook list and notification rules.
 type SettingsNotifications struct {
 	Webhooks           []internal.WebhookConfig      `json:"webhooks"`
-	Policies           []scheduler.AlertPolicy       `json:"policies,omitempty"`
+	Rules              []internal.NotificationRule   `json:"rules,omitempty"`
+	Policies           []scheduler.AlertPolicy       `json:"policies,omitempty"` // legacy — kept for migration
 	QuietHours         scheduler.QuietHours          `json:"quiet_hours,omitempty"`
 	MaintenanceWindows []scheduler.MaintenanceWindow `json:"maintenance_windows,omitempty"`
 	DefaultCooldownSec int                           `json:"default_cooldown_sec,omitempty"`
@@ -511,7 +512,8 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		// Update notifier webhooks at runtime.
 		s.scheduler.UpdateNotifier(s.buildNotifier(settings.Notifications.Webhooks))
 		s.scheduler.UpdateAlerting(scheduler.AlertingConfig{
-			Policies:           settings.Notifications.Policies,
+			Rules:              settings.Notifications.Rules,
+			Policies:           settings.Notifications.Policies, // legacy compat
 			QuietHours:         settings.Notifications.QuietHours,
 			MaintenanceWindows: settings.Notifications.MaintenanceWindows,
 			DefaultCooldownSec: settings.Notifications.DefaultCooldownSec,
@@ -790,9 +792,6 @@ func (s *Server) handleTestWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 	// Force enabled for the test
 	wh.Enabled = true
-	if wh.MinLevel == "" {
-		wh.MinLevel = internal.SeverityInfo
-	}
 
 	testFindings := []internal.Finding{
 		{

--- a/internal/api/templates/clean.html
+++ b/internal/api/templates/clean.html
@@ -1215,6 +1215,7 @@ body {
     html += '<div class="section-block" data-section="services">';
     if (snapshot && snapshot.service_checks && snapshot.service_checks.length > 0) {
       html += '<div class="section"><div class="section-title">Service Checks (' + snapshot.service_checks.length + ')</div>';
+      html += '<div style="background:var(--card-bg,#fff);border:1px solid rgba(0,0,0,0.08);border-radius:8px;overflow:hidden">';
       html += '<table style="width:100%;font-size:13px;border-collapse:collapse">';
       html += '<tr style="color:#808080;font-size:11px"><th style="text-align:left;padding:6px 0;border-bottom:1px solid rgba(0,0,0,0.08)">Name</th><th style="text-align:left;padding:6px 0;border-bottom:1px solid rgba(0,0,0,0.08)">Type</th><th style="text-align:left;padding:6px 0;border-bottom:1px solid rgba(0,0,0,0.08)">Status</th><th style="text-align:left;padding:6px 0;border-bottom:1px solid rgba(0,0,0,0.08)">Latency</th><th style="text-align:left;padding:6px 0;border-bottom:1px solid rgba(0,0,0,0.08)">Failures</th></tr>';
       for (var si = 0; si < snapshot.service_checks.length; si++) {
@@ -1226,7 +1227,7 @@ body {
         html += '<td style="padding:5px 0;border-bottom:1px solid rgba(0,0,0,0.04)">' + ((sc.response_ms != null) ? (sc.response_ms + ' ms') : '—') + '</td>';
         html += '<td style="padding:5px 0;border-bottom:1px solid rgba(0,0,0,0.04)">' + (sc.consecutive_failures || 0) + ' / ' + (sc.failure_threshold || 1) + '</td></tr>';
       }
-      html += '</table></div>';
+      html += '</table></div></div>'; // table + card + section
     }
     html += '</div>'; // end section-block services
 
@@ -1235,6 +1236,7 @@ body {
     var tunnels = snapshot ? snapshot.tunnels : null;
     if (tunnels && (tunnels.cloudflared || tunnels.tailscale)) {
       html += '<div class="section"><div class="section-title">Tunnels</div>';
+      html += '<div style="background:var(--card-bg,#fff);border:1px solid rgba(0,0,0,0.08);border-radius:8px;padding:12px">';
       if (tunnels.cloudflared && tunnels.cloudflared.tunnels && tunnels.cloudflared.tunnels.length > 0) {
         html += '<div style="font-size:11px;color:var(--text2);margin-bottom:6px;text-transform:uppercase;letter-spacing:0.5px">Cloudflared ' + escapeHTML(tunnels.cloudflared.version || '') + '</div>';
         for (var ti = 0; ti < tunnels.cloudflared.tunnels.length; ti++) {
@@ -1265,7 +1267,8 @@ body {
           html += '</div>';
         }
       }
-      html += '</div>';
+      html += '</div>'; // card
+      html += '</div>'; // section
     }
     html += '</div>'; // end section-block tunnels
 
@@ -1275,6 +1278,7 @@ body {
       var par = snapshot.parity;
       html += '<div class="section"><div class="section-title" style="display:flex;align-items:center;justify-content:space-between"><span>Parity</span><a href="/parity" style="font-size:11px;color:var(--text2);text-decoration:none;font-weight:400;margin-left:16px;white-space:nowrap">View all &rarr;</a></div>';
       if (par.history && par.history.length > 0) {
+        html += '<div style="background:var(--card-bg,#fff);border:1px solid rgba(0,0,0,0.08);border-radius:8px;padding:12px">';
         html += '<div style="display:flex;gap:8px;overflow-x:auto;padding-bottom:6px;scrollbar-width:thin">';
         var sorted = par.history.slice().sort(function(a,b){ return (b.date||"").localeCompare(a.date||""); });
         for (var pi = 0; pi < sorted.length; pi++) {
@@ -1288,9 +1292,10 @@ body {
           html += '<div style="font-size:11px;margin-top:2px;font-weight:600;color:'+(hasErr?'#dc2626':'#16a34a')+'">'+( hasErr ? pc.errors+' errors' : 'Clean' )+'</div>';
           html += '</div></a>';
         }
-        html += '</div>';
+        html += '</div>'; // flex row
+        html += '</div>'; // card
       } else {
-        html += '<div style="font-size:13px;color:#808080">Status: ' + escapeHTML(par.status || "idle") + '</div>';
+        html += '<div style="background:var(--card-bg,#fff);border:1px solid rgba(0,0,0,0.08);border-radius:8px;padding:12px;font-size:13px;color:#808080">Status: ' + escapeHTML(par.status || "idle") + '</div>';
       }
       html += '</div>';
     }

--- a/internal/api/templates/clean.html
+++ b/internal/api/templates/clean.html
@@ -685,6 +685,7 @@ body {
 .status-dot.amber  { background: #d97706; }
 .status-dot.red    { background: #dc2626; }
 .status-dot.gray   { background: #808080; }
+.status-dot.unknown { background: #b3b3b3; }
 
 /* ---- Loading ---- */
 .loading {
@@ -1007,6 +1008,7 @@ body {
     var healthOk = 0, healthWarn = 0, healthCrit = 0;
     for (var hc = 0; hc < _smart.length; hc++) {
       if (!_smart[hc].health_passed) healthCrit++;
+      else if (_smart[hc].data_available === false) healthWarn++;
       else if ((_smart[hc].temperature_c || 0) >= 50 || _smart[hc].reallocated_sectors > 0 || _smart[hc].pending_sectors > 0) healthWarn++;
       else healthOk++;
     }
@@ -1048,21 +1050,24 @@ body {
     if (_smart.length > 0) {
       for (var si = 0; si < _smart.length; si++) {
         var sm = _smart[si];
+        var noData = sm.data_available === false;
         var hlOk = sm.health_passed;
         var sizeStr = sm.size_gb >= 1000 ? (sm.size_gb/1000).toFixed(1)+' TB' : (sm.size_gb||0).toFixed(0)+' GB';
-        var ageStr = sm.power_on_hours > 8766 ? (sm.power_on_hours/8766).toFixed(1)+'y' : (sm.power_on_hours||0).toLocaleString()+'h';
+        var ageStr = noData ? '\u2014' : (sm.power_on_hours > 8766 ? (sm.power_on_hours/8766).toFixed(1)+'y' : (sm.power_on_hours||0).toLocaleString()+'h');
         var slot = sm.array_slot || '';
         html += '<div class="card" style="margin-bottom:6px;padding:10px 14px;cursor:pointer" onclick="window.location=\'/disk/'+encodeURIComponent(sm.serial||'')+'\'">';
         html += '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">';
-        html += '<span class="status-dot '+(hlOk?'green':'red')+'"></span>';
+        html += '<span class="status-dot '+(noData?'unknown':hlOk?'green':'red')+'"></span>';
         html += '<span style="font-weight:600;font-size:13px">'+escapeHTML(sm.device)+'</span>';
         if (slot) html += '<span style="font-size:11px;color:#808080;background:#f5f5f5;padding:1px 6px;border-radius:4px">'+escapeHTML(slot)+'</span>';
         html += '<span style="font-size:12px;color:#4d4d4d;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">'+escapeHTML(sm.model)+'</span>';
         html += '<span style="font-size:12px;color:#808080">'+sizeStr+'</span>';
-        html += '<span style="font-size:12px;font-weight:600;color:'+(sm.temperature_c>=55?'#dc2626':sm.temperature_c>=45?'#d97706':'#16a34a')+'">'+(sm.temperature_c||0)+'&deg;C</span>';
+        var tempColor = noData ? '#b3b3b3' : (sm.temperature_c>=55?'#dc2626':sm.temperature_c>=45?'#d97706':'#16a34a');
+        html += '<span style="font-size:12px;font-weight:600;color:'+tempColor+'">'+(noData?'\u2014':((sm.temperature_c||0)+'&deg;C'))+'</span>';
         html += '<span style="font-size:11px;color:#b3b3b3">'+ageStr+'</span>';
         html += '<canvas id="spark-temp-'+si+'" width="50" height="18" style="flex-shrink:0"></canvas>';
-        if (!hlOk) html += '<span style="font-size:10px;font-weight:600;color:#dc2626;background:rgba(220,38,38,0.06);padding:1px 6px;border-radius:9999px">FAILED</span>';
+        if (noData) html += '<span style="font-size:10px;font-weight:600;color:#d97706;background:rgba(217,119,6,0.06);padding:1px 6px;border-radius:9999px">NO DATA</span>';
+        else if (!hlOk) html += '<span style="font-size:10px;font-weight:600;color:#dc2626;background:rgba(220,38,38,0.06);padding:1px 6px;border-radius:9999px">FAILED</span>';
         if (sm.reallocated_sectors>0) html += '<span style="font-size:10px;color:#d97706;background:rgba(217,119,6,0.06);padding:1px 6px;border-radius:9999px">'+sm.reallocated_sectors+' realloc</span>';
         if (sm.pending_sectors>0) html += '<span style="font-size:10px;color:#dc2626;background:rgba(220,38,38,0.06);padding:1px 6px;border-radius:9999px">'+sm.pending_sectors+' pending</span>';
         html += '</div>';

--- a/internal/api/templates/ember.html
+++ b/internal/api/templates/ember.html
@@ -1377,6 +1377,7 @@ td.mono {
     var _hlOkC = 0, _hlWarnC = 0, _hlCritC = 0;
     for (var hc = 0; hc < _sm.length; hc++) {
       if (!_sm[hc].health_passed) _hlCritC++;
+      else if (_sm[hc].data_available === false) _hlWarnC++;
       else if ((_sm[hc].temperature_c || 0) >= 50 || _sm[hc].reallocated_sectors > 0 || _sm[hc].pending_sectors > 0) _hlWarnC++;
       else _hlOkC++;
     }
@@ -1418,21 +1419,23 @@ td.mono {
     if (_sm.length > 0) {
       for (var si=0;si<_sm.length;si++) {
         var sm = _sm[si];
+        var noData = sm.data_available === false;
         var hlOk = sm.health_passed;
         var szStr = sm.size_gb>=1000?(sm.size_gb/1000).toFixed(1)+" TB":(sm.size_gb||0).toFixed(0)+" GB";
-        var ageStr = sm.power_on_hours > 8766 ? (sm.power_on_hours/8766).toFixed(1)+"y" : (sm.power_on_hours||0).toLocaleString()+"h";
+        var ageStr = noData ? "\u2014" : (sm.power_on_hours > 8766 ? (sm.power_on_hours/8766).toFixed(1)+"y" : (sm.power_on_hours||0).toLocaleString()+"h");
         var slot = sm.array_slot||"";
         html += "<div class=\"card-static\" style=\"margin-bottom:6px;padding:10px 12px;cursor:pointer\" onclick=\"window.location='/disk/"+encodeURIComponent(sm.serial||"")+"'\">";
         html += "<div style=\"display:flex;align-items:center;gap:8px;flex-wrap:wrap\">";
-        html += "<span class=\"status-dot "+(hlOk?"s-green":"s-red")+"\"></span>";
+        html += "<span class=\"status-dot "+(noData?"s-gray":hlOk?"s-green":"s-red")+"\"></span>";
         html += "<span style=\"font-family:var(--font-mono);font-weight:500;font-size:13px\">"+esc(sm.device)+"</span>";
         if(slot)html+="<span style=\"font-size:11px;color:var(--text-dim);background:var(--surface-200);padding:1px 6px;border-radius:4px\">"+esc(slot)+"</span>";
         html+="<span style=\"font-size:12px;color:var(--text-tertiary);flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap\">"+esc(sm.model)+"</span>";
         html+="<span style=\"font-size:12px;color:var(--text-dim)\">"+szStr+"</span>";
-        html+="<span class=\"mono\" style=\"font-size:12px;font-weight:600;"+tempColor(sm.temperature_c)+"\">"+(sm.temperature_c||0)+"&deg;</span>";
+        html+="<span class=\"mono\" style=\"font-size:12px;font-weight:600;"+(noData?"color:var(--text-dim)":tempColor(sm.temperature_c))+"\">"+(noData?"\u2014":((sm.temperature_c||0)+"&deg;"))+"</span>";
         html+="<span style=\"font-size:11px;color:var(--text-dim)\">"+ageStr+"</span>";
         html+="<canvas id=\"spark-temp-"+si+"\" width=\"50\" height=\"18\" style=\"flex-shrink:0\"></canvas>";
-        if(!hlOk)html+="<span style=\"font-size:10px;font-weight:600;color:var(--red);background:rgba(255,99,99,0.1);padding:1px 6px;border-radius:9999px\">FAIL</span>";
+        if(noData)html+="<span style=\"font-size:10px;font-weight:600;color:#FACC15;background:rgba(250,204,21,0.1);padding:1px 6px;border-radius:9999px\">NO DATA</span>";
+        else if(!hlOk)html+="<span style=\"font-size:10px;font-weight:600;color:var(--red);background:rgba(255,99,99,0.1);padding:1px 6px;border-radius:9999px\">FAIL</span>";
         if(sm.reallocated_sectors>0)html+="<span style=\"font-size:10px;color:#FACC15;background:rgba(250,204,21,0.1);padding:1px 6px;border-radius:9999px\">"+sm.reallocated_sectors+" realloc</span>";
         if(sm.pending_sectors>0)html+="<span style=\"font-size:10px;color:var(--red);background:rgba(255,99,99,0.1);padding:1px 6px;border-radius:9999px\">"+sm.pending_sectors+" pending</span>";
         html+="</div>";

--- a/internal/api/templates/ember.html
+++ b/internal/api/templates/ember.html
@@ -1586,6 +1586,7 @@ td.mono {
     html += "<div class=\"section-block\" data-section=\"services\">";
     if (snapshot && snapshot.service_checks && snapshot.service_checks.length > 0) {
       html += "<div class=\"section\" style=\"margin-top:0\"><div class=\"section-title\">Service Checks (" + snapshot.service_checks.length + ")</div>";
+      html += "<div style=\"background:var(--surface-100);border-radius:12px;box-shadow:var(--shadow-card);overflow:hidden\">";
       html += "<table style=\"width:100%;font-size:12px;border-collapse:collapse\">";
       html += "<tr style=\"color:var(--text-dim);font-size:10px;text-transform:uppercase\"><th style=\"text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)\">Name</th><th style=\"text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)\">Type</th><th style=\"text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)\">Status</th><th style=\"text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)\">Latency</th><th style=\"text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)\">Failures</th></tr>";
       for (var si = 0; si < snapshot.service_checks.length; si++) {
@@ -1597,7 +1598,7 @@ td.mono {
         html += "<td style=\"padding:5px 8px;border-bottom:1px solid var(--border)\">" + ((sc.response_ms != null) ? (sc.response_ms + " ms") : "—") + "</td>";
         html += "<td style=\"padding:5px 8px;border-bottom:1px solid var(--border)\">" + (sc.consecutive_failures || 0) + " / " + (sc.failure_threshold || 1) + "</td></tr>";
       }
-      html += "</table></div>";
+      html += "</table></div></div>"; /* table + card + section */
     }
     html += "</div>"; /* section-block services */
 
@@ -1606,6 +1607,7 @@ td.mono {
     var tunnels = snapshot ? snapshot.tunnels : null;
     if (tunnels && (tunnels.cloudflared || tunnels.tailscale)) {
       html += "<div class=\"section\" style=\"margin-top:0\"><div class=\"section-title\">Tunnels</div>";
+      html += "<div style=\"background:var(--surface-100);border-radius:12px;box-shadow:var(--shadow-card);padding:12px\">";
       if (tunnels.cloudflared && tunnels.cloudflared.tunnels && tunnels.cloudflared.tunnels.length > 0) {
         html += "<div style=\"font-size:11px;color:var(--text-dim);margin-bottom:6px;text-transform:uppercase;letter-spacing:0.5px\">Cloudflared " + esc(tunnels.cloudflared.version || "") + "</div>";
         for (var ti = 0; ti < tunnels.cloudflared.tunnels.length; ti++) {
@@ -1636,7 +1638,8 @@ td.mono {
           html += "</div>";
         }
       }
-      html += "</div>";
+      html += "</div>"; /* card */
+      html += "</div>"; /* section */
     }
     html += "</div>"; /* section-block tunnels */
 
@@ -1646,6 +1649,7 @@ td.mono {
       var par = snapshot.parity;
       html += "<div class=\"section\" style=\"margin-top:0\"><div class=\"section-title\" style=\"display:flex;align-items:center;justify-content:space-between\"><span>Parity</span><a href=\"/parity\" style=\"font-size:11px;color:var(--text-dim);text-decoration:none;font-weight:400;margin-left:16px;white-space:nowrap\">View all &rarr;</a></div>";
       if (par.history && par.history.length > 0) {
+        html += "<div style=\"background:var(--surface-100);border-radius:12px;box-shadow:var(--shadow-card);padding:12px\">";
         html += "<div style=\"display:flex;gap:8px;overflow-x:auto;padding-bottom:6px;scrollbar-width:thin\">";
         var sorted = par.history.slice().sort(function(a,b){ return (b.date||"").localeCompare(a.date||""); });
         for (var pi = 0; pi < sorted.length; pi++) {
@@ -1659,9 +1663,10 @@ td.mono {
           html += "<div style=\"font-size:11px;margin-top:2px;font-weight:600;color:"+(hasErr?"var(--red)":"var(--green)")+"\">"+(hasErr?pc.errors+" errors":"Clean")+"</div>";
           html += "</div></a>";
         }
-        html += "</div>";
+        html += "</div>"; /* flex row */
+        html += "</div>"; /* card */
       } else {
-        html += "<div style=\"font-size:12px;color:var(--text-dim)\">Status: " + esc(par.status || "idle") + "</div>";
+        html += "<div style=\"background:var(--surface-100);border-radius:12px;box-shadow:var(--shadow-card);padding:12px;font-size:12px;color:var(--text-dim)\">Status: " + esc(par.status || "idle") + "</div>";
       }
       html += "</div>";
     }

--- a/internal/api/templates/midnight.html
+++ b/internal/api/templates/midnight.html
@@ -761,6 +761,7 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
     if (svcChecks && svcChecks.length > 0) {
       h += '<div>';
       h += '<div class="section-title">Service Checks (' + svcChecks.length + ')</div>';
+      h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);overflow:hidden">';
       h += '<table style="width:100%;font-size:12px;border-collapse:collapse">';
       h += '<tr style="color:var(--text-quaternary);font-size:10px;text-transform:uppercase;letter-spacing:0.5px">';
       h += '<th style="text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)">Name</th>';
@@ -782,6 +783,7 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
         h += '</tr>';
       }
       h += '</table>';
+      h += '</div>'; // card
       h += '</div>';
     }
     h += '</div>'; // end section-block services
@@ -792,6 +794,7 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
     if (tunnels && (tunnels.cloudflared || tunnels.tailscale)) {
       h += '<div>';
       h += '<div class="section-title">Tunnels</div>';
+      h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:12px">';
       if (tunnels.cloudflared && tunnels.cloudflared.tunnels && tunnels.cloudflared.tunnels.length > 0) {
         h += '<div style="font-size:11px;color:var(--text-quaternary);margin-bottom:6px;text-transform:uppercase;letter-spacing:0.5px">Cloudflared ' + esc(tunnels.cloudflared.version || '') + '</div>';
         for (var ti = 0; ti < tunnels.cloudflared.tunnels.length; ti++) {
@@ -823,6 +826,7 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
           h += '</div>';
         }
       }
+      h += '</div>'; // card
       h += '</div>';
     }
     h += '</div>'; // end section-block tunnels
@@ -834,6 +838,7 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
       h += '<div>';
       h += '<div class="section-title" style="display:flex;align-items:center;justify-content:space-between"><span>Parity History</span><a href="/parity" style="font-size:11px;color:var(--text-quaternary);text-decoration:none;font-weight:400;margin-left:16px;white-space:nowrap">View all &rarr;</a></div>';
       h += '<div style="font-size:12px;color:var(--text-tertiary);margin-bottom:8px">Status: ' + esc(parity.status || "idle") + '</div>';
+      h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:12px">';
       h += '<div style="display:flex;gap:8px;overflow-x:auto;padding-bottom:6px;scrollbar-width:thin">';
       var sorted = parity.history.slice().sort(function(a,b){ return (b.date||"").localeCompare(a.date||""); });
       for (var pi = 0; pi < sorted.length; pi++) {
@@ -847,12 +852,13 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
         h += '<div style="font-size:11px;margin-top:2px;font-weight:600;color:'+(hasErr?'var(--red)':'var(--green)')+'">'+( hasErr ? pc.errors+' errors' : 'Clean' )+'</div>';
         h += '</div></a>';
       }
-      h += '</div>';
+      h += '</div>'; // flex row
+      h += '</div>'; // card
       h += '</div>';
     } else if (parity && parity.status) {
       h += '<div>';
       h += '<div class="section-title">Parity</div>';
-      h += '<div style="font-size:12px;color:var(--text-tertiary)">Status: ' + esc(parity.status) + ' &middot; No parity check history found</div>';
+      h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:12px;font-size:12px;color:var(--text-tertiary)">Status: ' + esc(parity.status) + ' &middot; No parity check history found</div>';
       h += '</div>';
     }
     h += '</div>'; // end section-block parity

--- a/internal/api/templates/midnight.html
+++ b/internal/api/templates/midnight.html
@@ -190,6 +190,8 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
 .status-dot.running{background:var(--green)}
 .status-dot.exited{background:var(--red)}
 .status-dot.paused{background:var(--amber)}
+.status-dot.unknown{background:var(--text-quaternary)}
+.td-unknown{color:var(--text-quaternary)}
 
 /* Utility */
 .text-green{color:var(--green)}.text-amber{color:var(--amber)}.text-red{color:var(--red)}.text-brand{color:var(--accent)}
@@ -505,6 +507,7 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
       var healthOk = 0, healthWarn = 0, healthCrit = 0;
       for (var hc = 0; hc < smart.length; hc++) {
         if (!smart[hc].health_passed) healthCrit++;
+        else if (smart[hc].data_available === false) healthWarn++;
         else if ((smart[hc].temperature_c || 0) >= 50 || smart[hc].reallocated_sectors > 0 || smart[hc].pending_sectors > 0) healthWarn++;
         else healthOk++;
       }
@@ -554,10 +557,11 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
       if (smart.length > 0) {
         for (var si = 0; si < smart.length; si++) {
           var s = smart[si];
-          var healthDot = s.health_passed ? "running" : "exited";
-          var tempClass = (s.temperature_c || 0) >= 55 ? "td-crit" : (s.temperature_c || 0) >= 45 ? "td-warn" : "td-healthy";
+          var noData = s.data_available === false;
+          var healthDot = noData ? "unknown" : (s.health_passed ? "running" : "exited");
+          var tempClass = noData ? "td-unknown" : ((s.temperature_c || 0) >= 55 ? "td-crit" : (s.temperature_c || 0) >= 45 ? "td-warn" : "td-healthy");
           var sizeStr = s.size_gb >= 1000 ? (s.size_gb / 1000).toFixed(1) + ' TB' : (s.size_gb || 0).toFixed(0) + ' GB';
-          var ageStr = s.power_on_hours > 8766 ? (s.power_on_hours / 8766).toFixed(1) + 'y' : (s.power_on_hours || 0).toLocaleString() + 'h';
+          var ageStr = noData ? '—' : (s.power_on_hours > 8766 ? (s.power_on_hours / 8766).toFixed(1) + 'y' : (s.power_on_hours || 0).toLocaleString() + 'h');
           var slotLabel = s.array_slot || '';
 
           h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:10px 12px;margin-bottom:6px;cursor:pointer" onclick="window.location=\'/disk/' + encodeURIComponent(s.serial || '') + '\'">';
@@ -567,10 +571,11 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
           if (slotLabel) h += '<span style="font-size:11px;color:var(--text-quaternary);background:var(--bg-elevated);padding:1px 6px;border-radius:4px">' + esc(slotLabel) + '</span>';
           h += '<span style="font-size:12px;color:var(--text-tertiary);flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + esc(s.model) + '</span>';
           h += '<span style="font-size:12px;color:var(--text-tertiary)">' + sizeStr + '</span>';
-          h += '<span class="' + tempClass + '" style="font-size:12px;font-weight:600">' + (s.temperature_c || 0) + '&deg;C</span>';
+          h += '<span class="' + tempClass + '" style="font-size:12px;font-weight:600">' + (noData ? '—' : ((s.temperature_c || 0) + '&deg;C')) + '</span>';
           h += '<span style="font-size:11px;color:var(--text-quaternary)">' + ageStr + '</span>';
           h += '<canvas id="spark-temp-' + si + '" width="60" height="20" style="flex-shrink:0"></canvas>';
-          if (!s.health_passed) h += '<span style="font-size:10px;font-weight:600;color:var(--red);background:rgba(220,38,38,0.1);padding:1px 6px;border-radius:9999px">FAILED</span>';
+          if (noData) h += '<span style="font-size:10px;font-weight:600;color:var(--amber);background:rgba(217,119,6,0.1);padding:1px 6px;border-radius:9999px">NO DATA</span>';
+          else if (!s.health_passed) h += '<span style="font-size:10px;font-weight:600;color:var(--red);background:rgba(220,38,38,0.1);padding:1px 6px;border-radius:9999px">FAILED</span>';
           if (s.reallocated_sectors > 0) h += '<span style="font-size:10px;color:var(--amber);background:rgba(217,119,6,0.1);padding:1px 6px;border-radius:9999px">' + s.reallocated_sectors + ' realloc</span>';
           if (s.pending_sectors > 0) h += '<span style="font-size:10px;color:var(--red);background:rgba(220,38,38,0.1);padding:1px 6px;border-radius:9999px">' + s.pending_sectors + ' pending</span>';
           if (s.udma_crc_errors > 0) h += '<span style="font-size:10px;color:var(--amber);background:rgba(217,119,6,0.1);padding:1px 6px;border-radius:9999px">' + s.udma_crc_errors + ' CRC</span>';

--- a/internal/api/templates/service_checks.html
+++ b/internal/api/templates/service_checks.html
@@ -134,6 +134,11 @@
   function fetchJSON(url){return fetch(url).then(function(r){if(!r.ok)throw new Error(r.status);return r.json()});}
   function pillClass(t){t=(t||"").toLowerCase();if(t==="http")return"pill-http";if(t==="tcp")return"pill-tcp";if(t==="dns")return"pill-dns";if(t==="ping")return"pill-ping";if(t==="smb"||t==="nfs")return"pill-smb";return"pill-http";}
   function fmtInterval(sec){if(sec<60)return sec+"s";if(sec<3600)return Math.floor(sec/60)+"m";return Math.floor(sec/3600)+"h";}
+  function faviconHTML(type,target){
+    if((type||"").toLowerCase()!=="http")return"";
+    try{var u=new URL(target);return'<img src="https://www.google.com/s2/favicons?domain='+encodeURIComponent(u.hostname)+'&sz=16" width="16" height="16" style="border-radius:3px;flex-shrink:0" onerror="this.style.display=\'none\'">';}
+    catch(e){return"";}
+  }
 
   // ── Summary counters ──
   function renderSummary(){
@@ -173,6 +178,7 @@
       h+='<div class="badge-card'+(isActive?" active":"")+'" onclick="filterByCheck(\''+esc(c.key)+'\')">';
       h+='<div class="badge-top">';
       h+='<div class="badge-dot '+(isUp?"up":"down")+'"></div>';
+      h+=faviconHTML(c.type,c.target);
       h+='<div class="badge-name">'+esc(c.name)+'</div>';
       h+='<span class="pill '+pillClass(c.type)+'" style="font-size:9px;padding:1px 5px">'+esc((c.type||"").toUpperCase())+'</span>';
       h+='</div>';
@@ -238,7 +244,7 @@
       var ts=e.checked_at?new Date(e.checked_at).toLocaleString():"—";
       h+='<tr>';
       h+='<td>'+esc(ts)+'</td>';
-      h+='<td>'+esc(e.name||"—")+'</td>';
+      h+='<td style="display:flex;align-items:center;gap:5px">'+faviconHTML(e.type,e.target)+esc(e.name||"—")+'</td>';
       h+='<td><span class="pill '+pillClass(e.type)+'" style="font-size:9px;padding:1px 5px">'+esc((e.type||"").toUpperCase())+'</span></td>';
       h+='<td class="status-'+e.status+'">'+esc(e.status)+'</td>';
       h+='<td>'+(e.response_ms!=null?e.response_ms+' ms':'—')+'</td>';

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -169,63 +169,9 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
         <label for="wh-url">URL</label>
         <input type="url" id="wh-url" placeholder="https://...">
       </div>
-      <div class="form-row">
-        <div>
-          <label for="wh-level">Minimum Level</label>
-          <select id="wh-level">
-            <option value="critical">Critical</option>
-            <option value="warning">Warning</option>
-            <option value="info" selected>Info</option>
-          </select>
-        </div>
-        <div>
-          <label for="wh-secret">Secret (optional, HMAC signing)</label>
-          <input type="password" id="wh-secret" placeholder="Leave blank if not needed">
-        </div>
-      </div>
-      <!-- Notification Filters (granular) -->
-      <div class="form-group" style="margin-top:12px">
-        <label style="cursor:pointer;user-select:none;font-weight:600" onclick="document.getElementById('wh-filters-panel').style.display=document.getElementById('wh-filters-panel').style.display==='none'?'block':'none'">Notification Filters &#9662;</label>
-        <p style="font-size:11px;color:var(--text2);margin-top:2px">Fine-tune exactly which events trigger this webhook.</p>
-        <div id="wh-filters-panel" style="display:none;margin-top:8px;padding:16px;background:rgba(255,255,255,0.02);border:1px solid var(--border);border-radius:var(--radius)">
-          <div style="font-size:12px;font-weight:600;margin-bottom:8px;color:var(--text)">Severity &amp; Category</div>
-          <div class="form-row">
-            <div><label for="wf-severities">Severities (comma-separated, empty = use Min Level)</label>
-              <input type="text" id="wf-severities" placeholder="e.g. critical,warning"></div>
-            <div><label for="wf-categories">Categories (comma-separated, empty = all)</label>
-              <input type="text" id="wf-categories" placeholder="e.g. smart,disk,parity,ups"></div>
-          </div>
-          <div style="font-size:12px;font-weight:600;margin:16px 0 8px;color:var(--text)">Threshold Triggers</div>
-          <div class="form-row">
-            <div><label for="wf-disk-space">Disk free space below (%)</label>
-              <input type="number" id="wf-disk-space" min="0" max="100" step="1" placeholder="0 = disabled"></div>
-            <div><label for="wf-disk-temp">Any disk temp above (&deg;C)</label>
-              <input type="number" id="wf-disk-temp" min="0" max="100" placeholder="0 = disabled"></div>
-          </div>
-          <div class="form-row">
-            <div><label for="wf-avg-temp">Avg disk temp above (&deg;C)</label>
-              <input type="number" id="wf-avg-temp" min="0" max="100" placeholder="0 = disabled"></div>
-            <div><label for="wf-realloc">SMART reallocated sectors above</label>
-              <input type="number" id="wf-realloc" min="0" placeholder="0 = disabled"></div>
-          </div>
-          <div class="form-row">
-            <div><label for="wf-ups-battery">UPS battery below (%)</label>
-              <input type="number" id="wf-ups-battery" min="0" max="100" step="1" placeholder="0 = disabled"></div>
-            <div></div>
-          </div>
-          <div style="font-size:12px;font-weight:600;margin:16px 0 8px;color:var(--text)">Event Triggers</div>
-          <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px">
-            <label style="display:flex;gap:6px;align-items:center;font-size:12px;cursor:pointer"><input type="checkbox" id="wf-service-down"> Service check goes down</label>
-            <label style="display:flex;gap:6px;align-items:center;font-size:12px;cursor:pointer"><input type="checkbox" id="wf-parity-error"> Parity check has errors</label>
-            <label style="display:flex;gap:6px;align-items:center;font-size:12px;cursor:pointer"><input type="checkbox" id="wf-smart-fail"> SMART health fails</label>
-            <label style="display:flex;gap:6px;align-items:center;font-size:12px;cursor:pointer"><input type="checkbox" id="wf-ups-battery-mode"> UPS switches to battery</label>
-            <label style="display:flex;gap:6px;align-items:center;font-size:12px;cursor:pointer"><input type="checkbox" id="wf-update"> Platform update available</label>
-          </div>
-          <div style="margin-top:12px">
-            <label for="wf-service-names">Limit to specific service checks (comma-separated names, empty = all)</label>
-            <input type="text" id="wf-service-names" placeholder="e.g. Home Assistant,Gateway Ping">
-          </div>
-        </div>
+      <div class="form-group">
+        <label for="wh-secret">Secret (optional, HMAC signing)</label>
+        <input type="password" id="wh-secret" placeholder="Leave blank if not needed">
       </div>
       <!-- Custom Headers -->
       <div class="form-group" style="margin-top:12px">
@@ -342,63 +288,88 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
       </div>
     </div>
 
-    <!-- Notification Policies -->
+    <!-- Notification Rules -->
     <div style="margin-top:20px;padding-top:16px;border-top:1px solid var(--border)">
-      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
-        <div style="font-size:14px;font-weight:600">Notification Policies</div>
-        <button class="btn btn-secondary btn-sm" onclick="togglePolicyForm()">+ Add Policy</button>
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">
+        <div style="font-size:14px;font-weight:600">Notification Rules</div>
+        <button class="btn btn-secondary btn-sm" onclick="toggleRuleForm()">+ Add Notification</button>
       </div>
-      <p style="font-size:12px;color:var(--text2);margin-bottom:12px">Route alerts to specific webhooks by severity, category, and hostname. Policies override the default webhook min-level.</p>
-      <div id="policy-list"></div>
-      <div class="webhook-form" id="policy-form">
-        <input type="hidden" id="pol-edit-index" value="-1">
+      <p style="font-size:12px;color:var(--text2);margin-bottom:8px">Define exactly which events trigger each webhook.</p>
+      <!-- Quick Presets -->
+      <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:12px">
+        <button class="btn btn-secondary btn-sm" onclick="addPreset('critical')">Critical alerts</button>
+        <button class="btn btn-secondary btn-sm" onclick="addPreset('disk_health')">Disk health</button>
+        <button class="btn btn-secondary btn-sm" onclick="addPreset('services')">Service uptime</button>
+        <button class="btn btn-secondary btn-sm" onclick="addPreset('power')">Power protection</button>
+        <button class="btn btn-secondary btn-sm" onclick="addPreset('storage')">Storage warnings</button>
+      </div>
+      <div id="rule-list"></div>
+      <!-- Rule form — all fields visible -->
+      <div class="webhook-form" id="rule-form">
+        <input type="hidden" id="nr-edit-index" value="-1">
         <div class="form-row">
           <div>
-            <label for="pol-name">Policy Name</label>
-            <input type="text" id="pol-name" placeholder="e.g. Critical to Discord">
+            <label for="nr-name">Name</label>
+            <input type="text" id="nr-name" placeholder="e.g. Disk 1 temperature alert">
           </div>
           <div>
-            <label for="pol-webhook">Target Webhook</label>
-            <select id="pol-webhook"></select>
+            <label for="nr-webhook">Notify via</label>
+            <select id="nr-webhook"></select>
           </div>
         </div>
         <div class="form-row">
           <div>
-            <label for="pol-severity">Minimum Severity</label>
-            <select id="pol-severity">
-              <option value="critical">Critical</option>
-              <option value="warning">Warning</option>
-              <option value="info" selected>Info</option>
+            <label for="nr-category">Category</label>
+            <select id="nr-category" onchange="onRuleCategoryChange()">
+              <option value="findings">Findings (severity)</option>
+              <option value="disk_space">Disk Space</option>
+              <option value="disk_temp">Disk Temperature</option>
+              <option value="smart">SMART Health</option>
+              <option value="service">Service Check</option>
+              <option value="parity">Parity (Unraid)</option>
+              <option value="ups">UPS / Power</option>
+              <option value="docker">Docker</option>
+              <option value="system">System</option>
+              <option value="zfs">ZFS</option>
+              <option value="tunnels">Tunnels</option>
+              <option value="update">Platform Update</option>
             </select>
           </div>
           <div>
-            <label for="pol-cooldown">Cooldown (seconds)</label>
-            <input type="number" id="pol-cooldown" min="0" max="86400" value="900" style="text-align:center">
+            <label for="nr-condition">Condition</label>
+            <select id="nr-condition"></select>
           </div>
         </div>
         <div class="form-row">
           <div>
-            <label for="pol-categories">Categories (comma-separated, or leave blank for all)</label>
-            <input type="text" id="pol-categories" placeholder="e.g. storage,network,system">
+            <label for="nr-target">Target <span style="font-size:10px;color:var(--text3)">(optional — specific drive, service, container)</span></label>
+            <select id="nr-target"><option value="">Any / All</option></select>
           </div>
           <div>
-            <label for="pol-hostnames">Hostnames (comma-separated, or blank for all)</label>
-            <input type="text" id="pol-hostnames" placeholder="e.g. nas1,nas2">
+            <label for="nr-value">Threshold value</label>
+            <input type="number" id="nr-value" placeholder="e.g. 55" step="any">
           </div>
         </div>
         <div class="form-row">
           <div>
-            <div class="toggle-wrap" onclick="document.getElementById('pol-enabled').checked=!document.getElementById('pol-enabled').checked;this.querySelector('.toggle').classList.toggle('on',document.getElementById('pol-enabled').checked)">
-              <div class="toggle on"><div class="toggle-knob"></div></div>
-              <span class="toggle-label">Enabled</span>
-              <input type="checkbox" id="pol-enabled" checked style="display:none">
-            </div>
+            <label for="nr-cooldown">Cooldown</label>
+            <select id="nr-cooldown">
+              <option value="300">5 minutes</option>
+              <option value="900" selected>15 minutes</option>
+              <option value="1800">30 minutes</option>
+              <option value="3600">1 hour</option>
+              <option value="14400">4 hours</option>
+              <option value="43200">12 hours</option>
+              <option value="86400">24 hours</option>
+            </select>
           </div>
-          <div></div>
+          <div style="display:flex;align-items:flex-end;padding-bottom:4px">
+            <label style="display:flex;gap:6px;align-items:center;font-size:12px;cursor:pointer"><input type="checkbox" id="nr-enabled" checked> Enabled</label>
+          </div>
         </div>
         <div class="webhook-form-actions">
-          <button class="btn btn-primary" onclick="savePolicy()">Save Policy</button>
-          <button class="btn btn-secondary" onclick="cancelPolicyForm()">Cancel</button>
+          <button class="btn btn-primary" onclick="saveRule()">Save Rule</button>
+          <button class="btn btn-secondary" onclick="cancelRuleForm()">Cancel</button>
         </div>
       </div>
     </div>
@@ -941,9 +912,9 @@ function loadSettings() {
       /* Maintenance windows */
       maintenanceWindows = notif.maintenance_windows || [];
       renderMaintenanceWindows();
-      /* Policies */
-      policies = notif.policies || [];
-      renderPolicies();
+      /* Notification Rules */
+      notifRules = notif.rules || [];
+      renderRules();
     })
     .catch(function(e) { showToast("Failed to load settings: " + e, "error"); });
 }
@@ -954,7 +925,7 @@ function buildSettingsPayload() {
   var cooldownMin = parseInt(document.getElementById("notif-cooldown").value, 10) || 0;
   var notifications = {
     webhooks: webhooks,
-    policies: policies,
+    rules: notifRules,
     quiet_hours: {
       enabled: document.getElementById("qh-enabled").checked,
       timezone: document.getElementById("qh-timezone").value,
@@ -1014,7 +985,7 @@ function saveSettings() {
   .then(function(saved) {
     settings = saved;
     webhooks = (saved.notifications && saved.notifications.webhooks) ? saved.notifications.webhooks : webhooks;
-    policies = (saved.notifications && saved.notifications.policies) ? saved.notifications.policies : policies;
+    notifRules = (saved.notifications && saved.notifications.rules) ? saved.notifications.rules : notifRules;
     maintenanceWindows = (saved.notifications && saved.notifications.maintenance_windows) ? saved.notifications.maintenance_windows : maintenanceWindows;
     serviceChecks = (saved.service_checks && saved.service_checks.checks) ? saved.service_checks.checks : serviceChecks;
     showToast("Settings saved", "success");
@@ -1023,7 +994,7 @@ function saveSettings() {
     applyTheme(payload.theme);
     try { localStorage.setItem("nas-doctor-theme", payload.theme); } catch(e) {}
     renderWebhooks();
-    renderPolicies();
+    renderRules();
     renderMaintenanceWindows();
     renderServiceChecks();
     loadServiceCheckResults();
@@ -1061,20 +1032,6 @@ function renderWebhooks() {
     html += '  <div class="webhook-info">';
     html += '    <div class="webhook-name">' + escapeHtml(wh.name || "Unnamed") + '<span class="badge ' + badgeClass + '">' + typeName + '</span></div>';
     html += '    <div class="webhook-url">' + escapeHtml(maskUrl(wh.url)) + '</div>';
-    if (wh.filters) {
-      var tags = [];
-      if (wh.filters.severities && wh.filters.severities.length) tags.push("sev: " + wh.filters.severities.join(","));
-      if (wh.filters.categories && wh.filters.categories.length) tags.push("cat: " + wh.filters.categories.join(","));
-      if (wh.filters.on_service_down) tags.push("svc down");
-      if (wh.filters.on_parity_error) tags.push("parity err");
-      if (wh.filters.on_smart_failure) tags.push("SMART fail");
-      if (wh.filters.on_ups_on_battery) tags.push("UPS battery");
-      if (wh.filters.on_update_available) tags.push("updates");
-      if (wh.filters.disk_space_below_pct) tags.push("space <" + wh.filters.disk_space_below_pct + "%");
-      if (wh.filters.disk_temp_above_c) tags.push("temp >" + wh.filters.disk_temp_above_c + "\u00b0C");
-      if (wh.filters.ups_battery_below_pct) tags.push("UPS <" + wh.filters.ups_battery_below_pct + "%");
-      if (tags.length) html += '    <div class="inline-muted" style="margin-top:2px">Filters: ' + escapeHtml(tags.join(" \u00b7 ")) + '</div>';
-    }
     html += '  </div>';
     html += '  <div class="webhook-actions">';
     html += '    <div class="toggle-wrap" onclick="toggleWebhookEnabled(' + i + ')">';
@@ -1094,45 +1051,6 @@ function toggleWebhookEnabled(idx) {
   saveSettings();
 }
 
-function resetWebhookFiltersUI(f) {
-  f = f || {};
-  document.getElementById("wf-severities").value = (f.severities || []).join(",");
-  document.getElementById("wf-categories").value = (f.categories || []).join(",");
-  document.getElementById("wf-disk-space").value = f.disk_space_below_pct || "";
-  document.getElementById("wf-disk-temp").value = f.disk_temp_above_c || "";
-  document.getElementById("wf-avg-temp").value = f.avg_disk_temp_above_c || "";
-  document.getElementById("wf-realloc").value = f.smart_realloc_above || "";
-  document.getElementById("wf-ups-battery").value = f.ups_battery_below_pct || "";
-  document.getElementById("wf-service-down").checked = !!f.on_service_down;
-  document.getElementById("wf-parity-error").checked = !!f.on_parity_error;
-  document.getElementById("wf-smart-fail").checked = !!f.on_smart_failure;
-  document.getElementById("wf-ups-battery-mode").checked = !!f.on_ups_on_battery;
-  document.getElementById("wf-update").checked = !!f.on_update_available;
-  document.getElementById("wf-service-names").value = (f.service_check_names || []).join(",");
-}
-function readWebhookFiltersUI() {
-  var sev = document.getElementById("wf-severities").value.trim();
-  var cat = document.getElementById("wf-categories").value.trim();
-  var svcNames = document.getElementById("wf-service-names").value.trim();
-  var f = {};
-  if (sev) f.severities = sev.split(",").map(function(s){return s.trim().toLowerCase();}).filter(Boolean);
-  if (cat) f.categories = cat.split(",").map(function(s){return s.trim().toLowerCase();}).filter(Boolean);
-  var ds = parseFloat(document.getElementById("wf-disk-space").value); if (ds > 0) f.disk_space_below_pct = ds;
-  var dt = parseInt(document.getElementById("wf-disk-temp").value,10); if (dt > 0) f.disk_temp_above_c = dt;
-  var at = parseInt(document.getElementById("wf-avg-temp").value,10); if (at > 0) f.avg_disk_temp_above_c = at;
-  var ra = parseInt(document.getElementById("wf-realloc").value,10); if (ra > 0) f.smart_realloc_above = ra;
-  var ub = parseFloat(document.getElementById("wf-ups-battery").value); if (ub > 0) f.ups_battery_below_pct = ub;
-  if (document.getElementById("wf-service-down").checked) f.on_service_down = true;
-  if (document.getElementById("wf-parity-error").checked) f.on_parity_error = true;
-  if (document.getElementById("wf-smart-fail").checked) f.on_smart_failure = true;
-  if (document.getElementById("wf-ups-battery-mode").checked) f.on_ups_on_battery = true;
-  if (document.getElementById("wf-update").checked) f.on_update_available = true;
-  if (svcNames) f.service_check_names = svcNames.split(",").map(function(s){return s.trim();}).filter(Boolean);
-  // Return null if no filters set (to avoid sending empty object)
-  if (Object.keys(f).length === 0) return null;
-  return f;
-}
-
 function toggleWebhookForm() {
   var form = document.getElementById("webhook-form");
   if (form.classList.contains("visible")) {
@@ -1143,10 +1061,7 @@ function toggleWebhookForm() {
   document.getElementById("wh-name").value = "";
   document.getElementById("wh-url").value = "";
   document.getElementById("wh-type").value = "discord";
-  document.getElementById("wh-level").value = "info";
   document.getElementById("wh-secret").value = "";
-  resetWebhookFiltersUI({});
-  document.getElementById("wh-filters-panel").style.display = "none";
   form.classList.add("visible");
 }
 
@@ -1156,10 +1071,7 @@ function editWebhook(idx) {
   document.getElementById("wh-name").value = wh.name || "";
   document.getElementById("wh-url").value = wh.url || "";
   document.getElementById("wh-type").value = wh.type || "generic";
-  document.getElementById("wh-level").value = wh.min_level || "info";
   document.getElementById("wh-secret").value = wh.secret || "";
-  resetWebhookFiltersUI(wh.filters || {});
-  document.getElementById("wh-filters-panel").style.display = wh.filters ? "block" : "none";
   document.getElementById("webhook-form").classList.add("visible");
 }
 
@@ -1179,11 +1091,8 @@ function saveWebhook() {
     url: url,
     type: document.getElementById("wh-type").value,
     enabled: true,
-    min_level: document.getElementById("wh-level").value,
     secret: document.getElementById("wh-secret").value.trim() || ""
   };
-  var filters = readWebhookFiltersUI();
-  if (filters) wh.filters = filters;
   var editIdx = parseInt(document.getElementById("wh-edit-index").value, 10);
   if (editIdx >= 0 && editIdx < webhooks.length) {
     wh.enabled = webhooks[editIdx].enabled;
@@ -1916,120 +1825,188 @@ function toggleMaintenanceEnabled(idx) {
   markChanged();
 }
 
-/* ---------- Notification Policies ---------- */
-var policies = [];
+/* ---------- Notification Rules ---------- */
+var notifRules = [];
+var _snapshotCache = null; // cached snapshot for target dropdowns
 
-function renderPolicies() {
-  var container = document.getElementById("policy-list");
-  if (!container) return;
-  // Update the webhook dropdown in the policy form
-  var polWebhookSel = document.getElementById("pol-webhook");
-  if (polWebhookSel) {
-    var currentVal = polWebhookSel.value;
-    polWebhookSel.innerHTML = "";
-    for (var w = 0; w < webhooks.length; w++) {
-      var opt = document.createElement("option");
-      opt.value = webhooks[w].name || "";
-      opt.textContent = webhooks[w].name || "Unnamed";
-      polWebhookSel.appendChild(opt);
-    }
-    if (currentVal) polWebhookSel.value = currentVal;
+var CONDITION_MAP = {
+  findings:   [{v:"critical",l:"Any critical finding"},{v:"warning",l:"Any warning+ finding"},{v:"category",l:"Findings in category"},{v:"any",l:"Any finding"}],
+  disk_space: [{v:"free_below",l:"Free space below %"}],
+  disk_temp:  [{v:"above",l:"Single disk temp above \u00b0C"},{v:"avg_above",l:"Average disk temp above \u00b0C"}],
+  smart:      [{v:"health_fails",l:"SMART health fails"},{v:"reallocated_above",l:"Reallocated sectors above"},{v:"pending_above",l:"Pending sectors above"},{v:"crc_above",l:"CRC errors above"},{v:"power_hours_above",l:"Power-on hours above"}],
+  service:    [{v:"down",l:"Service goes down"},{v:"latency_above",l:"Latency above (ms)"}],
+  parity:     [{v:"errors",l:"Parity check has errors"},{v:"speed_below",l:"Parity speed below MB/s"}],
+  ups:        [{v:"on_battery",l:"UPS switches to battery"},{v:"battery_below",l:"Battery below %"},{v:"load_above",l:"Load above %"}],
+  docker:     [{v:"stopped",l:"Container stops"}],
+  system:     [{v:"cpu_above",l:"CPU above %"},{v:"mem_above",l:"Memory above %"},{v:"load_above",l:"Load average above"},{v:"iowait_above",l:"I/O wait above %"}],
+  zfs:        [{v:"degraded",l:"Pool degraded"},{v:"scrub_errors",l:"Scrub errors detected"},{v:"usage_above",l:"Pool usage above %"}],
+  tunnels:    [{v:"cloudflared_down",l:"Cloudflared tunnel down"},{v:"tailscale_offline",l:"Tailscale node offline"}],
+  update:     [{v:"available",l:"Platform update available"}]
+};
+var NEEDS_VALUE = {free_below:1,above:1,avg_above:1,reallocated_above:1,pending_above:1,crc_above:1,power_hours_above:1,latency_above:1,speed_below:1,battery_below:1,load_above:1,cpu_above:1,mem_above:1,iowait_above:1,usage_above:1};
+var NEEDS_TARGET = {above:1,health_fails:1,reallocated_above:1,pending_above:1,crc_above:1,power_hours_above:1,down:1,latency_above:1,stopped:1,degraded:1,scrub_errors:1,usage_above:1,cloudflared_down:1,tailscale_offline:1,free_below:1,category:1};
+
+function onRuleCategoryChange() {
+  var cat = document.getElementById("nr-category").value;
+  var condSel = document.getElementById("nr-condition");
+  condSel.innerHTML = "";
+  var opts = CONDITION_MAP[cat] || [];
+  for (var i = 0; i < opts.length; i++) {
+    var o = document.createElement("option"); o.value = opts[i].v; o.textContent = opts[i].l;
+    condSel.appendChild(o);
   }
-  if (!policies || policies.length === 0) {
-    container.innerHTML = '<div style="font-size:13px;color:var(--text2);padding:8px 0">No notification policies configured. Default webhook min-level rules apply.</div>';
+  populateTargetDropdown(cat);
+}
+
+function populateTargetDropdown(cat) {
+  var sel = document.getElementById("nr-target");
+  sel.innerHTML = '<option value="">Any / All</option>';
+  if (!_snapshotCache) return;
+  var sn = _snapshotCache;
+  if ((cat === "disk_temp" || cat === "smart") && sn.smart) {
+    for (var i = 0; i < sn.smart.length; i++) {
+      var d = sn.smart[i]; var lbl = d.device + " — " + d.model + " (" + d.serial + ")";
+      sel.innerHTML += '<option value="' + escapeHtml(d.serial) + '">' + escapeHtml(lbl) + '</option>';
+    }
+  } else if (cat === "disk_space" && sn.disks) {
+    for (var i = 0; i < sn.disks.length; i++) {
+      var d = sn.disks[i]; sel.innerHTML += '<option value="' + escapeHtml(d.mount_point) + '">' + escapeHtml(d.mount_point + " (" + d.label + ")") + '</option>';
+    }
+  } else if (cat === "service" && sn.service_checks) {
+    for (var i = 0; i < sn.service_checks.length; i++) {
+      var sc = sn.service_checks[i]; sel.innerHTML += '<option value="' + escapeHtml(sc.name) + '">' + escapeHtml(sc.name) + '</option>';
+    }
+  } else if (cat === "docker" && sn.docker && sn.docker.containers) {
+    for (var i = 0; i < sn.docker.containers.length; i++) {
+      var c = sn.docker.containers[i]; sel.innerHTML += '<option value="' + escapeHtml(c.name) + '">' + escapeHtml(c.name) + '</option>';
+    }
+  } else if (cat === "zfs" && sn.zfs && sn.zfs.pools) {
+    for (var i = 0; i < sn.zfs.pools.length; i++) {
+      sel.innerHTML += '<option value="' + escapeHtml(sn.zfs.pools[i].name) + '">' + escapeHtml(sn.zfs.pools[i].name) + '</option>';
+    }
+  } else if (cat === "tunnels" && sn.tunnels) {
+    if (sn.tunnels.cloudflared) { for (var i = 0; i < sn.tunnels.cloudflared.tunnels.length; i++) { var t = sn.tunnels.cloudflared.tunnels[i]; sel.innerHTML += '<option value="' + escapeHtml(t.name) + '">' + escapeHtml("CF: " + t.name) + '</option>'; } }
+    if (sn.tunnels.tailscale && sn.tunnels.tailscale.peers) { for (var i = 0; i < sn.tunnels.tailscale.peers.length; i++) { var nd = sn.tunnels.tailscale.peers[i]; sel.innerHTML += '<option value="' + escapeHtml(nd.name) + '">' + escapeHtml("TS: " + nd.name) + '</option>'; } }
+  } else if (cat === "findings") {
+    // For "category" condition, target = finding category
+    var cats = ["system","disk","smart","docker","network","service","memory","thermal","logs","parity","zfs","ups"];
+    for (var i = 0; i < cats.length; i++) sel.innerHTML += '<option value="' + cats[i] + '">' + cats[i] + '</option>';
+  }
+}
+
+function renderRules() {
+  var container = document.getElementById("rule-list");
+  // Update webhook dropdown
+  var whSel = document.getElementById("nr-webhook");
+  if (whSel) { var cv = whSel.value; whSel.innerHTML = ""; for (var w = 0; w < webhooks.length; w++) { var o = document.createElement("option"); o.value = webhooks[w].name; o.textContent = webhooks[w].name; whSel.appendChild(o); } if (cv) whSel.value = cv; }
+  if (!notifRules || notifRules.length === 0) {
+    container.innerHTML = '<div style="font-size:13px;color:var(--text2);padding:8px 0">No notification rules. All findings will be sent to all enabled webhooks.</div>';
     return;
   }
   var html = "";
-  for (var i = 0; i < policies.length; i++) {
-    var p = policies[i];
-    var cats = p.categories && p.categories.length ? p.categories.join(", ") : "all";
-    var hosts = p.hostnames && p.hostnames.length ? p.hostnames.join(", ") : "all";
+  for (var i = 0; i < notifRules.length; i++) {
+    var r = notifRules[i];
+    var desc = r.category + " / " + r.condition;
+    if (r.target) desc += " on " + r.target;
+    if (r.value) desc += " (threshold: " + r.value + ")";
     html += '<div class="webhook-item">';
-    html += '  <div class="webhook-info">';
-    html += '    <div class="webhook-name">' + escapeHtml(p.name || "Unnamed") + ' <span class="badge badge-generic">' + escapeHtml(p.min_severity || "info") + '+</span></div>';
-    html += '    <div class="webhook-url">Webhook: ' + escapeHtml(p.webhook_name || "—") + ' &middot; Categories: ' + escapeHtml(cats) + ' &middot; Hosts: ' + escapeHtml(hosts) + ' &middot; Cooldown: ' + (p.cooldown_sec || 0) + 's</div>';
-    html += '  </div>';
-    html += '  <div class="webhook-actions">';
-    html += '    <div class="toggle-wrap" onclick="togglePolicyEnabled(' + i + ')"><div class="toggle' + (p.enabled ? ' on' : '') + '"><div class="toggle-knob"></div></div></div>';
-    html += '    <button class="btn btn-secondary btn-sm" onclick="editPolicy(' + i + ')">Edit</button>';
-    html += '    <button class="btn btn-danger btn-sm" onclick="removePolicy(' + i + ')">Remove</button>';
-    html += '  </div>';
-    html += '</div>';
+    html += '<div class="webhook-info">';
+    html += '<div class="webhook-name">' + escapeHtml(r.name || "Unnamed") + '</div>';
+    html += '<div class="webhook-url">' + escapeHtml(desc) + ' &rarr; ' + escapeHtml(r.webhook || "—") + ' &middot; cooldown ' + (r.cooldown_sec || 900) + 's</div>';
+    html += '</div><div class="webhook-actions">';
+    html += '<div class="toggle-wrap" onclick="toggleRuleEnabled(' + i + ')"><div class="toggle' + (r.enabled ? " on" : "") + '"><div class="toggle-knob"></div></div></div>';
+    html += '<button class="btn btn-secondary btn-sm" onclick="editRule(' + i + ')">Edit</button>';
+    html += '<button class="btn btn-danger btn-sm" onclick="removeRule(' + i + ')">Remove</button>';
+    html += '</div></div>';
   }
   container.innerHTML = html;
 }
 
-function togglePolicyForm() {
-  var form = document.getElementById("policy-form");
-  if (form.classList.contains("visible")) { cancelPolicyForm(); return; }
-  document.getElementById("pol-edit-index").value = "-1";
-  document.getElementById("pol-name").value = "";
-  document.getElementById("pol-severity").value = "info";
-  document.getElementById("pol-cooldown").value = "900";
-  document.getElementById("pol-categories").value = "";
-  document.getElementById("pol-hostnames").value = "";
-  document.getElementById("pol-enabled").checked = true;
-  form.querySelector(".toggle").classList.add("on");
-  // Refresh webhook dropdown
-  renderPolicies();
+function toggleRuleForm() {
+  var form = document.getElementById("rule-form");
+  if (form.classList.contains("visible")) { cancelRuleForm(); return; }
+  document.getElementById("nr-edit-index").value = "-1";
+  document.getElementById("nr-name").value = "";
+  document.getElementById("nr-category").value = "findings";
+  document.getElementById("nr-value").value = "";
+  document.getElementById("nr-cooldown").value = "900";
+  document.getElementById("nr-enabled").checked = true;
+  onRuleCategoryChange();
+  renderRules();
   form.classList.add("visible");
 }
-
-function cancelPolicyForm() { document.getElementById("policy-form").classList.remove("visible"); }
-
-function editPolicy(idx) {
-  var p = policies[idx];
-  document.getElementById("pol-edit-index").value = String(idx);
-  document.getElementById("pol-name").value = p.name || "";
-  document.getElementById("pol-webhook").value = p.webhook_name || "";
-  document.getElementById("pol-severity").value = p.min_severity || "info";
-  document.getElementById("pol-cooldown").value = String(p.cooldown_sec || 900);
-  document.getElementById("pol-categories").value = (p.categories || []).join(", ");
-  document.getElementById("pol-hostnames").value = (p.hostnames || []).join(", ");
-  document.getElementById("pol-enabled").checked = p.enabled !== false;
-  var toggle = document.getElementById("policy-form").querySelector(".toggle");
-  toggle.classList.toggle("on", p.enabled !== false);
-  renderPolicies();
-  document.getElementById("policy-form").classList.add("visible");
+function cancelRuleForm() { document.getElementById("rule-form").classList.remove("visible"); }
+function editRule(idx) {
+  var r = notifRules[idx];
+  document.getElementById("nr-edit-index").value = String(idx);
+  document.getElementById("nr-name").value = r.name || "";
+  document.getElementById("nr-webhook").value = r.webhook || "";
+  document.getElementById("nr-category").value = r.category || "findings";
+  onRuleCategoryChange();
+  document.getElementById("nr-condition").value = r.condition || "";
+  document.getElementById("nr-target").value = r.target || "";
+  document.getElementById("nr-value").value = r.value || "";
+  document.getElementById("nr-cooldown").value = String(r.cooldown_sec || 900);
+  document.getElementById("nr-enabled").checked = r.enabled !== false;
+  renderRules();
+  document.getElementById("rule-form").classList.add("visible");
 }
-
-function savePolicy() {
-  var name = document.getElementById("pol-name").value.trim();
-  if (!name) { showToast("Policy name is required", "error"); return; }
-  var cats = document.getElementById("pol-categories").value.trim();
-  var hosts = document.getElementById("pol-hostnames").value.trim();
-  var pol = {
-    name: name,
-    enabled: document.getElementById("pol-enabled").checked,
-    webhook_name: document.getElementById("pol-webhook").value,
-    min_severity: document.getElementById("pol-severity").value,
-    cooldown_sec: parseInt(document.getElementById("pol-cooldown").value, 10) || 900,
-    categories: cats ? cats.split(",").map(function(c) { return c.trim(); }).filter(Boolean) : [],
-    hostnames: hosts ? hosts.split(",").map(function(h) { return h.trim(); }).filter(Boolean) : []
+function saveRule() {
+  var name = document.getElementById("nr-name").value.trim();
+  var wh = document.getElementById("nr-webhook").value;
+  if (!name) { showToast("Rule name is required", "error"); return; }
+  if (!wh) { showToast("Select a webhook", "error"); return; }
+  var rule = {
+    id: "rule-" + Date.now() + "-" + Math.random().toString(36).substr(2,6),
+    name: name, enabled: document.getElementById("nr-enabled").checked,
+    webhook: wh, category: document.getElementById("nr-category").value,
+    condition: document.getElementById("nr-condition").value,
+    target: document.getElementById("nr-target").value,
+    value: document.getElementById("nr-value").value,
+    cooldown_sec: parseInt(document.getElementById("nr-cooldown").value, 10) || 900
   };
-  var editIdx = parseInt(document.getElementById("pol-edit-index").value, 10);
-  if (editIdx >= 0 && editIdx < policies.length) {
-    policies[editIdx] = pol;
-  } else {
-    policies.push(pol);
+  var editIdx = parseInt(document.getElementById("nr-edit-index").value, 10);
+  if (editIdx >= 0 && editIdx < notifRules.length) { rule.id = notifRules[editIdx].id; notifRules[editIdx] = rule; }
+  else notifRules.push(rule);
+  renderRules(); cancelRuleForm(); saveSettings();
+}
+function removeRule(idx) { if (!confirm("Remove rule?")) return; notifRules.splice(idx, 1); renderRules(); saveSettings(); }
+function toggleRuleEnabled(idx) { notifRules[idx].enabled = !notifRules[idx].enabled; renderRules(); saveSettings(); }
+
+function addPreset(preset) {
+  var wh = webhooks.length > 0 ? webhooks[0].name : "";
+  if (!wh) { showToast("Add a webhook first", "error"); return; }
+  var rules = [];
+  switch(preset) {
+    case "critical": rules = [{name:"Critical alerts",category:"findings",condition:"critical",cooldown_sec:900}]; break;
+    case "disk_health": rules = [
+      {name:"SMART failure",category:"smart",condition:"health_fails",cooldown_sec:900},
+      {name:"Reallocated sectors",category:"smart",condition:"reallocated_above",value:"0",cooldown_sec:3600},
+      {name:"Disk temp >55\u00b0C",category:"disk_temp",condition:"above",value:"55",cooldown_sec:1800}
+    ]; break;
+    case "services": rules = [{name:"Service down",category:"service",condition:"down",cooldown_sec:300}]; break;
+    case "power": rules = [
+      {name:"UPS on battery",category:"ups",condition:"on_battery",cooldown_sec:300},
+      {name:"UPS battery <20%",category:"ups",condition:"battery_below",value:"20",cooldown_sec:300}
+    ]; break;
+    case "storage": rules = [{name:"Disk space <10%",category:"disk_space",condition:"free_below",value:"10",cooldown_sec:3600}]; break;
   }
-  renderPolicies();
-  cancelPolicyForm();
-  markChanged();
+  for (var i = 0; i < rules.length; i++) {
+    rules[i].id = "rule-" + Date.now() + "-" + Math.random().toString(36).substr(2,6);
+    rules[i].enabled = true;
+    rules[i].webhook = wh;
+    if (!rules[i].cooldown_sec) rules[i].cooldown_sec = 900;
+    notifRules.push(rules[i]);
+  }
+  renderRules(); saveSettings();
+  showToast("Added " + rules.length + " preset rule(s)", "success");
 }
 
-function removePolicy(idx) {
-  if (!confirm("Remove policy?")) return;
-  policies.splice(idx, 1);
-  renderPolicies();
-  markChanged();
+// Load snapshot for target dropdowns
+function loadSnapshotForTargets() {
+  fetch("/api/v1/snapshot/latest").then(function(r){return r.json()}).then(function(d){_snapshotCache=d;}).catch(function(){});
 }
-
-function togglePolicyEnabled(idx) {
-  policies[idx].enabled = !policies[idx].enabled;
-  renderPolicies();
-  markChanged();
-}
+loadSnapshotForTargets();
 
 /* ---------- Change Detection ---------- */
 var settingsChanged = false;

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -510,27 +510,54 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
     </div>
   </div>
 
-  <!-- 4. Log Forwarding (coming soon) -->
-  <div class="card coming-soon" id="card-logfwd">
+  <!-- 4. Log Forwarding -->
+  <div class="card" id="card-logfwd">
     <div class="card-title">Log Forwarding</div>
-    <div class="card-desc">Forward scan results and metrics to external logging or observability endpoints (e.g. Grafana via Prometheus).</div>
-    <div class="form-group">
-      <div class="toggle-wrap" style="margin-bottom:16px">
-        <div class="toggle" id="logfwd-toggle"><div class="toggle-knob"></div></div>
-        <span class="toggle-label">Enable Log Forwarding</span>
-      </div>
-      <label for="logfwd-url">Destination URL</label>
-      <input type="url" id="logfwd-url" placeholder="https://..." disabled>
+    <div class="card-desc">Forward scan results to Loki, syslog, or any HTTP JSON endpoint after each diagnostic scan.</div>
+    <div class="toggle-wrap" style="margin-bottom:16px">
+      <div class="toggle" id="logfwd-toggle" onclick="this.classList.toggle('on');saveSettings()"><div class="toggle-knob"></div></div>
+      <span class="toggle-label">Enable Log Forwarding</span>
     </div>
-    <div class="form-group">
-      <label for="logfwd-format">Format</label>
-      <select id="logfwd-format" disabled>
-        <option value="json">JSON</option>
-        <option value="syslog">Syslog</option>
-      </select>
+    <div id="logfwd-dest-list" style="margin-bottom:12px"></div>
+    <button class="btn btn-secondary btn-sm" onclick="toggleLogFwdForm()">+ Add Destination</button>
+    <div class="webhook-form" id="logfwd-form">
+      <input type="hidden" id="lf-edit-index" value="-1">
+      <div class="form-row">
+        <div><label for="lf-name">Name</label>
+          <input type="text" id="lf-name" placeholder="e.g. Grafana Loki"></div>
+        <div><label for="lf-type">Type</label>
+          <select id="lf-type" onchange="onLogFwdTypeChange()">
+            <option value="loki">Loki</option>
+            <option value="http_json">HTTP JSON</option>
+            <option value="syslog">Syslog</option>
+          </select></div>
+      </div>
+      <div class="form-group">
+        <label for="lf-url">URL</label>
+        <input type="text" id="lf-url" placeholder="http://loki:3100">
+        <p id="lf-url-hint" style="font-size:11px;color:var(--text2);margin-top:4px">Loki: base URL (e.g. http://loki:3100). /loki/api/v1/push is appended automatically.</p>
+      </div>
+      <div class="form-row">
+        <div><label for="lf-format">Payload format</label>
+          <select id="lf-format">
+            <option value="full">Full (findings + summary)</option>
+            <option value="findings_only">Findings only</option>
+            <option value="summary">Summary line only</option>
+          </select></div>
+        <div><label for="lf-labels">Labels / Tags (key=val, comma-sep)</label>
+          <input type="text" id="lf-labels" placeholder="e.g. env=prod,dc=home"></div>
+      </div>
+      <div class="form-group" id="lf-headers-wrap">
+        <label for="lf-headers">Auth header (optional, e.g. X-Scope-OrgID=tenant1)</label>
+        <input type="text" id="lf-headers" placeholder="Header-Name=value">
+      </div>
+      <div class="webhook-form-actions">
+        <button class="btn btn-primary" onclick="saveLogFwdDest()">Save Destination</button>
+        <button class="btn btn-secondary" onclick="cancelLogFwdForm()">Cancel</button>
+      </div>
     </div>
     <div class="form-group" style="margin-top:12px">
-      <p style="font-size:12px;color:var(--text2);line-height:1.6">Prometheus metrics are already available at <code style="background:rgba(255,255,255,0.06);padding:2px 6px;border-radius:4px;font-size:11px">/metrics</code> for Grafana integration. Configure your Prometheus scraper to target this endpoint.</p>
+      <p style="font-size:12px;color:var(--text2);line-height:1.6">Prometheus metrics (80+ gauges) are available at <code style="background:rgba(255,255,255,0.06);padding:2px 6px;border-radius:4px;font-size:11px">/metrics</code> for Grafana scraping.</p>
     </div>
   </div>
 
@@ -879,6 +906,12 @@ function loadSettings() {
       var bk = data.backup || {};
       var bkToggle = document.getElementById("backup-toggle");
       if (bk.enabled === false) { bkToggle.classList.remove("on"); } else { bkToggle.classList.add("on"); }
+      /* Log forwarding */
+      var lp = data.log_push || {};
+      var lfToggle = document.getElementById("logfwd-toggle");
+      if (lp.enabled) lfToggle.classList.add("on"); else lfToggle.classList.remove("on");
+      logFwdDests = lp.destinations || [];
+      renderLogFwdDests();
       /* Sections */
       var sec = data.sections || {};
       function setSecToggle(id, val) { var el = document.getElementById(id); if (el) { if (val === false) el.classList.remove("on"); else el.classList.add("on"); } }
@@ -938,7 +971,7 @@ function buildSettingsPayload() {
     icon: getSelectedIcon(),
     notifications: notifications,
     service_checks: { checks: serviceChecks },
-    log_push: base.log_push || { enabled: false, destinations: [] },
+    log_push: { enabled: document.getElementById("logfwd-toggle").classList.contains("on"), destinations: logFwdDests },
     retention: {
       snapshot_days: parseInt(document.getElementById("ret-snapshot-days").value, 10) || 90,
       max_db_size_mb: parseInt(document.getElementById("ret-max-db").value, 10) || 500,
@@ -1469,6 +1502,87 @@ function applyTheme(theme) {
 }
 
 /* Load theme before anything else to avoid flash */
+/* ---------- Log Forwarding ---------- */
+var logFwdDests = [];
+function renderLogFwdDests() {
+  var c = document.getElementById("logfwd-dest-list");
+  if (!logFwdDests || logFwdDests.length === 0) {
+    c.innerHTML = '<div style="font-size:12px;color:var(--text3);padding:8px 0">No destinations configured.</div>';
+    return;
+  }
+  var h = "";
+  for (var i = 0; i < logFwdDests.length; i++) {
+    var d = logFwdDests[i];
+    var t = (d.type || "http_json").toUpperCase().replace("_", " ");
+    h += '<div class="webhook-item">';
+    h += '<div class="webhook-info">';
+    h += '<div class="webhook-name">' + escapeHtml(d.name || "Unnamed") + ' <span class="badge" style="font-size:10px">' + t + '</span></div>';
+    h += '<div class="webhook-url">' + escapeHtml(d.url || "") + '</div>';
+    if (d.format && d.format !== "full") h += '<div class="inline-muted">Format: ' + escapeHtml(d.format) + '</div>';
+    h += '</div><div class="webhook-actions">';
+    h += '<div class="toggle-wrap" onclick="toggleLogFwdEnabled(' + i + ')">';
+    h += '<div class="toggle' + (d.enabled ? " on" : "") + '"><div class="toggle-knob"></div></div></div>';
+    h += '<button class="btn btn-secondary btn-sm" onclick="editLogFwdDest(' + i + ')">Edit</button>';
+    h += '<button class="btn btn-danger btn-sm" onclick="removeLogFwdDest(' + i + ')">Remove</button>';
+    h += '</div></div>';
+  }
+  c.innerHTML = h;
+}
+function toggleLogFwdEnabled(idx) { logFwdDests[idx].enabled = !logFwdDests[idx].enabled; renderLogFwdDests(); saveSettings(); }
+function removeLogFwdDest(idx) { logFwdDests.splice(idx, 1); renderLogFwdDests(); saveSettings(); }
+function toggleLogFwdForm() {
+  var f = document.getElementById("logfwd-form");
+  if (f.classList.contains("visible")) { cancelLogFwdForm(); return; }
+  document.getElementById("lf-edit-index").value = "-1";
+  document.getElementById("lf-name").value = "";
+  document.getElementById("lf-type").value = "loki";
+  document.getElementById("lf-url").value = "";
+  document.getElementById("lf-format").value = "full";
+  document.getElementById("lf-labels").value = "";
+  document.getElementById("lf-headers").value = "";
+  onLogFwdTypeChange();
+  f.classList.add("visible");
+}
+function editLogFwdDest(idx) {
+  var d = logFwdDests[idx];
+  document.getElementById("lf-edit-index").value = String(idx);
+  document.getElementById("lf-name").value = d.name || "";
+  document.getElementById("lf-type").value = d.type || "loki";
+  document.getElementById("lf-url").value = d.url || "";
+  document.getElementById("lf-format").value = d.format || "full";
+  var lbls = []; for (var k in (d.labels||{})) lbls.push(k + "=" + d.labels[k]);
+  document.getElementById("lf-labels").value = lbls.join(",");
+  var hdrs = []; for (var k in (d.headers||{})) hdrs.push(k + "=" + d.headers[k]);
+  document.getElementById("lf-headers").value = hdrs.join(",");
+  onLogFwdTypeChange();
+  document.getElementById("logfwd-form").classList.add("visible");
+}
+function cancelLogFwdForm() { document.getElementById("logfwd-form").classList.remove("visible"); }
+function onLogFwdTypeChange() {
+  var t = document.getElementById("lf-type").value;
+  var hint = document.getElementById("lf-url-hint");
+  if (hint) {
+    if (t === "loki") hint.textContent = "Loki: base URL (e.g. http://loki:3100). /loki/api/v1/push is appended automatically.";
+    else if (t === "syslog") hint.textContent = "Syslog: host:port (e.g. 192.168.1.5:514). Prefix with tcp:// for TCP, default is UDP.";
+    else hint.textContent = "HTTP endpoint that accepts POST with JSON body.";
+  }
+}
+function saveLogFwdDest() {
+  var name = document.getElementById("lf-name").value.trim();
+  var url = document.getElementById("lf-url").value.trim();
+  if (!name || !url) { showToast("Name and URL are required", "error"); return; }
+  var d = { name: name, type: document.getElementById("lf-type").value, url: url, enabled: true,
+    format: document.getElementById("lf-format").value };
+  var labelsRaw = document.getElementById("lf-labels").value.trim();
+  if (labelsRaw) { d.labels = {}; labelsRaw.split(",").forEach(function(p) { var kv = p.split("="); if (kv.length === 2) d.labels[kv[0].trim()] = kv[1].trim(); }); }
+  var headersRaw = document.getElementById("lf-headers").value.trim();
+  if (headersRaw) { d.headers = {}; headersRaw.split(",").forEach(function(p) { var kv = p.split("="); if (kv.length === 2) d.headers[kv[0].trim()] = kv[1].trim(); }); }
+  var idx = parseInt(document.getElementById("lf-edit-index").value, 10);
+  if (idx >= 0 && idx < logFwdDests.length) { d.enabled = logFwdDests[idx].enabled; logFwdDests[idx] = d; }
+  else logFwdDests.push(d);
+  renderLogFwdDests(); cancelLogFwdForm(); saveSettings();
+}
+
 (function() {
   try {
     var stored = localStorage.getItem("nas-doctor-theme");

--- a/internal/collector/disk.go
+++ b/internal/collector/disk.go
@@ -20,9 +20,24 @@ func collectDisks() ([]internal.DiskInfo, error) {
 	}
 	disks := parseDFOutput(out)
 
-	// If running inside Docker, also read host mounts via /host/mnt
+	// If running inside Docker, merge host mount disks with df disks.
+	// Host mounts override df entries for the same real mount point,
+	// but df entries for volumes not bind-mounted (e.g. /volume2 on
+	// Synology when only /volume1 is mapped) are preserved.
 	if hostDisks := collectHostMountDisks(); len(hostDisks) > 0 {
-		disks = hostDisks // prefer host disks over container view
+		merged := make(map[string]internal.DiskInfo)
+		// Start with df-detected disks (keyed by real mount point)
+		for _, d := range disks {
+			merged[d.MountPoint] = d
+		}
+		// Host-mount disks override and add new entries
+		for _, d := range hostDisks {
+			merged[d.MountPoint] = d
+		}
+		disks = make([]internal.DiskInfo, 0, len(merged))
+		for _, d := range merged {
+			disks = append(disks, d)
+		}
 	}
 
 	return disks, nil

--- a/internal/collector/smart.go
+++ b/internal/collector/smart.go
@@ -188,6 +188,11 @@ func parseSMARTJSON(device, out string) (internal.SMARTInfo, error) {
 	info.Temperature = data.Temperature.Current
 	info.PowerOnHours = data.PowerOnTime.Hours
 	info.SizeGB = float64(data.UserCapacity.Bytes) / (1024 * 1024 * 1024)
+	// Mark data as available if we got meaningful attributes (a powered drive
+	// always has temperature > 0 or power-on hours > 0)
+	info.DataAvailable = info.Temperature > 0 || info.PowerOnHours > 0 ||
+		strings.Contains(jsonStr, "\"ata_smart_attributes\"") ||
+		strings.Contains(jsonStr, "\"nvme_smart_health_information_log\"")
 
 	// Determine disk type
 	if strings.Contains(device, "nvme") {

--- a/internal/logfwd/logfwd.go
+++ b/internal/logfwd/logfwd.go
@@ -1,0 +1,295 @@
+// Package logfwd forwards diagnostic scan results to external logging/observability systems.
+package logfwd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// Destination mirrors the settings model for a single forwarding target.
+type Destination struct {
+	Name    string
+	Type    string // loki, http_json, syslog
+	URL     string
+	Enabled bool
+	Headers map[string]string
+	Labels  map[string]string
+	Format  string // full, findings_only, summary
+}
+
+// Forwarder sends scan results to configured destinations.
+type Forwarder struct {
+	destinations []Destination
+	logger       *slog.Logger
+	client       *http.Client
+}
+
+// New creates a new log forwarder.
+func New(logger *slog.Logger) *Forwarder {
+	return &Forwarder{
+		logger: logger,
+		client: &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+// SetDestinations updates the forwarding destinations.
+func (f *Forwarder) SetDestinations(dests []Destination) {
+	f.destinations = dests
+}
+
+// Forward sends the snapshot to all enabled destinations.
+func (f *Forwarder) Forward(snap *internal.Snapshot, hostname string) {
+	for _, dest := range f.destinations {
+		if !dest.Enabled {
+			continue
+		}
+		var err error
+		switch strings.ToLower(dest.Type) {
+		case "loki":
+			err = f.sendLoki(dest, snap, hostname)
+		case "http_json", "http":
+			err = f.sendHTTPJSON(dest, snap, hostname)
+		case "syslog":
+			err = f.sendSyslog(dest, snap, hostname)
+		default:
+			f.logger.Warn("unknown log forward type", "name", dest.Name, "type", dest.Type)
+			continue
+		}
+		if err != nil {
+			f.logger.Warn("log forward failed", "name", dest.Name, "type", dest.Type, "error", err)
+		} else {
+			f.logger.Info("log forward sent", "name", dest.Name, "type", dest.Type, "findings", len(snap.Findings))
+		}
+	}
+}
+
+// ── Loki Push API ──
+
+type lokiPushRequest struct {
+	Streams []lokiStream `json:"streams"`
+}
+type lokiStream struct {
+	Stream map[string]string `json:"stream"`
+	Values [][]string        `json:"values"`
+}
+
+func (f *Forwarder) sendLoki(dest Destination, snap *internal.Snapshot, hostname string) error {
+	labels := map[string]string{
+		"job":      "nasdoctor",
+		"hostname": hostname,
+		"platform": snap.System.Platform,
+	}
+	for k, v := range dest.Labels {
+		labels[k] = v
+	}
+
+	nowNano := strconv.FormatInt(time.Now().UnixNano(), 10)
+	var values [][]string
+
+	format := strings.ToLower(dest.Format)
+	if format == "" {
+		format = "full"
+	}
+
+	switch format {
+	case "findings_only":
+		for _, finding := range snap.Findings {
+			line := fmt.Sprintf("level=%s category=%s title=%q description=%q",
+				finding.Severity, finding.Category, finding.Title, finding.Description)
+			values = append(values, []string{nowNano, line})
+		}
+	case "summary":
+		critical, warnings, infos := countFindings(snap.Findings)
+		line := fmt.Sprintf("scan_complete host=%s findings=%d critical=%d warning=%d info=%d duration=%.1fs",
+			hostname, len(snap.Findings), critical, warnings, infos, snap.Duration)
+		values = append(values, []string{nowNano, line})
+	default: // full
+		for _, finding := range snap.Findings {
+			line := fmt.Sprintf("level=%s category=%s title=%q description=%q",
+				finding.Severity, finding.Category, finding.Title, finding.Description)
+			values = append(values, []string{nowNano, line})
+		}
+		// Also push a summary line
+		critical, warnings, infos := countFindings(snap.Findings)
+		summary := fmt.Sprintf("scan_complete host=%s findings=%d critical=%d warning=%d info=%d duration=%.1fs smart_drives=%d disks=%d containers=%d",
+			hostname, len(snap.Findings), critical, warnings, infos, snap.Duration,
+			len(snap.SMART), len(snap.Disks), len(snap.Docker.Containers))
+		values = append(values, []string{nowNano, summary})
+	}
+
+	if len(values) == 0 {
+		values = append(values, []string{nowNano, fmt.Sprintf("scan_complete host=%s findings=0 duration=%.1fs", hostname, snap.Duration)})
+	}
+
+	payload := lokiPushRequest{
+		Streams: []lokiStream{{Stream: labels, Values: values}},
+	}
+	return f.postJSON(dest, payload)
+}
+
+// ── HTTP JSON ──
+
+type httpJSONPayload struct {
+	Timestamp string                        `json:"timestamp"`
+	Hostname  string                        `json:"hostname"`
+	Platform  string                        `json:"platform"`
+	Duration  float64                       `json:"duration_seconds"`
+	Summary   httpJSONSummary               `json:"summary"`
+	Findings  []internal.Finding            `json:"findings,omitempty"`
+	Services  []internal.ServiceCheckResult `json:"service_checks,omitempty"`
+}
+
+type httpJSONSummary struct {
+	TotalFindings int     `json:"total_findings"`
+	Critical      int     `json:"critical"`
+	Warning       int     `json:"warning"`
+	Info          int     `json:"info"`
+	DiskCount     int     `json:"disk_count"`
+	SMARTCount    int     `json:"smart_drive_count"`
+	Containers    int     `json:"container_count"`
+	CPUUsage      float64 `json:"cpu_usage_percent"`
+	MemPercent    float64 `json:"mem_percent"`
+}
+
+func (f *Forwarder) sendHTTPJSON(dest Destination, snap *internal.Snapshot, hostname string) error {
+	critical, warnings, infos := countFindings(snap.Findings)
+
+	payload := httpJSONPayload{
+		Timestamp: snap.Timestamp.Format(time.RFC3339),
+		Hostname:  hostname,
+		Platform:  snap.System.Platform,
+		Duration:  snap.Duration,
+		Summary: httpJSONSummary{
+			TotalFindings: len(snap.Findings),
+			Critical:      critical,
+			Warning:       warnings,
+			Info:          infos,
+			DiskCount:     len(snap.Disks),
+			SMARTCount:    len(snap.SMART),
+			Containers:    len(snap.Docker.Containers),
+			CPUUsage:      snap.System.CPUUsage,
+			MemPercent:    snap.System.MemPercent,
+		},
+	}
+
+	format := strings.ToLower(dest.Format)
+	if format != "summary" {
+		payload.Findings = snap.Findings
+		payload.Services = snap.Services
+	}
+
+	return f.postJSON(dest, payload)
+}
+
+// ── Syslog (RFC 5424 over TCP/UDP) ──
+
+func (f *Forwarder) sendSyslog(dest Destination, snap *internal.Snapshot, hostname string) error {
+	addr := dest.URL
+	if !strings.Contains(addr, ":") {
+		addr += ":514"
+	}
+
+	proto := "udp"
+	if strings.HasPrefix(strings.ToLower(addr), "tcp://") {
+		proto = "tcp"
+		addr = strings.TrimPrefix(addr, "tcp://")
+	} else {
+		addr = strings.TrimPrefix(addr, "udp://")
+	}
+
+	conn, err := net.DialTimeout(proto, addr, 10*time.Second)
+	if err != nil {
+		return fmt.Errorf("syslog dial %s: %w", addr, err)
+	}
+	defer conn.Close()
+
+	now := time.Now().Format(time.RFC3339)
+	appName := "nasdoctor"
+
+	for _, finding := range snap.Findings {
+		pri := syslogPriority(finding.Severity)
+		msg := fmt.Sprintf("<%d>1 %s %s %s - - - [%s] %s: %s",
+			pri, now, hostname, appName, finding.Category, finding.Title, finding.Description)
+		if _, err := fmt.Fprintf(conn, "%s\n", msg); err != nil {
+			return fmt.Errorf("syslog write: %w", err)
+		}
+	}
+
+	// Summary line
+	critical, warnings, infos := countFindings(snap.Findings)
+	msg := fmt.Sprintf("<14>1 %s %s %s - - - scan_complete findings=%d critical=%d warning=%d info=%d duration=%.1fs",
+		now, hostname, appName, len(snap.Findings), critical, warnings, infos, snap.Duration)
+	_, err = fmt.Fprintf(conn, "%s\n", msg)
+	return err
+}
+
+func syslogPriority(sev internal.Severity) int {
+	// facility=1 (user-level) + severity
+	switch strings.ToLower(string(sev)) {
+	case "critical":
+		return 8 + 2 // user.crit
+	case "warning":
+		return 8 + 4 // user.warning
+	case "info":
+		return 8 + 6 // user.info
+	default:
+		return 8 + 6
+	}
+}
+
+// ── Helpers ──
+
+func (f *Forwarder) postJSON(dest Destination, payload interface{}) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+
+	url := dest.URL
+	if strings.ToLower(dest.Type) == "loki" && !strings.HasSuffix(url, "/loki/api/v1/push") {
+		url = strings.TrimRight(url, "/") + "/loki/api/v1/push"
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range dest.Headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("post: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
+	}
+	return nil
+}
+
+func countFindings(findings []internal.Finding) (critical, warnings, infos int) {
+	for _, f := range findings {
+		switch strings.ToLower(string(f.Severity)) {
+		case "critical":
+			critical++
+		case "warning":
+			warnings++
+		case "info":
+			infos++
+		}
+	}
+	return
+}

--- a/internal/models.go
+++ b/internal/models.go
@@ -446,40 +446,28 @@ type NotificationConfig struct {
 }
 
 type WebhookConfig struct {
-	Name     string            `json:"name"`
-	URL      string            `json:"url"`
-	Type     string            `json:"type"` // discord, slack, gotify, ntfy, generic
-	Enabled  bool              `json:"enabled"`
-	MinLevel Severity          `json:"min_level"` // minimum severity to notify (legacy; overridden by Filters)
-	Headers  map[string]string `json:"headers,omitempty"`
-	Secret   string            `json:"secret,omitempty"` // for HMAC signing
-	Filters  *WebhookFilters   `json:"filters,omitempty"`
+	Name    string            `json:"name"`
+	URL     string            `json:"url"`
+	Type    string            `json:"type"` // discord, slack, gotify, ntfy, generic
+	Enabled bool              `json:"enabled"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Secret  string            `json:"secret,omitempty"` // for HMAC signing
 }
 
-// WebhookFilters provides per-webhook granular control over which events
-// trigger a notification. When set, these override MinLevel.
-// Empty slices/zero values mean "disabled" (not "match everything").
-type WebhookFilters struct {
-	// ── Finding filters ──
-	Severities []Severity `json:"severities,omitempty"` // only fire on these severities (empty = use MinLevel fallback)
-	Categories []Category `json:"categories,omitempty"` // only fire on these categories (empty = all)
-
-	// ── Threshold triggers (evaluated against snapshot, 0 = disabled) ──
-	DiskSpaceBelowPct  float64 `json:"disk_space_below_pct,omitempty"`  // any disk free < X%
-	DiskTempAboveC     int     `json:"disk_temp_above_c,omitempty"`     // any single disk > X°C
-	AvgDiskTempAboveC  int     `json:"avg_disk_temp_above_c,omitempty"` // mean of all disks > X°C
-	SmartReallocAbove  int64   `json:"smart_realloc_above,omitempty"`   // any drive reallocated > X
-	UPSBatteryBelowPct float64 `json:"ups_battery_below_pct,omitempty"` // UPS battery < X%
-
-	// ── Boolean event triggers ──
-	OnServiceDown     bool `json:"on_service_down,omitempty"`     // any service check status=down
-	OnParityError     bool `json:"on_parity_error,omitempty"`     // parity check with errors > 0
-	OnSmartFailure    bool `json:"on_smart_failure,omitempty"`    // any drive health_passed=false
-	OnUPSOnBattery    bool `json:"on_ups_on_battery,omitempty"`   // UPS switched to battery
-	OnUpdateAvailable bool `json:"on_update_available,omitempty"` // platform update detected
-
-	// ── Scoped service check filter ──
-	ServiceCheckNames []string `json:"service_check_names,omitempty"` // only these checks (empty = all)
+// NotificationRule defines a single, user-created alert rule.
+// WHEN [Category] + [Condition] on [Target] crosses [Operator] [Value]
+// THEN notify via [Webhook].
+type NotificationRule struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Enabled     bool   `json:"enabled"`
+	Webhook     string `json:"webhook"`            // webhook name
+	Category    string `json:"category"`           // disk_space, disk_temp, smart, service, parity, ups, docker, system, zfs, tunnels, findings, update
+	Condition   string `json:"condition"`          // sub-condition within category
+	Target      string `json:"target,omitempty"`   // specific drive/service/container (empty = any)
+	Operator    string `json:"operator,omitempty"` // gt, lt, eq, any
+	Value       string `json:"value,omitempty"`    // threshold value
+	CooldownSec int    `json:"cooldown_sec"`       // min seconds between notifications
 }
 
 type PrometheusConfig struct {

--- a/internal/models.go
+++ b/internal/models.go
@@ -194,6 +194,7 @@ type SMARTInfo struct {
 	Firmware       string  `json:"firmware"`
 	SizeGB         float64 `json:"size_gb"`
 	HealthPassed   bool    `json:"health_passed"`
+	DataAvailable  bool    `json:"data_available"` // true if SMART attributes were successfully read
 	PowerOnHours   int64   `json:"power_on_hours"`
 	Temperature    int     `json:"temperature_c"`
 	TempMax        int     `json:"temperature_max_c"`

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -42,17 +42,13 @@ func (n *Notifier) SetResultHook(fn func(name, webhookType, status string, findi
 }
 
 // NotifyFindings sends alerts for the given findings to all configured webhooks.
+// This is a legacy fallback — the scheduler's rule engine should be preferred.
 func (n *Notifier) NotifyFindings(findings []internal.Finding, hostname string) {
 	for _, wh := range n.webhooks {
-		if !wh.Enabled {
+		if !wh.Enabled || len(findings) == 0 {
 			continue
 		}
-		// Filter findings by minimum severity
-		filtered := filterBySeverity(findings, wh.MinLevel)
-		if len(filtered) == 0 {
-			continue
-		}
-		n.NotifyWebhook(wh, filtered, hostname)
+		n.NotifyWebhook(wh, findings, hostname)
 	}
 }
 
@@ -343,30 +339,6 @@ func (n *Notifier) postJSON(wh internal.WebhookConfig, payload any) error {
 		return fmt.Errorf("webhook returned %d: %s", resp.StatusCode, string(body))
 	}
 	return nil
-}
-
-func filterBySeverity(findings []internal.Finding, minLevel internal.Severity) []internal.Finding {
-	minRank := severityRank(minLevel)
-	var filtered []internal.Finding
-	for _, f := range findings {
-		if severityRank(f.Severity) >= minRank {
-			filtered = append(filtered, f)
-		}
-	}
-	return filtered
-}
-
-func severityRank(s internal.Severity) int {
-	switch s {
-	case internal.SeverityCritical:
-		return 3
-	case internal.SeverityWarning:
-		return 2
-	case internal.SeverityInfo:
-		return 1
-	default:
-		return 0
-	}
 }
 
 func countBySeverity(findings []internal.Finding) (critical, warnings, infos int) {

--- a/internal/notifier/prometheus.go
+++ b/internal/notifier/prometheus.go
@@ -11,266 +11,471 @@ import (
 
 // Metrics holds all Prometheus metrics exposed by nas-doctor.
 type Metrics struct {
-	// System metrics
-	cpuUsage  prometheus.Gauge
-	memUsage  prometheus.Gauge
-	memTotal  prometheus.Gauge
-	loadAvg1  prometheus.Gauge
-	loadAvg5  prometheus.Gauge
-	loadAvg15 prometheus.Gauge
-	ioWait    prometheus.Gauge
-	uptime    prometheus.Gauge
+	// ── System ──
+	cpuUsage   prometheus.Gauge
+	memUsed    prometheus.Gauge
+	memTotal   prometheus.Gauge
+	memPercent prometheus.Gauge
+	swapUsed   prometheus.Gauge
+	swapTotal  prometheus.Gauge
+	loadAvg1   prometheus.Gauge
+	loadAvg5   prometheus.Gauge
+	loadAvg15  prometheus.Gauge
+	ioWait     prometheus.Gauge
+	uptime     prometheus.Gauge
+	cpuCores   prometheus.Gauge
 
-	// Disk metrics
+	// ── Disk ──
 	diskUsedBytes  *prometheus.GaugeVec
 	diskTotalBytes *prometheus.GaugeVec
 	diskUsedPct    *prometheus.GaugeVec
 
-	// SMART metrics
+	// ── SMART ──
 	smartHealthy      *prometheus.GaugeVec
 	smartTemp         *prometheus.GaugeVec
+	smartTempMax      *prometheus.GaugeVec
 	smartReallocated  *prometheus.GaugeVec
 	smartPending      *prometheus.GaugeVec
+	smartOffline      *prometheus.GaugeVec
 	smartUDMACRC      *prometheus.GaugeVec
+	smartCmdTimeout   *prometheus.GaugeVec
+	smartSpinRetry    *prometheus.GaugeVec
 	smartPowerOnHours *prometheus.GaugeVec
+	smartSizeBytes    *prometheus.GaugeVec
 
-	// Docker metrics
-	containerCPU *prometheus.GaugeVec
-	containerMem *prometheus.GaugeVec
+	// ── Docker ──
+	containerCPU   *prometheus.GaugeVec
+	containerMem   *prometheus.GaugeVec
+	containerState *prometheus.GaugeVec
+	containerTotal prometheus.Gauge
 
-	// Finding metrics
+	// ── Network ──
+	netInterfaceUp  *prometheus.GaugeVec
+	netInterfaceMTU *prometheus.GaugeVec
+
+	// ── UPS ──
+	upsBatteryPct  prometheus.Gauge
+	upsBatteryV    prometheus.Gauge
+	upsInputV      prometheus.Gauge
+	upsOutputV     prometheus.Gauge
+	upsLoadPct     prometheus.Gauge
+	upsRuntimeMins prometheus.Gauge
+	upsWattage     prometheus.Gauge
+	upsTemperature prometheus.Gauge
+	upsOnBattery   prometheus.Gauge
+	upsLowBattery  prometheus.Gauge
+
+	// ── ZFS ──
+	zpoolState        *prometheus.GaugeVec
+	zpoolUsedBytes    *prometheus.GaugeVec
+	zpoolTotalBytes   *prometheus.GaugeVec
+	zpoolUsedPct      *prometheus.GaugeVec
+	zpoolFragPct      *prometheus.GaugeVec
+	zpoolScanPct      *prometheus.GaugeVec
+	zpoolScanErrors   *prometheus.GaugeVec
+	zpoolReadErrors   *prometheus.GaugeVec
+	zpoolWriteErrors  *prometheus.GaugeVec
+	zpoolCksumErrors  *prometheus.GaugeVec
+	zfsARCSize        prometheus.Gauge
+	zfsARCMaxSize     prometheus.Gauge
+	zfsARCHitRate     prometheus.Gauge
+	zfsARCHits        prometheus.Gauge
+	zfsARCMisses      prometheus.Gauge
+	zfsL2Size         prometheus.Gauge
+	zfsL2HitRate      prometheus.Gauge
+	zdatasetUsed      *prometheus.GaugeVec
+	zdatasetAvail     *prometheus.GaugeVec
+	zdatasetCompRatio *prometheus.GaugeVec
+
+	// ── Service Checks ──
+	serviceUp       *prometheus.GaugeVec
+	serviceLatency  *prometheus.GaugeVec
+	serviceFailures *prometheus.GaugeVec
+
+	// ── Parity ──
+	paritySpeedMBs    prometheus.Gauge
+	parityDurationSec prometheus.Gauge
+	parityErrors      prometheus.Gauge
+	parityRunning     prometheus.Gauge
+
+	// ── Tunnels ──
+	cfTunnelUp    *prometheus.GaugeVec
+	cfTunnelConns *prometheus.GaugeVec
+	tsNodeOnline  *prometheus.GaugeVec
+	tsNodeTxBytes *prometheus.GaugeVec
+	tsNodeRxBytes *prometheus.GaugeVec
+
+	// ── Findings ──
 	findingsTotal    *prometheus.GaugeVec
 	findingsCritical prometheus.Gauge
 	findingsWarning  prometheus.Gauge
 
-	// Parity metrics (Unraid)
-	paritySpeedMBs    prometheus.Gauge
-	parityDurationSec prometheus.Gauge
-
-	// Collection metrics
+	// ── Collection ──
 	collectionDuration prometheus.Gauge
 	lastCollectionTime prometheus.Gauge
+
+	// ── Update ──
+	updateAvailable prometheus.Gauge
 
 	mu       sync.Mutex
 	registry *prometheus.Registry
 }
 
+func gauge(ns, sub, name, help string) prometheus.Gauge {
+	return prometheus.NewGauge(prometheus.GaugeOpts{Namespace: ns, Subsystem: sub, Name: name, Help: help})
+}
+func gaugeVec(ns, sub, name, help string, labels []string) *prometheus.GaugeVec {
+	return prometheus.NewGaugeVec(prometheus.GaugeOpts{Namespace: ns, Subsystem: sub, Name: name, Help: help}, labels)
+}
+
+const ns = "nasdoctor"
+
 // NewMetrics creates and registers all Prometheus metrics.
 func NewMetrics() *Metrics {
-	m := &Metrics{
-		registry: prometheus.NewRegistry(),
-	}
+	m := &Metrics{registry: prometheus.NewRegistry()}
 
-	m.cpuUsage = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "system", Name: "cpu_usage_percent",
-		Help: "Current CPU usage percentage",
-	})
-	m.memUsage = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "system", Name: "memory_used_bytes",
-		Help: "Used memory in bytes",
-	})
-	m.memTotal = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "system", Name: "memory_total_bytes",
-		Help: "Total memory in bytes",
-	})
-	m.loadAvg1 = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "system", Name: "load_avg_1",
-		Help: "1-minute load average",
-	})
-	m.loadAvg5 = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "system", Name: "load_avg_5",
-		Help: "5-minute load average",
-	})
-	m.loadAvg15 = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "system", Name: "load_avg_15",
-		Help: "15-minute load average",
-	})
-	m.ioWait = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "system", Name: "io_wait_percent",
-		Help: "CPU I/O wait percentage",
-	})
-	m.uptime = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "system", Name: "uptime_seconds",
-		Help: "System uptime in seconds",
-	})
+	// ── System ──
+	m.cpuUsage = gauge(ns, "system", "cpu_usage_percent", "CPU usage percentage")
+	m.memUsed = gauge(ns, "system", "memory_used_bytes", "Used memory in bytes")
+	m.memTotal = gauge(ns, "system", "memory_total_bytes", "Total memory in bytes")
+	m.memPercent = gauge(ns, "system", "memory_used_percent", "Memory usage percentage")
+	m.swapUsed = gauge(ns, "system", "swap_used_bytes", "Used swap in bytes")
+	m.swapTotal = gauge(ns, "system", "swap_total_bytes", "Total swap in bytes")
+	m.loadAvg1 = gauge(ns, "system", "load_avg_1", "1-minute load average")
+	m.loadAvg5 = gauge(ns, "system", "load_avg_5", "5-minute load average")
+	m.loadAvg15 = gauge(ns, "system", "load_avg_15", "15-minute load average")
+	m.ioWait = gauge(ns, "system", "io_wait_percent", "CPU I/O wait percentage")
+	m.uptime = gauge(ns, "system", "uptime_seconds", "System uptime in seconds")
+	m.cpuCores = gauge(ns, "system", "cpu_cores", "Number of CPU cores")
 
-	m.diskUsedBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "disk", Name: "used_bytes",
-		Help: "Used disk space in bytes",
-	}, []string{"device", "mountpoint", "label"})
-	m.diskTotalBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "disk", Name: "total_bytes",
-		Help: "Total disk space in bytes",
-	}, []string{"device", "mountpoint", "label"})
-	m.diskUsedPct = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "disk", Name: "used_percent",
-		Help: "Disk usage percentage",
-	}, []string{"device", "mountpoint", "label"})
+	// ── Disk ──
+	diskLabels := []string{"device", "mountpoint", "label"}
+	m.diskUsedBytes = gaugeVec(ns, "disk", "used_bytes", "Used disk space in bytes", diskLabels)
+	m.diskTotalBytes = gaugeVec(ns, "disk", "total_bytes", "Total disk space in bytes", diskLabels)
+	m.diskUsedPct = gaugeVec(ns, "disk", "used_percent", "Disk usage percentage", diskLabels)
 
-	m.smartHealthy = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "smart", Name: "healthy",
-		Help: "SMART health status (1=passed, 0=failed)",
-	}, []string{"device", "model", "serial"})
-	m.smartTemp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "smart", Name: "temperature_celsius",
-		Help: "Drive temperature in Celsius",
-	}, []string{"device", "model", "serial"})
-	m.smartReallocated = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "smart", Name: "reallocated_sectors",
-		Help: "SMART reallocated sector count",
-	}, []string{"device", "model", "serial"})
-	m.smartPending = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "smart", Name: "pending_sectors",
-		Help: "SMART pending sector count",
-	}, []string{"device", "model", "serial"})
-	m.smartUDMACRC = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "smart", Name: "udma_crc_errors",
-		Help: "UDMA CRC error count",
-	}, []string{"device", "model", "serial"})
-	m.smartPowerOnHours = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "smart", Name: "power_on_hours",
-		Help: "Drive power-on hours",
-	}, []string{"device", "model", "serial"})
+	// ── SMART ──
+	smartLabels := []string{"device", "model", "serial"}
+	m.smartHealthy = gaugeVec(ns, "smart", "healthy", "SMART health (1=passed, 0=failed)", smartLabels)
+	m.smartTemp = gaugeVec(ns, "smart", "temperature_celsius", "Drive temperature", smartLabels)
+	m.smartTempMax = gaugeVec(ns, "smart", "temperature_max_celsius", "Drive max temperature", smartLabels)
+	m.smartReallocated = gaugeVec(ns, "smart", "reallocated_sectors", "Reallocated sector count", smartLabels)
+	m.smartPending = gaugeVec(ns, "smart", "pending_sectors", "Pending sector count", smartLabels)
+	m.smartOffline = gaugeVec(ns, "smart", "offline_uncorrectable", "Offline uncorrectable count", smartLabels)
+	m.smartUDMACRC = gaugeVec(ns, "smart", "udma_crc_errors", "UDMA CRC error count", smartLabels)
+	m.smartCmdTimeout = gaugeVec(ns, "smart", "command_timeout", "Command timeout count", smartLabels)
+	m.smartSpinRetry = gaugeVec(ns, "smart", "spin_retry_count", "Spin retry count", smartLabels)
+	m.smartPowerOnHours = gaugeVec(ns, "smart", "power_on_hours", "Drive power-on hours", smartLabels)
+	m.smartSizeBytes = gaugeVec(ns, "smart", "size_bytes", "Drive size in bytes", smartLabels)
 
-	m.containerCPU = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "docker", Name: "container_cpu_percent",
-		Help: "Container CPU usage percentage",
-	}, []string{"name", "image"})
-	m.containerMem = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "docker", Name: "container_memory_bytes",
-		Help: "Container memory usage in bytes",
-	}, []string{"name", "image"})
+	// ── Docker ──
+	containerLabels := []string{"name", "image"}
+	m.containerCPU = gaugeVec(ns, "docker", "container_cpu_percent", "Container CPU usage", containerLabels)
+	m.containerMem = gaugeVec(ns, "docker", "container_memory_bytes", "Container memory usage in bytes", containerLabels)
+	m.containerState = gaugeVec(ns, "docker", "container_running", "Container running state (1=running, 0=stopped)", containerLabels)
+	m.containerTotal = gauge(ns, "docker", "container_count", "Total container count")
 
-	m.findingsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "findings", Name: "total",
-		Help: "Total number of findings by severity",
-	}, []string{"severity"})
-	m.findingsCritical = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "findings", Name: "critical_count",
-		Help: "Number of critical findings",
-	})
-	m.findingsWarning = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "findings", Name: "warning_count",
-		Help: "Number of warning findings",
-	})
+	// ── Network ──
+	netLabels := []string{"interface"}
+	m.netInterfaceUp = gaugeVec(ns, "network", "interface_up", "Interface up state (1=up, 0=down)", netLabels)
+	m.netInterfaceMTU = gaugeVec(ns, "network", "interface_mtu", "Interface MTU", netLabels)
 
-	m.paritySpeedMBs = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "parity", Name: "speed_mb_per_sec",
-		Help: "Latest parity check speed in MB/s",
-	})
-	m.parityDurationSec = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Subsystem: "parity", Name: "duration_seconds",
-		Help: "Latest parity check duration in seconds",
-	})
+	// ── UPS ──
+	m.upsBatteryPct = gauge(ns, "ups", "battery_percent", "UPS battery percentage")
+	m.upsBatteryV = gauge(ns, "ups", "battery_voltage", "UPS battery voltage")
+	m.upsInputV = gauge(ns, "ups", "input_voltage", "UPS input voltage")
+	m.upsOutputV = gauge(ns, "ups", "output_voltage", "UPS output voltage")
+	m.upsLoadPct = gauge(ns, "ups", "load_percent", "UPS load percentage")
+	m.upsRuntimeMins = gauge(ns, "ups", "runtime_minutes", "UPS estimated runtime in minutes")
+	m.upsWattage = gauge(ns, "ups", "wattage_watts", "UPS wattage draw")
+	m.upsTemperature = gauge(ns, "ups", "temperature_celsius", "UPS internal temperature")
+	m.upsOnBattery = gauge(ns, "ups", "on_battery", "UPS on battery (1=yes, 0=no)")
+	m.upsLowBattery = gauge(ns, "ups", "low_battery", "UPS low battery (1=yes, 0=no)")
 
-	m.collectionDuration = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Name: "collection_duration_seconds",
-		Help: "Time taken for the last diagnostic collection",
-	})
-	m.lastCollectionTime = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "nasdoctor", Name: "last_collection_timestamp",
-		Help: "Unix timestamp of the last collection",
-	})
+	// ── ZFS ──
+	poolLabels := []string{"pool"}
+	m.zpoolState = gaugeVec(ns, "zfs", "pool_healthy", "ZFS pool healthy (1=ONLINE, 0=other)", poolLabels)
+	m.zpoolUsedBytes = gaugeVec(ns, "zfs", "pool_used_bytes", "ZFS pool used in bytes", poolLabels)
+	m.zpoolTotalBytes = gaugeVec(ns, "zfs", "pool_total_bytes", "ZFS pool total in bytes", poolLabels)
+	m.zpoolUsedPct = gaugeVec(ns, "zfs", "pool_used_percent", "ZFS pool usage percentage", poolLabels)
+	m.zpoolFragPct = gaugeVec(ns, "zfs", "pool_fragmentation_percent", "ZFS pool fragmentation", poolLabels)
+	m.zpoolScanPct = gaugeVec(ns, "zfs", "pool_scan_percent", "ZFS scrub/resilver progress", poolLabels)
+	m.zpoolScanErrors = gaugeVec(ns, "zfs", "pool_scan_errors", "ZFS scan error count", poolLabels)
+	m.zpoolReadErrors = gaugeVec(ns, "zfs", "pool_read_errors", "ZFS pool read errors", poolLabels)
+	m.zpoolWriteErrors = gaugeVec(ns, "zfs", "pool_write_errors", "ZFS pool write errors", poolLabels)
+	m.zpoolCksumErrors = gaugeVec(ns, "zfs", "pool_checksum_errors", "ZFS pool checksum errors", poolLabels)
+	m.zfsARCSize = gauge(ns, "zfs", "arc_size_bytes", "ZFS ARC size in bytes")
+	m.zfsARCMaxSize = gauge(ns, "zfs", "arc_max_size_bytes", "ZFS ARC max size in bytes")
+	m.zfsARCHitRate = gauge(ns, "zfs", "arc_hit_rate_percent", "ZFS ARC hit rate")
+	m.zfsARCHits = gauge(ns, "zfs", "arc_hits_total", "ZFS ARC hits total")
+	m.zfsARCMisses = gauge(ns, "zfs", "arc_misses_total", "ZFS ARC misses total")
+	m.zfsL2Size = gauge(ns, "zfs", "l2arc_size_bytes", "ZFS L2ARC size in bytes")
+	m.zfsL2HitRate = gauge(ns, "zfs", "l2arc_hit_rate_percent", "ZFS L2ARC hit rate")
+	dsLabels := []string{"dataset", "pool"}
+	m.zdatasetUsed = gaugeVec(ns, "zfs", "dataset_used_bytes", "ZFS dataset used in bytes", dsLabels)
+	m.zdatasetAvail = gaugeVec(ns, "zfs", "dataset_avail_bytes", "ZFS dataset available in bytes", dsLabels)
+	m.zdatasetCompRatio = gaugeVec(ns, "zfs", "dataset_compression_ratio", "ZFS dataset compression ratio", dsLabels)
+
+	// ── Service Checks ──
+	svcLabels := []string{"name", "type", "target"}
+	m.serviceUp = gaugeVec(ns, "service", "up", "Service check up (1=up, 0=down)", svcLabels)
+	m.serviceLatency = gaugeVec(ns, "service", "response_ms", "Service check response latency in ms", svcLabels)
+	m.serviceFailures = gaugeVec(ns, "service", "consecutive_failures", "Service check consecutive failures", svcLabels)
+
+	// ── Parity ──
+	m.paritySpeedMBs = gauge(ns, "parity", "speed_mb_per_sec", "Latest parity check speed in MB/s")
+	m.parityDurationSec = gauge(ns, "parity", "duration_seconds", "Latest parity check duration in seconds")
+	m.parityErrors = gauge(ns, "parity", "errors", "Latest parity check error count")
+	m.parityRunning = gauge(ns, "parity", "running", "Parity check in progress (1=yes, 0=no)")
+
+	// ── Tunnels ──
+	m.cfTunnelUp = gaugeVec(ns, "tunnel", "cloudflared_up", "Cloudflared tunnel healthy (1=yes, 0=no)", []string{"name"})
+	m.cfTunnelConns = gaugeVec(ns, "tunnel", "cloudflared_connections", "Cloudflared tunnel connections", []string{"name"})
+	m.tsNodeOnline = gaugeVec(ns, "tunnel", "tailscale_node_online", "Tailscale node online (1=yes, 0=no)", []string{"name", "ip"})
+	m.tsNodeTxBytes = gaugeVec(ns, "tunnel", "tailscale_node_tx_bytes", "Tailscale node TX bytes", []string{"name", "ip"})
+	m.tsNodeRxBytes = gaugeVec(ns, "tunnel", "tailscale_node_rx_bytes", "Tailscale node RX bytes", []string{"name", "ip"})
+
+	// ── Findings ──
+	m.findingsTotal = gaugeVec(ns, "findings", "total", "Findings by severity", []string{"severity"})
+	m.findingsCritical = gauge(ns, "findings", "critical_count", "Critical finding count")
+	m.findingsWarning = gauge(ns, "findings", "warning_count", "Warning finding count")
+
+	// ── Collection ──
+	m.collectionDuration = gauge(ns, "", "collection_duration_seconds", "Last diagnostic collection duration")
+	m.lastCollectionTime = gauge(ns, "", "last_collection_timestamp", "Last collection unix timestamp")
+
+	// ── Update ──
+	m.updateAvailable = gauge(ns, "update", "available", "Platform update available (1=yes, 0=no)")
 
 	// Register all
 	collectors := []prometheus.Collector{
-		m.cpuUsage, m.memUsage, m.memTotal,
-		m.loadAvg1, m.loadAvg5, m.loadAvg15,
-		m.ioWait, m.uptime,
+		m.cpuUsage, m.memUsed, m.memTotal, m.memPercent, m.swapUsed, m.swapTotal,
+		m.loadAvg1, m.loadAvg5, m.loadAvg15, m.ioWait, m.uptime, m.cpuCores,
 		m.diskUsedBytes, m.diskTotalBytes, m.diskUsedPct,
-		m.smartHealthy, m.smartTemp, m.smartReallocated,
-		m.smartPending, m.smartUDMACRC, m.smartPowerOnHours,
-		m.containerCPU, m.containerMem,
+		m.smartHealthy, m.smartTemp, m.smartTempMax, m.smartReallocated, m.smartPending,
+		m.smartOffline, m.smartUDMACRC, m.smartCmdTimeout, m.smartSpinRetry,
+		m.smartPowerOnHours, m.smartSizeBytes,
+		m.containerCPU, m.containerMem, m.containerState, m.containerTotal,
+		m.netInterfaceUp, m.netInterfaceMTU,
+		m.upsBatteryPct, m.upsBatteryV, m.upsInputV, m.upsOutputV,
+		m.upsLoadPct, m.upsRuntimeMins, m.upsWattage, m.upsTemperature,
+		m.upsOnBattery, m.upsLowBattery,
+		m.zpoolState, m.zpoolUsedBytes, m.zpoolTotalBytes, m.zpoolUsedPct,
+		m.zpoolFragPct, m.zpoolScanPct, m.zpoolScanErrors,
+		m.zpoolReadErrors, m.zpoolWriteErrors, m.zpoolCksumErrors,
+		m.zfsARCSize, m.zfsARCMaxSize, m.zfsARCHitRate, m.zfsARCHits, m.zfsARCMisses,
+		m.zfsL2Size, m.zfsL2HitRate,
+		m.zdatasetUsed, m.zdatasetAvail, m.zdatasetCompRatio,
+		m.serviceUp, m.serviceLatency, m.serviceFailures,
+		m.paritySpeedMBs, m.parityDurationSec, m.parityErrors, m.parityRunning,
+		m.cfTunnelUp, m.cfTunnelConns, m.tsNodeOnline, m.tsNodeTxBytes, m.tsNodeRxBytes,
 		m.findingsTotal, m.findingsCritical, m.findingsWarning,
-		m.paritySpeedMBs, m.parityDurationSec,
-		m.collectionDuration, m.lastCollectionTime,
+		m.collectionDuration, m.lastCollectionTime, m.updateAvailable,
 	}
 	for _, c := range collectors {
 		m.registry.MustRegister(c)
 	}
-
 	return m
 }
 
 // Registry returns the prometheus registry for the HTTP handler.
-func (m *Metrics) Registry() *prometheus.Registry {
-	return m.registry
-}
+func (m *Metrics) Registry() *prometheus.Registry { return m.registry }
 
 // Update refreshes all Prometheus metrics from a snapshot.
 func (m *Metrics) Update(snap *internal.Snapshot) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// System
+	// ── System ──
 	m.cpuUsage.Set(snap.System.CPUUsage)
-	m.memUsage.Set(float64(snap.System.MemUsedMB) * 1024 * 1024)
+	m.memUsed.Set(float64(snap.System.MemUsedMB) * 1024 * 1024)
 	m.memTotal.Set(float64(snap.System.MemTotalMB) * 1024 * 1024)
+	m.memPercent.Set(snap.System.MemPercent)
+	m.swapUsed.Set(float64(snap.System.SwapUsedMB) * 1024 * 1024)
+	m.swapTotal.Set(float64(snap.System.SwapTotalMB) * 1024 * 1024)
 	m.loadAvg1.Set(snap.System.LoadAvg1)
 	m.loadAvg5.Set(snap.System.LoadAvg5)
 	m.loadAvg15.Set(snap.System.LoadAvg15)
 	m.ioWait.Set(snap.System.IOWait)
 	m.uptime.Set(float64(snap.System.UptimeSecs))
+	m.cpuCores.Set(float64(snap.System.CPUCores))
 
-	// Reset label-based metrics to clear stale entries from removed
-	// disks, drives, or containers that no longer appear in the snapshot.
+	// Reset label-based metrics to clear stale entries
 	m.diskUsedBytes.Reset()
 	m.diskTotalBytes.Reset()
 	m.diskUsedPct.Reset()
 	m.smartHealthy.Reset()
 	m.smartTemp.Reset()
+	m.smartTempMax.Reset()
 	m.smartReallocated.Reset()
 	m.smartPending.Reset()
+	m.smartOffline.Reset()
 	m.smartUDMACRC.Reset()
+	m.smartCmdTimeout.Reset()
+	m.smartSpinRetry.Reset()
 	m.smartPowerOnHours.Reset()
+	m.smartSizeBytes.Reset()
 	m.containerCPU.Reset()
 	m.containerMem.Reset()
+	m.containerState.Reset()
+	m.netInterfaceUp.Reset()
+	m.netInterfaceMTU.Reset()
+	m.zpoolState.Reset()
+	m.zpoolUsedBytes.Reset()
+	m.zpoolTotalBytes.Reset()
+	m.zpoolUsedPct.Reset()
+	m.zpoolFragPct.Reset()
+	m.zpoolScanPct.Reset()
+	m.zpoolScanErrors.Reset()
+	m.zpoolReadErrors.Reset()
+	m.zpoolWriteErrors.Reset()
+	m.zpoolCksumErrors.Reset()
+	m.zdatasetUsed.Reset()
+	m.zdatasetAvail.Reset()
+	m.zdatasetCompRatio.Reset()
+	m.serviceUp.Reset()
+	m.serviceLatency.Reset()
+	m.serviceFailures.Reset()
+	m.cfTunnelUp.Reset()
+	m.cfTunnelConns.Reset()
+	m.tsNodeOnline.Reset()
+	m.tsNodeTxBytes.Reset()
+	m.tsNodeRxBytes.Reset()
 
-	// Disks
+	// ── Disks ──
 	for _, d := range snap.Disks {
-		labels := prometheus.Labels{
-			"device":     d.Device,
-			"mountpoint": d.MountPoint,
-			"label":      d.Label,
-		}
-		m.diskUsedBytes.With(labels).Set(d.UsedGB * 1024 * 1024 * 1024)
-		m.diskTotalBytes.With(labels).Set(d.TotalGB * 1024 * 1024 * 1024)
-		m.diskUsedPct.With(labels).Set(d.UsedPct)
+		l := prometheus.Labels{"device": d.Device, "mountpoint": d.MountPoint, "label": d.Label}
+		m.diskUsedBytes.With(l).Set(d.UsedGB * 1024 * 1024 * 1024)
+		m.diskTotalBytes.With(l).Set(d.TotalGB * 1024 * 1024 * 1024)
+		m.diskUsedPct.With(l).Set(d.UsedPct)
 	}
 
-	// SMART
+	// ── SMART ──
 	for _, d := range snap.SMART {
-		labels := prometheus.Labels{
-			"device": d.Device,
-			"model":  sanitizeLabel(d.Model),
-			"serial": d.Serial,
-		}
-		healthy := 1.0
-		if !d.HealthPassed {
-			healthy = 0
-		}
-		m.smartHealthy.With(labels).Set(healthy)
-		m.smartTemp.With(labels).Set(float64(d.Temperature))
-		m.smartReallocated.With(labels).Set(float64(d.Reallocated))
-		m.smartPending.With(labels).Set(float64(d.Pending))
-		m.smartUDMACRC.With(labels).Set(float64(d.UDMACRC))
-		m.smartPowerOnHours.With(labels).Set(float64(d.PowerOnHours))
+		l := prometheus.Labels{"device": d.Device, "model": sanitizeLabel(d.Model), "serial": d.Serial}
+		m.smartHealthy.With(l).Set(boolToFloat(d.HealthPassed))
+		m.smartTemp.With(l).Set(float64(d.Temperature))
+		m.smartTempMax.With(l).Set(float64(d.TempMax))
+		m.smartReallocated.With(l).Set(float64(d.Reallocated))
+		m.smartPending.With(l).Set(float64(d.Pending))
+		m.smartOffline.With(l).Set(float64(d.Offline))
+		m.smartUDMACRC.With(l).Set(float64(d.UDMACRC))
+		m.smartCmdTimeout.With(l).Set(float64(d.CommandTimeout))
+		m.smartSpinRetry.With(l).Set(float64(d.SpinRetry))
+		m.smartPowerOnHours.With(l).Set(float64(d.PowerOnHours))
+		m.smartSizeBytes.With(l).Set(d.SizeGB * 1024 * 1024 * 1024)
 	}
 
-	// Docker
+	// ── Docker ──
+	m.containerTotal.Set(float64(len(snap.Docker.Containers)))
 	for _, c := range snap.Docker.Containers {
-		if c.State != "running" {
-			continue
+		l := prometheus.Labels{"name": c.Name, "image": sanitizeLabel(c.Image)}
+		running := c.State == "running"
+		m.containerState.With(l).Set(boolToFloat(running))
+		if running {
+			m.containerCPU.With(l).Set(c.CPU)
+			m.containerMem.With(l).Set(c.MemMB * 1024 * 1024)
 		}
-		labels := prometheus.Labels{
-			"name":  c.Name,
-			"image": sanitizeLabel(c.Image),
-		}
-		m.containerCPU.With(labels).Set(c.CPU)
-		m.containerMem.With(labels).Set(c.MemMB * 1024 * 1024)
 	}
 
-	// Findings
+	// ── Network ──
+	for _, iface := range snap.Network.Interfaces {
+		l := prometheus.Labels{"interface": iface.Name}
+		up := strings.EqualFold(iface.State, "up")
+		m.netInterfaceUp.With(l).Set(boolToFloat(up))
+		m.netInterfaceMTU.With(l).Set(float64(iface.MTU))
+	}
+
+	// ── UPS ──
+	if snap.UPS != nil && snap.UPS.Available {
+		m.upsBatteryPct.Set(snap.UPS.BatteryPct)
+		m.upsBatteryV.Set(snap.UPS.BatteryV)
+		m.upsInputV.Set(snap.UPS.InputV)
+		m.upsOutputV.Set(snap.UPS.OutputV)
+		m.upsLoadPct.Set(snap.UPS.LoadPct)
+		m.upsRuntimeMins.Set(snap.UPS.RuntimeMins)
+		m.upsWattage.Set(snap.UPS.WattageW)
+		m.upsTemperature.Set(snap.UPS.Temperature)
+		m.upsOnBattery.Set(boolToFloat(snap.UPS.OnBattery))
+		m.upsLowBattery.Set(boolToFloat(snap.UPS.LowBattery))
+	}
+
+	// ── ZFS ──
+	if snap.ZFS != nil && snap.ZFS.Available {
+		for _, pool := range snap.ZFS.Pools {
+			l := prometheus.Labels{"pool": pool.Name}
+			m.zpoolState.With(l).Set(boolToFloat(strings.EqualFold(pool.State, "ONLINE")))
+			m.zpoolUsedBytes.With(l).Set(pool.UsedGB * 1024 * 1024 * 1024)
+			m.zpoolTotalBytes.With(l).Set(pool.TotalGB * 1024 * 1024 * 1024)
+			m.zpoolUsedPct.With(l).Set(pool.UsedPct)
+			m.zpoolFragPct.With(l).Set(float64(pool.Fragmentation))
+			m.zpoolScanPct.With(l).Set(pool.ScanPct)
+			m.zpoolScanErrors.With(l).Set(float64(pool.ScanErrors))
+			m.zpoolReadErrors.With(l).Set(float64(pool.Errors.Read))
+			m.zpoolWriteErrors.With(l).Set(float64(pool.Errors.Write))
+			m.zpoolCksumErrors.With(l).Set(float64(pool.Errors.Checksum))
+		}
+		if snap.ZFS.ARC != nil {
+			m.zfsARCSize.Set(snap.ZFS.ARC.SizeMB * 1024 * 1024)
+			m.zfsARCMaxSize.Set(snap.ZFS.ARC.MaxSizeMB * 1024 * 1024)
+			m.zfsARCHitRate.Set(snap.ZFS.ARC.HitRate)
+			m.zfsARCHits.Set(float64(snap.ZFS.ARC.Hits))
+			m.zfsARCMisses.Set(float64(snap.ZFS.ARC.Misses))
+			m.zfsL2Size.Set(snap.ZFS.ARC.L2SizeMB * 1024 * 1024)
+			m.zfsL2HitRate.Set(snap.ZFS.ARC.L2HitRate)
+		}
+		for _, ds := range snap.ZFS.Datasets {
+			l := prometheus.Labels{"dataset": ds.Name, "pool": ds.Pool}
+			m.zdatasetUsed.With(l).Set(ds.UsedGB * 1024 * 1024 * 1024)
+			m.zdatasetAvail.With(l).Set(ds.AvailGB * 1024 * 1024 * 1024)
+			m.zdatasetCompRatio.With(l).Set(ds.CompRatio)
+		}
+	}
+
+	// ── Service Checks ──
+	for _, sc := range snap.Services {
+		l := prometheus.Labels{"name": sc.Name, "type": sc.Type, "target": sanitizeLabel(sc.Target)}
+		m.serviceUp.With(l).Set(boolToFloat(sc.Status == "up"))
+		m.serviceLatency.With(l).Set(float64(sc.ResponseMS))
+		m.serviceFailures.With(l).Set(float64(sc.ConsecutiveFailures))
+	}
+
+	// ── Parity ──
+	if snap.Parity != nil {
+		m.parityRunning.Set(boolToFloat(strings.EqualFold(snap.Parity.Status, "running")))
+		if len(snap.Parity.History) > 0 {
+			last := snap.Parity.History[len(snap.Parity.History)-1]
+			m.paritySpeedMBs.Set(last.SpeedMBs)
+			m.parityDurationSec.Set(float64(last.Duration))
+			m.parityErrors.Set(float64(last.Errors))
+		}
+	}
+
+	// ── Tunnels ──
+	if snap.Tunnels != nil {
+		if snap.Tunnels.Cloudflared != nil {
+			for _, t := range snap.Tunnels.Cloudflared.Tunnels {
+				l := prometheus.Labels{"name": t.Name}
+				m.cfTunnelUp.With(l).Set(boolToFloat(t.Status == "healthy"))
+				m.cfTunnelConns.With(l).Set(float64(t.Connections))
+			}
+		}
+		if snap.Tunnels.Tailscale != nil {
+			all := make([]internal.TailscaleNode, 0)
+			if snap.Tunnels.Tailscale.Self != nil {
+				all = append(all, *snap.Tunnels.Tailscale.Self)
+			}
+			all = append(all, snap.Tunnels.Tailscale.Peers...)
+			for _, nd := range all {
+				l := prometheus.Labels{"name": nd.Name, "ip": nd.IP}
+				m.tsNodeOnline.With(l).Set(boolToFloat(nd.Online))
+				m.tsNodeTxBytes.With(l).Set(float64(nd.TxBytes))
+				m.tsNodeRxBytes.With(l).Set(float64(nd.RxBytes))
+			}
+		}
+	}
+
+	// ── Findings ──
 	critical, warnings, infos := countBySeverity(snap.Findings)
 	m.findingsCritical.Set(float64(critical))
 	m.findingsWarning.Set(float64(warnings))
@@ -278,20 +483,24 @@ func (m *Metrics) Update(snap *internal.Snapshot) {
 	m.findingsTotal.With(prometheus.Labels{"severity": "warning"}).Set(float64(warnings))
 	m.findingsTotal.With(prometheus.Labels{"severity": "info"}).Set(float64(infos))
 
-	// Parity
-	if snap.Parity != nil && len(snap.Parity.History) > 0 {
-		last := snap.Parity.History[len(snap.Parity.History)-1]
-		m.paritySpeedMBs.Set(last.SpeedMBs)
-		m.parityDurationSec.Set(float64(last.Duration))
+	// ── Update ──
+	if snap.Update != nil {
+		m.updateAvailable.Set(boolToFloat(snap.Update.UpdateAvailable))
 	}
 
-	// Collection meta
+	// ── Collection ──
 	m.collectionDuration.Set(snap.Duration)
 	m.lastCollectionTime.Set(float64(snap.Timestamp.Unix()))
 }
 
+func boolToFloat(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
 func sanitizeLabel(s string) string {
-	// Prometheus labels can't have certain chars; replace common ones
 	s = strings.ReplaceAll(s, ":", "_")
 	s = strings.ReplaceAll(s, "/", "_")
 	if len(s) > 128 {
@@ -304,19 +513,14 @@ func sanitizeLabel(s string) string {
 // In practice, use promhttp.HandlerFor(m.Registry(), ...) instead.
 func FormatPrometheusTextExposition(snap *internal.Snapshot) string {
 	var b strings.Builder
-
-	// System
 	fmt.Fprintf(&b, "# HELP nasdoctor_system_cpu_usage_percent CPU usage percentage\n")
 	fmt.Fprintf(&b, "# TYPE nasdoctor_system_cpu_usage_percent gauge\n")
 	fmt.Fprintf(&b, "nasdoctor_system_cpu_usage_percent %.2f\n", snap.System.CPUUsage)
-
 	fmt.Fprintf(&b, "# HELP nasdoctor_system_memory_used_bytes Used memory in bytes\n")
 	fmt.Fprintf(&b, "# TYPE nasdoctor_system_memory_used_bytes gauge\n")
 	fmt.Fprintf(&b, "nasdoctor_system_memory_used_bytes %d\n", snap.System.MemUsedMB*1024*1024)
-
 	fmt.Fprintf(&b, "# HELP nasdoctor_system_io_wait_percent IO wait percentage\n")
 	fmt.Fprintf(&b, "# TYPE nasdoctor_system_io_wait_percent gauge\n")
 	fmt.Fprintf(&b, "nasdoctor_system_io_wait_percent %.2f\n", snap.System.IOWait)
-
 	return b.String()
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mcdays94/nas-doctor/internal"
 	"github.com/mcdays94/nas-doctor/internal/analyzer"
 	"github.com/mcdays94/nas-doctor/internal/collector"
+	"github.com/mcdays94/nas-doctor/internal/logfwd"
 	"github.com/mcdays94/nas-doctor/internal/notifier"
 	"github.com/mcdays94/nas-doctor/internal/storage"
 )
@@ -89,6 +90,8 @@ type Scheduler struct {
 	alerting      AlertingConfig
 	serviceChecks []internal.ServiceCheckConfig
 	lastCheckRun  map[string]time.Time // per-check last execution time
+
+	logForwarder *logfwd.Forwarder
 
 	mu      sync.RWMutex
 	latest  *internal.Snapshot
@@ -277,6 +280,18 @@ func (s *Scheduler) RunOnce() {
 		s.dispatchNotifications(notif, snap, hostname, snap.Timestamp)
 	}
 
+	// Log forwarding
+	s.mu.RLock()
+	fwd := s.logForwarder
+	s.mu.RUnlock()
+	if fwd != nil {
+		hostname := snap.System.Hostname
+		if hostname == "" {
+			hostname = "Unknown"
+		}
+		fwd.Forward(snap, hostname)
+	}
+
 	// Data lifecycle: prune old data
 	s.pruneData()
 
@@ -412,6 +427,17 @@ func (s *Scheduler) UpdateBackup(cfg BackupConfig) {
 		"keep", cfg.KeepCount,
 		"interval_h", cfg.IntervalH,
 	)
+}
+
+// UpdateLogForwarder sets the log forwarding destinations.
+func (s *Scheduler) UpdateLogForwarder(dests []logfwd.Destination) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.logForwarder == nil {
+		s.logForwarder = logfwd.New(s.logger)
+	}
+	s.logForwarder.SetDestinations(dests)
+	s.logger.Info("log forwarder updated", "destinations", len(dests))
 }
 
 // UpdateAlerting updates policy routing and suppression configuration.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -70,12 +70,13 @@ type MaintenanceWindow struct {
 	Hostnames []string `json:"hostnames,omitempty"`
 }
 
-// AlertingConfig controls policy routing and suppression behavior.
+// AlertingConfig controls notification rules and suppression behavior.
 type AlertingConfig struct {
-	Policies           []AlertPolicy       `json:"policies,omitempty"`
-	QuietHours         QuietHours          `json:"quiet_hours,omitempty"`
-	MaintenanceWindows []MaintenanceWindow `json:"maintenance_windows,omitempty"`
-	DefaultCooldownSec int                 `json:"default_cooldown_sec,omitempty"`
+	Rules              []internal.NotificationRule `json:"rules,omitempty"`
+	Policies           []AlertPolicy               `json:"policies,omitempty"` // legacy
+	QuietHours         QuietHours                  `json:"quiet_hours,omitempty"`
+	MaintenanceWindows []MaintenanceWindow         `json:"maintenance_windows,omitempty"`
+	DefaultCooldownSec int                         `json:"default_cooldown_sec,omitempty"`
 }
 
 // Scheduler periodically runs diagnostic collections and analysis.
@@ -1009,8 +1010,7 @@ func serviceCheckKey(check internal.ServiceCheckConfig) string {
 }
 
 func (s *Scheduler) dispatchNotifications(notif *notifier.Notifier, snap *internal.Snapshot, hostname string, now time.Time) {
-	findings := snap.Findings
-	if notif == nil || len(findings) == 0 {
+	if notif == nil {
 		return
 	}
 
@@ -1023,326 +1023,446 @@ func (s *Scheduler) dispatchNotifications(notif *notifier.Notifier, snap *intern
 	}
 
 	if inMaintenanceWindow(cfg.MaintenanceWindows, hostname, now) {
-		s.logSuppressed(notif, findings, hostname, cfg, "suppressed_maintenance")
+		s.logSuppressed(notif, snap.Findings, hostname, cfg, "suppressed_maintenance")
 		return
 	}
 	if inQuietHours(cfg.QuietHours, now) {
-		s.logSuppressed(notif, findings, hostname, cfg, "suppressed_quiet_hours")
+		s.logSuppressed(notif, snap.Findings, hostname, cfg, "suppressed_quiet_hours")
 		return
 	}
 
-	if len(cfg.Policies) == 0 {
-		s.dispatchLegacyNotifications(notif, snap, hostname, now, cfg.DefaultCooldownSec)
-		return
-	}
-
+	// Build webhook lookup
 	webhooks := make(map[string]internal.WebhookConfig)
 	for _, wh := range notif.Webhooks() {
 		webhooks[strings.ToLower(strings.TrimSpace(wh.Name))] = wh
 	}
 
-	matchedPolicy := false
-	for i, policy := range cfg.Policies {
-		if !policy.Enabled {
-			continue
+	if len(cfg.Rules) == 0 {
+		// No rules configured — send all findings to all enabled webhooks (legacy)
+		if len(snap.Findings) > 0 {
+			for _, wh := range notif.Webhooks() {
+				if !wh.Enabled {
+					continue
+				}
+				routeKey := "legacy:" + strings.ToLower(strings.TrimSpace(wh.Name))
+				toSend := s.applyCooldown(snap.Findings, routeKey, time.Duration(cfg.DefaultCooldownSec)*time.Second, now)
+				if len(toSend) == 0 {
+					continue
+				}
+				if err := notif.NotifyWebhook(wh, toSend, hostname); err != nil {
+					continue
+				}
+				s.recordSent(toSend, routeKey, now)
+			}
 		}
-		if !matchesHostname(policy.Hostnames, hostname) {
-			continue
-		}
+		return
+	}
 
-		whName := strings.ToLower(strings.TrimSpace(policy.WebhookName))
-		if whName == "" {
+	// ── Rule-based dispatch ──
+	for _, rule := range cfg.Rules {
+		if !rule.Enabled {
 			continue
 		}
+		whName := strings.ToLower(strings.TrimSpace(rule.Webhook))
 		wh, ok := webhooks[whName]
 		if !ok || !wh.Enabled {
-			s.logger.Warn("alert policy references unknown webhook", "policy", policy.Name, "webhook", policy.WebhookName)
 			continue
 		}
 
-		filtered := filterFindingsForPolicy(findings, policy)
-		if len(filtered) == 0 {
+		matched := evaluateRule(rule, snap)
+		if len(matched) == 0 {
 			continue
 		}
-		matchedPolicy = true
 
-		routeKey := policyRouteKey(policy, i, wh.Name)
-		cooldown := time.Duration(policy.CooldownSec) * time.Second
+		cooldown := time.Duration(rule.CooldownSec) * time.Second
 		if cooldown <= 0 {
 			cooldown = time.Duration(cfg.DefaultCooldownSec) * time.Second
 		}
-
-		toSend := s.applyCooldown(filtered, routeKey, cooldown, now)
+		routeKey := "rule:" + rule.ID
+		toSend := s.applyCooldown(matched, routeKey, cooldown, now)
 		if len(toSend) == 0 {
-			_ = s.store.SaveNotificationLog(wh.Name, wh.Type, "suppressed_cooldown", len(filtered), "")
+			_ = s.store.SaveNotificationLog(wh.Name, wh.Type, "suppressed_cooldown", len(matched), "")
 			continue
 		}
 
 		if err := notif.NotifyWebhook(wh, toSend, hostname); err != nil {
 			continue
 		}
-
-		fingerprints := make([]string, 0, len(toSend))
-		for _, f := range toSend {
-			fp := findingFingerprint(f)
-			fingerprints = append(fingerprints, fp)
-			if err := s.store.SaveNotificationState(fp, routeKey, "sent", now); err != nil {
-				s.logger.Warn("failed to save notification state", "fingerprint", fp, "route", routeKey, "error", err)
-			}
-		}
-		if err := s.store.MarkAlertsNotifiedByFingerprint(fingerprints, now); err != nil {
-			s.logger.Warn("failed to mark alerts notified", "error", err)
-		}
-	}
-
-	if !matchedPolicy {
-		s.dispatchLegacyNotifications(notif, snap, hostname, now, cfg.DefaultCooldownSec)
+		s.recordSent(toSend, routeKey, now)
 	}
 }
 
-func (s *Scheduler) dispatchLegacyNotifications(notif *notifier.Notifier, snap *internal.Snapshot, hostname string, now time.Time, defaultCooldownSec int) {
-	if defaultCooldownSec <= 0 {
-		defaultCooldownSec = 900
+func (s *Scheduler) recordSent(findings []internal.Finding, routeKey string, now time.Time) {
+	fingerprints := make([]string, 0, len(findings))
+	for _, f := range findings {
+		fp := findingFingerprint(f)
+		fingerprints = append(fingerprints, fp)
+		if err := s.store.SaveNotificationState(fp, routeKey, "sent", now); err != nil {
+			s.logger.Warn("failed to save notification state", "fingerprint", fp, "route", routeKey, "error", err)
+		}
 	}
-	for _, wh := range notif.Webhooks() {
-		if !wh.Enabled {
-			continue
-		}
-		filtered := applyWebhookFilters(wh, snap)
-		if len(filtered) == 0 {
-			continue
-		}
-		routeKey := "legacy:" + strings.ToLower(strings.TrimSpace(wh.Name))
-		toSend := s.applyCooldown(filtered, routeKey, time.Duration(defaultCooldownSec)*time.Second, now)
-		if len(toSend) == 0 {
-			_ = s.store.SaveNotificationLog(wh.Name, wh.Type, "suppressed_cooldown", len(filtered), "")
-			continue
-		}
-		if err := notif.NotifyWebhook(wh, toSend, hostname); err != nil {
-			continue
-		}
-		fingerprints := make([]string, 0, len(toSend))
-		for _, f := range toSend {
-			fp := findingFingerprint(f)
-			fingerprints = append(fingerprints, fp)
-			if err := s.store.SaveNotificationState(fp, routeKey, "sent", now); err != nil {
-				s.logger.Warn("failed to save notification state", "fingerprint", fp, "route", routeKey, "error", err)
-			}
-		}
-		if err := s.store.MarkAlertsNotifiedByFingerprint(fingerprints, now); err != nil {
-			s.logger.Warn("failed to mark alerts notified", "error", err)
-		}
+	if err := s.store.MarkAlertsNotifiedByFingerprint(fingerprints, now); err != nil {
+		s.logger.Warn("failed to mark alerts notified", "error", err)
 	}
 }
 
-// applyWebhookFilters evaluates a webhook's filter configuration against the
-// full snapshot. If the webhook has no filters, falls back to legacy MinLevel
-// severity filtering. When filters are set, they control both which findings
-// pass through AND generate synthetic trigger findings from threshold breaches.
-func applyWebhookFilters(wh internal.WebhookConfig, snap *internal.Snapshot) []internal.Finding {
-	if wh.Filters == nil {
-		return filterBySeverity(snap.Findings, wh.MinLevel)
+// evaluateRule checks a single notification rule against the snapshot and
+// returns matching findings (real or synthetic).
+func evaluateRule(rule internal.NotificationRule, snap *internal.Snapshot) []internal.Finding {
+	cat := strings.ToLower(rule.Category)
+	cond := strings.ToLower(rule.Condition)
+	target := strings.ToLower(strings.TrimSpace(rule.Target))
+	val := parseFloat(rule.Value)
+
+	switch cat {
+	case "findings":
+		return evalFindings(cond, target, snap.Findings)
+	case "disk_space":
+		return evalDiskSpace(cond, target, val, snap.Disks)
+	case "disk_temp":
+		return evalDiskTemp(cond, target, int(val), snap.SMART)
+	case "smart":
+		return evalSMART(cond, target, int64(val), snap.SMART)
+	case "service":
+		return evalService(cond, target, val, snap.Services)
+	case "parity":
+		return evalParity(cond, val, snap.Parity)
+	case "ups":
+		return evalUPS(cond, val, snap.UPS)
+	case "docker":
+		return evalDocker(cond, target, snap.Docker)
+	case "system":
+		return evalSystem(cond, val, snap.System)
+	case "zfs":
+		return evalZFS(cond, target, val, snap.ZFS)
+	case "tunnels":
+		return evalTunnels(cond, target, snap.Tunnels)
+	case "update":
+		return evalUpdate(snap.Update)
 	}
-	f := wh.Filters
+	return nil
+}
+
+func parseFloat(s string) float64 {
+	v, _ := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	return v
+}
+
+func synth(id string, sev internal.Severity, cat internal.Category, title, desc string) internal.Finding {
+	return internal.Finding{ID: id, Severity: sev, Category: cat, Title: title, Description: desc}
+}
+
+func matchTarget(target, candidate string) bool {
+	if target == "" {
+		return true
+	}
+	return strings.EqualFold(target, strings.TrimSpace(candidate))
+}
+
+// ── Category evaluators ──
+
+func evalFindings(cond, target string, findings []internal.Finding) []internal.Finding {
 	var out []internal.Finding
-
-	// ── 1. Filter existing findings by severity + category ──
-	for _, finding := range snap.Findings {
-		if !matchesSeverityFilter(finding.Severity, f.Severities, wh.MinLevel) {
-			continue
-		}
-		if len(f.Categories) > 0 && !containsCategory(f.Categories, finding.Category) {
-			continue
-		}
-		out = append(out, finding)
-	}
-
-	// ── 2. Threshold triggers → synthetic findings ──
-	if f.DiskSpaceBelowPct > 0 {
-		for _, d := range snap.Disks {
-			free := 100.0 - d.UsedPct
-			if free < f.DiskSpaceBelowPct {
-				out = append(out, internal.Finding{
-					ID: "trigger:disk-space:" + d.MountPoint, Severity: internal.SeverityWarning,
-					Category: internal.CategoryDisk, Title: "Disk space low: " + d.MountPoint,
-					Description: fmt.Sprintf("Free space %.1f%% is below threshold %.0f%%", free, f.DiskSpaceBelowPct),
-				})
+	for _, f := range findings {
+		switch cond {
+		case "critical":
+			if f.Severity == internal.SeverityCritical {
+				out = append(out, f)
 			}
-		}
-	}
-	if f.DiskTempAboveC > 0 {
-		for _, s := range snap.SMART {
-			if s.Temperature > f.DiskTempAboveC {
-				out = append(out, internal.Finding{
-					ID: "trigger:disk-temp:" + s.Serial, Severity: internal.SeverityWarning,
-					Category: internal.CategoryThermal, Title: "Disk temperature high: " + s.Device,
-					Description: fmt.Sprintf("%d°C exceeds threshold %d°C", s.Temperature, f.DiskTempAboveC),
-					RelatedDisk: s.Serial,
-				})
+		case "warning":
+			if f.Severity == internal.SeverityWarning || f.Severity == internal.SeverityCritical {
+				out = append(out, f)
 			}
-		}
-	}
-	if f.AvgDiskTempAboveC > 0 && len(snap.SMART) > 0 {
-		var sum int
-		for _, s := range snap.SMART {
-			sum += s.Temperature
-		}
-		avg := sum / len(snap.SMART)
-		if avg > f.AvgDiskTempAboveC {
-			out = append(out, internal.Finding{
-				ID: "trigger:avg-disk-temp", Severity: internal.SeverityWarning,
-				Category: internal.CategoryThermal, Title: "Average disk temperature high",
-				Description: fmt.Sprintf("Average %d°C exceeds threshold %d°C", avg, f.AvgDiskTempAboveC),
-			})
-		}
-	}
-	if f.SmartReallocAbove > 0 {
-		for _, s := range snap.SMART {
-			if s.Reallocated > f.SmartReallocAbove {
-				out = append(out, internal.Finding{
-					ID: "trigger:smart-realloc:" + s.Serial, Severity: internal.SeverityCritical,
-					Category: internal.CategorySMART, Title: "Reallocated sectors high: " + s.Device,
-					Description: fmt.Sprintf("%d reallocated sectors exceeds threshold %d", s.Reallocated, f.SmartReallocAbove),
-					RelatedDisk: s.Serial,
-				})
+		case "category":
+			if strings.EqualFold(string(f.Category), target) {
+				out = append(out, f)
 			}
+		case "any":
+			out = append(out, f)
 		}
 	}
-
-	// ── 3. Boolean event triggers ──
-	if f.OnSmartFailure {
-		for _, s := range snap.SMART {
-			if !s.HealthPassed {
-				out = append(out, internal.Finding{
-					ID: "trigger:smart-fail:" + s.Serial, Severity: internal.SeverityCritical,
-					Category: internal.CategorySMART, Title: "SMART health check failed: " + s.Device,
-					Description: s.Model + " (S/N: " + s.Serial + ") reports SMART failure",
-					RelatedDisk: s.Serial,
-				})
-			}
-		}
-	}
-	if f.OnServiceDown {
-		for _, sc := range snap.Services {
-			if sc.Status == "down" {
-				if len(f.ServiceCheckNames) > 0 && !containsString(f.ServiceCheckNames, sc.Name) {
-					continue
-				}
-				out = append(out, internal.Finding{
-					ID: "trigger:service-down:" + sc.Key, Severity: internal.SeverityWarning,
-					Category: internal.CategoryService, Title: "Service check down: " + sc.Name,
-					Description: fmt.Sprintf("%s (%s) is down — %s", sc.Target, sc.Type, sc.Error),
-				})
-			}
-		}
-	}
-	if f.OnParityError && snap.Parity != nil {
-		for _, pc := range snap.Parity.History {
-			if pc.Errors > 0 {
-				out = append(out, internal.Finding{
-					ID: "trigger:parity-error:" + pc.Date, Severity: internal.SeverityCritical,
-					Category: internal.CategoryParity, Title: "Parity check errors: " + pc.Date,
-					Description: fmt.Sprintf("%d errors found during parity check", pc.Errors),
-				})
-				break // only trigger for the most recent error
-			}
-		}
-	}
-	if f.OnUPSOnBattery && snap.UPS != nil && snap.UPS.Available && snap.UPS.OnBattery {
-		out = append(out, internal.Finding{
-			ID: "trigger:ups-battery", Severity: internal.SeverityCritical,
-			Category: internal.CategoryUPS, Title: "UPS running on battery",
-			Description: fmt.Sprintf("Battery at %.0f%%, estimated runtime %.0f minutes", snap.UPS.BatteryPct, snap.UPS.RuntimeMins),
-		})
-	}
-	if f.UPSBatteryBelowPct > 0 && snap.UPS != nil && snap.UPS.Available {
-		if snap.UPS.BatteryPct < f.UPSBatteryBelowPct {
-			out = append(out, internal.Finding{
-				ID: "trigger:ups-low-battery", Severity: internal.SeverityCritical,
-				Category: internal.CategoryUPS, Title: "UPS battery critically low",
-				Description: fmt.Sprintf("Battery %.0f%% is below threshold %.0f%%", snap.UPS.BatteryPct, f.UPSBatteryBelowPct),
-			})
-		}
-	}
-	if f.OnUpdateAvailable && snap.Update != nil && snap.Update.UpdateAvailable {
-		out = append(out, internal.Finding{
-			ID: "trigger:update-available", Severity: internal.SeverityInfo,
-			Category: internal.CategorySystem, Title: "Platform update available",
-			Description: fmt.Sprintf("%s → %s", snap.Update.InstalledVersion, snap.Update.LatestVersion),
-		})
-	}
-
 	return out
 }
 
-func matchesSeverityFilter(sev internal.Severity, allowed []internal.Severity, fallback internal.Severity) bool {
-	if len(allowed) == 0 {
-		return severityRank(sev) >= severityRank(fallback)
+func evalDiskSpace(cond, target string, val float64, disks []internal.DiskInfo) []internal.Finding {
+	if val <= 0 {
+		return nil
 	}
-	for _, a := range allowed {
-		if strings.EqualFold(string(sev), string(a)) {
-			return true
+	var out []internal.Finding
+	for _, d := range disks {
+		if !matchTarget(target, d.MountPoint) && !matchTarget(target, d.Label) {
+			continue
+		}
+		free := 100.0 - d.UsedPct
+		if free < val {
+			out = append(out, synth("rule:disk-space:"+d.MountPoint, internal.SeverityWarning, internal.CategoryDisk,
+				"Disk space low: "+d.MountPoint, fmt.Sprintf("Free space %.1f%% is below threshold %.0f%%", free, val)))
 		}
 	}
-	return false
+	return out
 }
 
-func containsCategory(list []internal.Category, cat internal.Category) bool {
-	for _, c := range list {
-		if strings.EqualFold(string(c), string(cat)) {
-			return true
+func evalDiskTemp(cond, target string, val int, smart []internal.SMARTInfo) []internal.Finding {
+	if val <= 0 {
+		return nil
+	}
+	var out []internal.Finding
+	switch cond {
+	case "above", "single_above":
+		for _, s := range smart {
+			if !matchTarget(target, s.Serial) && !matchTarget(target, s.Device) {
+				continue
+			}
+			if s.Temperature > val {
+				out = append(out, synth("rule:disk-temp:"+s.Serial, internal.SeverityWarning, internal.CategoryThermal,
+					"Disk temperature high: "+s.Device, fmt.Sprintf("%d°C exceeds threshold %d°C", s.Temperature, val)))
+			}
+		}
+	case "avg_above":
+		if len(smart) == 0 {
+			return nil
+		}
+		sum := 0
+		for _, s := range smart {
+			sum += s.Temperature
+		}
+		avg := sum / len(smart)
+		if avg > val {
+			out = append(out, synth("rule:avg-disk-temp", internal.SeverityWarning, internal.CategoryThermal,
+				"Average disk temperature high", fmt.Sprintf("Average %d°C exceeds threshold %d°C", avg, val)))
 		}
 	}
-	return false
+	return out
 }
 
-func containsString(list []string, s string) bool {
-	lower := strings.ToLower(strings.TrimSpace(s))
-	for _, item := range list {
-		if strings.ToLower(strings.TrimSpace(item)) == lower {
-			return true
+func evalSMART(cond, target string, val int64, smart []internal.SMARTInfo) []internal.Finding {
+	var out []internal.Finding
+	for _, s := range smart {
+		if !matchTarget(target, s.Serial) && !matchTarget(target, s.Device) {
+			continue
+		}
+		switch cond {
+		case "health_fails":
+			if !s.HealthPassed {
+				out = append(out, synth("rule:smart-fail:"+s.Serial, internal.SeverityCritical, internal.CategorySMART,
+					"SMART health failed: "+s.Device, s.Model+" (S/N: "+s.Serial+")"))
+			}
+		case "reallocated_above":
+			if val > 0 && s.Reallocated > val {
+				out = append(out, synth("rule:smart-realloc:"+s.Serial, internal.SeverityCritical, internal.CategorySMART,
+					"Reallocated sectors high: "+s.Device, fmt.Sprintf("%d exceeds threshold %d", s.Reallocated, val)))
+			}
+		case "pending_above":
+			if val > 0 && s.Pending > val {
+				out = append(out, synth("rule:smart-pending:"+s.Serial, internal.SeverityWarning, internal.CategorySMART,
+					"Pending sectors: "+s.Device, fmt.Sprintf("%d exceeds threshold %d", s.Pending, val)))
+			}
+		case "crc_above":
+			if val > 0 && s.UDMACRC > val {
+				out = append(out, synth("rule:smart-crc:"+s.Serial, internal.SeverityWarning, internal.CategorySMART,
+					"UDMA CRC errors: "+s.Device, fmt.Sprintf("%d exceeds threshold %d", s.UDMACRC, val)))
+			}
+		case "power_hours_above":
+			if val > 0 && s.PowerOnHours > val {
+				out = append(out, synth("rule:smart-age:"+s.Serial, internal.SeverityInfo, internal.CategorySMART,
+					"Drive age warning: "+s.Device, fmt.Sprintf("%.1f years (%.0f hours threshold)", float64(s.PowerOnHours)/8766, float64(val))))
+			}
 		}
 	}
-	return false
+	return out
+}
+
+func evalService(cond, target string, val float64, services []internal.ServiceCheckResult) []internal.Finding {
+	var out []internal.Finding
+	for _, sc := range services {
+		if !matchTarget(target, sc.Name) && !matchTarget(target, sc.Key) {
+			continue
+		}
+		switch cond {
+		case "down":
+			if sc.Status == "down" {
+				out = append(out, synth("rule:svc-down:"+sc.Key, internal.SeverityWarning, internal.CategoryService,
+					"Service down: "+sc.Name, fmt.Sprintf("%s (%s) — %s", sc.Target, sc.Type, sc.Error)))
+			}
+		case "latency_above":
+			if val > 0 && float64(sc.ResponseMS) > val {
+				out = append(out, synth("rule:svc-latency:"+sc.Key, internal.SeverityWarning, internal.CategoryService,
+					"Service latency high: "+sc.Name, fmt.Sprintf("%dms exceeds threshold %.0fms", sc.ResponseMS, val)))
+			}
+		}
+	}
+	return out
+}
+
+func evalParity(cond string, val float64, parity *internal.ParityInfo) []internal.Finding {
+	if parity == nil || len(parity.History) == 0 {
+		return nil
+	}
+	last := parity.History[len(parity.History)-1]
+	switch cond {
+	case "errors":
+		if last.Errors > 0 {
+			return []internal.Finding{synth("rule:parity-err:"+last.Date, internal.SeverityCritical, internal.CategoryParity,
+				"Parity check errors: "+last.Date, fmt.Sprintf("%d errors found", last.Errors))}
+		}
+	case "speed_below":
+		if val > 0 && last.SpeedMBs < val {
+			return []internal.Finding{synth("rule:parity-slow:"+last.Date, internal.SeverityWarning, internal.CategoryParity,
+				"Parity check slow", fmt.Sprintf("%.1f MB/s below threshold %.0f MB/s", last.SpeedMBs, val))}
+		}
+	}
+	return nil
+}
+
+func evalUPS(cond string, val float64, ups *internal.UPSInfo) []internal.Finding {
+	if ups == nil || !ups.Available {
+		return nil
+	}
+	switch cond {
+	case "on_battery":
+		if ups.OnBattery {
+			return []internal.Finding{synth("rule:ups-battery", internal.SeverityCritical, internal.CategoryUPS,
+				"UPS on battery", fmt.Sprintf("Battery %.0f%%, runtime %.0f min", ups.BatteryPct, ups.RuntimeMins))}
+		}
+	case "battery_below":
+		if val > 0 && ups.BatteryPct < val {
+			return []internal.Finding{synth("rule:ups-low", internal.SeverityCritical, internal.CategoryUPS,
+				"UPS battery low", fmt.Sprintf("%.0f%% below threshold %.0f%%", ups.BatteryPct, val))}
+		}
+	case "load_above":
+		if val > 0 && ups.LoadPct > val {
+			return []internal.Finding{synth("rule:ups-load", internal.SeverityWarning, internal.CategoryUPS,
+				"UPS load high", fmt.Sprintf("%.0f%% exceeds threshold %.0f%%", ups.LoadPct, val))}
+		}
+	}
+	return nil
+}
+
+func evalDocker(cond, target string, docker internal.DockerInfo) []internal.Finding {
+	var out []internal.Finding
+	for _, c := range docker.Containers {
+		if !matchTarget(target, c.Name) {
+			continue
+		}
+		switch cond {
+		case "stopped":
+			if c.State != "running" {
+				out = append(out, synth("rule:docker-stop:"+c.Name, internal.SeverityWarning, internal.CategoryDocker,
+					"Container stopped: "+c.Name, c.Image+" — state: "+c.State))
+			}
+		}
+	}
+	return out
+}
+
+func evalSystem(cond string, val float64, sys internal.SystemInfo) []internal.Finding {
+	if val <= 0 {
+		return nil
+	}
+	switch cond {
+	case "cpu_above":
+		if sys.CPUUsage > val {
+			return []internal.Finding{synth("rule:sys-cpu", internal.SeverityWarning, internal.CategorySystem,
+				"CPU usage high", fmt.Sprintf("%.1f%% exceeds threshold %.0f%%", sys.CPUUsage, val))}
+		}
+	case "mem_above":
+		if sys.MemPercent > val {
+			return []internal.Finding{synth("rule:sys-mem", internal.SeverityWarning, internal.CategorySystem,
+				"Memory usage high", fmt.Sprintf("%.1f%% exceeds threshold %.0f%%", sys.MemPercent, val))}
+		}
+	case "load_above":
+		if sys.LoadAvg1 > val {
+			return []internal.Finding{synth("rule:sys-load", internal.SeverityWarning, internal.CategorySystem,
+				"Load average high", fmt.Sprintf("%.2f exceeds threshold %.0f", sys.LoadAvg1, val))}
+		}
+	case "iowait_above":
+		if sys.IOWait > val {
+			return []internal.Finding{synth("rule:sys-iowait", internal.SeverityWarning, internal.CategorySystem,
+				"I/O wait high", fmt.Sprintf("%.1f%% exceeds threshold %.0f%%", sys.IOWait, val))}
+		}
+	}
+	return nil
+}
+
+func evalZFS(cond, target string, val float64, zfs *internal.ZFSInfo) []internal.Finding {
+	if zfs == nil || !zfs.Available {
+		return nil
+	}
+	var out []internal.Finding
+	for _, pool := range zfs.Pools {
+		if !matchTarget(target, pool.Name) {
+			continue
+		}
+		switch cond {
+		case "degraded":
+			if !strings.EqualFold(pool.State, "ONLINE") {
+				out = append(out, synth("rule:zfs-degraded:"+pool.Name, internal.SeverityCritical, internal.CategoryZFS,
+					"ZFS pool degraded: "+pool.Name, "State: "+pool.State))
+			}
+		case "scrub_errors":
+			if pool.ScanErrors > 0 {
+				out = append(out, synth("rule:zfs-scrub-err:"+pool.Name, internal.SeverityCritical, internal.CategoryZFS,
+					"ZFS scrub errors: "+pool.Name, fmt.Sprintf("%d errors found", pool.ScanErrors)))
+			}
+		case "usage_above":
+			if val > 0 && pool.UsedPct > val {
+				out = append(out, synth("rule:zfs-usage:"+pool.Name, internal.SeverityWarning, internal.CategoryZFS,
+					"ZFS pool usage high: "+pool.Name, fmt.Sprintf("%.1f%% exceeds threshold %.0f%%", pool.UsedPct, val)))
+			}
+		}
+	}
+	return out
+}
+
+func evalTunnels(cond, target string, tunnels *internal.TunnelInfo) []internal.Finding {
+	if tunnels == nil {
+		return nil
+	}
+	var out []internal.Finding
+	switch cond {
+	case "cloudflared_down":
+		if tunnels.Cloudflared != nil {
+			for _, t := range tunnels.Cloudflared.Tunnels {
+				if !matchTarget(target, t.Name) {
+					continue
+				}
+				if t.Status != "healthy" {
+					out = append(out, synth("rule:cf-down:"+t.Name, internal.SeverityWarning, internal.CategoryNetwork,
+						"Cloudflared tunnel down: "+t.Name, "Status: "+t.Status))
+				}
+			}
+		}
+	case "tailscale_offline":
+		if tunnels.Tailscale != nil {
+			all := tunnels.Tailscale.Peers
+			for _, nd := range all {
+				if !matchTarget(target, nd.Name) {
+					continue
+				}
+				if !nd.Online {
+					out = append(out, synth("rule:ts-offline:"+nd.Name, internal.SeverityWarning, internal.CategoryNetwork,
+						"Tailscale node offline: "+nd.Name, "IP: "+nd.IP))
+				}
+			}
+		}
+	}
+	return out
+}
+
+func evalUpdate(update *internal.UpdateInfo) []internal.Finding {
+	if update != nil && update.UpdateAvailable {
+		return []internal.Finding{synth("rule:update", internal.SeverityInfo, internal.CategorySystem,
+			"Platform update available", fmt.Sprintf("%s → %s", update.InstalledVersion, update.LatestVersion))}
+	}
+	return nil
 }
 
 func (s *Scheduler) logSuppressed(notif *notifier.Notifier, findings []internal.Finding, hostname string, cfg AlertingConfig, status string) {
-	if len(cfg.Policies) == 0 {
-		for _, wh := range notif.Webhooks() {
-			if !wh.Enabled {
-				continue
-			}
-			filtered := filterBySeverity(findings, wh.MinLevel)
-			if len(filtered) == 0 {
-				continue
-			}
-			if err := s.store.SaveNotificationLog(wh.Name, wh.Type, status, len(filtered), ""); err != nil {
-				s.logger.Warn("failed to save suppressed notification log", "error", err)
-			}
-		}
-		s.logger.Info("notifications suppressed", "reason", status, "hostname", hostname)
-		return
-	}
-
-	webhooks := make(map[string]internal.WebhookConfig)
 	for _, wh := range notif.Webhooks() {
-		webhooks[strings.ToLower(strings.TrimSpace(wh.Name))] = wh
-	}
-	for _, policy := range cfg.Policies {
-		if !policy.Enabled || !matchesHostname(policy.Hostnames, hostname) {
+		if !wh.Enabled || len(findings) == 0 {
 			continue
 		}
-		wh, ok := webhooks[strings.ToLower(strings.TrimSpace(policy.WebhookName))]
-		if !ok || !wh.Enabled {
-			continue
-		}
-		filtered := filterFindingsForPolicy(findings, policy)
-		if len(filtered) == 0 {
-			continue
-		}
-		if err := s.store.SaveNotificationLog(wh.Name, wh.Type, status, len(filtered), ""); err != nil {
-			s.logger.Warn("failed to save suppressed policy log", "error", err)
-		}
+		_ = s.store.SaveNotificationLog(wh.Name, wh.Type, status, len(findings), "")
 	}
 	s.logger.Info("notifications suppressed", "reason", status, "hostname", hostname)
 }
@@ -1381,44 +1501,17 @@ func (s *Scheduler) applyCooldown(findings []internal.Finding, routeKey string, 
 	return out
 }
 
-func filterFindingsForPolicy(findings []internal.Finding, policy AlertPolicy) []internal.Finding {
-	min := policy.MinSeverity
-	if min == "" {
-		min = internal.SeverityWarning
+func matchesHostname(hosts []string, hostname string) bool {
+	if len(hosts) == 0 {
+		return true
 	}
-
-	catSet := make(map[string]struct{}, len(policy.Categories))
-	for _, c := range policy.Categories {
-		catSet[strings.ToLower(string(c))] = struct{}{}
-	}
-
-	out := make([]internal.Finding, 0, len(findings))
-	for _, f := range findings {
-		if severityRank(f.Severity) < severityRank(min) {
-			continue
-		}
-		if len(catSet) > 0 {
-			if _, ok := catSet[strings.ToLower(string(f.Category))]; !ok {
-				continue
-			}
-		}
-		out = append(out, f)
-	}
-	return out
-}
-
-func filterBySeverity(findings []internal.Finding, minLevel internal.Severity) []internal.Finding {
-	min := minLevel
-	if min == "" {
-		min = internal.SeverityWarning
-	}
-	out := make([]internal.Finding, 0, len(findings))
-	for _, f := range findings {
-		if severityRank(f.Severity) >= severityRank(min) {
-			out = append(out, f)
+	h := strings.ToLower(strings.TrimSpace(hostname))
+	for _, c := range hosts {
+		if strings.ToLower(strings.TrimSpace(c)) == h {
+			return true
 		}
 	}
-	return out
+	return false
 }
 
 func severityRank(sev internal.Severity) int {
@@ -1432,26 +1525,6 @@ func severityRank(sev internal.Severity) int {
 	default:
 		return 0
 	}
-}
-
-func matchesHostname(policyHosts []string, hostname string) bool {
-	if len(policyHosts) == 0 {
-		return true
-	}
-	h := strings.ToLower(strings.TrimSpace(hostname))
-	for _, candidate := range policyHosts {
-		if strings.ToLower(strings.TrimSpace(candidate)) == h {
-			return true
-		}
-	}
-	return false
-}
-
-func policyRouteKey(policy AlertPolicy, idx int, webhookName string) string {
-	if name := strings.TrimSpace(policy.Name); name != "" {
-		return "policy:" + name
-	}
-	return fmt.Sprintf("policy:%d:%s", idx, strings.ToLower(strings.TrimSpace(webhookName)))
 }
 
 func inQuietHours(cfg QuietHours, now time.Time) bool {


### PR DESCRIPTION
## Summary

### New Features
- **Prometheus exporter**: expanded from 26 to 80+ metrics — full coverage for UPS (10 gauges), ZFS (pools/ARC/datasets), network interfaces, service checks, tunnels (cloudflared + tailscale), SMART gaps (offline uncorrectable, command timeout, spin retry, temp max, size), docker container state, swap, and update availability
- **Log forwarding**: new `logfwd` package with 3 destination types — Loki push API, HTTP JSON, and syslog (RFC 5424 over UDP/TCP). Configurable labels, auth headers, and payload formats (full/findings_only/summary). Settings UI with full destination management
- **Notification rules builder**: replaces the old alert policy engine with a unified rule-based system. 12 categories (findings, disk_space, disk_temp, smart, service, parity, ups, docker, system, zfs, tunnels, update) with dropdown-driven conditions, live target selection from snapshot data, and 5 one-click presets (critical alerts, disk health, service uptime, power protection, storage warnings). All form fields visible at once

### Bug Fixes
- **Synology: missing /volumeX** — `collectHostMountDisks()` was replacing all df-detected disks; now merges both sets preserving volumes not bind-mounted as `/host/*`
- **Synology: false green "OK" on drives with no SMART data** — new `DataAvailable` field; all 3 themes show grey dot + "NO DATA" badge + em-dash for temp/age instead of 0°C/0h green
- **Synology: 0 findings** — analyzer now generates warnings for drives where SMART data is unavailable
- **Dashboard card consistency** — parity, services, tunnels sections now wrapped in matching bg-panel cards across all 3 themes
- **HTTP service check favicons** — badge cards show target website favicon via Google's API

### Other
- README tagline: "Sleep tight. Your server never does."
- Prometheus metrics list updated in README (80+ metrics)
- Buy-me-a-coffee badge repositioned