### PR TITLE
fix(ci): use semver tag for demo version

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -37,10 +37,9 @@ jobs:
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
           else
-            LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
-            echo "value=${LATEST_TAG#v}" >> "$GITHUB_OUTPUT"
+            LATEST_TAG=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1)
+            echo "value=${LATEST_TAG:-v0.0.0}" | sed 's/^v//' >> "$GITHUB_OUTPUT"
           fi
-          echo "Version: $(cat "$GITHUB_OUTPUT" | grep value | cut -d= -f2)"
 
       - name: Build NAS Doctor
         run: go build -ldflags="-X main.version=${{ steps.version.outputs.value }}" -o nas-doctor ./cmd/nas-doctor


### PR DESCRIPTION
Was picking up 'latest' tag. Now filters to v* semver tags only.