### PR TITLE
fix: protect /health with API key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,6 @@ ENV NAS_DOCTOR_LISTEN=":8060" \
 EXPOSE 8060
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8060/api/v1/health || exit 1
+    CMD nc -z localhost 8060 || exit 1
 
 ENTRYPOINT ["/app/nas-doctor"]

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -76,13 +76,10 @@ func (s *Server) Router() http.Handler {
 		MaxAge:           300,
 	}))
 
-	// API routes
+	// API routes — all protected by API key when set
 	r.Route("/api/v1", func(r chi.Router) {
-		// Health is always public (load balancers, probes)
-		r.Get("/health", s.handleHealth)
-
-		// All other API routes require API key when set
 		r.Use(s.apiKeyMiddleware)
+		r.Get("/health", s.handleHealth)
 		r.Get("/status", s.handleStatus)
 		r.Get("/snapshot/latest", s.handleLatestSnapshot)
 		r.Get("/snapshot/{id}", s.handleGetSnapshot)


### PR DESCRIPTION
All API endpoints now behind API key. TCP probes for Docker + K8s.