### PR TITLE
v0.7.2 — K8s split sections, fleet fixes, API key toggle, CI nightly tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,6 +58,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=raw,value=nightly,enable=${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
             type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc') }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,9 +58,8 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc') }}
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,45 +7,85 @@
 After every merge to `main` that includes code changes (not just docs):
 
 1. Determine the version bump:
-   - Patch (`v0.4.x`) for bug fixes
+   - Patch (`v0.7.x`) for bug fixes
    - Minor (`v0.x.0`) for new features
    - Major (`vX.0.0`) for breaking changes
 2. Tag: `git tag v<version> && git push origin v<version>`
 3. Create release: `gh release create v<version> --title "v<version> — <summary>" --notes "<notes>"`
+4. Update latest tag: `git tag -f latest && git push -f origin latest`
 
-The Docker CI workflow on `.github/workflows/docker.yml` publishes to GHCR on every push to `main` with `latest` tag, and on version tags with semver tags (`0.4.0`, `0.4`).
+The Docker CI workflow on `.github/workflows/docker.yml` publishes multi-arch (amd64+arm64) images to GHCR on every push to `main` with `latest` tag, and on version tags with semver tags.
 
 **Never push to main without tagging a version afterward.**
 
+**Use dev branches for testing — never push untested code to prod tags.**
+
 ## Versioning
 
-- Current: semver (`v0.2.0`, `v0.3.0`, `v0.3.1`, `v0.4.0`, `v0.4.1`)
+- Current: v0.7.0
 - Main branch is protected — all changes go through PRs
 - Docker images: `ghcr.io/mcdays94/nas-doctor:{latest,version,major.minor}`
+- Multi-arch: linux/amd64, linux/arm64 (Raspberry Pi, Apple Silicon)
+- RC tags (`v0.x.0-rc1`) for pre-release testing
 
 ## Architecture
 
 - Go backend, single binary, embedded HTML templates
+- Multi-stage Dockerfile with Go cross-compilation (no pre-compiled binaries)
 - 3 dashboard themes: midnight (default), clean, ember — each is a self-contained HTML file
-- Subpages (alerts, settings, stats, fleet, disk_detail) share `/css/shared.css` design system
+- Subpages: alerts, settings, stats, fleet, disk_detail, service_checks, parity
+- All subpages share `/css/shared.css` design system
 - SQLite database at `/data/nas-doctor.db`
 - Charts: custom vanilla JS library at `/js/charts.js` (no dependencies)
+- API key authentication: all `/api/v1/*` except `/health` protected when key is set
+- `/api/v1/health` is always public (Docker HEALTHCHECK, K8s probes, load balancers)
 
 ## Platform Support
 
-- **Tested**: Unraid, Synology DSM
-- **Untested**: TrueNAS SCALE, QNAP, Proxmox, generic Linux
-- The app must be platform-aware: detect the OS and adapt behavior (disk paths, SMART parsing, network interfaces, volume mounts)
-- Synology uses `/volume<#>` for data, `/dev/mapper/cachedev_*` devices
-- Unraid uses `/mnt/disk<#>`, `/mnt/cache`, md arrays
+- **Tested**: Unraid, Synology DSM (community), Proxmox (VM), Kubernetes (k3s)
+- **Untested**: TrueNAS SCALE, QNAP, generic Linux
+- The app must be platform-aware: detect the OS and adapt behavior
+- Synology: `/volume<#>` for data, `/dev/mapper/cachedev_*` devices
+- Unraid: `/mnt/disk<#>`, `/mnt/cache`, md arrays
+- Proxmox: PVE REST API integration (nodes, VMs, LXCs, storage, HA, tasks)
+- Kubernetes: K8s API integration (nodes, pods, deployments, services, PVCs, events)
 
 ## Key Files
 
-- `internal/collector/platform.go` — **centralized platform detection singleton** (Unraid, Synology, TrueNAS, QNAP, Proxmox, Linux). Detected once, cached for process lifetime. All collectors use `GetPlatform().IsUnraid()` etc.
-- `internal/collector/` — data collection (SMART, disk, docker, network, UPS, system, parity)
-- `internal/analyzer/` — diagnostic rules engine, Backblaze thresholds
-- `internal/api/` — HTTP handlers, embedded templates, chart library
+- `internal/collector/platform.go` — centralized platform detection singleton
+- `internal/collector/` — data collection (SMART, disk, docker, network, UPS, system, parity, tunnels, proxmox, kubernetes)
+- `internal/analyzer/` — diagnostic rules engine, Backblaze thresholds, Proxmox rules, K8s rules
+- `internal/api/` — HTTP handlers, embedded templates, API key middleware
 - `internal/api/styles.go` — shared CSS design system
-- `internal/api/templates/` — all HTML templates
-- `internal/scheduler/` — scan scheduling, alert lifecycle, notification policies
-- `internal/notifier/` — webhook delivery (Discord, Slack, Gotify, Ntfy, generic)
+- `internal/api/templates/` — all HTML templates (10 pages)
+- `internal/scheduler/` — scan scheduling, notification rules, service checks (independent 30s loop)
+- `internal/notifier/` — webhook delivery (Discord, Slack, Gotify, Ntfy, generic) + Prometheus exporter (90+ metrics)
+- `internal/fleet/` — multi-server fleet polling with custom headers
+- `internal/logfwd/` — log forwarding (Loki, HTTP JSON, syslog)
+- `internal/storage/` — SQLite database layer
+- `internal/demo/` — mock data (drives, Docker, ZFS, UPS, tunnels, Proxmox, K8s)
+
+## Integrations
+
+- **Proxmox VE**: REST API collector, settings UI with test connection + node auto-detect + alias
+- **Kubernetes**: API collector (in-cluster + external), nodes/pods/deployments/services/PVCs/events
+- **Cloudflared**: Tunnel detection (host + Docker), status, connections, routes
+- **Tailscale**: Peer graph, online status, TX/RX, exit nodes
+- **Fleet**: Multi-instance monitoring with custom auth headers, NAS Doctor signature validation
+- **Prometheus**: 90+ gauges covering all subsystems
+- **Log Forwarding**: Loki push, HTTP JSON, syslog (RFC 5424)
+
+## Important Patterns
+
+- **Never use `lsof -ti:PORT | xargs kill`** — it kills the user's browser. Use `pkill -f "nas-doctor"` instead
+- **Fleet servers persist via settings DB** — `buildSettingsPayload()` must use live `fleetServers` variable, not stale `base.fleet`
+- **Section toggles**: Must be in `sectionMap` in all 3 themes AND in `secIds` in settings.html
+- **Auto-enable sections**: When an integration is enabled (Proxmox, K8s), auto-set the section toggle to true
+- **Settings load on startup**: Proxmox + K8s configs must be applied to collector at startup from persisted settings
+- **Orphaned checks**: Match by target URL too, not just name (fleet auto-created checks have different names)
+
+## App Store Submissions
+
+- **Unraid CA**: Asana form submitted, docker-templates repo at mcdays94/docker-templates
+- **TrueNAS**: PR #4804 at truenas/apps
+- **Synology**: No app catalog (Docker Compose in README)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -76,12 +76,11 @@ func (s *Server) Router() http.Handler {
 		MaxAge:           300,
 	}))
 
-	// API routes
-	r.Route("/api/v1", func(r chi.Router) {
-		// Health is always public (Docker HEALTHCHECK, K8s probes, load balancers)
-		r.Get("/health", s.handleHealth)
+	// Health endpoint — always public (Docker HEALTHCHECK, K8s probes, load balancers)
+	r.Get("/api/v1/health", s.handleHealth)
 
-		// All other API routes require API key when set
+	// API routes — protected by API key when set
+	r.Route("/api/v1", func(r chi.Router) {
 		r.Use(s.apiKeyMiddleware)
 		r.Get("/status", s.handleStatus)
 		r.Get("/snapshot/latest", s.handleLatestSnapshot)

--- a/internal/api/templates/fleet.html
+++ b/internal/api/templates/fleet.html
@@ -87,8 +87,10 @@ body{padding:0}
     if(p.indexOf("synology")>=0)return{cls:"synology",icon:"S"};
     if(p.indexOf("proxmox")>=0||p.indexOf("pve")>=0)return{cls:"proxmox",icon:"P"};
     if(p.indexOf("truenas")>=0||p.indexOf("freenas")>=0)return{cls:"linux",icon:"T"};
-    if(p.indexOf("linux")>=0)return{cls:"linux",icon:"L"};
-    return{cls:"unknown",icon:"?"};
+    if(p.indexOf("k3s")>=0||p.indexOf("k8s")>=0||p.indexOf("kube")>=0)return{cls:"linux",icon:"K"};
+    if(p.indexOf("alpine")>=0||p.indexOf("linux")>=0||p.indexOf("ubuntu")>=0||p.indexOf("debian")>=0)return{cls:"linux",icon:"L"};
+    if(p.indexOf("docker")>=0)return{cls:"linux",icon:"D"};
+    return{cls:"unknown",icon:"N"};
   }
 
   function parseConnection(url){

--- a/internal/api/templates/fleet.html
+++ b/internal/api/templates/fleet.html
@@ -10,14 +10,15 @@
 body{padding:0}
 .container{max-width:1200px;margin:0 auto;padding:24px}
 /* Topology layout */
-.topo-container{margin-top:24px}
-.topo-center{display:flex;flex-direction:column;align-items:center;margin-bottom:0}
-.topo-self{background:var(--surface);border:2px solid var(--accent);border-radius:16px;padding:20px 32px;text-align:center;position:relative;z-index:2}
+.topo-container{margin-top:24px;display:flex;flex-direction:column;align-items:center}
+.topo-center{display:flex;flex-direction:column;align-items:center;width:100%}
+.topo-self{background:var(--surface);border:2px solid var(--accent);border-radius:16px;padding:20px 32px;text-align:center;position:relative;z-index:2;max-width:400px}
 .topo-self .node-name{font-size:18px;font-weight:700;margin-bottom:4px}
 .topo-self .node-role{font-size:11px;color:var(--accent);text-transform:uppercase;letter-spacing:1px;font-weight:600}
-.topo-spine{width:2px;height:32px;background:var(--border);margin:0 auto}
+.topo-spine{width:2px;height:32px;background:var(--border)}
+.topo-bus{height:2px;background:var(--border);align-self:stretch;margin:0 10%}
 /* Remote nodes grid */
-.topo-nodes{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:0 20px}
+.topo-nodes{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:0 20px;width:100%;margin-top:0}
 .topo-node-wrap{display:flex;flex-direction:column;align-items:center}
 .topo-drop{width:2px;height:28px;background:var(--border)}
 .node-card{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:16px;width:100%;transition:border-color 0.15s,transform 0.15s;margin-bottom:16px}
@@ -190,8 +191,7 @@ body{padding:0}
     h+='</div>';
     h+='<div class="topo-spine"></div>';
     // Horizontal bus bar rendered via SVG for clean connections
-    var cols=Math.min(statuses.length,4);
-    h+='<div style="width:100%;display:flex;justify-content:center"><div style="width:'+(cols>1?'80':'0')+'%;height:2px;background:var(--border)"></div></div>';
+    if(statuses.length>1)h+='<div class="topo-bus"></div>';
     h+='</div>';
     // Remote nodes
     h+='<div class="topo-nodes">';

--- a/internal/api/templates/midnight.html
+++ b/internal/api/templates/midnight.html
@@ -932,149 +932,102 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
     h += '</div>'; // end section-block proxmox
 
     // ======= Section: Kubernetes =======
-    h += '<div class="section-block" data-section="kubernetes">';
+    // ======= K8s: shared data prep =======
     var k8s = sn ? sn.kubernetes : null;
-    if (k8s) {
+    var k8sConnected = k8s && k8s.connected && !k8s.error;
+    var k8sTitle = k8s ? (k8s.alias ? esc(k8s.alias) : 'K8s') : 'K8s';
+    var k8sBadge = (k8s && k8s.platform ? ' <span style="font-size:10px;padding:1px 6px;border-radius:999px;background:rgba(94,106,210,0.12);color:var(--accent)">' + esc(k8s.platform) + '</span>' : '');
+
+    // ======= Section: K8s Nodes =======
+    h += '<div class="section-block" data-section="k8s_nodes">';
+    if (k8sConnected && k8s.nodes && k8s.nodes.length > 0) {
       h += '<div>';
-      var k8sTitle = k8s.alias ? esc(k8s.alias) : 'Kubernetes';
-      h += '<div class="section-title">' + k8sTitle + (k8s.platform ? ' <span style="font-size:10px;padding:1px 6px;border-radius:999px;background:rgba(94,106,210,0.12);color:var(--accent)">' + esc(k8s.platform) + '</span>' : '') + (k8s.version ? ' <span style="font-size:11px;color:var(--text-quaternary);font-weight:400">' + esc(k8s.version) + '</span>' : '') + '</div>';
-      if (k8s.error) {
-        h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:12px;color:var(--red);font-size:12px">' + esc(k8s.error) + '</div>';
-      } else if (k8s.connected) {
-        // Nodes
-        if (k8s.nodes && k8s.nodes.length > 0) {
-          h += '<div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:12px">';
-          for (var ki = 0; ki < k8s.nodes.length; ki++) {
-            var kn = k8s.nodes[ki];
-            var knReady = kn.status === 'Ready';
-            var knMemPct = kn.mem_total > 0 ? (kn.mem_usage / kn.mem_total * 100) : 0;
-            h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:10px 14px;flex:1;min-width:200px">';
-            h += '<div style="display:flex;align-items:center;gap:6px;margin-bottom:6px">';
-            h += '<span style="width:8px;height:8px;border-radius:50%;background:' + (knReady ? 'var(--green)' : 'var(--red)') + '"></span>';
-            h += '<span style="font-weight:600;font-size:13px">' + esc(kn.name) + '</span>';
-            if (kn.roles) h += '<span style="font-size:10px;padding:1px 6px;border-radius:999px;background:rgba(94,106,210,0.1);color:var(--accent)">' + esc(kn.roles) + '</span>';
-            h += '</div>';
-            h += '<div style="font-size:11px;color:var(--text-tertiary)">' + kn.cpu_cores + ' cores &middot; ' + (kn.mem_total > 0 ? (kn.mem_total/1073741824).toFixed(0) + ' GB RAM' : '?') + ' &middot; ' + kn.pod_count + '/' + kn.pod_capacity + ' pods</div>';
-            if (kn.disk_total > 0) {
-              var diskUsed = kn.disk_total - kn.disk_allocatable;
-              var diskPct = (diskUsed / kn.disk_total * 100);
-              var diskColor = diskPct >= 90 ? 'var(--red)' : diskPct >= 75 ? 'var(--amber)' : 'var(--green)';
-              var diskStr = kn.disk_total >= 1073741824 ? (kn.disk_total/1073741824).toFixed(0) + ' GB' : (kn.disk_total/1048576).toFixed(0) + ' MB';
-              h += '<div style="margin-top:4px"><div style="display:flex;justify-content:space-between;font-size:10px;color:var(--text-quaternary);margin-bottom:2px"><span>Disk</span><span>' + diskPct.toFixed(0) + '% of ' + diskStr + '</span></div>';
-              h += '<div style="height:3px;background:var(--border);border-radius:2px;overflow:hidden"><div style="height:100%;width:' + diskPct.toFixed(1) + '%;background:' + diskColor + ';border-radius:2px"></div></div></div>';
-            }
-            if (kn.conditions && kn.conditions.length > 0) h += '<div style="font-size:10px;color:var(--amber);margin-top:4px">' + esc(kn.conditions.join(', ')) + '</div>';
-            h += '</div>';
-          }
-          h += '</div>';
-        }
-        // Pods grouped by node
-        if (k8s.pods && k8s.pods.length > 0) {
-          var runningPods = k8s.pods.filter(function(p){ return p.status === 'Running'; });
-          var completedPods = k8s.pods.filter(function(p){ return p.status === 'Succeeded'; });
-          var problemPods = k8s.pods.filter(function(p){ return p.status !== 'Running' && p.status !== 'Succeeded'; });
-          var countStr = runningPods.length + ' running';
-          if (completedPods.length > 0) countStr += ', ' + completedPods.length + ' completed';
-          if (problemPods.length > 0) countStr += ', <span style="color:var(--red)">' + problemPods.length + ' issues</span>';
-          h += '<div style="font-size:11px;color:var(--text-quaternary);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:6px">Workloads (' + countStr + ')</div>';
-          // Problem pods banner
-          if (problemPods.length > 0) {
-            h += '<div style="background:rgba(220,38,38,0.08);border:1px solid rgba(220,38,38,0.2);border-radius:calc(var(--radius)*1.5);padding:8px 12px;margin-bottom:8px">';
-            for (var pp = 0; pp < problemPods.length; pp++) {
-              var prb = problemPods[pp];
-              h += '<div style="display:flex;align-items:center;gap:8px;padding:3px 0;font-size:12px">';
-              h += '<span style="color:var(--red);font-weight:600">' + esc(prb.status) + '</span>';
-              h += '<span style="font-weight:500">' + esc(prb.name) + '</span>';
-              h += '<span style="color:var(--text-quaternary);font-size:11px">' + esc(prb.namespace) + '</span>';
-              if (prb.restarts > 0) h += '<span style="color:var(--amber);font-size:11px">' + prb.restarts + ' restarts</span>';
-              h += '</div>';
-            }
-            h += '</div>';
-          }
-          // Group running pods by node
-          var podsByNode = {};
-          for (var pi = 0; pi < runningPods.length; pi++) {
-            var nd = runningPods[pi].node || 'unassigned';
-            if (!podsByNode[nd]) podsByNode[nd] = [];
-            podsByNode[nd].push(runningPods[pi]);
-          }
-          h += '<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:8px">';
-          var nodeNames = Object.keys(podsByNode).sort();
-          for (var nni = 0; nni < nodeNames.length; nni++) {
-            var nodeName = nodeNames[nni];
-            var nodePods = podsByNode[nodeName];
-            // Find node info
-            var nodeInfo = null;
-            for (var fi = 0; fi < (k8s.nodes||[]).length; fi++) { if (k8s.nodes[fi].name === nodeName) { nodeInfo = k8s.nodes[fi]; break; } }
-            h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:10px 12px">';
-            h += '<div style="display:flex;align-items:center;gap:6px;margin-bottom:8px;padding-bottom:6px;border-bottom:1px solid var(--border)">';
-            h += '<span style="width:8px;height:8px;border-radius:50%;background:' + (nodeInfo && nodeInfo.status === 'Ready' ? 'var(--green)' : 'var(--text-quaternary)') + '"></span>';
-            h += '<span style="font-weight:600;font-size:13px">' + esc(nodeName) + '</span>';
-            h += '<span style="font-size:10px;color:var(--text-quaternary);margin-left:auto">' + nodePods.length + ' pods</span>';
-            if (nodeInfo && nodeInfo.roles) h += '<span style="font-size:10px;padding:1px 6px;border-radius:999px;background:rgba(94,106,210,0.1);color:var(--accent)">' + esc(nodeInfo.roles) + '</span>';
-            h += '</div>';
-            // Disk bar for this node
-            if (nodeInfo && nodeInfo.disk_total > 0) {
-              var ndu = nodeInfo.disk_total - nodeInfo.disk_allocatable;
-              var ndp = (ndu / nodeInfo.disk_total * 100);
-              var ndc = ndp >= 90 ? 'var(--red)' : ndp >= 75 ? 'var(--amber)' : 'var(--green)';
-              h += '<div style="display:flex;align-items:center;gap:6px;margin-bottom:6px;font-size:10px;color:var(--text-quaternary)">';
-              h += '<span>Disk ' + ndp.toFixed(0) + '%</span>';
-              h += '<div style="flex:1;height:3px;background:var(--border);border-radius:2px;overflow:hidden"><div style="height:100%;width:' + ndp.toFixed(1) + '%;background:' + ndc + '"></div></div>';
-              h += '<span>' + (nodeInfo.disk_total >= 1073741824 ? (nodeInfo.disk_total/1073741824).toFixed(0) + 'G' : (nodeInfo.disk_total/1048576).toFixed(0) + 'M') + '</span>';
-              h += '</div>';
-            }
-            // Group pods by namespace within node
-            var nsPods = {};
-            for (var npi = 0; npi < nodePods.length; npi++) { var ns = nodePods[npi].namespace; if (!nsPods[ns]) nsPods[ns] = []; nsPods[ns].push(nodePods[npi]); }
-            var nsKeys = Object.keys(nsPods).sort();
-            for (var nsk = 0; nsk < nsKeys.length; nsk++) {
-              h += '<div style="margin-bottom:4px">';
-              h += '<div style="font-size:10px;color:var(--text-quaternary);text-transform:uppercase;letter-spacing:0.3px;margin-bottom:2px">' + esc(nsKeys[nsk]) + '</div>';
-              for (var npj = 0; npj < nsPods[nsKeys[nsk]].length; npj++) {
-                var pod = nsPods[nsKeys[nsk]][npj];
-                h += '<div style="display:flex;align-items:center;gap:6px;padding:2px 0;font-size:11px">';
-                h += '<span style="width:6px;height:6px;border-radius:50%;background:var(--green);flex-shrink:0"></span>';
-                h += '<span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1">' + esc(pod.name) + '</span>';
-                h += '<span style="color:var(--text-quaternary);font-size:10px">' + esc(pod.ready) + '</span>';
-                if (pod.restarts > 0) h += '<span style="color:var(--amber);font-size:10px">' + pod.restarts + 'r</span>';
-                h += '</div>';
-              }
-              h += '</div>';
-            }
-            h += '</div>';
-          }
-          h += '</div>';
-        }
-        // Deployments summary
-        if (k8s.deployments && k8s.deployments.length > 0) {
-          var unhealthy = k8s.deployments.filter(function(d){ return d.unavailable > 0; });
-          if (unhealthy.length > 0) {
-            h += '<div style="font-size:11px;color:var(--text-quaternary);text-transform:uppercase;letter-spacing:0.5px;margin:12px 0 6px">Unhealthy Deployments (' + unhealthy.length + ')</div>';
-            for (var di = 0; di < unhealthy.length; di++) {
-              var dep = unhealthy[di];
-              h += '<div style="display:flex;align-items:center;gap:8px;padding:4px 0;font-size:12px"><span style="color:var(--red);font-weight:600">' + esc(dep.name) + '</span><span style="color:var(--text-tertiary)">' + dep.ready_replicas + '/' + dep.replicas + ' ready</span><span style="font-size:11px;color:var(--text-quaternary)">' + esc(dep.namespace) + '</span></div>';
-            }
-          }
-        }
-        // Warning events
-        if (k8s.events && k8s.events.length > 0) {
-          h += '<div style="font-size:11px;color:var(--text-quaternary);text-transform:uppercase;letter-spacing:0.5px;margin:12px 0 6px">Recent Warnings (' + k8s.events.length + ')</div>';
-          h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:8px;max-height:150px;overflow-y:auto;scrollbar-width:thin">';
-          for (var ei = 0; ei < Math.min(k8s.events.length, 10); ei++) {
-            var ev = k8s.events[ei];
-            h += '<div style="font-size:11px;padding:3px 0;border-bottom:1px solid var(--border)">';
-            h += '<span style="color:var(--amber);font-weight:600">' + esc(ev.reason) + '</span>';
-            h += ' <span style="color:var(--text-quaternary)">' + esc(ev.object) + '</span>';
-            h += ' <span style="color:var(--text-tertiary)">' + esc(ev.message).substring(0, 80) + '</span>';
-            h += '</div>';
-          }
-          h += '</div>';
-        }
+      h += '<div class="section-title">' + k8sTitle + ' Nodes' + k8sBadge + (k8s.version ? ' <span style="font-size:11px;color:var(--text-quaternary);font-weight:400">' + esc(k8s.version) + '</span>' : '') + '</div>';
+      h += '<div style="display:flex;gap:8px;flex-wrap:wrap">';
+      for (var ki = 0; ki < k8s.nodes.length; ki++) {
+        var kn = k8s.nodes[ki]; var knReady = kn.status === 'Ready';
+        h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:10px 14px;flex:1;min-width:200px">';
+        h += '<div style="display:flex;align-items:center;gap:6px;margin-bottom:6px"><span style="width:8px;height:8px;border-radius:50%;background:' + (knReady ? 'var(--green)' : 'var(--red)') + '"></span><span style="font-weight:600;font-size:13px">' + esc(kn.name) + '</span>';
+        if (kn.roles) h += '<span style="font-size:10px;padding:1px 6px;border-radius:999px;background:rgba(94,106,210,0.1);color:var(--accent)">' + esc(kn.roles) + '</span>';
+        h += '</div>';
+        h += '<div style="font-size:11px;color:var(--text-tertiary)">' + kn.cpu_cores + ' cores &middot; ' + (kn.mem_total > 0 ? (kn.mem_total/1073741824).toFixed(0) + ' GB RAM' : '?') + ' &middot; ' + kn.pod_count + '/' + kn.pod_capacity + ' pods</div>';
+        if (kn.disk_total > 0) { var du=kn.disk_total-kn.disk_allocatable,dp=du/kn.disk_total*100,dc=dp>=90?'var(--red)':dp>=75?'var(--amber)':'var(--green)',ds=kn.disk_total>=1073741824?(kn.disk_total/1073741824).toFixed(0)+' GB':(kn.disk_total/1048576).toFixed(0)+' MB'; h += '<div style="margin-top:4px"><div style="display:flex;justify-content:space-between;font-size:10px;color:var(--text-quaternary);margin-bottom:2px"><span>Disk</span><span>'+dp.toFixed(0)+'% of '+ds+'</span></div><div style="height:3px;background:var(--border);border-radius:2px;overflow:hidden"><div style="height:100%;width:'+dp.toFixed(1)+'%;background:'+dc+'"></div></div></div>'; }
+        if (kn.conditions && kn.conditions.length > 0) h += '<div style="font-size:10px;color:var(--amber);margin-top:4px">' + esc(kn.conditions.join(', ')) + '</div>';
+        h += '</div>';
       }
-      h += '</div>';
+      h += '</div></div>';
+    } else if (k8s && k8s.error) {
+      h += '<div><div class="section-title">' + k8sTitle + ' Nodes</div><div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:12px;color:var(--red);font-size:12px">' + esc(k8s.error) + '</div></div>';
     }
-    h += '</div>'; // end section-block kubernetes
+    h += '</div>'; // end k8s_nodes
+
+    // ======= Section: K8s Workloads (pods by node) =======
+    h += '<div class="section-block" data-section="k8s_workloads">';
+    if (k8sConnected && k8s.pods && k8s.pods.length > 0) {
+      var runningPods = k8s.pods.filter(function(p){ return p.status === 'Running'; });
+      var completedPods = k8s.pods.filter(function(p){ return p.status === 'Succeeded'; });
+      var problemPods = k8s.pods.filter(function(p){ return p.status !== 'Running' && p.status !== 'Succeeded'; });
+      var countStr = runningPods.length + ' running';
+      if (completedPods.length > 0) countStr += ', ' + completedPods.length + ' completed';
+      if (problemPods.length > 0) countStr += ', <span style="color:var(--red)">' + problemPods.length + ' issues</span>';
+      h += '<div>';
+      h += '<div class="section-title">' + k8sTitle + ' Workloads (' + countStr + ')</div>';
+      if (problemPods.length > 0) {
+        h += '<div style="background:rgba(220,38,38,0.08);border:1px solid rgba(220,38,38,0.2);border-radius:calc(var(--radius)*1.5);padding:8px 12px;margin-bottom:8px">';
+        for (var pp = 0; pp < problemPods.length; pp++) { var prb = problemPods[pp]; h += '<div style="display:flex;align-items:center;gap:8px;padding:3px 0;font-size:12px"><span style="color:var(--red);font-weight:600">'+esc(prb.status)+'</span><span style="font-weight:500">'+esc(prb.name)+'</span><span style="color:var(--text-quaternary);font-size:11px">'+esc(prb.namespace)+'</span>'+(prb.restarts>0?'<span style="color:var(--amber);font-size:11px">'+prb.restarts+' restarts</span>':'')+'</div>'; }
+        h += '</div>';
+      }
+      var podsByNode = {}; for (var pi = 0; pi < runningPods.length; pi++) { var nd = runningPods[pi].node || 'unassigned'; if (!podsByNode[nd]) podsByNode[nd] = []; podsByNode[nd].push(runningPods[pi]); }
+      h += '<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:8px">';
+      var nodeNames = Object.keys(podsByNode).sort();
+      for (var nni = 0; nni < nodeNames.length; nni++) {
+        var nodeName = nodeNames[nni]; var nodePods = podsByNode[nodeName];
+        var nodeInfo = null; for (var fi = 0; fi < (k8s.nodes||[]).length; fi++) { if (k8s.nodes[fi].name === nodeName) { nodeInfo = k8s.nodes[fi]; break; } }
+        h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:10px 12px">';
+        h += '<div style="display:flex;align-items:center;gap:6px;margin-bottom:8px;padding-bottom:6px;border-bottom:1px solid var(--border)"><span style="width:8px;height:8px;border-radius:50%;background:'+(nodeInfo&&nodeInfo.status==='Ready'?'var(--green)':'var(--text-quaternary)')+'"></span><span style="font-weight:600;font-size:13px">'+esc(nodeName)+'</span><span style="font-size:10px;color:var(--text-quaternary);margin-left:auto">'+nodePods.length+' pods</span>';
+        if (nodeInfo&&nodeInfo.roles) h+='<span style="font-size:10px;padding:1px 6px;border-radius:999px;background:rgba(94,106,210,0.1);color:var(--accent)">'+esc(nodeInfo.roles)+'</span>';
+        h += '</div>';
+        if (nodeInfo&&nodeInfo.disk_total>0){var ndu=nodeInfo.disk_total-nodeInfo.disk_allocatable,ndp=ndu/nodeInfo.disk_total*100,ndc=ndp>=90?'var(--red)':ndp>=75?'var(--amber)':'var(--green)';h+='<div style="display:flex;align-items:center;gap:6px;margin-bottom:6px;font-size:10px;color:var(--text-quaternary)"><span>Disk '+ndp.toFixed(0)+'%</span><div style="flex:1;height:3px;background:var(--border);border-radius:2px;overflow:hidden"><div style="height:100%;width:'+ndp.toFixed(1)+'%;background:'+ndc+'"></div></div><span>'+(nodeInfo.disk_total>=1073741824?(nodeInfo.disk_total/1073741824).toFixed(0)+'G':(nodeInfo.disk_total/1048576).toFixed(0)+'M')+'</span></div>';}
+        var nsPods = {}; for (var npi = 0; npi < nodePods.length; npi++) { var ns = nodePods[npi].namespace; if (!nsPods[ns]) nsPods[ns] = []; nsPods[ns].push(nodePods[npi]); }
+        var nsKeys = Object.keys(nsPods).sort();
+        for (var nsk = 0; nsk < nsKeys.length; nsk++) {
+          h += '<div style="margin-bottom:4px"><div style="font-size:10px;color:var(--text-quaternary);text-transform:uppercase;letter-spacing:0.3px;margin-bottom:2px">' + esc(nsKeys[nsk]) + '</div>';
+          for (var npj = 0; npj < nsPods[nsKeys[nsk]].length; npj++) { var pod = nsPods[nsKeys[nsk]][npj]; h += '<div style="display:flex;align-items:center;gap:6px;padding:2px 0;font-size:11px"><span style="width:6px;height:6px;border-radius:50%;background:var(--green);flex-shrink:0"></span><span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1">'+esc(pod.name)+'</span><span style="color:var(--text-quaternary);font-size:10px">'+esc(pod.ready)+'</span>'+(pod.restarts>0?'<span style="color:var(--amber);font-size:10px">'+pod.restarts+'r</span>':'')+'</div>'; }
+          h += '</div>';
+        }
+        h += '</div>';
+      }
+      h += '</div></div>';
+    }
+    h += '</div>'; // end k8s_workloads
+
+    // ======= Section: K8s Deployments =======
+    h += '<div class="section-block" data-section="k8s_deployments">';
+    if (k8sConnected && k8s.deployments && k8s.deployments.length > 0) {
+      var unhealthyDeps = k8s.deployments.filter(function(d){ return d.unavailable > 0; });
+      h += '<div>';
+      h += '<div class="section-title">' + k8sTitle + ' Deployments (' + k8s.deployments.length + ')' + (unhealthyDeps.length > 0 ? ' <span style="color:var(--red)">' + unhealthyDeps.length + ' unhealthy</span>' : '') + '</div>';
+      h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);overflow:hidden;max-height:250px;overflow-y:auto;scrollbar-width:thin">';
+      h += '<table style="width:100%;font-size:12px;border-collapse:collapse"><tr style="color:var(--text-quaternary);font-size:10px;text-transform:uppercase;letter-spacing:0.5px;position:sticky;top:0;background:var(--bg-panel)"><th style="text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)">Name</th><th style="text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)">NS</th><th style="text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)">Ready</th><th style="text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)">Strategy</th></tr>';
+      for (var di = 0; di < k8s.deployments.length; di++) { var dep = k8s.deployments[di]; var dOk = dep.unavailable === 0 && dep.ready_replicas >= dep.replicas;
+        h += '<tr><td style="padding:5px 8px;border-bottom:1px solid var(--border);font-weight:500;color:'+(dOk?'inherit':'var(--red)')+'">'+esc(dep.name)+'</td><td style="padding:5px 8px;border-bottom:1px solid var(--border);font-size:11px;color:var(--text-tertiary)">'+esc(dep.namespace)+'</td><td style="padding:5px 8px;border-bottom:1px solid var(--border);color:'+(dOk?'var(--green)':'var(--red)')+'">'+dep.ready_replicas+'/'+dep.replicas+'</td><td style="padding:5px 8px;border-bottom:1px solid var(--border);font-size:11px;color:var(--text-quaternary)">'+esc(dep.strategy||'')+'</td></tr>';
+      }
+      h += '</table></div></div>';
+    }
+    h += '</div>'; // end k8s_deployments
+
+    // ======= Section: K8s Events =======
+    h += '<div class="section-block" data-section="k8s_events">';
+    if (k8sConnected && k8s.events && k8s.events.length > 0) {
+      h += '<div>';
+      h += '<div class="section-title">' + k8sTitle + ' Events (' + k8s.events.length + ' warnings)</div>';
+      h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:8px;max-height:200px;overflow-y:auto;scrollbar-width:thin">';
+      for (var ei = 0; ei < Math.min(k8s.events.length, 15); ei++) { var ev = k8s.events[ei];
+        h += '<div style="font-size:11px;padding:4px 0;border-bottom:1px solid var(--border)"><span style="color:var(--amber);font-weight:600">' + esc(ev.reason) + '</span> <span style="color:var(--text-quaternary)">' + esc(ev.object) + '</span> <span style="color:var(--text-tertiary)">' + esc(ev.message).substring(0, 100) + '</span></div>';
+      }
+      h += '</div></div>';
+    }
+    h += '</div>'; // end k8s_events
 
     // ======= Section: Parity =======
     h += '<div class="section-block" data-section="parity">';
@@ -1179,6 +1132,10 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
       "tunnels": sec.tunnels !== false,
       "proxmox": sec.proxmox !== false,
       "kubernetes": sec.kubernetes !== false,
+      "k8s_nodes": sec.kubernetes !== false,
+      "k8s_workloads": sec.kubernetes !== false,
+      "k8s_deployments": sec.kubernetes !== false,
+      "k8s_events": sec.kubernetes !== false,
       "parity": sec.parity !== false
     };
 

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -146,7 +146,10 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
     <div class="card-title">API Key</div>
     <div class="card-desc">Protect this instance's API. When set, all API requests (fleet polling, service checks, etc.) require this key in the Authorization header. The dashboard UI is not affected.</div>
     <div style="display:flex;align-items:center;gap:10px;margin-top:12px">
-      <input type="text" id="api-key-display" readonly style="flex:1;font-family:var(--font-mono);font-size:12px;letter-spacing:0.5px" placeholder="No API key set — instance is open">
+      <input type="password" id="api-key-display" readonly style="flex:1;font-family:var(--font-mono);font-size:12px;letter-spacing:0.5px" placeholder="No API key set — instance is open">
+      <button class="btn btn-secondary btn-sm" onclick="toggleAPIKeyVisibility()" title="Show/Hide">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align:middle"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+      </button>
       <button class="btn btn-secondary btn-sm" onclick="generateAPIKey()">Generate</button>
       <button class="btn btn-secondary btn-sm" onclick="copyAPIKey()">Copy</button>
       <button class="btn btn-danger btn-sm" onclick="revokeAPIKey()">Revoke</button>
@@ -2242,6 +2245,10 @@ function addPreset(preset) {
 }
 
 // Load snapshot for target dropdowns
+function toggleAPIKeyVisibility() {
+  var el = document.getElementById("api-key-display");
+  el.type = el.type === "password" ? "text" : "password";
+}
 function generateAPIKey() {
   var key = 'nd-' + crypto.randomUUID().replace(/-/g, '');
   document.getElementById("api-key-display").value = key;

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -118,7 +119,7 @@ func (m *Manager) pollServer(srv internal.RemoteServer) *internal.RemoteServerSt
 		LastPoll: time.Now().Format(time.RFC3339),
 	}
 
-	url := srv.URL + "/api/v1/status"
+	url := strings.TrimRight(srv.URL, "/") + "/api/v1/status"
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		result.Error = fmt.Sprintf("invalid URL: %v", err)


### PR DESCRIPTION
### Features
- K8s dashboard split into 4 independent draggable sections (Nodes, Workloads, Deployments, Events)
- CI: `nightly` Docker tag for non-main builds (RC tags never get `latest`)
- API key field: hide/show toggle for screen sharing

### Fixes
- Fleet: trailing slash in URL causing 404 on polling
- Fleet: platform icons for alpine, k3s, ubuntu, docker
- Chi middleware panic: /health registered outside middleware group
- Fleet topology centering CSS

### Other
- AGENTS.md updated to v0.7.0 context