### PR TITLE
feat: add slogan to app header

### DIFF
--- a/internal/api/styles.go
+++ b/internal/api/styles.go
@@ -117,6 +117,7 @@ body.theme-ember code { font-family:var(--font-mono) }
   font-size:20px; font-weight:600; letter-spacing:-0.5px; color:var(--text);
 }
 .logo img { width:24px; height:24px; border-radius:4px }
+.logo-slogan { font-size:11px; font-style:italic; font-weight:400; color:var(--text3,#888); margin-left:4px; white-space:nowrap }
 .page-title { font-size:20px; font-weight:600; color:var(--text2) }
 .header-sub { font-size:13px; color:var(--text2) }
 

--- a/internal/api/templates/alerts.html
+++ b/internal/api/templates/alerts.html
@@ -16,7 +16,7 @@
   <!-- Header -->
   <div class="header">
     <div class="header-left">
-      <a href="/" class="logo" style="text-decoration:none;color:inherit"><img src="/icon.png" alt="">NAS Doctor</a>
+      <a href="/" class="logo" style="text-decoration:none;color:inherit"><img src="/icon.png" alt="">NAS Doctor</a><span class="logo-slogan">Sleep tight knowing your server never does.</span>
       <span class="page-title">Alerts</span>
     </div>
     <div class="nav-links">

--- a/internal/api/templates/clean.html
+++ b/internal/api/templates/clean.html
@@ -715,6 +715,7 @@ body {
 
 <header class="header">
   <a href="/" class="header-brand"><img src="/icon.png" alt="" style="width:22px;height:22px;border-radius:4px;vertical-align:middle;margin-right:6px;">NAS Doctor</a>
+  <span class="logo-slogan">Sleep tight knowing your server never does.</span>
   <div class="header-right">
     <div class="nav-links">
       <a href="/alerts" class="nav-link">Alerts</a>

--- a/internal/api/templates/ember.html
+++ b/internal/api/templates/ember.html
@@ -966,6 +966,7 @@ td.mono {
     <img src="/icon.png" alt="" style="width:26px;height:26px;border-radius:5px;vertical-align:middle;margin-right:8px;">
     NAS Doctor
   </a>
+  <span class="logo-slogan">Sleep tight knowing your server never does.</span>
   <div class="header-right">
     <div class="nav-links">
       <a href="/alerts" class="nav-link">Alerts</a>

--- a/internal/api/templates/fleet.html
+++ b/internal/api/templates/fleet.html
@@ -54,7 +54,7 @@ body{padding:0}
 <div class="container">
   <div class="header">
     <div class="header-left">
-      <a href="/" class="logo" style="text-decoration:none;color:inherit"><img src="/icon.png" alt="" style="width:28px;height:28px;border-radius:6px">NAS Doctor</a>
+      <a href="/" class="logo" style="text-decoration:none;color:inherit"><img src="/icon.png" alt="" style="width:28px;height:28px;border-radius:6px">NAS Doctor</a><span class="logo-slogan">Sleep tight knowing your server never does.</span>
       <span class="page-title">Fleet</span>
     </div>
     <div class="nav-links">

--- a/internal/api/templates/midnight.html
+++ b/internal/api/templates/midnight.html
@@ -340,6 +340,7 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
     h += '<header class="header fade-in">';
     h += '<div class="header-left">';
     h += '<a href="/" class="logo" style="text-decoration:none;color:inherit"><img src="/icon.png" alt="" style="width:24px;height:24px;border-radius:4px;vertical-align:middle;margin-right:8px;">NAS Doctor</a>';
+    h += '<span class="logo-slogan">Sleep tight knowing your server never does.</span>';
     h += '<span class="hostname">' + esc(hostname) + '</span>';
     h += '</div>';
     h += '<div class="header-right">';

--- a/internal/api/templates/parity.html
+++ b/internal/api/templates/parity.html
@@ -37,7 +37,7 @@
 <div class="container">
   <div class="header">
     <div class="header-left">
-      <a href="/" class="logo" style="text-decoration:none;color:inherit"><img src="/icon.png" alt="">NAS Doctor</a>
+      <a href="/" class="logo" style="text-decoration:none;color:inherit"><img src="/icon.png" alt="">NAS Doctor</a><span class="logo-slogan">Sleep tight knowing your server never does.</span>
       <span class="page-title">Parity History</span>
     </div>
     <div class="nav-links">

--- a/internal/api/templates/service_checks.html
+++ b/internal/api/templates/service_checks.html
@@ -58,7 +58,7 @@
 <div class="container">
   <div class="header">
     <div class="header-left">
-      <a href="/" class="logo" style="text-decoration:none;color:inherit"><img src="/icon.png" alt="">NAS Doctor</a>
+      <a href="/" class="logo" style="text-decoration:none;color:inherit"><img src="/icon.png" alt="">NAS Doctor</a><span class="logo-slogan">Sleep tight knowing your server never does.</span>
       <span class="page-title">Service Checks</span>
     </div>
     <div class="nav-links">

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -38,7 +38,7 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
   <!-- Header -->
   <div class="header">
     <div class="header-left">
-      <a href="/" class="logo" style="text-decoration:none;color:inherit"><img src="/icon.png" alt="">NAS Doctor</a>
+      <a href="/" class="logo" style="text-decoration:none;color:inherit"><img src="/icon.png" alt="">NAS Doctor</a><span class="logo-slogan">Sleep tight knowing your server never does.</span>
       <span class="page-title">Settings</span>
     </div>
     <div class="nav-links">

--- a/internal/api/templates/stats.html
+++ b/internal/api/templates/stats.html
@@ -107,7 +107,7 @@ body.theme-clean .sort-pill.active{color:rgba(0,0,0,0.7);background:rgba(0,0,0,0
 <div class="stats-container">
   <div class="header">
     <div class="header-left">
-      <a href="/" class="logo" style="text-decoration:none;color:inherit"><img src="/icon.png" alt="">NAS Doctor</a>
+      <a href="/" class="logo" style="text-decoration:none;color:inherit"><img src="/icon.png" alt="">NAS Doctor</a><span class="logo-slogan">Sleep tight knowing your server never does.</span>
       <span class="page-title">Stats</span>
     </div>
     <div class="nav-links">


### PR DESCRIPTION
Adds slogan in subtle italic to all pages via shared CSS .logo-slogan class.