### PR TITLE
Define Store interface hierarchy + FakeStore + update callers

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -34,7 +34,7 @@ const (
 
 // Server holds dependencies for the HTTP API.
 type Server struct {
-	store     *storage.DB
+	store     storage.Store
 	scheduler *scheduler.Scheduler
 	collector *collector.Collector
 	metrics   *notifier.Metrics
@@ -45,7 +45,7 @@ type Server struct {
 }
 
 // New creates a new API server.
-func New(store *storage.DB, sched *scheduler.Scheduler, coll *collector.Collector, metrics *notifier.Metrics, fleetMgr *fleet.Manager, logger *slog.Logger, version string) *Server {
+func New(store storage.Store, sched *scheduler.Scheduler, coll *collector.Collector, metrics *notifier.Metrics, fleetMgr *fleet.Manager, logger *slog.Logger, version string) *Server {
 	return &Server{
 		store:     store,
 		scheduler: sched,

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -82,7 +82,7 @@ type AlertingConfig struct {
 // Scheduler periodically runs diagnostic collections and analysis.
 type Scheduler struct {
 	collector         *collector.Collector
-	store             *storage.DB
+	store             storage.Store
 	notifier          *notifier.Notifier
 	metrics           *notifier.Metrics
 	logger            *slog.Logger
@@ -109,7 +109,7 @@ type Scheduler struct {
 // New creates a new Scheduler.
 func New(
 	col *collector.Collector,
-	store *storage.DB,
+	store storage.Store,
 	notif *notifier.Notifier,
 	metrics *notifier.Metrics,
 	logger *slog.Logger,

--- a/internal/storage/fake.go
+++ b/internal/storage/fake.go
@@ -1,0 +1,525 @@
+package storage
+
+import (
+	"fmt"
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// FakeStore is an in-memory Store implementation for testing.
+// It provides correct behavior for the most commonly tested methods;
+// less-used methods return zero values and are marked with TODO comments.
+type FakeStore struct {
+	mu sync.RWMutex
+
+	// Snapshots keyed by ID, ordered slice for listing.
+	snapshots []*internal.Snapshot
+
+	// Service check history, newest first per key.
+	serviceChecks []internal.ServiceCheckResult
+
+	// Config key/value pairs.
+	config map[string]string
+
+	// Notification log entries.
+	notificationLog []NotificationLogEntry
+
+	// Notification dedup state: "fingerprint|routeKey" → sentAt.
+	notificationState map[string]time.Time
+
+	// Alert state.
+	alerts      []AlertRecord
+	alertSeq    int64
+	alertEvents []AlertEvent
+
+	// Finding history keyed by category.
+	findingsByCategory map[string][]internal.Finding
+}
+
+// NewFakeStore creates a ready-to-use in-memory store.
+func NewFakeStore() *FakeStore {
+	return &FakeStore{
+		config:             make(map[string]string),
+		notificationState:  make(map[string]time.Time),
+		findingsByCategory: make(map[string][]internal.Finding),
+	}
+}
+
+// Compile-time check: FakeStore must satisfy Store.
+var _ Store = (*FakeStore)(nil)
+
+// ── SnapshotStore ──
+
+func (f *FakeStore) SaveSnapshot(snap *internal.Snapshot) error {
+	if snap == nil {
+		return fmt.Errorf("nil snapshot")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	// Store a shallow copy to avoid mutation.
+	cp := *snap
+	f.snapshots = append(f.snapshots, &cp)
+	return nil
+}
+
+func (f *FakeStore) GetLatestSnapshot() (*internal.Snapshot, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if len(f.snapshots) == 0 {
+		return nil, nil
+	}
+	// Return the most recent by timestamp.
+	latest := f.snapshots[0]
+	for _, s := range f.snapshots[1:] {
+		if s.Timestamp.After(latest.Timestamp) {
+			latest = s
+		}
+	}
+	return latest, nil
+}
+
+func (f *FakeStore) GetSnapshot(id string) (*internal.Snapshot, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	for _, s := range f.snapshots {
+		if s.ID == id {
+			return s, nil
+		}
+	}
+	return nil, nil
+}
+
+func (f *FakeStore) ListSnapshots(limit int) ([]SnapshotSummary, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	// Sort by timestamp descending.
+	sorted := make([]*internal.Snapshot, len(f.snapshots))
+	copy(sorted, f.snapshots)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Timestamp.After(sorted[j].Timestamp)
+	})
+	if limit > 0 && len(sorted) > limit {
+		sorted = sorted[:limit]
+	}
+	var out []SnapshotSummary
+	for _, s := range sorted {
+		summary := SnapshotSummary{
+			ID:        s.ID,
+			Timestamp: s.Timestamp,
+			Duration:  s.Duration,
+		}
+		for _, f := range s.Findings {
+			switch f.Severity {
+			case "critical":
+				summary.CriticalCount++
+			case "warning":
+				summary.WarningCount++
+			case "info":
+				summary.InfoCount++
+			}
+		}
+		out = append(out, summary)
+	}
+	return out, nil
+}
+
+// ── AlertStore ──
+
+func (f *FakeStore) SyncAlertStates(_ string, _ []AlertStateFinding, _ time.Time) error {
+	// TODO: implement alert sync for testing
+	return nil
+}
+
+func (f *FakeStore) ListAlerts(_ string, _ int, _ time.Time) ([]AlertRecord, error) {
+	// TODO: implement alert listing for testing
+	return nil, nil
+}
+
+func (f *FakeStore) GetAlert(_ int64, _ time.Time) (*AlertRecord, error) {
+	// TODO: implement alert retrieval for testing
+	return nil, nil
+}
+
+func (f *FakeStore) GetAlertEvents(_ int64, _ int) ([]AlertEvent, error) {
+	// TODO: implement alert events for testing
+	return nil, nil
+}
+
+func (f *FakeStore) AcknowledgeAlert(_ int64, _ string, _ time.Time) (bool, error) {
+	// TODO: implement for testing
+	return false, nil
+}
+
+func (f *FakeStore) UnacknowledgeAlert(_ int64, _ string, _ time.Time) (bool, error) {
+	// TODO: implement for testing
+	return false, nil
+}
+
+func (f *FakeStore) SnoozeAlert(_ int64, _ time.Time, _ string, _ time.Time) (bool, error) {
+	// TODO: implement for testing
+	return false, nil
+}
+
+func (f *FakeStore) UnsnoozeAlert(_ int64, _ string, _ time.Time) (bool, error) {
+	// TODO: implement for testing
+	return false, nil
+}
+
+func (f *FakeStore) IsAlertSuppressed(_ string, _ time.Time) (bool, string, error) {
+	return false, "", nil
+}
+
+func (f *FakeStore) MarkAlertsNotifiedByFingerprint(_ []string, _ time.Time) error {
+	return nil
+}
+
+// ── ServiceCheckStore ──
+
+func (f *FakeStore) SaveServiceCheckResults(results []internal.ServiceCheckResult) error {
+	if len(results) == 0 {
+		return nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.serviceChecks = append(f.serviceChecks, results...)
+	return nil
+}
+
+func (f *FakeStore) GetLatestServiceCheckState(checkKey string) (ServiceCheckState, bool, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	// Walk backwards to find the most recent entry for this key.
+	for i := len(f.serviceChecks) - 1; i >= 0; i-- {
+		r := f.serviceChecks[i]
+		if r.Key == checkKey {
+			checkedAt, _ := time.Parse(time.RFC3339, r.CheckedAt)
+			return ServiceCheckState{
+				Status:              r.Status,
+				ConsecutiveFailures: r.ConsecutiveFailures,
+				CheckedAt:           checkedAt,
+			}, true, nil
+		}
+	}
+	return ServiceCheckState{}, false, nil
+}
+
+func (f *FakeStore) ListLatestServiceChecks(limit int) ([]ServiceCheckEntry, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	// Collect the latest result per key.
+	latest := make(map[string]internal.ServiceCheckResult)
+	for _, r := range f.serviceChecks {
+		if _, exists := latest[r.Key]; !exists {
+			latest[r.Key] = r
+		} else {
+			// Keep the one with the later CheckedAt.
+			existing := latest[r.Key]
+			if r.CheckedAt > existing.CheckedAt {
+				latest[r.Key] = r
+			}
+		}
+	}
+	var entries []ServiceCheckEntry
+	for _, r := range latest {
+		entries = append(entries, ServiceCheckEntry{
+			Key:                 r.Key,
+			Name:                r.Name,
+			Type:                r.Type,
+			Target:              r.Target,
+			Status:              r.Status,
+			ResponseMS:          r.ResponseMS,
+			Error:               r.Error,
+			ConsecutiveFailures: r.ConsecutiveFailures,
+			FailureThreshold:    r.FailureThreshold,
+			FailureSeverity:     string(r.FailureSeverity),
+			CheckedAt:           r.CheckedAt,
+		})
+	}
+	// Sort by CheckedAt descending.
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].CheckedAt > entries[j].CheckedAt
+	})
+	if limit > 0 && len(entries) > limit {
+		entries = entries[:limit]
+	}
+	return entries, nil
+}
+
+func (f *FakeStore) GetServiceCheckHistory(checkKey string, limit int) ([]ServiceCheckEntry, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	var entries []ServiceCheckEntry
+	for i := len(f.serviceChecks) - 1; i >= 0; i-- {
+		r := f.serviceChecks[i]
+		if r.Key != checkKey {
+			continue
+		}
+		entries = append(entries, ServiceCheckEntry{
+			Key:                 r.Key,
+			Name:                r.Name,
+			Type:                r.Type,
+			Target:              r.Target,
+			Status:              r.Status,
+			ResponseMS:          r.ResponseMS,
+			Error:               r.Error,
+			ConsecutiveFailures: r.ConsecutiveFailures,
+			FailureThreshold:    r.FailureThreshold,
+			FailureSeverity:     string(r.FailureSeverity),
+			CheckedAt:           r.CheckedAt,
+		})
+		if limit > 0 && len(entries) >= limit {
+			break
+		}
+	}
+	return entries, nil
+}
+
+func (f *FakeStore) PruneServiceCheckHistory(_ time.Duration) (int, error) {
+	// TODO: implement for testing
+	return 0, nil
+}
+
+func (f *FakeStore) DeleteServiceCheckByKey(key string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var kept []internal.ServiceCheckResult
+	deleted := 0
+	for _, r := range f.serviceChecks {
+		if r.Key == key {
+			deleted++
+		} else {
+			kept = append(kept, r)
+		}
+	}
+	f.serviceChecks = kept
+	return deleted, nil
+}
+
+// ── HistoryStore ──
+
+func (f *FakeStore) GetDiskHistory(_ string, _ int) ([]DiskHistoryPoint, error) {
+	// TODO: implement for testing
+	return nil, nil
+}
+
+func (f *FakeStore) GetAvgTempDuringRange(_, _ time.Time) (float64, float64, error) {
+	// TODO: implement for testing
+	return 0, 0, nil
+}
+
+func (f *FakeStore) ListDisks() ([]DiskSummary, error) {
+	// TODO: implement for testing
+	return nil, nil
+}
+
+func (f *FakeStore) GetAllDiskSparklines(_ int) ([]DiskSparklines, error) {
+	// TODO: implement for testing
+	return nil, nil
+}
+
+func (f *FakeStore) GetAverageDiskTemperatureRange(_, _ time.Time, _ int) ([]NumericPoint, error) {
+	// TODO: implement for testing
+	return nil, nil
+}
+
+func (f *FakeStore) GetDiskUsageHistory(_ int) ([]DiskUsageSeries, error) {
+	// TODO: implement for testing
+	return nil, nil
+}
+
+func (f *FakeStore) GetSystemHistory(_ int) ([]SystemHistoryPoint, error) {
+	// TODO: implement for testing
+	return nil, nil
+}
+
+func (f *FakeStore) GetSystemHistoryRange(_, _ time.Time, _ int) ([]SystemHistoryPoint, error) {
+	// TODO: implement for testing
+	return nil, nil
+}
+
+func (f *FakeStore) GetSystemSparkline(_ int) ([]SystemHistoryPoint, error) {
+	// TODO: implement for testing
+	return nil, nil
+}
+
+func (f *FakeStore) GetGPUHistory(_ int) ([]GPUHistoryPoint, error) {
+	// TODO: implement for testing
+	return nil, nil
+}
+
+func (f *FakeStore) SaveContainerStats(_ *internal.DockerInfo) error {
+	// TODO: implement for testing
+	return nil
+}
+
+func (f *FakeStore) GetContainerHistory(_ int) ([]ContainerHistoryPoint, error) {
+	// TODO: implement for testing
+	return nil, nil
+}
+
+func (f *FakeStore) SaveSpeedTest(_ string, _ *internal.SpeedTestResult) error {
+	// TODO: implement for testing
+	return nil
+}
+
+func (f *FakeStore) GetSpeedTestHistory(_ int) ([]SpeedTestHistoryPoint, error) {
+	// TODO: implement for testing
+	return nil, nil
+}
+
+// ── ConfigStore ──
+
+func (f *FakeStore) GetConfig(key string) (string, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	v, ok := f.config[key]
+	if !ok {
+		return "", fmt.Errorf("config key %q not found", key)
+	}
+	return v, nil
+}
+
+func (f *FakeStore) SetConfig(key, value string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.config[key] = value
+	return nil
+}
+
+// ── NotificationStore ──
+
+func (f *FakeStore) CanSendNotification(fingerprint, routeKey string, cooldown time.Duration, now time.Time) (bool, error) {
+	if fingerprint == "" || routeKey == "" || cooldown <= 0 {
+		return true, nil
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	key := fingerprint + "|" + routeKey
+	lastSent, ok := f.notificationState[key]
+	if !ok {
+		return true, nil
+	}
+	return now.Sub(lastSent) >= cooldown, nil
+}
+
+func (f *FakeStore) SaveNotificationState(fingerprint, routeKey, _ string, sentAt time.Time) error {
+	if fingerprint == "" || routeKey == "" {
+		return nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := fingerprint + "|" + routeKey
+	f.notificationState[key] = sentAt
+	return nil
+}
+
+func (f *FakeStore) SaveNotificationLog(name, webhookType, status string, findingsCount int, errMsg string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.notificationLog = append(f.notificationLog, NotificationLogEntry{
+		ID:            len(f.notificationLog) + 1,
+		WebhookName:   name,
+		WebhookType:   webhookType,
+		Status:        status,
+		FindingsCount: findingsCount,
+		ErrorMessage:  errMsg,
+		CreatedAt:     time.Now(),
+	})
+	return nil
+}
+
+func (f *FakeStore) GetNotificationLog(limit int) ([]NotificationLogEntry, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if len(f.notificationLog) == 0 {
+		return nil, nil
+	}
+	// Return newest first.
+	out := make([]NotificationLogEntry, len(f.notificationLog))
+	copy(out, f.notificationLog)
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].CreatedAt.After(out[j].CreatedAt)
+	})
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func (f *FakeStore) GetNotificationLogRange(_, _ time.Time, _ int) ([]NotificationLogEntry, error) {
+	// TODO: implement for testing
+	return nil, nil
+}
+
+// ── FindingStore ──
+
+func (f *FakeStore) GetFindingHistory(category string, limit int) ([]internal.Finding, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	findings := f.findingsByCategory[category]
+	if limit > 0 && len(findings) > limit {
+		findings = findings[:limit]
+	}
+	return findings, nil
+}
+
+// ── LifecycleStore ──
+
+func (f *FakeStore) PruneSnapshots(_ time.Duration, _ int) (int, error) {
+	// TODO: implement for testing
+	return 0, nil
+}
+
+func (f *FakeStore) PruneNotificationLog(_ time.Duration) (int, error) {
+	// TODO: implement for testing
+	return 0, nil
+}
+
+func (f *FakeStore) PruneAlerts(_ time.Duration) (int, error) {
+	// TODO: implement for testing
+	return 0, nil
+}
+
+func (f *FakeStore) PruneOrphanedFindings() (int, error) {
+	// TODO: implement for testing
+	return 0, nil
+}
+
+func (f *FakeStore) PruneToSizeMB(_ float64) (int, error) {
+	// TODO: implement for testing
+	return 0, nil
+}
+
+func (f *FakeStore) Vacuum() error {
+	return nil
+}
+
+func (f *FakeStore) GetDBStats() (*DBStats, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return &DBStats{
+		SnapshotCount:    len(f.snapshots),
+		ServiceCheckRows: len(f.serviceChecks),
+		NotifyLogRows:    len(f.notificationLog),
+	}, nil
+}
+
+func (f *FakeStore) CreateBackup(_ string, _ *slog.Logger) (*BackupResult, error) {
+	return &BackupResult{
+		Path:      "/tmp/fake-backup.db.gz",
+		SizeMB:    0.1,
+		Timestamp: time.Now(),
+	}, nil
+}
+
+func (f *FakeStore) Close() error {
+	return nil
+}
+
+func (f *FakeStore) DataDir() string {
+	return "/tmp/fake-store"
+}

--- a/internal/storage/fake_test.go
+++ b/internal/storage/fake_test.go
@@ -1,0 +1,300 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+func TestFakeStore_SaveAndGetSnapshot(t *testing.T) {
+	store := NewFakeStore()
+
+	snap := &internal.Snapshot{
+		ID:        "snap-001",
+		Timestamp: time.Now(),
+		Duration:  1.5,
+		Findings: []internal.Finding{
+			{Severity: "critical", Title: "disk failure"},
+			{Severity: "warning", Title: "high temp"},
+			{Severity: "info", Title: "update available"},
+		},
+	}
+
+	if err := store.SaveSnapshot(snap); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	got, err := store.GetLatestSnapshot()
+	if err != nil {
+		t.Fatalf("GetLatestSnapshot: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected snapshot, got nil")
+	}
+	if got.ID != "snap-001" {
+		t.Errorf("expected ID snap-001, got %s", got.ID)
+	}
+}
+
+func TestFakeStore_GetSnapshotByID(t *testing.T) {
+	store := NewFakeStore()
+
+	snap1 := &internal.Snapshot{ID: "snap-001", Timestamp: time.Now().Add(-time.Hour)}
+	snap2 := &internal.Snapshot{ID: "snap-002", Timestamp: time.Now()}
+	store.SaveSnapshot(snap1)
+	store.SaveSnapshot(snap2)
+
+	got, err := store.GetSnapshot("snap-001")
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if got == nil || got.ID != "snap-001" {
+		t.Errorf("expected snap-001, got %v", got)
+	}
+
+	got, err = store.GetSnapshot("nonexistent")
+	if err != nil {
+		t.Fatalf("GetSnapshot nonexistent: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for nonexistent snapshot, got %v", got)
+	}
+}
+
+func TestFakeStore_ListSnapshots(t *testing.T) {
+	store := NewFakeStore()
+
+	for i := 0; i < 5; i++ {
+		store.SaveSnapshot(&internal.Snapshot{
+			ID:        "snap-" + string(rune('A'+i)),
+			Timestamp: time.Now().Add(time.Duration(i) * time.Minute),
+		})
+	}
+
+	summaries, err := store.ListSnapshots(3)
+	if err != nil {
+		t.Fatalf("ListSnapshots: %v", err)
+	}
+	if len(summaries) != 3 {
+		t.Errorf("expected 3 summaries, got %d", len(summaries))
+	}
+	// Should be newest first.
+	if len(summaries) >= 2 && summaries[0].Timestamp.Before(summaries[1].Timestamp) {
+		t.Error("expected newest-first order")
+	}
+}
+
+func TestFakeStore_SaveAndListServiceChecks(t *testing.T) {
+	store := NewFakeStore()
+
+	now := time.Now().UTC()
+	results := []internal.ServiceCheckResult{
+		{
+			Key:       "key-1",
+			Name:      "Web Server",
+			Type:      "http",
+			Target:    "http://localhost",
+			Status:    "up",
+			CheckedAt: now.Format(time.RFC3339),
+		},
+		{
+			Key:       "key-2",
+			Name:      "DNS",
+			Type:      "dns",
+			Target:    "8.8.8.8",
+			Status:    "down",
+			Error:     "timeout",
+			CheckedAt: now.Add(-time.Minute).Format(time.RFC3339),
+		},
+	}
+
+	if err := store.SaveServiceCheckResults(results); err != nil {
+		t.Fatalf("SaveServiceCheckResults: %v", err)
+	}
+
+	entries, err := store.ListLatestServiceChecks(10)
+	if err != nil {
+		t.Fatalf("ListLatestServiceChecks: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+
+	// Verify the "up" result is there.
+	found := false
+	for _, e := range entries {
+		if e.Key == "key-1" && e.Status == "up" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected to find key-1 with status up")
+	}
+}
+
+func TestFakeStore_GetLatestServiceCheckState(t *testing.T) {
+	store := NewFakeStore()
+
+	now := time.Now().UTC()
+	store.SaveServiceCheckResults([]internal.ServiceCheckResult{
+		{Key: "key-1", Status: "up", ConsecutiveFailures: 0, CheckedAt: now.Add(-time.Minute).Format(time.RFC3339)},
+		{Key: "key-1", Status: "down", ConsecutiveFailures: 1, CheckedAt: now.Format(time.RFC3339)},
+	})
+
+	state, found, err := store.GetLatestServiceCheckState("key-1")
+	if err != nil {
+		t.Fatalf("GetLatestServiceCheckState: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found=true")
+	}
+	if state.Status != "down" {
+		t.Errorf("expected status=down, got %s", state.Status)
+	}
+	if state.ConsecutiveFailures != 1 {
+		t.Errorf("expected 1 consecutive failure, got %d", state.ConsecutiveFailures)
+	}
+
+	_, found, _ = store.GetLatestServiceCheckState("nonexistent")
+	if found {
+		t.Error("expected found=false for nonexistent key")
+	}
+}
+
+func TestFakeStore_ConfigGetSet(t *testing.T) {
+	store := NewFakeStore()
+
+	// Get missing key returns error.
+	_, err := store.GetConfig("missing")
+	if err == nil {
+		t.Error("expected error for missing config key")
+	}
+
+	// Set and get.
+	if err := store.SetConfig("theme", "midnight"); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	val, err := store.GetConfig("theme")
+	if err != nil {
+		t.Fatalf("GetConfig: %v", err)
+	}
+	if val != "midnight" {
+		t.Errorf("expected midnight, got %s", val)
+	}
+
+	// Overwrite.
+	store.SetConfig("theme", "clean")
+	val, _ = store.GetConfig("theme")
+	if val != "clean" {
+		t.Errorf("expected clean after overwrite, got %s", val)
+	}
+}
+
+func TestFakeStore_NotificationLog(t *testing.T) {
+	store := NewFakeStore()
+
+	if err := store.SaveNotificationLog("webhook1", "discord", "sent", 3, ""); err != nil {
+		t.Fatalf("SaveNotificationLog: %v", err)
+	}
+	if err := store.SaveNotificationLog("webhook1", "discord", "failed", 2, "timeout"); err != nil {
+		t.Fatalf("SaveNotificationLog: %v", err)
+	}
+
+	entries, err := store.GetNotificationLog(10)
+	if err != nil {
+		t.Fatalf("GetNotificationLog: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+}
+
+func TestFakeStore_CanSendNotification(t *testing.T) {
+	store := NewFakeStore()
+	now := time.Now()
+	cooldown := 10 * time.Minute
+
+	// First send: should be allowed.
+	allowed, err := store.CanSendNotification("fp-1", "route-1", cooldown, now)
+	if err != nil {
+		t.Fatalf("CanSendNotification: %v", err)
+	}
+	if !allowed {
+		t.Error("expected allowed=true for first send")
+	}
+
+	// Record the send.
+	store.SaveNotificationState("fp-1", "route-1", "sent", now)
+
+	// Immediately after: should be blocked.
+	allowed, _ = store.CanSendNotification("fp-1", "route-1", cooldown, now.Add(time.Minute))
+	if allowed {
+		t.Error("expected allowed=false within cooldown")
+	}
+
+	// After cooldown: should be allowed.
+	allowed, _ = store.CanSendNotification("fp-1", "route-1", cooldown, now.Add(11*time.Minute))
+	if !allowed {
+		t.Error("expected allowed=true after cooldown expires")
+	}
+}
+
+func TestFakeStore_DeleteServiceCheckByKey(t *testing.T) {
+	store := NewFakeStore()
+
+	now := time.Now().UTC()
+	store.SaveServiceCheckResults([]internal.ServiceCheckResult{
+		{Key: "keep", Name: "Keep", CheckedAt: now.Format(time.RFC3339)},
+		{Key: "delete-me", Name: "Delete", CheckedAt: now.Format(time.RFC3339)},
+		{Key: "delete-me", Name: "Delete", CheckedAt: now.Add(time.Minute).Format(time.RFC3339)},
+	})
+
+	deleted, err := store.DeleteServiceCheckByKey("delete-me")
+	if err != nil {
+		t.Fatalf("DeleteServiceCheckByKey: %v", err)
+	}
+	if deleted != 2 {
+		t.Errorf("expected 2 deleted, got %d", deleted)
+	}
+
+	entries, _ := store.ListLatestServiceChecks(10)
+	if len(entries) != 1 {
+		t.Errorf("expected 1 remaining entry, got %d", len(entries))
+	}
+}
+
+func TestFakeStore_LifecycleMethods(t *testing.T) {
+	store := NewFakeStore()
+
+	// These should not panic and return zero values.
+	if _, err := store.PruneSnapshots(24*time.Hour, 5); err != nil {
+		t.Errorf("PruneSnapshots: %v", err)
+	}
+	if _, err := store.PruneNotificationLog(24 * time.Hour); err != nil {
+		t.Errorf("PruneNotificationLog: %v", err)
+	}
+	if _, err := store.PruneAlerts(24 * time.Hour); err != nil {
+		t.Errorf("PruneAlerts: %v", err)
+	}
+	if _, err := store.PruneOrphanedFindings(); err != nil {
+		t.Errorf("PruneOrphanedFindings: %v", err)
+	}
+	if err := store.Vacuum(); err != nil {
+		t.Errorf("Vacuum: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+	if dir := store.DataDir(); dir == "" {
+		t.Error("expected non-empty DataDir")
+	}
+
+	stats, err := store.GetDBStats()
+	if err != nil {
+		t.Errorf("GetDBStats: %v", err)
+	}
+	if stats == nil {
+		t.Error("expected non-nil DBStats")
+	}
+}

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -1,0 +1,115 @@
+// Package storage — interfaces.go defines the Store interface hierarchy.
+//
+// These interfaces are extracted from the 52 exported methods on *DB.
+// Every consumer (api.Server, scheduler.Scheduler, etc.) should depend
+// on the narrowest interface it needs, or on the composed Store when
+// it needs everything.
+package storage
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// SnapshotStore handles snapshot persistence and retrieval.
+type SnapshotStore interface {
+	SaveSnapshot(snap *internal.Snapshot) error
+	GetLatestSnapshot() (*internal.Snapshot, error)
+	GetSnapshot(id string) (*internal.Snapshot, error)
+	ListSnapshots(limit int) ([]SnapshotSummary, error)
+}
+
+// AlertStore handles alert lifecycle (open, ack, snooze, resolve).
+type AlertStore interface {
+	SyncAlertStates(snapshotID string, findings []AlertStateFinding, now time.Time) error
+	ListAlerts(status string, limit int, now time.Time) ([]AlertRecord, error)
+	GetAlert(id int64, now time.Time) (*AlertRecord, error)
+	GetAlertEvents(alertID int64, limit int) ([]AlertEvent, error)
+	AcknowledgeAlert(id int64, actor string, now time.Time) (bool, error)
+	UnacknowledgeAlert(id int64, actor string, now time.Time) (bool, error)
+	SnoozeAlert(id int64, until time.Time, actor string, now time.Time) (bool, error)
+	UnsnoozeAlert(id int64, actor string, now time.Time) (bool, error)
+	IsAlertSuppressed(fingerprint string, now time.Time) (bool, string, error)
+	MarkAlertsNotifiedByFingerprint(fingerprints []string, notifiedAt time.Time) error
+}
+
+// ServiceCheckStore handles service check results and history.
+type ServiceCheckStore interface {
+	SaveServiceCheckResults(results []internal.ServiceCheckResult) error
+	GetLatestServiceCheckState(checkKey string) (ServiceCheckState, bool, error)
+	ListLatestServiceChecks(limit int) ([]ServiceCheckEntry, error)
+	GetServiceCheckHistory(checkKey string, limit int) ([]ServiceCheckEntry, error)
+	PruneServiceCheckHistory(olderThan time.Duration) (int, error)
+	DeleteServiceCheckByKey(key string) (int, error)
+}
+
+// HistoryStore handles time-series history for disks, system, GPU, containers, and speed tests.
+type HistoryStore interface {
+	GetDiskHistory(serial string, limit int) ([]DiskHistoryPoint, error)
+	GetAvgTempDuringRange(start, end time.Time) (float64, float64, error)
+	ListDisks() ([]DiskSummary, error)
+	GetAllDiskSparklines(pointsPerDisk int) ([]DiskSparklines, error)
+	GetAverageDiskTemperatureRange(start, end time.Time, maxPoints int) ([]NumericPoint, error)
+	GetDiskUsageHistory(limit int) ([]DiskUsageSeries, error)
+	GetSystemHistory(limit int) ([]SystemHistoryPoint, error)
+	GetSystemHistoryRange(start, end time.Time, maxPoints int) ([]SystemHistoryPoint, error)
+	GetSystemSparkline(limit int) ([]SystemHistoryPoint, error)
+	GetGPUHistory(hours int) ([]GPUHistoryPoint, error)
+	SaveContainerStats(docker *internal.DockerInfo) error
+	GetContainerHistory(hours int) ([]ContainerHistoryPoint, error)
+	SaveSpeedTest(snapshotID string, result *internal.SpeedTestResult) error
+	GetSpeedTestHistory(hours int) ([]SpeedTestHistoryPoint, error)
+}
+
+// ConfigStore handles key/value configuration persistence.
+type ConfigStore interface {
+	GetConfig(key string) (string, error)
+	SetConfig(key, value string) error
+}
+
+// NotificationStore handles notification delivery tracking and deduplication.
+type NotificationStore interface {
+	CanSendNotification(fingerprint, routeKey string, cooldown time.Duration, now time.Time) (bool, error)
+	SaveNotificationState(fingerprint, routeKey, status string, sentAt time.Time) error
+	SaveNotificationLog(name, webhookType, status string, findingsCount int, errMsg string) error
+	GetNotificationLog(limit int) ([]NotificationLogEntry, error)
+	GetNotificationLogRange(start, end time.Time, limit int) ([]NotificationLogEntry, error)
+}
+
+// FindingStore handles finding history queries.
+type FindingStore interface {
+	GetFindingHistory(category string, limit int) ([]internal.Finding, error)
+}
+
+// LifecycleStore handles data lifecycle operations (pruning, backup, stats).
+type LifecycleStore interface {
+	PruneSnapshots(olderThan time.Duration, keepMin int) (int, error)
+	PruneNotificationLog(olderThan time.Duration) (int, error)
+	PruneAlerts(olderThan time.Duration) (int, error)
+	PruneOrphanedFindings() (int, error)
+	PruneToSizeMB(targetMB float64) (int, error)
+	Vacuum() error
+	GetDBStats() (*DBStats, error)
+	CreateBackup(backupDir string, logger *slog.Logger) (*BackupResult, error)
+	Close() error
+	DataDir() string
+}
+
+// Store composes all domain-specific interfaces into a single aggregate.
+// Use the narrower interfaces when possible; use Store when a consumer
+// genuinely needs access to multiple domains.
+type Store interface {
+	SnapshotStore
+	AlertStore
+	ServiceCheckStore
+	HistoryStore
+	ConfigStore
+	NotificationStore
+	FindingStore
+	LifecycleStore
+}
+
+// Compile-time checks: *DB must satisfy Store.
+var _ Store = (*DB)(nil)


### PR DESCRIPTION
Closes #88

## Summary

- Extract a `Store` interface hierarchy from the 52 exported methods on `*storage.DB`, split into 8 composable domain-specific interfaces (`SnapshotStore`, `AlertStore`, `ServiceCheckStore`, `HistoryStore`, `ConfigStore`, `NotificationStore`, `FindingStore`, `LifecycleStore`)
- Create `FakeStore` — an in-memory implementation for fast, deterministic testing
- Update `api.Server` and `scheduler.Scheduler` to accept `storage.Store` interface instead of `*storage.DB`

## Changes

### `internal/storage/interfaces.go` (new)
- 8 domain-specific interfaces composing into a single `Store` interface
- Compile-time check: `var _ Store = (*DB)(nil)`
- Every method signature matches the existing `*DB` methods exactly

### `internal/storage/fake.go` (new)
- In-memory `FakeStore` using maps and slices
- Compile-time check: `var _ Store = (*FakeStore)(nil)`
- Fully implemented: `SaveSnapshot`, `GetLatestSnapshot`, `GetSnapshot`, `ListSnapshots`, `SaveServiceCheckResults`, `ListLatestServiceChecks`, `GetLatestServiceCheckState`, `GetServiceCheckHistory`, `DeleteServiceCheckByKey`, `GetConfig`, `SetConfig`, `SaveNotificationLog`, `GetNotificationLog`, `CanSendNotification`, `SaveNotificationState`, `GetDBStats`, `CreateBackup`, `Close`, `DataDir`, `Vacuum`
- Stubbed with TODO: history methods, alert lifecycle, pruning — these return zero values safely

### `internal/storage/fake_test.go` (new)
- 10 smoke tests covering all implemented FakeStore methods
- Table-driven style consistent with existing project conventions

### `internal/api/api.go` (modified)
- `Server.store` field: `*storage.DB` → `storage.Store`
- `New()` parameter: `*storage.DB` → `storage.Store`

### `internal/scheduler/scheduler.go` (modified)
- `Scheduler.store` field: `*storage.DB` → `storage.Store`
- `New()` parameter: `*storage.DB` → `storage.Store`

### Not modified
- `fleet.Manager` — has no store dependency
- `cmd/nas-doctor/main.go` — passes `*storage.DB` which satisfies `storage.Store`; no signature changes needed
- All existing test files — zero modifications

## Verification

- `go build ./...` passes
- `go test ./...` passes (all existing tests green + 10 new FakeStore tests)
- Pure refactor — zero behavior changes