### PR TITLE
v0.6.0 — Proxmox integration, fleet improvements, notification rules, Synology fixes

### DIFF
--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -106,12 +106,14 @@ func main() {
 
 	var sched *scheduler.Scheduler
 
+	// Create collector (shared between demo and production paths)
+	coll := collector.New(cfg.HostPaths, logger)
+
 	if *demoMode {
 		// Demo mode: inject fake data with historical snapshots
 		logger.Info("demo mode: generating mock diagnostic data with history")
 
-		col := collector.New(cfg.HostPaths, logger)
-		sched = scheduler.New(col, store, nil, metrics, logger, 24*time.Hour)
+		sched = scheduler.New(coll, store, nil, metrics, logger, 24*time.Hour)
 
 		// Generate 30 days of historical snapshots (one per day) for chart data
 		for i := 29; i >= 0; i-- {
@@ -220,7 +222,6 @@ func main() {
 		)
 	} else {
 		// Production mode: real collectors
-		col := collector.New(cfg.HostPaths, logger)
 		interval = intervalFromSettings(persistedSettings, interval, logger)
 
 		webhooks := cfg.Notifications.Webhooks
@@ -229,7 +230,7 @@ func main() {
 		}
 		notif := buildNotifier(webhooks, logger, store)
 
-		sched = scheduler.New(col, store, notif, metrics, logger, interval)
+		sched = scheduler.New(coll, store, notif, metrics, logger, interval)
 		applySchedulerSettingsFromStore(sched, persistedSettings)
 		sched.Start()
 		defer sched.Stop()
@@ -252,7 +253,7 @@ func main() {
 	}
 
 	// Create API server
-	apiServer := api.New(store, sched, metrics, fleetMgr, logger, version)
+	apiServer := api.New(store, sched, coll, metrics, fleetMgr, logger, version)
 
 	// HTTP server
 	srv := &http.Server{

--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -240,6 +240,7 @@ func main() {
 				TokenID:  persistedSettings.Proxmox.TokenID,
 				Secret:   persistedSettings.Proxmox.Secret,
 				NodeName: persistedSettings.Proxmox.NodeName,
+				Alias:    persistedSettings.Proxmox.Alias,
 			})
 			logger.Info("proxmox integration loaded", "url", persistedSettings.Proxmox.URL)
 		}

--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -232,6 +232,17 @@ func main() {
 
 		sched = scheduler.New(coll, store, notif, metrics, logger, interval)
 		applySchedulerSettingsFromStore(sched, persistedSettings)
+		// Apply Proxmox config to collector on startup
+		if persistedSettings != nil && persistedSettings.Proxmox.Enabled {
+			coll.SetProxmoxConfig(collector.ProxmoxConfig{
+				Enabled:  true,
+				URL:      persistedSettings.Proxmox.URL,
+				TokenID:  persistedSettings.Proxmox.TokenID,
+				Secret:   persistedSettings.Proxmox.Secret,
+				NodeName: persistedSettings.Proxmox.NodeName,
+			})
+			logger.Info("proxmox integration loaded", "url", persistedSettings.Proxmox.URL)
+		}
 		sched.Start()
 		defer sched.Stop()
 	}

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -41,6 +41,10 @@ func Analyze(snap *internal.Snapshot) []internal.Finding {
 		findings = append(findings, analyzeOSUpdate(snap.Update)...)
 	}
 
+	if snap.Proxmox != nil && snap.Proxmox.Connected {
+		findings = append(findings, analyzeProxmox(snap.Proxmox)...)
+	}
+
 	// Cross-correlation: combine related findings
 	findings = correlate(findings, snap)
 

--- a/internal/analyzer/proxmox.go
+++ b/internal/analyzer/proxmox.go
@@ -1,0 +1,179 @@
+package analyzer
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+func analyzeProxmox(pve *internal.ProxmoxInfo) []internal.Finding {
+	var findings []internal.Finding
+
+	// Node offline
+	for _, n := range pve.Nodes {
+		if n.Status != "online" {
+			findings = append(findings, internal.Finding{
+				Severity:    internal.SeverityCritical,
+				Category:    internal.CategorySystem,
+				Title:       fmt.Sprintf("Proxmox node offline: %s", n.Name),
+				Description: fmt.Sprintf("Node %s is reporting status '%s'. This may indicate a hardware failure, network issue, or planned maintenance.", n.Name, n.Status),
+				Impact:      "VMs and containers on this node are unavailable",
+				Action:      "Check physical server power, network connectivity, and PVE cluster logs",
+				Priority:    "immediate",
+			})
+		}
+		// Node memory high (>90%)
+		if n.MemTotal > 0 {
+			memPct := float64(n.MemUsed) / float64(n.MemTotal) * 100
+			if memPct > 95 {
+				findings = append(findings, internal.Finding{
+					Severity:    internal.SeverityCritical,
+					Category:    internal.CategoryMemory,
+					Title:       fmt.Sprintf("Proxmox node memory critical: %s (%.0f%%)", n.Name, memPct),
+					Description: fmt.Sprintf("Node %s is using %.0f%% of %.0f GB RAM. VMs may be killed by the OOM killer.", n.Name, memPct, float64(n.MemTotal)/1073741824),
+					Impact:      "Risk of VM/container termination due to out-of-memory",
+					Action:      "Migrate VMs to other nodes, increase RAM, or reduce VM memory allocations",
+					Priority:    "immediate",
+				})
+			} else if memPct > 90 {
+				findings = append(findings, internal.Finding{
+					Severity:    internal.SeverityWarning,
+					Category:    internal.CategoryMemory,
+					Title:       fmt.Sprintf("Proxmox node memory high: %s (%.0f%%)", n.Name, memPct),
+					Description: fmt.Sprintf("Node %s is using %.0f%% of %.0f GB RAM.", n.Name, memPct, float64(n.MemTotal)/1073741824),
+					Impact:      "Performance degradation, risk of OOM if usage increases",
+					Action:      "Consider migrating workloads or adding more RAM",
+					Priority:    "short-term",
+				})
+			}
+		}
+		// Node CPU sustained high (>90%)
+		if n.CPUUsage > 0.9 {
+			findings = append(findings, internal.Finding{
+				Severity:    internal.SeverityWarning,
+				Category:    internal.CategorySystem,
+				Title:       fmt.Sprintf("Proxmox node CPU high: %s (%.0f%%)", n.Name, n.CPUUsage*100),
+				Description: fmt.Sprintf("Node %s CPU at %.0f%% across %d cores (%s)", n.Name, n.CPUUsage*100, n.CPUCores, n.CPUModel),
+				Impact:      "VM performance degradation",
+				Action:      "Identify high-CPU VMs, consider migrating workloads",
+				Priority:    "short-term",
+			})
+		}
+	}
+
+	// Guest issues
+	for _, g := range pve.Guests {
+		// Stopped VMs/LXCs that might be unexpected
+		if g.Status == "stopped" && g.HAState == "started" {
+			findings = append(findings, internal.Finding{
+				Severity:    internal.SeverityCritical,
+				Category:    internal.CategorySystem,
+				Title:       fmt.Sprintf("HA-managed guest stopped: %s (VMID %d)", g.Name, g.VMID),
+				Description: fmt.Sprintf("%s %s on node %s is stopped but configured for HA with state 'started'. This indicates an HA failure.", strings.ToUpper(g.Type), g.Name, g.Node),
+				Impact:      "Service outage for applications running in this guest",
+				Action:      "Check PVE HA logs, verify guest can start, check for resource constraints",
+				Priority:    "immediate",
+			})
+		}
+		// Guest memory high (>95%)
+		if g.Status == "running" && g.MemMax > 0 {
+			memPct := float64(g.MemUsed) / float64(g.MemMax) * 100
+			if memPct > 95 {
+				findings = append(findings, internal.Finding{
+					Severity:    internal.SeverityWarning,
+					Category:    internal.CategoryMemory,
+					Title:       fmt.Sprintf("Guest memory critical: %s (%.0f%%)", g.Name, memPct),
+					Description: fmt.Sprintf("VMID %d (%s) is using %.0f%% of %.1f GB allocated memory", g.VMID, g.Name, memPct, float64(g.MemMax)/1073741824),
+					Impact:      "Application performance issues or crashes inside the guest",
+					Action:      "Increase memory allocation or optimize applications",
+					Priority:    "short-term",
+				})
+			}
+		}
+	}
+
+	// Storage pools high usage
+	for _, s := range pve.Storage {
+		if s.Total <= 0 || s.Status != "available" {
+			continue
+		}
+		if s.UsedPct > 95 {
+			findings = append(findings, internal.Finding{
+				Severity:    internal.SeverityCritical,
+				Category:    internal.CategoryDisk,
+				Title:       fmt.Sprintf("PVE storage critical: %s on %s (%.0f%%)", s.Storage, s.Node, s.UsedPct),
+				Description: fmt.Sprintf("Storage pool '%s' (%s) on node %s is %.0f%% full. Total: %.0f GB", s.Storage, s.Type, s.Node, s.UsedPct, float64(s.Total)/1073741824),
+				Impact:      "Cannot create snapshots, backups, or new VMs. Running VMs may fail on disk writes.",
+				Action:      "Free space immediately: remove old backups, snapshots, or unused disk images",
+				Priority:    "immediate",
+			})
+		} else if s.UsedPct > 85 {
+			findings = append(findings, internal.Finding{
+				Severity:    internal.SeverityWarning,
+				Category:    internal.CategoryDisk,
+				Title:       fmt.Sprintf("PVE storage high: %s on %s (%.0f%%)", s.Storage, s.Node, s.UsedPct),
+				Description: fmt.Sprintf("Storage pool '%s' (%s) on node %s is %.0f%% full", s.Storage, s.Type, s.Node, s.UsedPct),
+				Impact:      "May run out of space for backups and snapshots",
+				Action:      "Plan storage cleanup or expansion",
+				Priority:    "short-term",
+			})
+		}
+	}
+
+	// Backup freshness — check if any backup task ran in the last 48 hours
+	if len(pve.Tasks) > 0 {
+		lastBackup := int64(0)
+		for _, t := range pve.Tasks {
+			if t.Type == "vzdump" && t.EndTime > lastBackup {
+				lastBackup = t.EndTime
+			}
+		}
+		if lastBackup > 0 {
+			age := time.Now().Unix() - lastBackup
+			if age > 172800 { // >48 hours
+				findings = append(findings, internal.Finding{
+					Severity:    internal.SeverityWarning,
+					Category:    internal.CategorySystem,
+					Title:       "Proxmox backups may be stale",
+					Description: fmt.Sprintf("Last successful backup was %.0f hours ago. Consider verifying your backup schedule.", float64(age)/3600),
+					Impact:      "Data loss risk if a VM fails without recent backup",
+					Action:      "Check Datacenter → Backup in PVE to verify backup jobs are scheduled and running",
+					Priority:    "short-term",
+				})
+			}
+		}
+		// Failed tasks
+		for _, t := range pve.Tasks {
+			if t.Status != "" && t.Status != "OK" && t.Status != "running" && t.EndTime > time.Now().Add(-24*time.Hour).Unix() {
+				findings = append(findings, internal.Finding{
+					Severity:    internal.SeverityWarning,
+					Category:    internal.CategorySystem,
+					Title:       fmt.Sprintf("PVE task failed: %s on %s", t.Type, t.Node),
+					Description: fmt.Sprintf("Task %s for VMID %d on node %s finished with status: %s", t.Type, t.VMID, t.Node, t.Status),
+					Impact:      "Backup/migration may not have completed",
+					Action:      "Check task log in PVE for details",
+					Priority:    "short-term",
+				})
+			}
+		}
+	}
+
+	// HA service errors
+	for _, ha := range pve.HAServices {
+		if ha.State == "error" || ha.State == "fence" {
+			findings = append(findings, internal.Finding{
+				Severity:    internal.SeverityCritical,
+				Category:    internal.CategorySystem,
+				Title:       fmt.Sprintf("PVE HA service error: %s", ha.SID),
+				Description: fmt.Sprintf("HA service %s on node %s is in state '%s': %s", ha.SID, ha.Node, ha.State, ha.Status),
+				Impact:      "HA-managed service may be unavailable",
+				Action:      "Check HA logs, verify fencing configuration, check node health",
+				Priority:    "immediate",
+			})
+		}
+	}
+
+	return findings
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -13,6 +13,8 @@ import (
 	"github.com/go-chi/cors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"github.com/mcdays94/nas-doctor/internal/collector"
+
 	"github.com/mcdays94/nas-doctor/internal"
 	"github.com/mcdays94/nas-doctor/internal/fleet"
 	"github.com/mcdays94/nas-doctor/internal/notifier"
@@ -32,6 +34,7 @@ const (
 type Server struct {
 	store     *storage.DB
 	scheduler *scheduler.Scheduler
+	collector *collector.Collector
 	metrics   *notifier.Metrics
 	fleet     *fleet.Manager
 	logger    *slog.Logger
@@ -40,10 +43,11 @@ type Server struct {
 }
 
 // New creates a new API server.
-func New(store *storage.DB, sched *scheduler.Scheduler, metrics *notifier.Metrics, fleetMgr *fleet.Manager, logger *slog.Logger, version string) *Server {
+func New(store *storage.DB, sched *scheduler.Scheduler, coll *collector.Collector, metrics *notifier.Metrics, fleetMgr *fleet.Manager, logger *slog.Logger, version string) *Server {
 	return &Server{
 		store:     store,
 		scheduler: sched,
+		collector: coll,
 		metrics:   metrics,
 		fleet:     fleetMgr,
 		logger:    logger,

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -141,11 +141,13 @@ func (s *Server) Router() http.Handler {
 // ---------- Handlers ----------
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("X-NAS-Doctor", "true")
 	writeJSON(w, http.StatusOK, map[string]any{
-		"status":  "ok",
-		"version": s.version,
-		"uptime":  time.Since(s.startTime).String(),
-		"themes":  []string{ThemeMidnight, ThemeClean, ThemeEmber},
+		"status":     "ok",
+		"nas_doctor": true,
+		"version":    s.version,
+		"uptime":     time.Since(s.startTime).String(),
+		"themes":     []string{ThemeMidnight, ThemeClean, ThemeEmber},
 	})
 }
 

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -96,7 +96,8 @@ type SettingsProxmox struct {
 	URL      string `json:"url"`       // e.g. https://192.168.1.10:8006
 	TokenID  string `json:"token_id"`  // e.g. root@pam!nas-doctor
 	Secret   string `json:"secret"`    // API token UUID secret
-	NodeName string `json:"node_name"` // optional: limit to specific node
+	NodeName string `json:"node_name"` // optional: real PVE node name to filter (auto-detected)
+	Alias    string `json:"alias"`     // optional: friendly display name
 }
 
 // SettingsLogForward holds the log-forwarding configuration within settings.
@@ -543,6 +544,7 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 			TokenID:  settings.Proxmox.TokenID,
 			Secret:   settings.Proxmox.Secret,
 			NodeName: settings.Proxmox.NodeName,
+			Alias:    settings.Proxmox.Alias,
 		})
 
 		// Update log forwarding
@@ -1787,13 +1789,18 @@ func (s *Server) handleTestProxmox(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]interface{}{"success": false, "error": "failed to connect"})
 		return
 	}
+	nodeNames := make([]string, 0, len(result.Nodes))
+	for _, n := range result.Nodes {
+		nodeNames = append(nodeNames, n.Name)
+	}
 	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"success": true,
-		"version": result.Version,
-		"cluster": result.ClusterName,
-		"nodes":   len(result.Nodes),
-		"guests":  len(result.Guests),
-		"storage": len(result.Storage),
+		"success":    true,
+		"version":    result.Version,
+		"cluster":    result.ClusterName,
+		"nodes":      len(result.Nodes),
+		"node_names": nodeNames,
+		"guests":     len(result.Guests),
+		"storage":    len(result.Storage),
 	})
 }
 

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 
 	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/collector"
 	"github.com/mcdays94/nas-doctor/internal/logfwd"
 	"github.com/mcdays94/nas-doctor/internal/notifier"
 	"github.com/mcdays94/nas-doctor/internal/scheduler"
@@ -35,6 +36,7 @@ type Settings struct {
 	Retention         RetentionSettings       `json:"retention"`
 	Backup            BackupSettings          `json:"backup"`
 	Sections          DashboardSections       `json:"sections"`
+	Proxmox           SettingsProxmox         `json:"proxmox"`
 	Fleet             []internal.RemoteServer `json:"fleet,omitempty"`
 	DismissedFindings []string                `json:"dismissed_findings,omitempty"`
 }
@@ -53,6 +55,7 @@ type DashboardSections struct {
 	Parity       bool `json:"parity"`
 	Network      bool `json:"network"`
 	Tunnels      bool `json:"tunnels"`
+	Proxmox      bool `json:"proxmox"`
 	MergedDrives bool `json:"merged_drives"` // Combine SMART + storage into one card per drive
 }
 
@@ -85,6 +88,15 @@ type SettingsNotifications struct {
 // SettingsServiceChecks holds configured service checks.
 type SettingsServiceChecks struct {
 	Checks []internal.ServiceCheckConfig `json:"checks"`
+}
+
+// SettingsProxmox holds the Proxmox VE API connection settings.
+type SettingsProxmox struct {
+	Enabled  bool   `json:"enabled"`
+	URL      string `json:"url"`       // e.g. https://192.168.1.10:8006
+	TokenID  string `json:"token_id"`  // e.g. root@pam!nas-doctor
+	Secret   string `json:"secret"`    // API token UUID secret
+	NodeName string `json:"node_name"` // optional: limit to specific node
 }
 
 // SettingsLogForward holds the log-forwarding configuration within settings.
@@ -519,6 +531,15 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 			DefaultCooldownSec: settings.Notifications.DefaultCooldownSec,
 		})
 		s.scheduler.UpdateServiceChecks(settings.ServiceChecks.Checks)
+
+		// Update Proxmox config on the collector
+		s.collector.SetProxmoxConfig(collector.ProxmoxConfig{
+			Enabled:  settings.Proxmox.Enabled,
+			URL:      settings.Proxmox.URL,
+			TokenID:  settings.Proxmox.TokenID,
+			Secret:   settings.Proxmox.Secret,
+			NodeName: settings.Proxmox.NodeName,
+		})
 
 		// Update log forwarding
 		if settings.LogPush.Enabled && len(settings.LogPush.Destinations) > 0 {

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -540,6 +540,11 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		})
 		s.scheduler.UpdateServiceChecks(settings.ServiceChecks.Checks)
 
+		// Auto-enable Proxmox dashboard section when PVE integration is turned on
+		if settings.Proxmox.Enabled && !settings.Sections.Proxmox {
+			settings.Sections.Proxmox = true
+		}
+
 		// Update Proxmox config on the collector
 		s.collector.SetProxmoxConfig(collector.ProxmoxConfig{
 			Enabled:  settings.Proxmox.Enabled,

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -184,6 +184,7 @@ func (s *Server) RegisterExtendedRoutes(r chi.Router) {
 	r.Get("/api/v1/service-checks", s.handleServiceChecks)
 	r.Get("/api/v1/service-checks/history", s.handleServiceCheckHistory)
 	r.Post("/api/v1/service-checks/run", s.handleRunServiceChecks)
+	r.Delete("/api/v1/service-checks/{key}", s.handleDeleteServiceCheck)
 	r.Get("/api/v1/incidents/timeline", s.handleIncidentTimeline)
 	r.Get("/api/v1/incidents/correlation", s.handleIncidentCorrelation)
 	r.Get("/api/v1/smart/trends", s.handleSMARTTrends)
@@ -1030,6 +1031,22 @@ func (s *Server) handleRunServiceChecks(w http.ResponseWriter, r *http.Request) 
 		results = []internal.ServiceCheckResult{}
 	}
 	writeJSON(w, http.StatusOK, results)
+}
+
+// handleDeleteServiceCheck removes all history for a service check key.
+// DELETE /api/v1/service-checks/{key}
+func (s *Server) handleDeleteServiceCheck(w http.ResponseWriter, r *http.Request) {
+	key := chi.URLParam(r, "key")
+	if key == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "key is required"})
+		return
+	}
+	deleted, err := s.store.DeleteServiceCheckByKey(key)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"deleted": deleted, "key": key})
 }
 
 type incidentTimelineEvent struct {

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -208,6 +208,9 @@ func (s *Server) RegisterExtendedRoutes(r chi.Router) {
 	// Alerts page
 	r.Get("/alerts", s.handleAlertsPage)
 
+	// Proxmox test
+	r.Post("/api/v1/proxmox/test", s.handleTestProxmox)
+
 	// Service Checks page
 	r.Get("/service-checks", s.handleServiceChecksPage)
 
@@ -1760,6 +1763,38 @@ func (s *Server) handleSettingsPage(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleAlertsPage(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write([]byte(alertsPageHTML))
+}
+
+// handleTestProxmox tests the Proxmox VE API connection.
+// POST /api/v1/proxmox/test
+func (s *Server) handleTestProxmox(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		URL     string `json:"url"`
+		TokenID string `json:"token_id"`
+		Secret  string `json:"secret"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+		return
+	}
+	if req.URL == "" || req.TokenID == "" || req.Secret == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "URL, token ID, and secret are required"})
+		return
+	}
+	cfg := collector.ProxmoxConfig{Enabled: true, URL: req.URL, TokenID: req.TokenID, Secret: req.Secret}
+	result := collector.CollectProxmox(cfg)
+	if result == nil {
+		writeJSON(w, http.StatusOK, map[string]interface{}{"success": false, "error": "failed to connect"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"success": true,
+		"version": result.Version,
+		"cluster": result.ClusterName,
+		"nodes":   len(result.Nodes),
+		"guests":  len(result.Guests),
+		"storage": len(result.Storage),
+	})
 }
 
 // handleServiceChecksPage serves the service checks HTML page.

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -1815,12 +1815,27 @@ func (s *Server) handleTestFleetServer(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]interface{}{"success": false, "error": fmt.Sprintf("HTTP %d from %s", resp.StatusCode, healthURL)})
 		return
 	}
+	// Verify this is actually a NAS Doctor instance (not a proxy login page)
 	var health struct {
 		Status  string `json:"status"`
+		NasDoc  bool   `json:"nas_doctor"`
 		Version string `json:"version"`
 		Uptime  string `json:"uptime"`
 	}
-	json.NewDecoder(resp.Body).Decode(&health)
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		writeJSON(w, http.StatusOK, map[string]interface{}{"success": false, "error": "Response is not valid JSON — likely a proxy login page (Cloudflare Access?). Add the required auth headers."})
+		return
+	}
+	// Check for NAS Doctor signature (header or JSON field)
+	hasHeader := resp.Header.Get("X-NAS-Doctor") == "true"
+	if !health.NasDoc && !hasHeader {
+		writeJSON(w, http.StatusOK, map[string]interface{}{"success": false, "error": "Response does not contain NAS Doctor signature — this may be a proxy login page. Check your auth headers."})
+		return
+	}
+	if health.Status != "ok" {
+		writeJSON(w, http.StatusOK, map[string]interface{}{"success": false, "error": "NAS Doctor responded but status is not 'ok': " + health.Status})
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"success": true,
 		"status":  health.Status,

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -209,6 +209,9 @@ func (s *Server) RegisterExtendedRoutes(r chi.Router) {
 	// Alerts page
 	r.Get("/alerts", s.handleAlertsPage)
 
+	// Fleet test
+	r.Post("/api/v1/fleet/test", s.handleTestFleetServer)
+
 	// Proxmox test
 	r.Post("/api/v1/proxmox/test", s.handleTestProxmox)
 
@@ -1765,6 +1768,60 @@ func (s *Server) handleSettingsPage(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleAlertsPage(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write([]byte(alertsPageHTML))
+}
+
+// handleTestFleetServer tests connectivity to a remote NAS Doctor instance.
+// POST /api/v1/fleet/test
+func (s *Server) handleTestFleetServer(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		URL     string            `json:"url"`
+		APIKey  string            `json:"api_key"`
+		Headers map[string]string `json:"headers"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request"})
+		return
+	}
+	if req.URL == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "URL is required"})
+		return
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	healthURL := strings.TrimRight(req.URL, "/") + "/api/v1/health"
+	httpReq, err := http.NewRequest("GET", healthURL, nil)
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]interface{}{"success": false, "error": "invalid URL: " + err.Error()})
+		return
+	}
+	httpReq.Header.Set("User-Agent", "nas-doctor-fleet-test/1.0")
+	if req.APIKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+req.APIKey)
+	}
+	for k, v := range req.Headers {
+		httpReq.Header.Set(k, v)
+	}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]interface{}{"success": false, "error": err.Error()})
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		writeJSON(w, http.StatusOK, map[string]interface{}{"success": false, "error": fmt.Sprintf("HTTP %d from %s", resp.StatusCode, healthURL)})
+		return
+	}
+	var health struct {
+		Status  string `json:"status"`
+		Version string `json:"version"`
+		Uptime  string `json:"uptime"`
+	}
+	json.NewDecoder(resp.Body).Decode(&health)
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"success": true,
+		"status":  health.Status,
+		"version": health.Version,
+		"uptime":  health.Uptime,
+	})
 }
 
 // handleTestProxmox tests the Proxmox VE API connection.

--- a/internal/api/templates/alerts.html
+++ b/internal/api/templates/alerts.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>NAS Doctor — Alerts</title>
+<title>NAS Doctor</title>
 <link rel="icon" type="image/png" href="/icon.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -488,6 +488,7 @@ function applyTheme(theme) {
 fetch("/api/v1/settings").then(function(r){return r.json()}).then(function(d){
   if(d.theme){applyTheme(d.theme);try{localStorage.setItem("nas-doctor-theme",d.theme)}catch(e){}}
 }).catch(function(){});
+fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d.hostname)document.title="NAS Doctor — "+d.hostname;}).catch(function(){});
 
 /* ========== Alert summary ========== */
 function loadAlertSummary() {

--- a/internal/api/templates/clean.html
+++ b/internal/api/templates/clean.html
@@ -1281,6 +1281,41 @@ body {
     }
     html += '</div>'; // end section-block tunnels
 
+    // ==== Section: Proxmox ====
+    html += '<div class="section-block" data-section="proxmox">';
+    var pve = snapshot ? snapshot.proxmox : null;
+    if (pve && pve.connected) {
+      html += '<div class="section"><div class="section-title">Proxmox VE' + (pve.cluster_name ? ' &middot; ' + escapeHTML(pve.cluster_name) : '') + '</div>';
+      if (pve.nodes && pve.nodes.length > 0) {
+        html += '<div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:12px">';
+        for (var ni = 0; ni < pve.nodes.length; ni++) {
+          var nd = pve.nodes[ni]; var ndOn = nd.status==='online'; var mP = nd.mem_total>0?(nd.mem_used/nd.mem_total*100):0;
+          html += '<div style="background:var(--card-bg,#fff);border:1px solid rgba(0,0,0,0.08);border-radius:8px;padding:10px 14px;flex:1;min-width:200px">';
+          html += '<div style="display:flex;align-items:center;gap:6px;margin-bottom:6px"><span class="status-dot '+(ndOn?'green':'red')+'"></span><span style="font-weight:600">' + escapeHTML(nd.name) + '</span></div>';
+          html += '<div style="font-size:11px;color:#808080">CPU '+(nd.cpu_usage*100).toFixed(0)+'% &middot; Mem '+mP.toFixed(0)+'% &middot; '+nd.cpu_cores+' cores</div>';
+          html += '</div>';
+        }
+        html += '</div>';
+      }
+      if (pve.guests && pve.guests.length > 0) {
+        html += '<div style="background:var(--card-bg,#fff);border:1px solid rgba(0,0,0,0.08);border-radius:8px;overflow:hidden">';
+        html += '<table style="width:100%;font-size:12px;border-collapse:collapse">';
+        html += '<tr style="color:#808080;font-size:10px;text-transform:uppercase"><th style="text-align:left;padding:6px 8px;border-bottom:1px solid rgba(0,0,0,0.08)">ID</th><th style="text-align:left;padding:6px 8px;border-bottom:1px solid rgba(0,0,0,0.08)">Name</th><th style="text-align:left;padding:6px 8px;border-bottom:1px solid rgba(0,0,0,0.08)">Type</th><th style="text-align:left;padding:6px 8px;border-bottom:1px solid rgba(0,0,0,0.08)">Status</th><th style="text-align:left;padding:6px 8px;border-bottom:1px solid rgba(0,0,0,0.08)">CPU</th><th style="text-align:left;padding:6px 8px;border-bottom:1px solid rgba(0,0,0,0.08)">Memory</th></tr>';
+        for (var gi = 0; gi < pve.guests.length; gi++) {
+          var g = pve.guests[gi]; var gR = g.status==='running'; var gMP = g.mem_max>0?(g.mem_used/g.mem_max*100).toFixed(0)+'%':'—';
+          html += '<tr><td style="padding:5px 8px;border-bottom:1px solid rgba(0,0,0,0.04);font-family:monospace;font-size:11px">'+g.vmid+'</td>';
+          html += '<td style="padding:5px 8px;border-bottom:1px solid rgba(0,0,0,0.04);font-weight:500">'+escapeHTML(g.name)+'</td>';
+          html += '<td style="padding:5px 8px;border-bottom:1px solid rgba(0,0,0,0.04)">'+(g.type==='qemu'?'VM':'LXC')+'</td>';
+          html += '<td style="padding:5px 8px;border-bottom:1px solid rgba(0,0,0,0.04);color:'+(gR?'#16a34a':'#808080')+';font-weight:600">'+escapeHTML(g.status)+'</td>';
+          html += '<td style="padding:5px 8px;border-bottom:1px solid rgba(0,0,0,0.04)">'+(gR?(g.cpu_usage*100).toFixed(0)+'%':'—')+'</td>';
+          html += '<td style="padding:5px 8px;border-bottom:1px solid rgba(0,0,0,0.04)">'+gMP+'</td></tr>';
+        }
+        html += '</table></div>';
+      }
+      html += '</div>';
+    }
+    html += '</div>'; // end section-block proxmox
+
     // ==== Section: Parity ====
     html += '<div class="section-block" data-section="parity">';
     if (snapshot && snapshot.parity) {
@@ -1399,13 +1434,16 @@ body {
       }).catch(function() {});
   }
 
-  window._findingSevFilters = {};
+  try { window._findingSevFilters = JSON.parse(localStorage.getItem("nas-doctor-sev-filters")) || {}; } catch(e) { window._findingSevFilters = {}; }
   window._toggleSevFilter = function(sev) {
     window._findingSevFilters[sev] = !window._findingSevFilters[sev];
+    if (!window._findingSevFilters[sev]) delete window._findingSevFilters[sev];
+    try { localStorage.setItem("nas-doctor-sev-filters", JSON.stringify(window._findingSevFilters)); } catch(e) {}
     loadData();
   };
   window._clearSevFilters = function() {
     window._findingSevFilters = {};
+    try { localStorage.removeItem("nas-doctor-sev-filters"); } catch(e) {}
     loadData();
   };
 

--- a/internal/api/templates/clean.html
+++ b/internal/api/templates/clean.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>NAS Doctor — Clean</title>
+<title>NAS Doctor</title>
 <link rel="icon" type="image/png" href="/icon.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -1391,7 +1391,7 @@ body {
     var colR = document.getElementById("col-right");
     if (!staging || !colL || !colR) return;
     var sec = (_cachedStatus && _cachedStatus.sections) ? _cachedStatus.sections : {};
-    var sectionMap = { "findings": sec.findings !== false, "drives": sec.disk_space !== false || sec.smart !== false, "docker": sec.docker !== false, "zfs": sec.zfs !== false, "ups": sec.ups !== false, "services": true, "network": sec.network !== false, "parity": sec.parity !== false };
+    var sectionMap = { "findings": sec.findings !== false, "drives": sec.disk_space !== false || sec.smart !== false, "docker": sec.docker !== false, "zfs": sec.zfs !== false, "ups": sec.ups !== false, "services": true, "network": sec.network !== false, "tunnels": sec.tunnels !== false, "proxmox": sec.proxmox !== false, "parity": sec.parity !== false };
     var blocks = staging.querySelectorAll(".section-block");
     if (blocks.length === 0) return;
     var blockMap={};var visibleItems=[];

--- a/internal/api/templates/disk_detail.html
+++ b/internal/api/templates/disk_detail.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Disk Detail — NAS Doctor</title>
+<title>NAS Doctor</title>
 <link rel="icon" type="image/png" href="/icon.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -158,6 +158,7 @@ a:hover{color:var(--accent-hover)}
 </div>
 
 <script>
+fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d.hostname)document.title="NAS Doctor — "+d.hostname;}).catch(function(){});
 /* Theme detection */
 (function(){
   function applyTheme(t){document.body.classList.remove("theme-midnight","theme-clean","theme-ember");document.body.classList.add("theme-"+(t||"midnight"));}

--- a/internal/api/templates/ember.html
+++ b/internal/api/templates/ember.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>NAS Doctor — Ember</title>
+<title>NAS Doctor</title>
 <link rel="icon" type="image/png" href="/icon.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -1805,7 +1805,7 @@ td.mono {
     var colR = document.getElementById("col-right");
     if (!staging || !colL || !colR) return;
     var sec = (_cachedStatus && _cachedStatus.sections) ? _cachedStatus.sections : {};
-    var sectionMap = { "findings": sec.findings !== false, "drives": sec.disk_space !== false || sec.smart !== false, "docker": sec.docker !== false, "zfs": sec.zfs !== false, "ups": sec.ups !== false, "services": true, "network": sec.network !== false, "parity": sec.parity !== false };
+    var sectionMap = { "findings": sec.findings !== false, "drives": sec.disk_space !== false || sec.smart !== false, "docker": sec.docker !== false, "zfs": sec.zfs !== false, "ups": sec.ups !== false, "services": true, "network": sec.network !== false, "tunnels": sec.tunnels !== false, "proxmox": sec.proxmox !== false, "parity": sec.parity !== false };
     var blocks = staging.querySelectorAll(".section-block");
     if (blocks.length === 0) return;
     var blockMap={};var visibleItems=[];

--- a/internal/api/templates/ember.html
+++ b/internal/api/templates/ember.html
@@ -997,7 +997,7 @@ td.mono {
   var _cachedStatus = null;
   var _lastScanTime = null;
   var _wasScanRunning = false;
-  window._findingSevFilters = {};
+  try { window._findingSevFilters = JSON.parse(localStorage.getItem("nas-doctor-sev-filters")) || {}; } catch(e) { window._findingSevFilters = {}; }
 
   // Lightweight status-only poll — only fetches full snapshot when data changes
   function _pollStatus() {
@@ -1650,6 +1650,41 @@ td.mono {
     }
     html += "</div>"; /* section-block tunnels */
 
+    /* ==== Section: Proxmox ==== */
+    html += "<div class=\"section-block\" data-section=\"proxmox\">";
+    var pve = snapshot ? snapshot.proxmox : null;
+    if (pve && pve.connected) {
+      html += "<div class=\"section\" style=\"margin-top:0\"><div class=\"section-title\">Proxmox VE" + (pve.cluster_name ? " &middot; " + esc(pve.cluster_name) : "") + "</div>";
+      if (pve.nodes && pve.nodes.length > 0) {
+        html += "<div style=\"display:flex;gap:8px;flex-wrap:wrap;margin-bottom:12px\">";
+        for (var ni = 0; ni < pve.nodes.length; ni++) {
+          var nd = pve.nodes[ni]; var ndOn = nd.status==="online"; var mP = nd.mem_total>0?(nd.mem_used/nd.mem_total*100):0;
+          html += "<div style=\"background:var(--surface-100);border-radius:12px;box-shadow:var(--shadow-card);padding:10px 14px;flex:1;min-width:200px\">";
+          html += "<div style=\"display:flex;align-items:center;gap:6px;margin-bottom:6px\"><span class=\"status-dot "+(ndOn?"s-green":"s-red")+"\"></span><span style=\"font-weight:600\">" + esc(nd.name) + "</span></div>";
+          html += "<div style=\"font-size:11px;color:var(--text-dim)\">CPU "+(nd.cpu_usage*100).toFixed(0)+"% &middot; Mem "+mP.toFixed(0)+"% &middot; "+nd.cpu_cores+" cores</div>";
+          html += "</div>";
+        }
+        html += "</div>";
+      }
+      if (pve.guests && pve.guests.length > 0) {
+        html += "<div style=\"background:var(--surface-100);border-radius:12px;box-shadow:var(--shadow-card);overflow:hidden\">";
+        html += "<table style=\"width:100%;font-size:12px;border-collapse:collapse\">";
+        html += "<tr style=\"color:var(--text-dim);font-size:10px;text-transform:uppercase\"><th style=\"text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)\">ID</th><th style=\"text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)\">Name</th><th style=\"text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)\">Type</th><th style=\"text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)\">Status</th><th style=\"text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)\">CPU</th><th style=\"text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)\">Memory</th></tr>";
+        for (var gi = 0; gi < pve.guests.length; gi++) {
+          var g = pve.guests[gi]; var gR = g.status==="running"; var gMP = g.mem_max>0?(g.mem_used/g.mem_max*100).toFixed(0)+"%":"\u2014";
+          html += "<tr><td style=\"padding:5px 8px;border-bottom:1px solid var(--border);font-family:var(--font-mono);font-size:11px\">"+g.vmid+"</td>";
+          html += "<td style=\"padding:5px 8px;border-bottom:1px solid var(--border);font-weight:500\">"+esc(g.name)+"</td>";
+          html += "<td style=\"padding:5px 8px;border-bottom:1px solid var(--border)\">"+(g.type==="qemu"?"VM":"LXC")+"</td>";
+          html += "<td style=\"padding:5px 8px;border-bottom:1px solid var(--border);color:"+(gR?"var(--green)":"var(--text-dim)")+";font-weight:600\">"+esc(g.status)+"</td>";
+          html += "<td style=\"padding:5px 8px;border-bottom:1px solid var(--border)\">"+(gR?(g.cpu_usage*100).toFixed(0)+"%":"\u2014")+"</td>";
+          html += "<td style=\"padding:5px 8px;border-bottom:1px solid var(--border)\">"+gMP+"</td></tr>";
+        }
+        html += "</table></div>";
+      }
+      html += "</div>";
+    }
+    html += "</div>"; /* section-block proxmox */
+
     /* ==== Section: Parity ==== */
     html += "<div class=\"section-block\" data-section=\"parity\">";
     if (snapshot && snapshot.parity) {
@@ -1725,10 +1760,13 @@ td.mono {
 
   window._toggleSevFilter = function(sev) {
     window._findingSevFilters[sev] = !window._findingSevFilters[sev];
+    if (!window._findingSevFilters[sev]) delete window._findingSevFilters[sev];
+    try { localStorage.setItem("nas-doctor-sev-filters", JSON.stringify(window._findingSevFilters)); } catch(e) {}
     loadData();
   };
   window._clearSevFilters = function() {
     window._findingSevFilters = {};
+    try { localStorage.removeItem("nas-doctor-sev-filters"); } catch(e) {}
     loadData();
   };
 

--- a/internal/api/templates/fleet.html
+++ b/internal/api/templates/fleet.html
@@ -141,6 +141,9 @@ body{padding:0}
         if(s.info_count>0)h+='<span class="pill-sm info">'+s.info_count+' info</span>';
         h+='</div>';
       }
+      h+='<div style="margin-top:8px;display:flex;gap:6px">';
+      h+='<a href="'+esc(url)+'" target="_blank" style="font-size:11px;color:var(--accent);text-decoration:none" onclick="event.stopPropagation()">Open Dashboard &rarr;</a>';
+      h+='</div>';
     } else {
       h+='<div class="node-meta">';
       h+='<div class="node-meta-row"><span class="meta-label">'+(conn.isLocal?"LAN":"Endpoint")+'</span><span class="meta-val">'+esc(conn.display)+'</span></div>';

--- a/internal/api/templates/fleet.html
+++ b/internal/api/templates/fleet.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>NAS Doctor — Fleet</title>
+<title>NAS Doctor</title>
 <link rel="icon" href="/icon.png">
 <link rel="stylesheet" href="/css/shared.css">
 <style>
@@ -74,6 +74,7 @@ body{padding:0}
   function applyTheme(t){document.body.classList.remove("theme-midnight","theme-clean","theme-ember");document.body.classList.add("theme-"+(t||"midnight"));}
   try{var s=localStorage.getItem("nas-doctor-theme");if(s)applyTheme(s);}catch(e){}
   fetch("/api/v1/settings").then(function(r){return r.json()}).then(function(d){if(d.theme){applyTheme(d.theme);try{localStorage.setItem("nas-doctor-theme",d.theme)}catch(e){}}}).catch(function(){});
+  fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d.hostname)document.title="NAS Doctor — "+d.hostname;}).catch(function(){});
 })();
 (function() {
   "use strict";

--- a/internal/api/templates/fleet.html
+++ b/internal/api/templates/fleet.html
@@ -90,15 +90,29 @@ body{padding:0}
     return{cls:"unknown",icon:"?"};
   }
 
-  function extractIP(url){
-    try{var u=new URL(url);return u.hostname+":"+u.port;}catch(e){return url;}
+  function parseConnection(url){
+    try{
+      var u=new URL(url);
+      var host=u.hostname;
+      var port=u.port?":"+u.port:"";
+      // Detect if local (private IP) vs public hostname
+      var isLocal=/^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|localhost|127\.)/.test(host);
+      var tunnelType="";
+      if(!isLocal){
+        // Heuristic: if it's a public hostname, try to detect tunnel
+        if(host.indexOf(".trycloudflare.com")>=0||host.indexOf("cloudflare")>=0)tunnelType="cfd";
+        // Tailscale IPs are in 100.x.x.x range
+        if(/^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(host))tunnelType="tailscale";
+      }
+      return{host:host,port:port,isLocal:isLocal,tunnelType:tunnelType,display:host+port};
+    }catch(e){return{host:url,port:"",isLocal:false,tunnelType:"",display:url};}
   }
 
   function renderNode(s){
     var healthClass=s.online?(s.overall_health||"healthy"):"offline";
     var p=platformIcon(s.platform||"");
     var url=s.server.url||"#";
-    var ip=extractIP(url);
+    var conn=parseConnection(url);
     var h='<div class="node-branch"></div>';
     h+='<div class="node-card">';
     h+='<a href="'+esc(url)+'" target="_blank">';
@@ -112,7 +126,11 @@ body{padding:0}
       if(s.hostname&&s.hostname!==s.server.name){
         h+='<div class="node-meta-row"><span class="meta-label">Host</span><span class="meta-val">'+esc(s.hostname)+'</span></div>';
       }
-      h+='<div class="node-meta-row"><span class="meta-label">IP</span><span class="meta-val">'+esc(ip)+'</span></div>';
+      h+='<div class="node-meta-row"><span class="meta-label">'+(conn.isLocal?"LAN":"Endpoint")+'</span><span class="meta-val">'+esc(conn.display)+'</span></div>';
+      if(conn.tunnelType){
+        var tLabel=conn.tunnelType==="cfd"?"Cloudflare Tunnel":conn.tunnelType==="tailscale"?"Tailscale":"Tunnel";
+        h+='<div class="node-meta-row"><span class="meta-label">Via</span><span class="meta-val" style="color:var(--accent)">'+esc(tLabel)+'</span></div>';
+      }
       h+='<div class="node-meta-row"><span class="meta-label">OS</span><span class="meta-val">'+esc(s.platform||"unknown")+'</span></div>';
       h+='<div class="node-meta-row"><span class="meta-label">Up</span><span class="meta-val">'+esc(s.uptime||"—")+'</span></div>';
       h+='</div>';
@@ -124,7 +142,10 @@ body{padding:0}
         h+='</div>';
       }
     } else {
-      h+='<div class="node-meta"><div class="node-meta-row"><span class="meta-label">IP</span><span class="meta-val">'+esc(ip)+'</span></div></div>';
+      h+='<div class="node-meta">';
+      h+='<div class="node-meta-row"><span class="meta-label">'+(conn.isLocal?"LAN":"Endpoint")+'</span><span class="meta-val">'+esc(conn.display)+'</span></div>';
+      if(conn.tunnelType){var tl2=conn.tunnelType==="cfd"?"Cloudflare Tunnel":conn.tunnelType==="tailscale"?"Tailscale":"Tunnel";h+='<div class="node-meta-row"><span class="meta-label">Via</span><span class="meta-val" style="color:var(--accent)">'+esc(tl2)+'</span></div>';}
+      h+='</div>';
       h+='<div class="node-error">'+esc(s.error||"Offline")+'</div>';
     }
     h+='</a></div>';
@@ -148,7 +169,17 @@ body{padding:0}
     h+='<div class="node-name">'+esc(selfName)+'</div>';
     h+='<div class="node-role">Primary &middot; Fleet Controller</div>';
     if(selfStatus){
-      h+='<div style="font-size:11px;color:var(--text2);margin-top:6px">'+esc(selfPlatform)+' &middot; Up '+esc(selfStatus.uptime||"—")+'</div>';
+      // Get local IP from network interfaces
+      var selfIP="";
+      if(selfStatus.network&&selfStatus.network.interfaces){
+        for(var ni=0;ni<selfStatus.network.interfaces.length;ni++){
+          var iface=selfStatus.network.interfaces[ni];
+          if(iface.state==="UP"&&iface.ipv4&&iface.ipv4.indexOf("127.")!==0){selfIP=iface.ipv4.split("/")[0];break;}
+        }
+      }
+      h+='<div style="font-size:11px;color:var(--text2);margin-top:6px">';
+      if(selfIP)h+=esc(selfIP)+' &middot; ';
+      h+=esc(selfPlatform)+' &middot; Up '+esc(selfStatus.uptime||"—")+'</div>';
     }
     h+='</div>';
     h+='<div class="topo-spine"></div>';

--- a/internal/api/templates/midnight.html
+++ b/internal/api/templates/midnight.html
@@ -844,9 +844,14 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
     // ======= Section: Proxmox =======
     h += '<div class="section-block" data-section="proxmox">';
     var pve = sn ? sn.proxmox : null;
-    if (pve && pve.connected) {
+    if (pve) {
       h += '<div>';
       h += '<div class="section-title">Proxmox VE' + (pve.cluster_name ? ' &middot; ' + esc(pve.cluster_name) : '') + (pve.version ? ' <span style="font-size:11px;color:var(--text-quaternary);font-weight:400">v' + esc(pve.version) + '</span>' : '') + '</div>';
+      if (pve.error) {
+        h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:12px;color:var(--red);font-size:12px">' + esc(pve.error) + '</div>';
+      } else if (!pve.connected) {
+        h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:12px;color:var(--text-tertiary);font-size:12px">Not connected. Configure API credentials in Settings.</div>';
+      } else {
       // Node cards
       if (pve.nodes && pve.nodes.length > 0) {
         h += '<div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:12px">';
@@ -920,6 +925,7 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
         }
         h += '</div>';
       }
+      } // end else (connected, no error)
       h += '</div>';
     }
     h += '</div>'; // end section-block proxmox

--- a/internal/api/templates/midnight.html
+++ b/internal/api/templates/midnight.html
@@ -841,6 +841,89 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
     }
     h += '</div>'; // end section-block tunnels
 
+    // ======= Section: Proxmox =======
+    h += '<div class="section-block" data-section="proxmox">';
+    var pve = sn ? sn.proxmox : null;
+    if (pve && pve.connected) {
+      h += '<div>';
+      h += '<div class="section-title">Proxmox VE' + (pve.cluster_name ? ' &middot; ' + esc(pve.cluster_name) : '') + (pve.version ? ' <span style="font-size:11px;color:var(--text-quaternary);font-weight:400">v' + esc(pve.version) + '</span>' : '') + '</div>';
+      // Node cards
+      if (pve.nodes && pve.nodes.length > 0) {
+        h += '<div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:12px">';
+        for (var ni = 0; ni < pve.nodes.length; ni++) {
+          var nd = pve.nodes[ni];
+          var ndOnline = nd.status === 'online';
+          var memPct = nd.mem_total > 0 ? (nd.mem_used / nd.mem_total * 100) : 0;
+          var uptStr = nd.uptime > 86400 ? Math.floor(nd.uptime/86400) + 'd' : Math.floor(nd.uptime/3600) + 'h';
+          h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:10px 14px;flex:1;min-width:200px">';
+          h += '<div style="display:flex;align-items:center;gap:6px;margin-bottom:6px">';
+          h += '<span style="width:8px;height:8px;border-radius:50%;background:' + (ndOnline ? 'var(--green)' : 'var(--red)') + '"></span>';
+          h += '<span style="font-weight:600;font-size:13px">' + esc(nd.name) + '</span>';
+          h += '<span style="font-size:11px;color:var(--text-quaternary);margin-left:auto">' + uptStr + '</span>';
+          h += '</div>';
+          h += '<div style="display:flex;gap:12px;font-size:11px;color:var(--text-tertiary)">';
+          h += '<span>CPU ' + (nd.cpu_usage * 100).toFixed(0) + '%</span>';
+          h += '<span>Mem ' + memPct.toFixed(0) + '%</span>';
+          h += '<span>' + nd.cpu_cores + ' cores</span>';
+          h += '</div>';
+          if (nd.cpu_model) h += '<div style="font-size:10px;color:var(--text-quaternary);margin-top:4px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + esc(nd.cpu_model) + '</div>';
+          h += '</div>';
+        }
+        h += '</div>';
+      }
+      // Guest table (VMs + LXCs)
+      if (pve.guests && pve.guests.length > 0) {
+        h += '<div style="font-size:11px;color:var(--text-quaternary);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:6px">Guests (' + pve.guests.length + ')</div>';
+        h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);overflow:hidden">';
+        h += '<table style="width:100%;font-size:12px;border-collapse:collapse">';
+        h += '<tr style="color:var(--text-quaternary);font-size:10px;text-transform:uppercase;letter-spacing:0.5px">';
+        h += '<th style="text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)">ID</th>';
+        h += '<th style="text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)">Name</th>';
+        h += '<th style="text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)">Type</th>';
+        h += '<th style="text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)">Node</th>';
+        h += '<th style="text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)">Status</th>';
+        h += '<th style="text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)">CPU</th>';
+        h += '<th style="text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)">Memory</th>';
+        h += '</tr>';
+        for (var gi = 0; gi < pve.guests.length; gi++) {
+          var g = pve.guests[gi];
+          var gRunning = g.status === 'running';
+          var gMemPct = g.mem_max > 0 ? (g.mem_used / g.mem_max * 100).toFixed(0) + '%' : '—';
+          var gMemStr = g.mem_max > 0 ? (g.mem_max / 1073741824).toFixed(1) + ' GB' : '—';
+          var gType = g.type === 'qemu' ? 'VM' : 'LXC';
+          h += '<tr>';
+          h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border);font-family:var(--font-mono);font-size:11px">' + g.vmid + '</td>';
+          h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border);font-weight:500">' + esc(g.name) + '</td>';
+          h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border)"><span style="font-size:10px;padding:1px 6px;border-radius:999px;background:' + (g.type === 'qemu' ? 'rgba(94,106,210,0.12);color:var(--accent)' : 'rgba(245,158,11,0.12);color:var(--amber)') + '">' + gType + '</span></td>';
+          h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border);font-size:11px;color:var(--text-tertiary)">' + esc(g.node) + '</td>';
+          h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border)"><span style="color:' + (gRunning ? 'var(--green)' : 'var(--text-quaternary)') + ';font-weight:600">' + esc(g.status) + '</span></td>';
+          h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border);font-size:11px">' + (gRunning ? (g.cpu_usage * 100).toFixed(0) + '%' : '—') + '</td>';
+          h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border);font-size:11px">' + (gRunning ? gMemPct + ' / ' + gMemStr : gMemStr) + '</td>';
+          h += '</tr>';
+        }
+        h += '</table></div>';
+      }
+      // Storage pools
+      if (pve.storage && pve.storage.length > 0) {
+        h += '<div style="font-size:11px;color:var(--text-quaternary);text-transform:uppercase;letter-spacing:0.5px;margin:12px 0 6px">Storage Pools (' + pve.storage.length + ')</div>';
+        h += '<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:6px">';
+        for (var si = 0; si < pve.storage.length; si++) {
+          var st = pve.storage[si];
+          var stPct = st.used_pct || 0;
+          var stColor = stPct >= 90 ? 'var(--red)' : stPct >= 75 ? 'var(--amber)' : 'var(--green)';
+          var stTotal = st.total > 1099511627776 ? (st.total / 1099511627776).toFixed(1) + ' TB' : (st.total / 1073741824).toFixed(0) + ' GB';
+          h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:var(--radius);padding:8px 10px">';
+          h += '<div style="display:flex;justify-content:space-between;font-size:12px;margin-bottom:4px"><span style="font-weight:500">' + esc(st.storage) + '</span><span style="color:var(--text-quaternary);font-size:10px">' + esc(st.node) + ' &middot; ' + esc(st.type) + '</span></div>';
+          h += '<div style="height:4px;background:var(--border);border-radius:2px;overflow:hidden"><div style="height:100%;width:' + stPct.toFixed(1) + '%;background:' + stColor + ';border-radius:2px"></div></div>';
+          h += '<div style="display:flex;justify-content:space-between;font-size:10px;color:var(--text-quaternary);margin-top:3px"><span>' + stPct.toFixed(0) + '% used</span><span>' + stTotal + '</span></div>';
+          h += '</div>';
+        }
+        h += '</div>';
+      }
+      h += '</div>';
+    }
+    h += '</div>'; // end section-block proxmox
+
     // ======= Section: Parity =======
     h += '<div class="section-block" data-section="parity">';
     var parity = sn ? sn.parity : null;
@@ -973,13 +1056,17 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
     initSortBars();
   }
 
-  window._findingSevFilters = {};
+  // Restore persisted severity filters
+  try { window._findingSevFilters = JSON.parse(localStorage.getItem("nas-doctor-sev-filters")) || {}; } catch(e) { window._findingSevFilters = {}; }
   window._toggleSevFilter = function(sev) {
     window._findingSevFilters[sev] = !window._findingSevFilters[sev];
+    if (!window._findingSevFilters[sev]) delete window._findingSevFilters[sev];
+    try { localStorage.setItem("nas-doctor-sev-filters", JSON.stringify(window._findingSevFilters)); } catch(e) {}
     render(); distributeSections();
   };
   window._clearSevFilters = function() {
     window._findingSevFilters = {};
+    try { localStorage.removeItem("nas-doctor-sev-filters"); } catch(e) {}
     render(); distributeSections();
   };
 

--- a/internal/api/templates/midnight.html
+++ b/internal/api/templates/midnight.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>NAS Doctor — Midnight</title>
+<title>NAS Doctor</title>
 <link rel="icon" type="image/png" href="/icon.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -1029,6 +1029,8 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
       "ups": sec.ups !== false,
       "services": true,
       "network": sec.network !== false,
+      "tunnels": sec.tunnels !== false,
+      "proxmox": sec.proxmox !== false,
       "parity": sec.parity !== false
     };
 

--- a/internal/api/templates/midnight.html
+++ b/internal/api/templates/midnight.html
@@ -846,7 +846,8 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
     var pve = sn ? sn.proxmox : null;
     if (pve) {
       h += '<div>';
-      h += '<div class="section-title">Proxmox VE' + (pve.cluster_name ? ' &middot; ' + esc(pve.cluster_name) : '') + (pve.version ? ' <span style="font-size:11px;color:var(--text-quaternary);font-weight:400">v' + esc(pve.version) + '</span>' : '') + '</div>';
+      var pveTitle = pve.alias ? esc(pve.alias) : 'Proxmox VE';
+      h += '<div class="section-title">' + pveTitle + (pve.cluster_name ? ' &middot; ' + esc(pve.cluster_name) : '') + (pve.version ? ' <span style="font-size:11px;color:var(--text-quaternary);font-weight:400">v' + esc(pve.version) + '</span>' : '') + '</div>';
       if (pve.error) {
         h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:12px;color:var(--red);font-size:12px">' + esc(pve.error) + '</div>';
       } else if (!pve.connected) {

--- a/internal/api/templates/parity.html
+++ b/internal/api/templates/parity.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>NAS Doctor — Parity History</title>
+<title>NAS Doctor</title>
 <link rel="icon" type="image/png" href="/icon.png">
 <link rel="stylesheet" href="/css/shared.css">
 <style>
@@ -68,6 +68,7 @@
   function applyTheme(t){document.body.classList.remove("theme-midnight","theme-clean","theme-ember");document.body.classList.add("theme-"+(t||"midnight"));}
   try{var s=localStorage.getItem("nas-doctor-theme");if(s)applyTheme(s);}catch(e){}
   fetch("/api/v1/settings").then(function(r){return r.json()}).then(function(d){if(d.theme){applyTheme(d.theme);try{localStorage.setItem("nas-doctor-theme",d.theme)}catch(e){}}}).catch(function(){});
+  fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d.hostname)document.title="NAS Doctor — "+d.hostname;}).catch(function(){});
 })();
 (function(){
   "use strict";

--- a/internal/api/templates/service_checks.html
+++ b/internal/api/templates/service_checks.html
@@ -52,6 +52,19 @@
 .pagination button:disabled{opacity:0.4;cursor:default}
 .pagination button:not(:disabled):hover{border-color:var(--accent)}
 .actions-bar{display:flex;justify-content:flex-end;gap:8px;margin-bottom:16px}
+/* Expandable log detail */
+.log-table tr{cursor:pointer}
+.log-table tr:hover{background:var(--bg-elevated)}
+.log-detail-row td{padding:0!important;border-bottom:1px solid var(--border)}
+.log-detail{padding:12px 16px;background:var(--bg-elevated);font-size:12px;display:none}
+.log-detail.open{display:block}
+.log-detail-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:8px}
+.log-detail-item{padding:6px 8px;background:var(--surface);border-radius:var(--radius);border:1px solid var(--border)}
+.log-detail-item .ld-label{font-size:10px;color:var(--text3);text-transform:uppercase;letter-spacing:0.3px}
+.log-detail-item .ld-val{font-size:13px;font-weight:600;margin-top:2px}
+/* Orphan badge */
+.orphan-badge{font-size:9px;padding:1px 6px;border-radius:999px;background:rgba(217,119,6,0.12);color:var(--amber);margin-left:6px}
+.btn-delete-check{font-size:10px;padding:2px 8px;border:1px solid var(--border);border-radius:var(--radius);background:var(--surface);color:var(--red);cursor:pointer;margin-left:auto}
 </style>
 </head>
 <body>
@@ -128,6 +141,7 @@
   "use strict";
   var PAGE_SIZE=25;
   var checksData=[];       // latest status per check (deduplicated)
+  var configuredKeys={};   // keys from settings (non-orphaned)
   var historyCache={};     // key -> history[]
   var allLogs=[];          // merged+filtered log entries for the table
   var currentPage=0;
@@ -185,10 +199,12 @@
       h+='<span class="pill '+pillClass(c.type)+'" style="font-size:9px;padding:1px 5px">'+esc((c.type||"").toUpperCase())+'</span>';
       h+='</div>';
       h+=buildHeartbeat(hist);
+      var isOrphan = !configuredKeys[c.key] && !configuredKeys[(c.name||"").toLowerCase()];
       h+='<div class="badge-meta" style="margin-top:6px">';
       h+='<span class="badge-pct '+pctCls+'">'+pct.toFixed(1)+'%</span>';
       h+='<span>'+(isUp?(c.response_ms||0)+'ms':'DOWN')+'</span>';
       if(c.interval_sec)h+='<span>every '+fmtInterval(c.interval_sec)+'</span>';
+      if(isOrphan)h+='<span class="orphan-badge">orphaned</span><button class="btn-delete-check" onclick="event.stopPropagation();deleteCheck(\''+esc(c.key)+'\')">Delete</button>';
       h+='</div>';
       h+='</div>';
     }
@@ -244,20 +260,45 @@
     for(var i=start;i<end;i++){
       var e=allLogs[i];
       var ts=e.checked_at?new Date(e.checked_at).toLocaleString():"—";
-      h+='<tr>';
+      var rid="log-detail-"+i;
+      h+='<tr onclick="toggleLogDetail(\''+rid+'\')">';
       h+='<td>'+esc(ts)+'</td>';
-      h+='<td style="display:flex;align-items:center;gap:5px">'+faviconHTML(e.type,e.target)+esc(e.name||"—")+'</td>';
+      h+='<td>'+faviconHTML(e.type,e.target)+esc(e.name||"—")+'</td>';
       h+='<td><span class="pill '+pillClass(e.type)+'" style="font-size:9px;padding:1px 5px">'+esc((e.type||"").toUpperCase())+'</span></td>';
       h+='<td class="status-'+e.status+'">'+esc(e.status)+'</td>';
       h+='<td>'+(e.response_ms!=null?e.response_ms+' ms':'—')+'</td>';
       h+='<td style="color:var(--text3);max-width:250px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">'+esc(e.error||"—")+'</td>';
       h+='</tr>';
+      // Expandable detail row
+      h+='<tr class="log-detail-row"><td colspan="6"><div class="log-detail" id="'+rid+'">';
+      h+='<div class="log-detail-grid">';
+      h+='<div class="log-detail-item"><div class="ld-label">Check Name</div><div class="ld-val">'+esc(e.name||"—")+'</div></div>';
+      h+='<div class="log-detail-item"><div class="ld-label">Type</div><div class="ld-val">'+esc((e.type||"").toUpperCase())+'</div></div>';
+      h+='<div class="log-detail-item"><div class="ld-label">Target</div><div class="ld-val" style="font-size:11px;font-family:var(--font-mono);word-break:break-all">'+esc(e.target||"—")+'</div></div>';
+      h+='<div class="log-detail-item"><div class="ld-label">Status</div><div class="ld-val" style="color:'+(e.status==="up"?"var(--green)":"var(--red)")+'">'+esc(e.status||"—")+'</div></div>';
+      h+='<div class="log-detail-item"><div class="ld-label">Response Time</div><div class="ld-val">'+(e.response_ms!=null?e.response_ms+' ms':'—')+'</div></div>';
+      h+='<div class="log-detail-item"><div class="ld-label">Checked At</div><div class="ld-val" style="font-size:11px">'+esc(ts)+'</div></div>';
+      h+='<div class="log-detail-item"><div class="ld-label">Consecutive Failures</div><div class="ld-val">'+(e.consecutive_failures||0)+' / '+(e.failure_threshold||1)+'</div></div>';
+      h+='<div class="log-detail-item"><div class="ld-label">Check Key</div><div class="ld-val" style="font-size:10px;font-family:var(--font-mono);word-break:break-all;color:var(--text3)">'+esc(e.key||"—")+'</div></div>';
+      if(e.error)h+='<div class="log-detail-item" style="grid-column:1/-1"><div class="ld-label">Error</div><div class="ld-val" style="font-size:12px;color:var(--red);font-weight:400;word-break:break-all">'+esc(e.error)+'</div></div>';
+      // Type-specific details
+      if((e.type||"").toLowerCase()==="http"){
+        h+='<div class="log-detail-item"><div class="ld-label">Expected Status</div><div class="ld-val">'+(e.expected_status_min||200)+' – '+(e.expected_status_max||399)+'</div></div>';
+      }
+      if((e.type||"").toLowerCase()==="dns"){
+        h+='<div class="log-detail-item"><div class="ld-label">DNS Lookup</div><div class="ld-val">'+esc(e.target||"")+'</div></div>';
+      }
+      if((e.type||"").toLowerCase()==="ping"){
+        h+='<div class="log-detail-item"><div class="ld-label">RTT</div><div class="ld-val">'+(e.response_ms||0)+' ms</div></div>';
+      }
+      h+='</div></div></td></tr>';
     }
     tbody.innerHTML=h;
   }
 
   window.prevPage=function(){if(currentPage>0){currentPage--;renderLogTable();}};
   window.nextPage=function(){currentPage++;renderLogTable();};
+  window.toggleLogDetail=function(id){var el=document.getElementById(id);if(el)el.classList.toggle("open");};
 
   window.filterByCheck=function(key){
     var sel=document.getElementById("f-check");
@@ -269,6 +310,11 @@
 
   window.runAllChecks=function(){
     fetch("/api/v1/service-checks/run",{method:"POST"}).then(function(){setTimeout(loadAll,2000);}).catch(function(){});
+  };
+
+  window.deleteCheck=function(key){
+    if(!confirm("Delete all history for this orphaned check?"))return;
+    fetch("/api/v1/service-checks/"+encodeURIComponent(key),{method:"DELETE"}).then(function(){loadAll();}).catch(function(){});
   };
 
   // ── Data loading ──
@@ -292,10 +338,11 @@
       return fetchJSON("/api/v1/settings");
     }).then(function(settings){
       var cfgChecks=(settings.service_checks&&settings.service_checks.checks)||[];
-      var cfgMap={};for(var i=0;i<cfgChecks.length;i++){cfgMap[cfgChecks[i].name.toLowerCase()]=cfgChecks[i];}
+      configuredKeys={};
+      var cfgMap={};for(var i=0;i<cfgChecks.length;i++){cfgMap[cfgChecks[i].name.toLowerCase()]=cfgChecks[i];configuredKeys[cfgChecks[i].name.toLowerCase()]=true;}
       for(var i=0;i<checksData.length;i++){
         var cfg=cfgMap[(checksData[i].name||"").toLowerCase()];
-        if(cfg)checksData[i].interval_sec=cfg.interval_sec||300;
+        if(cfg){checksData[i].interval_sec=cfg.interval_sec||300;configuredKeys[checksData[i].key]=true;}
       }
       renderSummary();
       populateCheckFilter();

--- a/internal/api/templates/service_checks.html
+++ b/internal/api/templates/service_checks.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>NAS Doctor — Service Checks</title>
+<title>NAS Doctor</title>
 <link rel="icon" type="image/png" href="/icon.png">
 <link rel="stylesheet" href="/css/shared.css">
 <style>
@@ -136,6 +136,7 @@
   function applyTheme(t){document.body.classList.remove("theme-midnight","theme-clean","theme-ember");document.body.classList.add("theme-"+(t||"midnight"));}
   try{var s=localStorage.getItem("nas-doctor-theme");if(s)applyTheme(s);}catch(e){}
   fetch("/api/v1/settings").then(function(r){return r.json()}).then(function(d){if(d.theme){applyTheme(d.theme);try{localStorage.setItem("nas-doctor-theme",d.theme)}catch(e){}}}).catch(function(){});
+  fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d.hostname)document.title="NAS Doctor — "+d.hostname;}).catch(function(){});
 })();
 (function(){
   "use strict";

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -598,17 +598,37 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
     <div class="card-title">Fleet Monitoring</div>
     <div class="card-desc">Monitor multiple NAS Doctor instances from this dashboard. Supports private IPs and public hostnames (with custom auth headers for Cloudflare Access, etc.).</div>
     <div id="fleet-list" style="margin-bottom:12px"></div>
-    <div style="display:flex;gap:8px;flex-wrap:wrap">
-      <input type="text" id="fleet-name" placeholder="Server name" style="flex:1;min-width:120px">
-      <input type="url" id="fleet-url" placeholder="http://192.168.1.50:8060 or https://nas.example.com" style="flex:2;min-width:200px">
-      <input type="password" id="fleet-apikey" placeholder="API Key (optional)" style="flex:1;min-width:100px">
-      <button class="btn-secondary" onclick="addFleetServer()">Add</button>
+    <!-- Add/Edit form -->
+    <div class="webhook-form" id="fleet-form">
+      <input type="hidden" id="fleet-edit-index" value="-1">
+      <div class="form-row">
+        <div><label for="fleet-name">Server Name</label>
+          <input type="text" id="fleet-name" placeholder="e.g. Backup NAS"></div>
+        <div><label for="fleet-url">URL</label>
+          <input type="url" id="fleet-url" placeholder="http://192.168.1.50:8060 or https://nas.example.com"></div>
+      </div>
+      <div class="form-row">
+        <div><label for="fleet-apikey">API Key (optional)</label>
+          <input type="password" id="fleet-apikey" placeholder="Leave blank if not needed"></div>
+      </div>
+      <div class="form-group">
+        <label for="fleet-headers">Custom Headers (optional — for CF Access, auth proxies)</label>
+        <textarea id="fleet-headers" rows="2" placeholder="CF-Access-Client-Id: xxxxx&#10;CF-Access-Client-Secret: xxxxx" style="width:100%;font-size:12px;font-family:var(--font-mono);padding:8px;border:1px solid var(--border);border-radius:var(--radius);background:var(--input-bg);color:var(--text);resize:vertical"></textarea>
+      </div>
+      <div style="display:flex;align-items:center;gap:12px">
+        <button class="btn btn-primary" onclick="saveFleetServerForm()">Save</button>
+        <button class="btn btn-secondary" onclick="cancelFleetForm()">Cancel</button>
+        <button class="btn btn-secondary btn-sm" onclick="testFleetFromForm()">Test</button>
+        <span id="fleet-test-result" style="font-size:12px"></span>
+      </div>
     </div>
-    <div style="margin-top:8px">
-      <label for="fleet-headers" style="font-size:11px;color:var(--text2)">Custom Headers (for CF Access, auth proxies — format: <code style="font-size:10px;background:var(--input-bg);padding:1px 4px;border-radius:3px">Key:Value</code>, one per line)</label>
-      <textarea id="fleet-headers" rows="2" placeholder="CF-Access-Client-Id: xxxxx&#10;CF-Access-Client-Secret: xxxxx" style="width:100%;font-size:12px;font-family:var(--font-mono);margin-top:4px;padding:8px;border:1px solid var(--border);border-radius:var(--radius);background:var(--input-bg);color:var(--text);resize:vertical"></textarea>
+    <div style="display:flex;align-items:center;gap:8px;margin-top:8px">
+      <button class="btn btn-secondary btn-sm" onclick="toggleFleetForm()" style="display:inline-flex;align-items:center;gap:4px">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        Add Server
+      </button>
+      <a href="/fleet" style="color:var(--accent);font-size:13px;margin-left:auto">Open Fleet Dashboard &rarr;</a>
     </div>
-    <div style="margin-top:8px"><a href="/fleet" style="color:var(--accent);font-size:13px">Open Fleet Dashboard &rarr;</a></div>
   </div>
 
   <!-- 7. Dashboard Sections -->
@@ -1550,12 +1570,20 @@ function renderFleetList() {
   for (var i = 0; i < fleetServers.length; i++) {
     var s = fleetServers[i];
     var hdrs = s.headers ? Object.keys(s.headers).length : 0;
-    h += '<div style="display:flex;align-items:center;gap:8px;padding:8px 0;border-bottom:1px solid var(--border)">';
-    h += '<span style="font-weight:500;flex:1">' + escapeHtml(s.name || 'Server ' + (i+1)) + '</span>';
-    h += '<span style="font-size:12px;color:var(--text2);flex:2;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + escapeHtml(s.url || '') + '</span>';
-    if (hdrs > 0) h += '<span style="font-size:10px;padding:1px 6px;border-radius:999px;background:rgba(94,106,210,0.12);color:var(--accent)">' + hdrs + ' header' + (hdrs>1?'s':'') + '</span>';
-    if (s.api_key) h += '<span style="font-size:10px;padding:1px 6px;border-radius:999px;background:rgba(39,166,68,0.12);color:var(--green)">auth</span>';
-    h += '<button class="btn-danger" onclick="removeFleetServer(' + i + ')" style="padding:4px 10px;font-size:11px">Remove</button>';
+    h += '<div class="webhook-item">';
+    h += '<div class="webhook-info">';
+    h += '<div class="webhook-name">' + escapeHtml(s.name || 'Server ' + (i+1)) + '</div>';
+    h += '<div class="webhook-url">' + escapeHtml(s.url || '') + '</div>';
+    var tags = [];
+    if (hdrs > 0) tags.push(hdrs + ' header' + (hdrs>1?'s':''));
+    if (s.api_key) tags.push('API key');
+    if (tags.length) h += '<div class="inline-muted">' + escapeHtml(tags.join(' · ')) + '</div>';
+    h += '</div>';
+    h += '<div class="webhook-actions">';
+    h += '<button class="btn btn-secondary btn-sm" onclick="testFleetServer(' + i + ')">Test</button>';
+    h += '<button class="btn btn-secondary btn-sm" onclick="editFleetServer(' + i + ')">Edit</button>';
+    h += '<button class="btn btn-danger btn-sm" onclick="removeFleetServer(' + i + ')">Remove</button>';
+    h += '</div>';
     h += '</div>';
   }
   el.innerHTML = h;
@@ -1571,24 +1599,96 @@ function parseHeadersTextarea() {
   });
   return Object.keys(headers).length > 0 ? headers : null;
 }
-function addFleetServer() {
-  var name = document.getElementById("fleet-name").value.trim();
-  var url = document.getElementById("fleet-url").value.trim();
-  var apikey = document.getElementById("fleet-apikey").value.trim();
-  if (!name || !url) { showToast("Name and URL required", "error"); return; }
-  var server = { id: "", name: name, url: url, enabled: true };
-  if (apikey) server.api_key = apikey;
-  var headers = parseHeadersTextarea();
-  if (headers) server.headers = headers;
-  fleetServers.push(server);
-  saveFleetServers();
+function headersToText(hdrs) {
+  if (!hdrs) return "";
+  var lines = [];
+  for (var k in hdrs) lines.push(k + ": " + hdrs[k]);
+  return lines.join("\n");
+}
+function toggleFleetForm() {
+  var form = document.getElementById("fleet-form");
+  if (form.classList.contains("visible")) { cancelFleetForm(); return; }
+  document.getElementById("fleet-edit-index").value = "-1";
   document.getElementById("fleet-name").value = "";
   document.getElementById("fleet-url").value = "";
   document.getElementById("fleet-apikey").value = "";
   document.getElementById("fleet-headers").value = "";
+  document.getElementById("fleet-test-result").textContent = "";
+  form.classList.add("visible");
+}
+function editFleetServer(idx) {
+  var s = fleetServers[idx];
+  document.getElementById("fleet-edit-index").value = String(idx);
+  document.getElementById("fleet-name").value = s.name || "";
+  document.getElementById("fleet-url").value = s.url || "";
+  document.getElementById("fleet-apikey").value = s.api_key || "";
+  document.getElementById("fleet-headers").value = headersToText(s.headers);
+  document.getElementById("fleet-test-result").textContent = "";
+  document.getElementById("fleet-form").classList.add("visible");
+}
+function cancelFleetForm() {
+  document.getElementById("fleet-form").classList.remove("visible");
+}
+function saveFleetServerForm() {
+  var name = document.getElementById("fleet-name").value.trim();
+  var url = document.getElementById("fleet-url").value.trim();
+  if (!name || !url) { showToast("Name and URL required", "error"); return; }
+  var server = { id: "", name: name, url: url, enabled: true };
+  var apikey = document.getElementById("fleet-apikey").value.trim();
+  if (apikey) server.api_key = apikey;
+  var headers = parseHeadersTextarea();
+  if (headers) server.headers = headers;
+  var editIdx = parseInt(document.getElementById("fleet-edit-index").value, 10);
+  if (editIdx >= 0 && editIdx < fleetServers.length) {
+    server.id = fleetServers[editIdx].id;
+    server.enabled = fleetServers[editIdx].enabled;
+    fleetServers[editIdx] = server;
+  } else {
+    fleetServers.push(server);
+  }
+  saveFleetServers();
+  cancelFleetForm();
+}
+function testFleetFromForm() {
+  var url = document.getElementById("fleet-url").value.trim();
+  var apikey = document.getElementById("fleet-apikey").value.trim();
+  var headers = parseHeadersTextarea();
+  _doFleetTest(url, apikey, headers, document.getElementById("fleet-test-result"));
+}
+function testFleetServer(idx) {
+  var s = fleetServers[idx];
+  var resultEl = document.createElement("span");
+  resultEl.style.fontSize = "12px";
+  resultEl.textContent = "Testing...";
+  resultEl.style.color = "var(--text2)";
+  var row = document.getElementById("fleet-list").children[idx];
+  if (row) { var existing = row.querySelector(".fleet-test-inline"); if(existing) existing.remove(); resultEl.className = "fleet-test-inline"; row.querySelector(".webhook-info").appendChild(resultEl); }
+  _doFleetTest(s.url, s.api_key, s.headers, resultEl);
+}
+function _doFleetTest(url, apikey, headers, resultEl) {
+  if (!url) { resultEl.textContent = "URL required"; resultEl.style.color = "var(--red)"; return; }
+  resultEl.textContent = "Testing...";
+  resultEl.style.color = "var(--text2)";
+  fetch("/api/v1/fleet/test", {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({ url: url, api_key: apikey || "", headers: headers || {} })
+  })
+  .then(function(r) { return r.json(); })
+  .then(function(d) {
+    if (d.success) {
+      resultEl.style.color = "var(--green)";
+      resultEl.textContent = "Connected — " + (d.version || "NAS Doctor") + " · " + (d.uptime || "");
+    } else {
+      resultEl.style.color = "var(--red)";
+      resultEl.textContent = "Failed: " + (d.error || "unknown");
+    }
+  })
+  .catch(function(e) { resultEl.style.color = "var(--red)"; resultEl.textContent = "Error: " + e.message; });
 }
 
 function removeFleetServer(idx) {
+  if (!confirm("Remove this server from the fleet?")) return;
   fleetServers.splice(idx, 1);
   saveFleetServers();
 }

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -1018,7 +1018,7 @@ function buildSettingsPayload() {
       keep_count: parseInt(document.getElementById("backup-keep").value, 10) || 4,
       interval_hours: getBackupIntervalH()
     },
-    fleet: base.fleet || [],
+    fleet: fleetServers || base.fleet || [],
     dismissed_findings: base.dismissed_findings || []
   };
 }

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -504,6 +504,10 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
       <div><label for="pve-secret">Token Secret</label>
         <input type="password" id="pve-secret" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"></div>
     </div>
+    <div style="margin-top:12px;display:flex;align-items:center;gap:12px">
+      <button class="btn btn-secondary btn-sm" onclick="testProxmoxConnection()">Test Connection</button>
+      <span id="pve-test-result" style="font-size:12px"></span>
+    </div>
   </div>
 
   <!-- 5. Log Forwarding -->
@@ -2006,6 +2010,35 @@ function addPreset(preset) {
 }
 
 // Load snapshot for target dropdowns
+function testProxmoxConnection() {
+  var result = document.getElementById("pve-test-result");
+  result.textContent = "Testing...";
+  result.style.color = "var(--text2)";
+  fetch("/api/v1/proxmox/test", {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({
+      url: document.getElementById("pve-url").value.trim(),
+      token_id: document.getElementById("pve-token").value.trim(),
+      secret: document.getElementById("pve-secret").value.trim()
+    })
+  })
+  .then(function(r) { return r.json(); })
+  .then(function(d) {
+    if (d.success) {
+      result.style.color = "var(--green)";
+      result.textContent = "Connected — PVE " + (d.version || "?") + (d.cluster ? " · cluster: " + d.cluster : "") + " · " + d.nodes + " node(s), " + d.guests + " guest(s), " + d.storage + " storage pool(s)";
+    } else {
+      result.style.color = "var(--red)";
+      result.textContent = "Failed: " + (d.error || "unknown error");
+    }
+  })
+  .catch(function(e) {
+    result.style.color = "var(--red)";
+    result.textContent = "Error: " + e.message;
+  });
+}
+
 function loadSnapshotForTargets() {
   fetch("/api/v1/snapshot/latest").then(function(r){return r.json()}).then(function(d){_snapshotCache=d;}).catch(function(){});
 }

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -404,6 +404,13 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
           </select>
         </div>
       </div>
+      <div class="form-row" id="sc-instance-wrap" style="display:none">
+        <div>
+          <label for="sc-instance">Instance</label>
+          <select id="sc-instance"><option value="">This server (local)</option></select>
+          <p style="font-size:11px;color:var(--text2);margin-top:4px">Run this check from a fleet member instead of locally.</p>
+        </div>
+      </div>
       <div class="form-row">
         <div>
           <label for="sc-target">Target</label>
@@ -580,13 +587,17 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
   <!-- 6. Fleet / Multi-Server -->
   <div class="card" id="card-fleet">
     <div class="card-title">Fleet Monitoring</div>
-    <div class="card-desc">Monitor multiple NAS Doctor instances from this dashboard. Each remote server must be running NAS Doctor.</div>
+    <div class="card-desc">Monitor multiple NAS Doctor instances from this dashboard. Supports private IPs and public hostnames (with custom auth headers for Cloudflare Access, etc.).</div>
     <div id="fleet-list" style="margin-bottom:12px"></div>
     <div style="display:flex;gap:8px;flex-wrap:wrap">
       <input type="text" id="fleet-name" placeholder="Server name" style="flex:1;min-width:120px">
-      <input type="url" id="fleet-url" placeholder="http://192.168.1.50:8080" style="flex:2;min-width:200px">
-      <input type="password" id="fleet-apikey" placeholder="API Key (optional)" style="flex:1;min-width:120px">
-      <button class="btn-secondary" onclick="addFleetServer()">Add Server</button>
+      <input type="url" id="fleet-url" placeholder="http://192.168.1.50:8060 or https://nas.example.com" style="flex:2;min-width:200px">
+      <input type="password" id="fleet-apikey" placeholder="API Key (optional)" style="flex:1;min-width:100px">
+      <button class="btn-secondary" onclick="addFleetServer()">Add</button>
+    </div>
+    <div style="margin-top:8px">
+      <label for="fleet-headers" style="font-size:11px;color:var(--text2)">Custom Headers (for CF Access, auth proxies — format: <code style="font-size:10px;background:var(--input-bg);padding:1px 4px;border-radius:3px">Key:Value</code>, one per line)</label>
+      <textarea id="fleet-headers" rows="2" placeholder="CF-Access-Client-Id: xxxxx&#10;CF-Access-Client-Secret: xxxxx" style="width:100%;font-size:12px;font-family:var(--font-mono);margin-top:4px;padding:8px;border:1px solid var(--border);border-radius:var(--radius);background:var(--input-bg);color:var(--text);resize:vertical"></textarea>
     </div>
     <div style="margin-top:8px"><a href="/fleet" style="color:var(--accent);font-size:13px">Open Fleet Dashboard &rarr;</a></div>
   </div>
@@ -886,6 +897,26 @@ function loadSettings() {
       /* Service checks */
       serviceChecks = (data.service_checks && data.service_checks.checks) ? data.service_checks.checks : [];
       renderServiceChecks();
+      /* Dashboard section toggles */
+      var sec = data.sections || {};
+      var secMap = {findings:1,disk_space:1,smart:1,docker:1,zfs:1,ups:1,parity:1,network:1,tunnels:1,proxmox:1,merged_drives:1};
+      var secIds = {"findings":"sec-findings","disk_space":"sec-disk","smart":"sec-smart","docker":"sec-docker","zfs":"sec-zfs","ups":"sec-ups","parity":"sec-parity","network":"sec-network","tunnels":"sec-tunnels","proxmox":"sec-proxmox","merged_drives":"sec-merged-drives"};
+      for (var sk in secIds) { var el = document.getElementById(secIds[sk]); if (el) { if (sec[sk] === false) el.classList.remove("on"); else el.classList.add("on"); } }
+      /* Proxmox VE */
+      var pve = data.proxmox || {};
+      if (pve.enabled) document.getElementById("pve-toggle").classList.add("on"); else document.getElementById("pve-toggle").classList.remove("on");
+      document.getElementById("pve-url").value = pve.url || "";
+      document.getElementById("pve-node").value = pve.node_name || "";
+      document.getElementById("pve-token").value = pve.token_id || "";
+      document.getElementById("pve-secret").value = pve.secret || "";
+      /* Log forwarding */
+      var lp = data.log_push || {};
+      if (lp.enabled) document.getElementById("logfwd-toggle").classList.add("on"); else document.getElementById("logfwd-toggle").classList.remove("on");
+      logFwdDests = lp.destinations || [];
+      renderLogFwdDests();
+      /* Notification Rules */
+      notifRules = (data.notifications && data.notifications.rules) ? data.notifications.rules : [];
+      renderRules();
     })
     .catch(function(e) { showToast("Failed to load settings: " + e, "error"); });
 }
@@ -1154,6 +1185,17 @@ function serviceTypePillClass(t) {
   return "pill-http";
 }
 
+function populateInstanceSelector() {
+  var sel = document.getElementById("sc-instance");
+  var wrap = document.getElementById("sc-instance-wrap");
+  if (!sel || !wrap) return;
+  sel.innerHTML = '<option value="">This server (local)</option>';
+  for (var i = 0; i < fleetServers.length; i++) {
+    var s = fleetServers[i];
+    sel.innerHTML += '<option value="' + escapeHtml(s.id || s.name) + '">' + escapeHtml(s.name) + ' (' + escapeHtml(s.url) + ')</option>';
+  }
+  wrap.style.display = fleetServers.length > 0 ? '' : 'none';
+}
 function renderServiceChecks() {
   var container = document.getElementById("service-check-list");
   if (!container) return;
@@ -1201,6 +1243,7 @@ function toggleServiceCheckForm() {
   document.getElementById("sc-type").value = "http";
   document.getElementById("sc-target").value = "";
   document.getElementById("sc-port").value = "";
+  document.getElementById("sc-instance").value = "";
   document.getElementById("sc-interval").value = "300";
   document.getElementById("sc-timeout").value = "5";
   document.getElementById("sc-threshold").value = "1";
@@ -1208,6 +1251,7 @@ function toggleServiceCheckForm() {
   document.getElementById("sc-http-min").value = "200";
   document.getElementById("sc-http-max").value = "399";
   setServiceCheckEnabledUI(true);
+  populateInstanceSelector();
   onServiceTypeChange();
   form.classList.add("visible");
 }
@@ -1242,6 +1286,8 @@ function editServiceCheck(idx) {
   document.getElementById("sc-type").value = sc.type;
   document.getElementById("sc-target").value = sc.target;
   document.getElementById("sc-port").value = sc.port > 0 ? String(sc.port) : "";
+  populateInstanceSelector();
+  document.getElementById("sc-instance").value = sc.instance || "";
   document.getElementById("sc-interval").value = String(sc.interval_sec || 300);
   document.getElementById("sc-timeout").value = String(sc.timeout_sec || 5);
   document.getElementById("sc-threshold").value = String(sc.failure_threshold || 1);
@@ -1270,6 +1316,7 @@ function saveServiceCheck() {
     type: type,
     target: target,
     enabled: document.getElementById("sc-enabled").checked,
+    instance: document.getElementById("sc-instance").value || "",
     interval_sec: parseInt(document.getElementById("sc-interval").value, 10) || 300,
     timeout_sec: parseInt(document.getElementById("sc-timeout").value, 10) || 5,
     port: parseInt(document.getElementById("sc-port").value, 10) || 0,
@@ -1484,15 +1531,28 @@ function renderFleetList() {
   var h = '';
   for (var i = 0; i < fleetServers.length; i++) {
     var s = fleetServers[i];
+    var hdrs = s.headers ? Object.keys(s.headers).length : 0;
     h += '<div style="display:flex;align-items:center;gap:8px;padding:8px 0;border-bottom:1px solid var(--border)">';
-    h += '<span style="font-weight:500;flex:1">' + (s.name || 'Server ' + (i+1)) + '</span>';
-    h += '<span style="font-size:12px;color:var(--text2);flex:2">' + (s.url || '') + '</span>';
+    h += '<span style="font-weight:500;flex:1">' + escapeHtml(s.name || 'Server ' + (i+1)) + '</span>';
+    h += '<span style="font-size:12px;color:var(--text2);flex:2;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + escapeHtml(s.url || '') + '</span>';
+    if (hdrs > 0) h += '<span style="font-size:10px;padding:1px 6px;border-radius:999px;background:rgba(94,106,210,0.12);color:var(--accent)">' + hdrs + ' header' + (hdrs>1?'s':'') + '</span>';
+    if (s.api_key) h += '<span style="font-size:10px;padding:1px 6px;border-radius:999px;background:rgba(39,166,68,0.12);color:var(--green)">auth</span>';
     h += '<button class="btn-danger" onclick="removeFleetServer(' + i + ')" style="padding:4px 10px;font-size:11px">Remove</button>';
     h += '</div>';
   }
   el.innerHTML = h;
 }
 
+function parseHeadersTextarea() {
+  var raw = document.getElementById("fleet-headers").value.trim();
+  if (!raw) return null;
+  var headers = {};
+  raw.split("\n").forEach(function(line) {
+    var idx = line.indexOf(":");
+    if (idx > 0) headers[line.substring(0, idx).trim()] = line.substring(idx + 1).trim();
+  });
+  return Object.keys(headers).length > 0 ? headers : null;
+}
 function addFleetServer() {
   var name = document.getElementById("fleet-name").value.trim();
   var url = document.getElementById("fleet-url").value.trim();
@@ -1500,11 +1560,14 @@ function addFleetServer() {
   if (!name || !url) { showToast("Name and URL required", "error"); return; }
   var server = { id: "", name: name, url: url, enabled: true };
   if (apikey) server.api_key = apikey;
+  var headers = parseHeadersTextarea();
+  if (headers) server.headers = headers;
   fleetServers.push(server);
   saveFleetServers();
   document.getElementById("fleet-name").value = "";
   document.getElementById("fleet-url").value = "";
   document.getElementById("fleet-apikey").value = "";
+  document.getElementById("fleet-headers").value = "";
 }
 
 function removeFleetServer(idx) {

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>NAS Doctor — Settings</title>
+<title>NAS Doctor</title>
 <link rel="icon" type="image/png" href="/icon.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -462,6 +462,10 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
             <input type="number" id="sc-http-max" min="100" max="599" value="399" placeholder="Max">
           </div>
         </div>
+      </div>
+      <div class="form-group" id="sc-headers-wrap">
+        <label for="sc-headers">Custom HTTP Headers (optional — for auth, CF Access, etc.)</label>
+        <textarea id="sc-headers" rows="2" placeholder="Authorization: Bearer token123&#10;CF-Access-Client-Id: xxxxx" style="width:100%;font-size:12px;font-family:var(--font-mono);padding:8px;border:1px solid var(--border);border-radius:var(--radius);background:var(--input-bg);color:var(--text);resize:vertical"></textarea>
       </div>
       <div class="form-row">
         <div>
@@ -1288,6 +1292,7 @@ function toggleServiceCheckForm() {
   document.getElementById("sc-severity").value = "warning";
   document.getElementById("sc-http-min").value = "200";
   document.getElementById("sc-http-max").value = "399";
+  document.getElementById("sc-headers").value = "";
   setServiceCheckEnabledUI(true);
   populateInstanceSelector();
   onServiceTypeChange();
@@ -1306,14 +1311,27 @@ function onServiceTypeChange() {
   var type = document.getElementById("sc-type").value;
   var httpWrap = document.getElementById("sc-http-expected-wrap");
   var portWrap = document.getElementById("sc-port-wrap");
+  var headersWrap = document.getElementById("sc-headers-wrap");
   if (httpWrap) httpWrap.style.display = (type === "http") ? "block" : "none";
   if (portWrap) portWrap.style.display = (type === "tcp" || type === "smb" || type === "nfs") ? "block" : "none";
+  if (headersWrap) headersWrap.style.display = (type === "http") ? "block" : "none";
   var targetInput = document.getElementById("sc-target");
   if (targetInput) {
     if (type === "ping") targetInput.placeholder = "e.g. 8.8.8.8 or gateway.local";
     else if (type === "dns") targetInput.placeholder = "e.g. google.com";
     else targetInput.placeholder = "https://nas.local/health, 192.168.1.10, or host:port";
   }
+}
+function parseScHeaders() {
+  var raw = (document.getElementById("sc-headers") || {}).value || "";
+  if (!raw.trim()) return null;
+  var h = {};
+  raw.trim().split("\n").forEach(function(l) { var i = l.indexOf(":"); if (i > 0) h[l.substring(0,i).trim()] = l.substring(i+1).trim(); });
+  return Object.keys(h).length > 0 ? h : null;
+}
+function scHeadersToText(hdrs) {
+  if (!hdrs) return "";
+  var lines = []; for (var k in hdrs) lines.push(k + ": " + hdrs[k]); return lines.join("\n");
 }
 
 function editServiceCheck(idx) {
@@ -1332,6 +1350,7 @@ function editServiceCheck(idx) {
   document.getElementById("sc-severity").value = sc.failure_severity || "warning";
   document.getElementById("sc-http-min").value = String(sc.expected_status_min || 200);
   document.getElementById("sc-http-max").value = String(sc.expected_status_max || 399);
+  document.getElementById("sc-headers").value = scHeadersToText(sc.headers);
   setServiceCheckEnabledUI(sc.enabled !== false);
   onServiceTypeChange();
   document.getElementById("service-check-form").classList.add("visible");
@@ -1363,6 +1382,8 @@ function saveServiceCheck() {
     expected_status_min: parseInt(document.getElementById("sc-http-min").value, 10) || 200,
     expected_status_max: parseInt(document.getElementById("sc-http-max").value, 10) || 399
   };
+  var scHdrs = parseScHeaders();
+  if (scHdrs) sc.headers = scHdrs;
   if (sc.timeout_sec < 1) sc.timeout_sec = 5;
   if (sc.timeout_sec > 30) sc.timeout_sec = 30;
   if (sc.failure_threshold < 1) sc.failure_threshold = 1;
@@ -2203,6 +2224,7 @@ loadDBStats();
 loadBackupInfo();
 loadFleetServers();
 onServiceTypeChange();
+fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d.hostname)document.title="NAS Doctor — "+d.hostname;}).catch(function(){});
 </script>
 </body>
 </html>

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -493,9 +493,9 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
       <div><label for="pve-url">PVE API URL</label>
         <input type="text" id="pve-url" placeholder="https://192.168.1.10:8006">
         <p style="font-size:11px;color:var(--text2);margin-top:4px">The Proxmox web UI URL (default port 8006). Self-signed certs are accepted.</p></div>
-      <div><label for="pve-node">Node name (optional)</label>
-        <input type="text" id="pve-node" placeholder="Leave empty for all nodes">
-        <p style="font-size:11px;color:var(--text2);margin-top:4px">Limit to a specific node. Empty polls all cluster nodes.</p></div>
+      <div><label for="pve-alias">Display Name (optional)</label>
+        <input type="text" id="pve-alias" placeholder="e.g. Proxmox LDN">
+        <p style="font-size:11px;color:var(--text2);margin-top:4px">Friendly name shown on the dashboard instead of the node hostname.</p></div>
     </div>
     <div class="form-row">
       <div><label for="pve-token">API Token ID</label>
@@ -503,6 +503,11 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
         <p style="font-size:11px;color:var(--text2);margin-top:4px">Format: <code style="font-size:10px;background:var(--input-bg);padding:1px 4px;border-radius:3px">user@realm!tokenname</code></p></div>
       <div><label for="pve-secret">Token Secret</label>
         <input type="password" id="pve-secret" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"></div>
+    </div>
+    <div class="form-row">
+      <div><label for="pve-node">Node filter (optional)</label>
+        <select id="pve-node"><option value="">All nodes (poll entire cluster)</option></select>
+        <p style="font-size:11px;color:var(--text2);margin-top:4px">Auto-detected from PVE. Click Test Connection to populate.</p></div>
     </div>
     <div style="margin-top:12px;display:flex;align-items:center;gap:12px">
       <button class="btn btn-secondary btn-sm" onclick="testProxmoxConnection()">Test Connection</button>
@@ -910,9 +915,17 @@ function loadSettings() {
       var pve = data.proxmox || {};
       if (pve.enabled) document.getElementById("pve-toggle").classList.add("on"); else document.getElementById("pve-toggle").classList.remove("on");
       document.getElementById("pve-url").value = pve.url || "";
-      document.getElementById("pve-node").value = pve.node_name || "";
+      document.getElementById("pve-alias").value = pve.alias || "";
       document.getElementById("pve-token").value = pve.token_id || "";
       document.getElementById("pve-secret").value = pve.secret || "";
+      // Restore node filter — add as option if not already in dropdown
+      var nodeSel = document.getElementById("pve-node");
+      if (pve.node_name) {
+        var found = false;
+        for (var ni = 0; ni < nodeSel.options.length; ni++) { if (nodeSel.options[ni].value === pve.node_name) { found = true; break; } }
+        if (!found) nodeSel.innerHTML += '<option value="' + pve.node_name + '">' + pve.node_name + '</option>';
+        nodeSel.value = pve.node_name;
+      }
       /* Log forwarding */
       var lp = data.log_push || {};
       if (lp.enabled) document.getElementById("logfwd-toggle").classList.add("on"); else document.getElementById("logfwd-toggle").classList.remove("on");
@@ -970,7 +983,8 @@ function buildSettingsPayload() {
     proxmox: {
       enabled: document.getElementById("pve-toggle").classList.contains("on"),
       url: document.getElementById("pve-url").value.trim(),
-      node_name: document.getElementById("pve-node").value.trim(),
+      alias: document.getElementById("pve-alias").value.trim(),
+      node_name: document.getElementById("pve-node").value,
       token_id: document.getElementById("pve-token").value.trim(),
       secret: document.getElementById("pve-secret").value.trim()
     },
@@ -2028,6 +2042,16 @@ function testProxmoxConnection() {
     if (d.success) {
       result.style.color = "var(--green)";
       result.textContent = "Connected — PVE " + (d.version || "?") + (d.cluster ? " · cluster: " + d.cluster : "") + " · " + d.nodes + " node(s), " + d.guests + " guest(s), " + d.storage + " storage pool(s)";
+      // Populate node dropdown from detected nodes
+      var sel = document.getElementById("pve-node");
+      var current = sel.value;
+      sel.innerHTML = '<option value="">All nodes (poll entire cluster)</option>';
+      if (d.node_names) {
+        for (var i = 0; i < d.node_names.length; i++) {
+          sel.innerHTML += '<option value="' + d.node_names[i] + '">' + d.node_names[i] + '</option>';
+        }
+      }
+      if (current) sel.value = current;
     } else {
       result.style.color = "var(--red)";
       result.textContent = "Failed: " + (d.error || "unknown error");

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -474,7 +474,32 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
 
   </div>
 
-  <!-- 4. Log Forwarding -->
+  <!-- 4. Proxmox VE Integration -->
+  <div class="card" id="card-proxmox">
+    <div class="card-title">Proxmox VE</div>
+    <div class="card-desc">Connect to a Proxmox VE API to monitor VMs, LXC containers, storage pools, and cluster health. Create an API token in PVE: Datacenter → Permissions → API Tokens.</div>
+    <div class="toggle-wrap" style="margin-bottom:16px">
+      <div class="toggle" id="pve-toggle" onclick="this.classList.toggle('on');saveSettings()"><div class="toggle-knob"></div></div>
+      <span class="toggle-label">Enable Proxmox Integration</span>
+    </div>
+    <div class="form-row">
+      <div><label for="pve-url">PVE API URL</label>
+        <input type="text" id="pve-url" placeholder="https://192.168.1.10:8006">
+        <p style="font-size:11px;color:var(--text2);margin-top:4px">The Proxmox web UI URL (default port 8006). Self-signed certs are accepted.</p></div>
+      <div><label for="pve-node">Node name (optional)</label>
+        <input type="text" id="pve-node" placeholder="Leave empty for all nodes">
+        <p style="font-size:11px;color:var(--text2);margin-top:4px">Limit to a specific node. Empty polls all cluster nodes.</p></div>
+    </div>
+    <div class="form-row">
+      <div><label for="pve-token">API Token ID</label>
+        <input type="text" id="pve-token" placeholder="root@pam!nas-doctor">
+        <p style="font-size:11px;color:var(--text2);margin-top:4px">Format: <code style="font-size:10px;background:var(--input-bg);padding:1px 4px;border-radius:3px">user@realm!tokenname</code></p></div>
+      <div><label for="pve-secret">Token Secret</label>
+        <input type="password" id="pve-secret" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"></div>
+    </div>
+  </div>
+
+  <!-- 5. Log Forwarding -->
   <div class="card" id="card-logfwd">
     <div class="card-title">Log Forwarding</div>
     <div class="card-desc">Forward scan results to Loki, syslog, or any HTTP JSON endpoint after each diagnostic scan.</div>
@@ -580,6 +605,7 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
       <div class="toggle-wrap"><div class="toggle on" id="sec-parity" onclick="this.classList.toggle('on');saveSettings()"><div class="toggle-knob"></div></div><span class="toggle-label">Parity (Unraid)</span></div>
       <div class="toggle-wrap"><div class="toggle on" id="sec-network" onclick="this.classList.toggle('on');saveSettings()"><div class="toggle-knob"></div></div><span class="toggle-label">Network</span></div>
       <div class="toggle-wrap"><div class="toggle on" id="sec-tunnels" onclick="this.classList.toggle('on');saveSettings()"><div class="toggle-knob"></div></div><span class="toggle-label">Tunnels (Cloudflared / Tailscale)</span></div>
+      <div class="toggle-wrap"><div class="toggle on" id="sec-proxmox" onclick="this.classList.toggle('on');saveSettings()"><div class="toggle-knob"></div></div><span class="toggle-label">Proxmox VE</span></div>
       <div style="margin-top:12px;padding-top:12px;border-top:1px solid var(--border)">
         <div class="toggle-wrap"><div class="toggle on" id="sec-merged-drives" onclick="this.classList.toggle('on');saveSettings()"><div class="toggle-knob"></div></div><span class="toggle-label">Merged Drive View <span style="font-size:11px;color:var(--text2)">(combine SMART + storage into one card per drive)</span></span></div>
       </div>
@@ -903,7 +929,15 @@ function buildSettingsPayload() {
       parity: document.getElementById("sec-parity").classList.contains("on"),
       network: document.getElementById("sec-network").classList.contains("on"),
       tunnels: document.getElementById("sec-tunnels").classList.contains("on"),
+      proxmox: document.getElementById("sec-proxmox").classList.contains("on"),
       merged_drives: document.getElementById("sec-merged-drives").classList.contains("on")
+    },
+    proxmox: {
+      enabled: document.getElementById("pve-toggle").classList.contains("on"),
+      url: document.getElementById("pve-url").value.trim(),
+      node_name: document.getElementById("pve-node").value.trim(),
+      token_id: document.getElementById("pve-token").value.trim(),
+      secret: document.getElementById("pve-secret").value.trim()
     },
     backup: {
       enabled: document.getElementById("backup-toggle").classList.contains("on"),

--- a/internal/api/templates/stats.html
+++ b/internal/api/templates/stats.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>NAS Doctor — Drive Health</title>
+<title>NAS Doctor</title>
 <link rel="icon" href="/icon.png">
 <link rel="stylesheet" href="/css/shared.css">
 <style>
@@ -124,6 +124,7 @@ body.theme-clean .sort-pill.active{color:rgba(0,0,0,0.7);background:rgba(0,0,0,0
 </div>
 <script src="/js/charts.js"></script>
 <script>
+fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d.hostname)document.title="NAS Doctor — "+d.hostname;}).catch(function(){});
 (function() {
   var snapshot = null, sparklines = null, expandedIdx = -1;
   function esc(s) { var d = document.createElement("div"); d.textContent = s || ""; return d.innerHTML; }

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -138,6 +138,7 @@ func (c *Collector) Collect() (*internal.Snapshot, error) {
 		c.logger.Info("collecting Proxmox VE data")
 		pveInfo := CollectProxmox(c.proxmoxConfig)
 		if pveInfo != nil {
+			pveInfo.Alias = c.proxmoxConfig.Alias
 			snap.Proxmox = pveInfo
 			if pveInfo.Error != "" {
 				c.logger.Warn("Proxmox VE collection error", "error", pveInfo.Error)

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -13,8 +13,14 @@ import (
 
 // Collector runs all diagnostic sub-collectors and assembles a Snapshot.
 type Collector struct {
-	hostPaths internal.HostPaths
-	logger    *slog.Logger
+	hostPaths     internal.HostPaths
+	logger        *slog.Logger
+	proxmoxConfig ProxmoxConfig
+}
+
+// SetProxmoxConfig updates the Proxmox VE API connection settings.
+func (c *Collector) SetProxmoxConfig(cfg ProxmoxConfig) {
+	c.proxmoxConfig = cfg
 }
 
 // New creates a new Collector with the given host path mappings.
@@ -125,6 +131,15 @@ func (c *Collector) Collect() (*internal.Snapshot, error) {
 	tunnelInfo := collectTunnels(docker)
 	if tunnelInfo != nil {
 		snap.Tunnels = tunnelInfo
+	}
+
+	// Proxmox VE (if configured)
+	if c.proxmoxConfig.Enabled {
+		c.logger.Info("collecting Proxmox VE data")
+		pveInfo := CollectProxmox(c.proxmoxConfig)
+		if pveInfo != nil {
+			snap.Proxmox = pveInfo
+		}
 	}
 
 	// ZFS (if available)

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -139,6 +139,11 @@ func (c *Collector) Collect() (*internal.Snapshot, error) {
 		pveInfo := CollectProxmox(c.proxmoxConfig)
 		if pveInfo != nil {
 			snap.Proxmox = pveInfo
+			if pveInfo.Error != "" {
+				c.logger.Warn("Proxmox VE collection error", "error", pveInfo.Error)
+			} else {
+				c.logger.Info("Proxmox VE data collected", "nodes", len(pveInfo.Nodes), "guests", len(pveInfo.Guests))
+			}
 		}
 	}
 

--- a/internal/collector/proxmox.go
+++ b/internal/collector/proxmox.go
@@ -1,0 +1,304 @@
+package collector
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// ProxmoxConfig holds the connection details for a Proxmox VE API.
+type ProxmoxConfig struct {
+	URL      string // e.g. https://192.168.1.10:8006
+	TokenID  string // e.g. root@pam!nas-doctor
+	Secret   string // the UUID token secret
+	NodeName string // optional: limit to a specific node (empty = all)
+	Enabled  bool
+}
+
+type proxmoxClient struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+func newProxmoxClient(cfg ProxmoxConfig) *proxmoxClient {
+	base := strings.TrimRight(cfg.URL, "/")
+	return &proxmoxClient{
+		baseURL: base + "/api2/json",
+		token:   fmt.Sprintf("PVEAPIToken=%s=%s", cfg.TokenID, cfg.Secret),
+		http: &http.Client{
+			Timeout: 15 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // PVE uses self-signed certs
+			},
+		},
+	}
+}
+
+func (c *proxmoxClient) get(path string) (json.RawMessage, error) {
+	url := c.baseURL + path
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", c.token)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body[:min(len(body), 200)]))
+	}
+	var envelope struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return envelope.Data, nil
+}
+
+// CollectProxmox gathers data from a Proxmox VE API.
+func CollectProxmox(cfg ProxmoxConfig) *internal.ProxmoxInfo {
+	if !cfg.Enabled || cfg.URL == "" || cfg.TokenID == "" || cfg.Secret == "" {
+		return nil
+	}
+	client := newProxmoxClient(cfg)
+	info := &internal.ProxmoxInfo{Connected: true}
+
+	// Version
+	if data, err := client.get("/version"); err == nil {
+		var ver struct {
+			Version string `json:"version"`
+		}
+		json.Unmarshal(data, &ver)
+		info.Version = ver.Version
+	}
+
+	// Cluster status
+	if data, err := client.get("/cluster/status"); err == nil {
+		var entries []struct {
+			Type    string `json:"type"`
+			Name    string `json:"name"`
+			Online  int    `json:"online"`
+			Quorate int    `json:"quorate"`
+		}
+		json.Unmarshal(data, &entries)
+		for _, e := range entries {
+			if e.Type == "cluster" {
+				info.ClusterName = e.Name
+			}
+		}
+	}
+
+	// Nodes
+	if data, err := client.get("/nodes"); err == nil {
+		var nodes []struct {
+			Node    string  `json:"node"`
+			Status  string  `json:"status"`
+			Uptime  int64   `json:"uptime"`
+			CPU     float64 `json:"cpu"`
+			MaxCPU  int     `json:"maxcpu"`
+			Mem     int64   `json:"mem"`
+			MaxMem  int64   `json:"maxmem"`
+			Disk    int64   `json:"disk"`
+			MaxDisk int64   `json:"maxdisk"`
+		}
+		json.Unmarshal(data, &nodes)
+		for _, n := range nodes {
+			if cfg.NodeName != "" && !strings.EqualFold(n.Node, cfg.NodeName) {
+				continue
+			}
+			node := internal.ProxmoxNode{
+				Name:      n.Node,
+				Status:    n.Status,
+				Uptime:    n.Uptime,
+				CPUUsage:  n.CPU,
+				CPUCores:  n.MaxCPU,
+				MemUsed:   n.Mem,
+				MemTotal:  n.MaxMem,
+				DiskUsed:  n.Disk,
+				DiskTotal: n.MaxDisk,
+			}
+			// Get detailed node status for kernel + PVE version
+			if detail, err := client.get("/nodes/" + n.Node + "/status"); err == nil {
+				var st struct {
+					PVEVersion string `json:"pveversion"`
+					KVer       string `json:"kversion"`
+					CPUInfo    struct {
+						Model string `json:"model"`
+					} `json:"cpuinfo"`
+				}
+				json.Unmarshal(detail, &st)
+				node.PVEVersion = st.PVEVersion
+				node.KernelVer = st.KVer
+				node.CPUModel = st.CPUInfo.Model
+			}
+			info.Nodes = append(info.Nodes, node)
+		}
+	}
+
+	// Cluster resources (VMs + LXC + storage in one call)
+	if data, err := client.get("/cluster/resources"); err == nil {
+		var resources []struct {
+			Type    string  `json:"type"`
+			ID      string  `json:"id"`
+			Node    string  `json:"node"`
+			Name    string  `json:"name"`
+			Status  string  `json:"status"`
+			VMID    int     `json:"vmid"`
+			Uptime  int64   `json:"uptime"`
+			CPU     float64 `json:"cpu"`
+			MaxCPU  int     `json:"maxcpu"`
+			Mem     int64   `json:"mem"`
+			MaxMem  int64   `json:"maxmem"`
+			Disk    int64   `json:"disk"`
+			MaxDisk int64   `json:"maxdisk"`
+			NetIn   int64   `json:"netin"`
+			NetOut  int64   `json:"netout"`
+			Tags    string  `json:"tags"`
+			Tmpl    int     `json:"template"`
+			HAState string  `json:"hastate"`
+			Storage string  `json:"storage"`
+			SType   string  `json:"plugintype"`
+			Content string  `json:"content"`
+			Shared  int     `json:"shared"`
+		}
+		json.Unmarshal(data, &resources)
+
+		for _, r := range resources {
+			if cfg.NodeName != "" && r.Node != "" && !strings.EqualFold(r.Node, cfg.NodeName) {
+				continue
+			}
+			switch r.Type {
+			case "qemu", "lxc":
+				guest := internal.ProxmoxGuest{
+					VMID:     r.VMID,
+					Name:     r.Name,
+					Node:     r.Node,
+					Type:     r.Type,
+					Status:   r.Status,
+					Uptime:   r.Uptime,
+					CPUUsage: r.CPU,
+					CPUs:     r.MaxCPU,
+					MemUsed:  r.Mem,
+					MemMax:   r.MaxMem,
+					DiskUsed: r.Disk,
+					DiskMax:  r.MaxDisk,
+					NetIn:    r.NetIn,
+					NetOut:   r.NetOut,
+					Tags:     r.Tags,
+					Template: r.Tmpl == 1,
+					HAState:  r.HAState,
+				}
+				if !guest.Template {
+					info.Guests = append(info.Guests, guest)
+				}
+			case "storage":
+				usedPct := 0.0
+				if r.MaxDisk > 0 {
+					usedPct = float64(r.Disk) / float64(r.MaxDisk) * 100
+				}
+				info.Storage = append(info.Storage, internal.ProxmoxStorage{
+					Storage: r.Storage,
+					Node:    r.Node,
+					Type:    r.SType,
+					Status:  r.Status,
+					Used:    r.Disk,
+					Total:   r.MaxDisk,
+					UsedPct: usedPct,
+					Shared:  r.Shared == 1,
+					Content: r.Content,
+				})
+			}
+		}
+	}
+
+	// Sort guests: running first, then by VMID
+	sort.Slice(info.Guests, func(i, j int) bool {
+		if info.Guests[i].Status != info.Guests[j].Status {
+			if info.Guests[i].Status == "running" {
+				return true
+			}
+			if info.Guests[j].Status == "running" {
+				return false
+			}
+		}
+		return info.Guests[i].VMID < info.Guests[j].VMID
+	})
+
+	// Recent tasks (last 20)
+	for _, node := range info.Nodes {
+		if taskData, err := client.get("/nodes/" + node.Name + "/tasks?limit=20&source=active,all"); err == nil {
+			var tasks []struct {
+				UPID      string `json:"upid"`
+				Type      string `json:"type"`
+				Status    string `json:"status"`
+				User      string `json:"user"`
+				StartTime int64  `json:"starttime"`
+				EndTime   int64  `json:"endtime"`
+				ID        string `json:"id"`
+			}
+			json.Unmarshal(taskData, &tasks)
+			for _, t := range tasks {
+				vmid := 0
+				if t.ID != "" {
+					fmt.Sscanf(t.ID, "%d", &vmid)
+				}
+				info.Tasks = append(info.Tasks, internal.ProxmoxTask{
+					UPID:      t.UPID,
+					Node:      node.Name,
+					Type:      t.Type,
+					Status:    t.Status,
+					User:      t.User,
+					StartTime: t.StartTime,
+					EndTime:   t.EndTime,
+					VMID:      vmid,
+				})
+			}
+		}
+	}
+
+	// HA status
+	if data, err := client.get("/cluster/ha/status/current"); err == nil {
+		var haEntries []struct {
+			SID    string `json:"sid"`
+			State  string `json:"state"`
+			Node   string `json:"node"`
+			Status string `json:"status"`
+			Type   string `json:"type"`
+		}
+		json.Unmarshal(data, &haEntries)
+		for _, h := range haEntries {
+			if h.Type == "service" {
+				info.HAServices = append(info.HAServices, internal.ProxmoxHA{
+					SID:    h.SID,
+					State:  h.State,
+					Node:   h.Node,
+					Status: h.Status,
+				})
+			}
+		}
+	}
+
+	return info
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/collector/proxmox.go
+++ b/internal/collector/proxmox.go
@@ -19,6 +19,7 @@ type ProxmoxConfig struct {
 	TokenID  string // e.g. root@pam!nas-doctor
 	Secret   string // the UUID token secret
 	NodeName string // optional: limit to a specific node (empty = all)
+	Alias    string // optional: friendly display name
 	Enabled  bool
 }
 

--- a/internal/collector/proxmox.go
+++ b/internal/collector/proxmox.go
@@ -76,16 +76,20 @@ func CollectProxmox(cfg ProxmoxConfig) *internal.ProxmoxInfo {
 		return nil
 	}
 	client := newProxmoxClient(cfg)
-	info := &internal.ProxmoxInfo{Connected: true}
+	info := &internal.ProxmoxInfo{Connected: false}
 
-	// Version
-	if data, err := client.get("/version"); err == nil {
-		var ver struct {
-			Version string `json:"version"`
-		}
-		json.Unmarshal(data, &ver)
-		info.Version = ver.Version
+	// Version — use as connectivity test
+	data, err := client.get("/version")
+	if err != nil {
+		info.Error = fmt.Sprintf("PVE API connection failed: %v", err)
+		return info
 	}
+	info.Connected = true
+	var ver struct {
+		Version string `json:"version"`
+	}
+	json.Unmarshal(data, &ver)
+	info.Version = ver.Version
 
 	// Cluster status
 	if data, err := client.get("/cluster/status"); err == nil {

--- a/internal/demo/demo.go
+++ b/internal/demo/demo.go
@@ -30,8 +30,46 @@ func GenerateSnapshot() *internal.Snapshot {
 	snap.Update = demoUpdate(snap.System.Platform, snap.System.PlatformVer)
 	snap.Services = demoServiceChecks()
 	snap.Tunnels = demoTunnels()
+	snap.Proxmox = demoProxmox()
 
 	return snap
+}
+
+func demoProxmox() *internal.ProxmoxInfo {
+	return &internal.ProxmoxInfo{
+		Connected:   true,
+		Version:     "8.3.2",
+		ClusterName: "homelab",
+		Nodes: []internal.ProxmoxNode{
+			{Name: "pve-01", Status: "online", Uptime: 7776000, CPUUsage: 0.23, CPUCores: 16, MemUsed: 27917287424, MemTotal: 68719476736, DiskUsed: 42949672960, DiskTotal: 214748364800, PVEVersion: "pve-manager/8.3.2", KernelVer: "6.8.12-6-pve", CPUModel: "AMD EPYC 7543P"},
+			{Name: "pve-02", Status: "online", Uptime: 5184000, CPUUsage: 0.14, CPUCores: 8, MemUsed: 12884901888, MemTotal: 34359738368, DiskUsed: 21474836480, DiskTotal: 107374182400, PVEVersion: "pve-manager/8.3.2", KernelVer: "6.8.12-6-pve", CPUModel: "Intel Core i5-13500"},
+		},
+		Guests: []internal.ProxmoxGuest{
+			{VMID: 100, Name: "ubuntu-docker", Node: "pve-01", Type: "qemu", Status: "running", Uptime: 2592000, CPUUsage: 0.12, CPUs: 4, MemUsed: 4294967296, MemMax: 8589934592, DiskUsed: 42949672960, DiskMax: 107374182400, NetIn: 154618822656, NetOut: 98784247808, Tags: "docker,production"},
+			{VMID: 101, Name: "home-assistant", Node: "pve-01", Type: "qemu", Status: "running", Uptime: 2592000, CPUUsage: 0.05, CPUs: 2, MemUsed: 1073741824, MemMax: 4294967296, DiskUsed: 10737418240, DiskMax: 32212254720, NetIn: 5368709120, NetOut: 2147483648, Tags: "automation"},
+			{VMID: 102, Name: "windows-11", Node: "pve-01", Type: "qemu", Status: "stopped", CPUs: 4, MemMax: 17179869184, DiskMax: 214748364800, Tags: "desktop"},
+			{VMID: 200, Name: "pihole", Node: "pve-01", Type: "lxc", Status: "running", Uptime: 7776000, CPUUsage: 0.01, CPUs: 1, MemUsed: 134217728, MemMax: 536870912, DiskUsed: 1073741824, DiskMax: 8589934592, NetIn: 87241523200, NetOut: 85899345920, Tags: "dns,network"},
+			{VMID: 201, Name: "nginx-proxy", Node: "pve-01", Type: "lxc", Status: "running", Uptime: 7776000, CPUUsage: 0.02, CPUs: 1, MemUsed: 268435456, MemMax: 1073741824, DiskUsed: 2147483648, DiskMax: 8589934592, NetIn: 214748364800, NetOut: 193273528320, Tags: "proxy,web"},
+			{VMID: 300, Name: "media-server", Node: "pve-02", Type: "qemu", Status: "running", Uptime: 5184000, CPUUsage: 0.35, CPUs: 4, MemUsed: 6442450944, MemMax: 8589934592, DiskUsed: 53687091200, DiskMax: 107374182400, NetIn: 1099511627776, NetOut: 549755813888, Tags: "media"},
+			{VMID: 301, Name: "backup-vm", Node: "pve-02", Type: "qemu", Status: "running", Uptime: 5184000, CPUUsage: 0.08, CPUs: 2, MemUsed: 2147483648, MemMax: 4294967296, DiskUsed: 85899345920, DiskMax: 214748364800, NetIn: 21474836480, NetOut: 10737418240, Tags: "backup"},
+		},
+		Storage: []internal.ProxmoxStorage{
+			{Storage: "local", Node: "pve-01", Type: "dir", Status: "available", Used: 42949672960, Total: 214748364800, UsedPct: 20.0, Content: "vztmpl,iso,backup"},
+			{Storage: "local-lvm", Node: "pve-01", Type: "lvmthin", Status: "available", Used: 171798691840, Total: 429496729600, UsedPct: 40.0, Content: "images,rootdir"},
+			{Storage: "nfs-backup", Node: "pve-01", Type: "nfs", Status: "available", Used: 2147483648000, Total: 8589934592000, UsedPct: 25.0, Shared: true, Content: "backup,images"},
+			{Storage: "local", Node: "pve-02", Type: "dir", Status: "available", Used: 21474836480, Total: 107374182400, UsedPct: 20.0, Content: "vztmpl,iso,backup"},
+			{Storage: "local-lvm", Node: "pve-02", Type: "lvmthin", Status: "available", Used: 107374182400, Total: 214748364800, UsedPct: 50.0, Content: "images,rootdir"},
+		},
+		Tasks: []internal.ProxmoxTask{
+			{Node: "pve-01", Type: "vzdump", Status: "OK", User: "root@pam", StartTime: time.Now().Add(-6 * time.Hour).Unix(), EndTime: time.Now().Add(-5*time.Hour - 45*time.Minute).Unix(), VMID: 100},
+			{Node: "pve-01", Type: "vzdump", Status: "OK", User: "root@pam", StartTime: time.Now().Add(-6 * time.Hour).Unix(), EndTime: time.Now().Add(-5*time.Hour - 50*time.Minute).Unix(), VMID: 101},
+			{Node: "pve-02", Type: "vzdump", Status: "OK", User: "root@pam", StartTime: time.Now().Add(-6 * time.Hour).Unix(), EndTime: time.Now().Add(-5*time.Hour - 30*time.Minute).Unix(), VMID: 300},
+		},
+		HAServices: []internal.ProxmoxHA{
+			{SID: "vm:100", State: "started", Node: "pve-01", Status: "OK"},
+			{SID: "vm:101", State: "started", Node: "pve-01", Status: "OK"},
+		},
+	}
 }
 
 func demoTunnels() *internal.TunnelInfo {

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -128,6 +128,10 @@ func (m *Manager) pollServer(srv internal.RemoteServer) *internal.RemoteServerSt
 	if srv.APIKey != "" {
 		req.Header.Set("Authorization", "Bearer "+srv.APIKey)
 	}
+	// Inject custom headers (e.g. Cloudflare Access service tokens)
+	for k, v := range srv.Headers {
+		req.Header.Set(k, v)
+	}
 
 	resp, err := m.client.Do(req)
 	if err != nil {

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -158,7 +158,12 @@ func (m *Manager) pollServer(srv internal.RemoteServer) *internal.RemoteServerSt
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&statusResp); err != nil {
-		result.Error = fmt.Sprintf("parse error: %v", err)
+		result.Error = "response is not valid JSON — likely a proxy login page (check auth headers)"
+		return result
+	}
+	// Validate this is a NAS Doctor instance
+	if statusResp.Hostname == "" && statusResp.Platform == "" {
+		result.Error = "response does not look like a NAS Doctor instance — check URL and auth headers"
 		return result
 	}
 

--- a/internal/models.go
+++ b/internal/models.go
@@ -59,6 +59,7 @@ type Snapshot struct {
 type ProxmoxInfo struct {
 	Connected   bool             `json:"connected"`
 	Error       string           `json:"error,omitempty"`
+	Alias       string           `json:"alias,omitempty"` // user-defined display name
 	Version     string           `json:"version,omitempty"`
 	ClusterName string           `json:"cluster_name,omitempty"`
 	Nodes       []ProxmoxNode    `json:"nodes,omitempty"`

--- a/internal/models.go
+++ b/internal/models.go
@@ -49,8 +49,88 @@ type Snapshot struct {
 	UPS       *UPSInfo             `json:"ups,omitempty"`
 	Update    *UpdateInfo          `json:"update,omitempty"`
 	Tunnels   *TunnelInfo          `json:"tunnels,omitempty"`
+	Proxmox   *ProxmoxInfo         `json:"proxmox,omitempty"`
 	Services  []ServiceCheckResult `json:"service_checks,omitempty"`
 	Findings  []Finding            `json:"findings"`
+}
+
+// ---------- Proxmox VE ----------
+
+type ProxmoxInfo struct {
+	Connected   bool             `json:"connected"`
+	Error       string           `json:"error,omitempty"`
+	Version     string           `json:"version,omitempty"`
+	ClusterName string           `json:"cluster_name,omitempty"`
+	Nodes       []ProxmoxNode    `json:"nodes,omitempty"`
+	Guests      []ProxmoxGuest   `json:"guests,omitempty"` // VMs + LXC combined
+	Storage     []ProxmoxStorage `json:"storage,omitempty"`
+	Tasks       []ProxmoxTask    `json:"tasks,omitempty"`
+	HAServices  []ProxmoxHA      `json:"ha_services,omitempty"`
+}
+
+type ProxmoxNode struct {
+	Name       string  `json:"name"`
+	Status     string  `json:"status"`     // online, offline
+	Uptime     int64   `json:"uptime"`     // seconds
+	CPUUsage   float64 `json:"cpu_usage"`  // 0.0-1.0
+	MemUsed    int64   `json:"mem_used"`   // bytes
+	MemTotal   int64   `json:"mem_total"`  // bytes
+	DiskUsed   int64   `json:"disk_used"`  // bytes (root fs)
+	DiskTotal  int64   `json:"disk_total"` // bytes
+	PVEVersion string  `json:"pve_version,omitempty"`
+	KernelVer  string  `json:"kernel_version,omitempty"`
+	CPUModel   string  `json:"cpu_model,omitempty"`
+	CPUCores   int     `json:"cpu_cores,omitempty"`
+}
+
+type ProxmoxGuest struct {
+	VMID     int     `json:"vmid"`
+	Name     string  `json:"name"`
+	Node     string  `json:"node"`
+	Type     string  `json:"type"`      // qemu, lxc
+	Status   string  `json:"status"`    // running, stopped, paused
+	Uptime   int64   `json:"uptime"`    // seconds
+	CPUUsage float64 `json:"cpu_usage"` // 0.0-1.0
+	CPUs     int     `json:"cpus"`
+	MemUsed  int64   `json:"mem_used"`  // bytes
+	MemMax   int64   `json:"mem_max"`   // bytes
+	DiskUsed int64   `json:"disk_used"` // bytes
+	DiskMax  int64   `json:"disk_max"`  // bytes
+	NetIn    int64   `json:"net_in"`    // bytes
+	NetOut   int64   `json:"net_out"`   // bytes
+	Tags     string  `json:"tags,omitempty"`
+	Template bool    `json:"template,omitempty"`
+	HAState  string  `json:"ha_state,omitempty"` // managed, started, error, etc.
+}
+
+type ProxmoxStorage struct {
+	Storage string  `json:"storage"`
+	Node    string  `json:"node"`
+	Type    string  `json:"type"`   // dir, lvm, lvmthin, zfspool, nfs, cifs, ceph
+	Status  string  `json:"status"` // available, unavailable
+	Used    int64   `json:"used"`   // bytes
+	Total   int64   `json:"total"`  // bytes
+	UsedPct float64 `json:"used_pct"`
+	Shared  bool    `json:"shared"`
+	Content string  `json:"content"` // images,rootdir,vztmpl,iso,backup
+}
+
+type ProxmoxTask struct {
+	UPID      string `json:"upid"`
+	Node      string `json:"node"`
+	Type      string `json:"type"`   // vzdump, qmigrate, vzmigrate, etc.
+	Status    string `json:"status"` // OK, Error, running
+	User      string `json:"user"`
+	StartTime int64  `json:"start_time"` // unix epoch
+	EndTime   int64  `json:"end_time"`
+	VMID      int    `json:"vmid,omitempty"`
+}
+
+type ProxmoxHA struct {
+	SID    string `json:"sid"`   // e.g., "vm:100"
+	State  string `json:"state"` // started, stopped, error, fence
+	Node   string `json:"node"`
+	Status string `json:"status"` // OK, error message
 }
 
 // ---------- Tunnels (Cloudflared / Tailscale) ----------
@@ -112,17 +192,19 @@ const (
 )
 
 type ServiceCheckConfig struct {
-	Name             string   `json:"name"`
-	Type             string   `json:"type"`
-	Target           string   `json:"target"`
-	Enabled          bool     `json:"enabled"`
-	IntervalSec      int      `json:"interval_sec,omitempty"` // Per-check interval in seconds (default 300 = 5min)
-	TimeoutSec       int      `json:"timeout_sec,omitempty"`
-	Port             int      `json:"port,omitempty"`
-	FailureThreshold int      `json:"failure_threshold,omitempty"`
-	FailureSeverity  Severity `json:"failure_severity,omitempty"`
-	ExpectedMin      int      `json:"expected_status_min,omitempty"`
-	ExpectedMax      int      `json:"expected_status_max,omitempty"`
+	Name             string            `json:"name"`
+	Type             string            `json:"type"`
+	Target           string            `json:"target"`
+	Enabled          bool              `json:"enabled"`
+	Instance         string            `json:"instance,omitempty"`     // fleet server ID; empty = local
+	IntervalSec      int               `json:"interval_sec,omitempty"` // Per-check interval in seconds (default 300 = 5min)
+	TimeoutSec       int               `json:"timeout_sec,omitempty"`
+	Port             int               `json:"port,omitempty"`
+	FailureThreshold int               `json:"failure_threshold,omitempty"`
+	FailureSeverity  Severity          `json:"failure_severity,omitempty"`
+	ExpectedMin      int               `json:"expected_status_min,omitempty"`
+	ExpectedMax      int               `json:"expected_status_max,omitempty"`
+	Headers          map[string]string `json:"headers,omitempty"` // custom request headers for HTTP checks
 }
 
 type ServiceCheckResult struct {
@@ -280,11 +362,12 @@ type ParityCheck struct {
 // ---------- Fleet / Multi-Server ----------
 
 type RemoteServer struct {
-	ID      string `json:"id"`
-	Name    string `json:"name"` // friendly name ("Backup NAS", "Proxmox")
-	URL     string `json:"url"`  // base URL ("http://192.168.1.50:8080")
-	Enabled bool   `json:"enabled"`
-	APIKey  string `json:"api_key,omitempty"` // for future auth
+	ID      string            `json:"id"`
+	Name    string            `json:"name"` // friendly name ("Backup NAS", "Proxmox")
+	URL     string            `json:"url"`  // base URL ("http://192.168.1.50:8080" or "https://nas.example.com")
+	Enabled bool              `json:"enabled"`
+	APIKey  string            `json:"api_key,omitempty"` // NAS Doctor API key auth
+	Headers map[string]string `json:"headers,omitempty"` // custom request headers (e.g. CF-Access-Client-Id, Authorization)
 }
 
 type RemoteServerStatus struct {

--- a/internal/notifier/prometheus.go
+++ b/internal/notifier/prometheus.go
@@ -105,6 +105,18 @@ type Metrics struct {
 	tsNodeTxBytes *prometheus.GaugeVec
 	tsNodeRxBytes *prometheus.GaugeVec
 
+	// ── Proxmox ──
+	pveNodeCPU      *prometheus.GaugeVec
+	pveNodeMemUsed  *prometheus.GaugeVec
+	pveNodeMemTotal *prometheus.GaugeVec
+	pveNodeOnline   *prometheus.GaugeVec
+	pveGuestCPU     *prometheus.GaugeVec
+	pveGuestMemUsed *prometheus.GaugeVec
+	pveGuestMemMax  *prometheus.GaugeVec
+	pveGuestRunning *prometheus.GaugeVec
+	pveStorageUsed  *prometheus.GaugeVec
+	pveStorageTotal *prometheus.GaugeVec
+
 	// ── Findings ──
 	findingsTotal    *prometheus.GaugeVec
 	findingsCritical prometheus.Gauge
@@ -235,6 +247,21 @@ func NewMetrics() *Metrics {
 	m.tsNodeTxBytes = gaugeVec(ns, "tunnel", "tailscale_node_tx_bytes", "Tailscale node TX bytes", []string{"name", "ip"})
 	m.tsNodeRxBytes = gaugeVec(ns, "tunnel", "tailscale_node_rx_bytes", "Tailscale node RX bytes", []string{"name", "ip"})
 
+	// ── Proxmox ──
+	pveNodeLabels := []string{"node"}
+	m.pveNodeCPU = gaugeVec(ns, "proxmox", "node_cpu_usage", "PVE node CPU usage (0-1)", pveNodeLabels)
+	m.pveNodeMemUsed = gaugeVec(ns, "proxmox", "node_memory_used_bytes", "PVE node memory used", pveNodeLabels)
+	m.pveNodeMemTotal = gaugeVec(ns, "proxmox", "node_memory_total_bytes", "PVE node memory total", pveNodeLabels)
+	m.pveNodeOnline = gaugeVec(ns, "proxmox", "node_online", "PVE node online (1=yes)", pveNodeLabels)
+	pveGuestLabels := []string{"vmid", "name", "type", "node"}
+	m.pveGuestCPU = gaugeVec(ns, "proxmox", "guest_cpu_usage", "PVE guest CPU usage (0-1)", pveGuestLabels)
+	m.pveGuestMemUsed = gaugeVec(ns, "proxmox", "guest_memory_used_bytes", "PVE guest memory used", pveGuestLabels)
+	m.pveGuestMemMax = gaugeVec(ns, "proxmox", "guest_memory_max_bytes", "PVE guest memory max", pveGuestLabels)
+	m.pveGuestRunning = gaugeVec(ns, "proxmox", "guest_running", "PVE guest running (1=yes)", pveGuestLabels)
+	pveStorageLabels := []string{"storage", "node", "type"}
+	m.pveStorageUsed = gaugeVec(ns, "proxmox", "storage_used_bytes", "PVE storage used", pveStorageLabels)
+	m.pveStorageTotal = gaugeVec(ns, "proxmox", "storage_total_bytes", "PVE storage total", pveStorageLabels)
+
 	// ── Findings ──
 	m.findingsTotal = gaugeVec(ns, "findings", "total", "Findings by severity", []string{"severity"})
 	m.findingsCritical = gauge(ns, "findings", "critical_count", "Critical finding count")
@@ -269,6 +296,9 @@ func NewMetrics() *Metrics {
 		m.serviceUp, m.serviceLatency, m.serviceFailures,
 		m.paritySpeedMBs, m.parityDurationSec, m.parityErrors, m.parityRunning,
 		m.cfTunnelUp, m.cfTunnelConns, m.tsNodeOnline, m.tsNodeTxBytes, m.tsNodeRxBytes,
+		m.pveNodeCPU, m.pveNodeMemUsed, m.pveNodeMemTotal, m.pveNodeOnline,
+		m.pveGuestCPU, m.pveGuestMemUsed, m.pveGuestMemMax, m.pveGuestRunning,
+		m.pveStorageUsed, m.pveStorageTotal,
 		m.findingsTotal, m.findingsCritical, m.findingsWarning,
 		m.collectionDuration, m.lastCollectionTime, m.updateAvailable,
 	}
@@ -472,6 +502,39 @@ func (m *Metrics) Update(snap *internal.Snapshot) {
 				m.tsNodeTxBytes.With(l).Set(float64(nd.TxBytes))
 				m.tsNodeRxBytes.With(l).Set(float64(nd.RxBytes))
 			}
+		}
+	}
+
+	// ── Proxmox ──
+	m.pveNodeCPU.Reset()
+	m.pveNodeMemUsed.Reset()
+	m.pveNodeMemTotal.Reset()
+	m.pveNodeOnline.Reset()
+	m.pveGuestCPU.Reset()
+	m.pveGuestMemUsed.Reset()
+	m.pveGuestMemMax.Reset()
+	m.pveGuestRunning.Reset()
+	m.pveStorageUsed.Reset()
+	m.pveStorageTotal.Reset()
+	if snap.Proxmox != nil && snap.Proxmox.Connected {
+		for _, n := range snap.Proxmox.Nodes {
+			l := prometheus.Labels{"node": n.Name}
+			m.pveNodeCPU.With(l).Set(n.CPUUsage)
+			m.pveNodeMemUsed.With(l).Set(float64(n.MemUsed))
+			m.pveNodeMemTotal.With(l).Set(float64(n.MemTotal))
+			m.pveNodeOnline.With(l).Set(boolToFloat(n.Status == "online"))
+		}
+		for _, g := range snap.Proxmox.Guests {
+			l := prometheus.Labels{"vmid": fmt.Sprintf("%d", g.VMID), "name": g.Name, "type": g.Type, "node": g.Node}
+			m.pveGuestCPU.With(l).Set(g.CPUUsage)
+			m.pveGuestMemUsed.With(l).Set(float64(g.MemUsed))
+			m.pveGuestMemMax.With(l).Set(float64(g.MemMax))
+			m.pveGuestRunning.With(l).Set(boolToFloat(g.Status == "running"))
+		}
+		for _, s := range snap.Proxmox.Storage {
+			l := prometheus.Labels{"storage": s.Storage, "node": s.Node, "type": s.Type}
+			m.pveStorageUsed.With(l).Set(float64(s.Used))
+			m.pveStorageTotal.With(l).Set(float64(s.Total))
 		}
 	}
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -831,6 +831,10 @@ func executeServiceCheck(check internal.ServiceCheckConfig, now time.Time) inter
 			result.Error = err.Error()
 			break
 		}
+		req.Header.Set("User-Agent", "nas-doctor-service-check/1.0")
+		for k, v := range check.Headers {
+			req.Header.Set(k, v)
+		}
 		resp, err := (&http.Client{Timeout: time.Duration(timeoutSec) * time.Second}).Do(req)
 		result.ResponseMS = time.Since(start).Milliseconds()
 		if err != nil {

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -1155,6 +1155,18 @@ func (d *DB) PruneServiceCheckHistory(olderThan time.Duration) (int, error) {
 	return int(n), nil
 }
 
+// DeleteServiceCheckByKey removes all history for a specific service check key.
+func (d *DB) DeleteServiceCheckByKey(key string) (int, error) {
+	result, err := d.db.Exec("DELETE FROM service_checks_history WHERE key = ?", key)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := result.RowsAffected()
+	// Also remove from latest state
+	d.db.Exec("DELETE FROM service_checks_latest WHERE key = ?", key)
+	return int(n), nil
+}
+
 // GetFindingHistory returns how a specific finding category has changed over time.
 func (d *DB) GetFindingHistory(category string, limit int) ([]internal.Finding, error) {
 	rows, err := d.db.Query(`


### PR DESCRIPTION
## Summary

### New Features
- **Proxmox VE integration**: REST API collector for nodes, VMs, LXCs, storage pools, tasks, HA services. Settings UI with Test Connection + auto-detected node dropdown + display alias. Dashboard section in all 3 themes. Analyzer findings (node offline, memory critical, storage full, stale backups, HA errors). Prometheus metrics (10 gauges).
- **Fleet improvements**: Edit button per server, Test Connection with NAS Doctor signature validation (rejects proxy login pages), custom headers UI (CF Access support), clickable "Open Dashboard" links on fleet nodes, local IP + tunnel type detection in topology
- **Notification rules builder**: Replaces policy engine with dropdown-driven rule builder — 12 categories, live target selection, 5 one-click presets
- **Service check improvements**: Per-check HTTP custom headers, instance selector for fleet members, expandable log entries with full detail panel, orphaned check deletion
- **Dashboard filter persistence**: Severity filters saved to localStorage across refreshes
- **Page titles**: All pages show "NAS Doctor — {hostname}" dynamically

### Bug Fixes
- **Synology: missing /volumeX** — disk collector merges host mounts with df volumes
- **Synology: false green OK** — DataAvailable field, NO DATA badge, analyzer warnings
- **Section toggles**: Tunnels and Proxmox now properly hide/show
- **Fleet persistence**: Fixed stale data overwriting fleet servers when saving other settings
- **Proxmox startup**: Config loaded from DB on container restart
- **Parity/services/tunnels card wrappers**: Consistent bg-panel styling

### Other
- 80+ Prometheus metrics (UPS, ZFS, services, tunnels, Proxmox)
- Log forwarding: Loki, HTTP JSON, syslog
- HTTP service check favicon on badge cards
- README: motto, file structure, Proxmox docs