### PR TITLE
fix(ci): build demo binary with version ldflags

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -28,8 +28,19 @@ jobs:
         with:
           go-version: '1.23'
 
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
+            echo "value=${LATEST_TAG#v}" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Version: $(cat "$GITHUB_OUTPUT" | grep value | cut -d= -f2)"
+
       - name: Build NAS Doctor
-        run: go build -o nas-doctor ./cmd/nas-doctor
+        run: go build -ldflags="-X main.version=${{ steps.version.outputs.value }}" -o nas-doctor ./cmd/nas-doctor
 
       - name: Run demo & capture everything
         run: |


### PR DESCRIPTION
Binary was built without -ldflags, returning 'dev'. Now injects the version from the git tag.