### PR TITLE
fix: container chart history + Synology SMART detection (#73, #74)

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -200,3 +200,13 @@ func (c *Collector) Collect() (*internal.Snapshot, error) {
 	c.logger.Info("collection complete", "duration", fmt.Sprintf("%.1fs", snap.Duration))
 	return snap, nil
 }
+
+// CollectDockerStats runs a lightweight Docker stats collection (no full scan).
+// Used by the scheduler's independent container stats loop for chart history.
+func (c *Collector) CollectDockerStats() (*internal.DockerInfo, error) {
+	info, err := collectDocker()
+	if err != nil {
+		return nil, err
+	}
+	return &info, nil
+}

--- a/internal/collector/smart.go
+++ b/internal/collector/smart.go
@@ -56,6 +56,9 @@ func discoverDrives() []string {
 	// Discover /dev/sd* drives (Linux SCSI/SATA)
 	matches, _ := filepath.Glob("/dev/sd[a-z]")
 	drives = append(drives, matches...)
+	// Multi-letter (sdaa, sdab, etc.)
+	matches2, _ := filepath.Glob("/dev/sd[a-z][a-z]")
+	drives = append(drives, matches2...)
 
 	// Discover /dev/da* drives (FreeBSD SCSI/SAS — TrueNAS CORE)
 	daMatches, _ := filepath.Glob("/dev/da[0-9]")
@@ -69,9 +72,17 @@ func discoverDrives() []string {
 	adaMatches2, _ := filepath.Glob("/dev/ada[0-9][0-9]")
 	drives = append(drives, adaMatches2...)
 
+	// Synology: /dev/sata* devices (maps to internal bays)
+	sataMatches, _ := filepath.Glob("/dev/sata[0-9]")
+	drives = append(drives, sataMatches...)
+	sataMatches2, _ := filepath.Glob("/dev/sata[0-9][0-9]")
+	drives = append(drives, sataMatches2...)
+
 	// Discover NVMe drives
 	nvmeMatches, _ := filepath.Glob("/dev/nvme[0-9]n1")
 	drives = append(drives, nvmeMatches...)
+	nvmeMatches2, _ := filepath.Glob("/dev/nvme[0-9][0-9]n1")
+	drives = append(drives, nvmeMatches2...)
 
 	return drives
 }
@@ -87,6 +98,18 @@ func readSMARTDevice(device string) (internal.SMARTInfo, error) {
 	out, _ := execCmd("smartctl", "--json=c", "-a", device)
 	if strings.Contains(out, "json_format_version") {
 		return parseSMARTJSON(device, out)
+	}
+
+	// Fallback: try with SCSI-to-ATA translation (needed for some Synology/QNAP bays)
+	if strings.Contains(out, "Unknown USB bridge") || strings.Contains(out, "Please specify device type") ||
+		strings.Contains(out, "INQUIRY failed") || strings.Contains(out, "unable to detect device") ||
+		out == "" {
+		for _, devType := range []string{"sat", "auto", "scsi"} {
+			out2, _ := execCmd("smartctl", "--json=c", "-a", "-d", devType, device)
+			if strings.Contains(out2, "json_format_version") {
+				return parseSMARTJSON(device, out2)
+			}
+		}
 	}
 
 	// Check for USB bridge / unsupported device

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -177,6 +177,22 @@ func (s *Scheduler) Start() {
 		}
 	}()
 
+	// Independent container stats loop — collects Docker metrics every 5 minutes
+	// for chart history (full scans happen every 6h which is too infrequent for charts)
+	go func() {
+		time.Sleep(30 * time.Second) // let first scan finish
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				s.collectContainerStats()
+			case <-s.stop:
+				return
+			}
+		}
+	}()
+
 	// Independent speed test loop — default 4h interval
 	go func() {
 		// Run first test 2 minutes after startup
@@ -754,6 +770,26 @@ const defaultCheckIntervalSec = 300 // 5 minutes
 // runDueServiceChecks is called every 30s by the independent service check
 // loop. It checks each configured check's per-check interval and only
 // executes those whose interval has elapsed since their last run.
+// collectContainerStats runs a lightweight Docker stats collection and saves to DB.
+// This runs every 5 minutes independently of the main scan (which runs every 6h)
+// to provide enough data points for the container metrics charts.
+func (s *Scheduler) collectContainerStats() {
+	docker, err := s.collector.CollectDockerStats()
+	if err != nil || docker == nil || !docker.Available {
+		return
+	}
+	if err := s.store.SaveContainerStats(docker); err != nil {
+		s.logger.Warn("failed to save container stats", "error", err)
+		return
+	}
+	// Update the cached snapshot's Docker data so the dashboard shows fresh values
+	s.mu.Lock()
+	if s.latest != nil {
+		s.latest.Docker = *docker
+	}
+	s.mu.Unlock()
+}
+
 // runSpeedTest executes a network speed test and stores the result.
 func (s *Scheduler) runSpeedTest() {
 	s.logger.Info("running speed test")

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -470,6 +470,33 @@ func (d *DB) saveContainerHistory(tx *sql.Tx, snap *internal.Snapshot) error {
 	return nil
 }
 
+// SaveContainerStats saves a standalone container stats snapshot (not tied to a full scan).
+// Used by the lightweight container stats collection loop.
+func (d *DB) SaveContainerStats(docker *internal.DockerInfo) error {
+	if docker == nil || !docker.Available {
+		return nil
+	}
+	now := time.Now()
+	snapshotID := fmt.Sprintf("cstats-%d", now.UnixMilli())
+	for _, c := range docker.Containers {
+		if c.State != "running" {
+			continue
+		}
+		_, err := d.db.Exec(
+			`INSERT INTO container_stats_history (snapshot_id, container_id, name, image, cpu_pct, mem_mb, mem_pct, net_in_bytes, net_out_bytes, block_read_bytes, block_write_bytes, timestamp)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			snapshotID, c.ID, c.Name, c.Image,
+			c.CPU, c.MemMB, c.MemPct,
+			c.NetIn, c.NetOut, c.BlockRead, c.BlockWrite,
+			now,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // ContainerHistoryPoint represents a single time-series data point for a container.
 type ContainerHistoryPoint struct {
 	Timestamp  time.Time `json:"timestamp"`


### PR DESCRIPTION
Fixes #73 (container charts empty) and #74 (Synology SMART unavailable). See commit for details.