### PR TITLE
feat(scheduler): add NotificationDispatcher module with tests

### DIFF
--- a/internal/scheduler/notify.go
+++ b/internal/scheduler/notify.go
@@ -1,0 +1,345 @@
+// Package scheduler — notify.go contains the NotificationDispatcher module.
+//
+// NotificationDispatcher owns rule evaluation, cooldown enforcement, alert
+// suppression, and webhook dispatch orchestration. It is designed to be
+// tested in isolation using storage.FakeStore.
+//
+// This file is ADDITIVE — it does not replace any code in scheduler.go.
+// Wiring into the main Scheduler happens in a later issue (#94).
+package scheduler
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// Sender abstracts webhook delivery so tests can avoid real HTTP calls.
+// The production implementation is notifier.Notifier.NotifyWebhook.
+type Sender interface {
+	NotifyWebhook(wh internal.WebhookConfig, findings []internal.Finding, hostname string) error
+}
+
+// DispatchAction groups a set of findings to deliver to a single webhook.
+type DispatchAction struct {
+	Webhook  internal.WebhookConfig
+	Findings []internal.Finding
+	RouteKey string // dedup key for cooldown state (e.g., "rule:<ruleID>")
+	RuleName string // human-readable label for logging
+}
+
+// NotificationDispatcher evaluates notification rules against findings,
+// applies cooldown and alert suppression, and dispatches to webhooks.
+type NotificationDispatcher struct {
+	store      storage.NotificationStore
+	alertStore storage.AlertStore
+	sender     Sender
+	logger     *slog.Logger
+}
+
+// NewNotificationDispatcher creates a ready-to-use dispatcher.
+func NewNotificationDispatcher(
+	store storage.NotificationStore,
+	alertStore storage.AlertStore,
+	sender Sender,
+	logger *slog.Logger,
+) *NotificationDispatcher {
+	return &NotificationDispatcher{
+		store:      store,
+		alertStore: alertStore,
+		sender:     sender,
+		logger:     logger,
+	}
+}
+
+// EvaluateRules determines which findings should be sent to which webhooks,
+// respecting cooldowns, dedup, and alert suppression.
+//
+// If no rules are configured, all findings are routed to every enabled webhook
+// (legacy behaviour). Otherwise each rule is evaluated independently and
+// matched findings are collected into DispatchActions.
+func (nd *NotificationDispatcher) EvaluateRules(
+	findings []internal.Finding,
+	rules []internal.NotificationRule,
+	webhooks []internal.WebhookConfig,
+	defaultCooldownSec int,
+	now time.Time,
+) []DispatchAction {
+	if defaultCooldownSec <= 0 {
+		defaultCooldownSec = 900
+	}
+
+	// Build webhook lookup (case-insensitive).
+	whMap := make(map[string]internal.WebhookConfig, len(webhooks))
+	for _, wh := range webhooks {
+		whMap[strings.ToLower(strings.TrimSpace(wh.Name))] = wh
+	}
+
+	// ── Legacy mode: no rules configured ──
+	if len(rules) == 0 {
+		return nd.evaluateLegacy(findings, webhooks, defaultCooldownSec, now)
+	}
+
+	// ── Rule-based dispatch ──
+	var actions []DispatchAction
+	for _, rule := range rules {
+		if !rule.Enabled {
+			continue
+		}
+		whName := strings.ToLower(strings.TrimSpace(rule.Webhook))
+		wh, ok := whMap[whName]
+		if !ok || !wh.Enabled {
+			continue
+		}
+
+		matched := matchRuleFindings(rule, findings)
+		if len(matched) == 0 {
+			continue
+		}
+
+		cooldown := time.Duration(rule.CooldownSec) * time.Second
+		if cooldown <= 0 {
+			cooldown = time.Duration(defaultCooldownSec) * time.Second
+		}
+		routeKey := "rule:" + rule.ID
+
+		toSend := nd.applyCooldownAndSuppression(matched, routeKey, cooldown, now)
+		if len(toSend) == 0 {
+			_ = nd.store.SaveNotificationLog(wh.Name, wh.Type, "suppressed_cooldown", len(matched), "")
+			continue
+		}
+
+		actions = append(actions, DispatchAction{
+			Webhook:  wh,
+			Findings: toSend,
+			RouteKey: routeKey,
+			RuleName: rule.Name,
+		})
+	}
+	return actions
+}
+
+// evaluateLegacy implements the no-rules fallback: all findings to all enabled webhooks.
+func (nd *NotificationDispatcher) evaluateLegacy(
+	findings []internal.Finding,
+	webhooks []internal.WebhookConfig,
+	defaultCooldownSec int,
+	now time.Time,
+) []DispatchAction {
+	if len(findings) == 0 {
+		return nil
+	}
+	var actions []DispatchAction
+	for _, wh := range webhooks {
+		if !wh.Enabled {
+			continue
+		}
+		routeKey := "legacy:" + strings.ToLower(strings.TrimSpace(wh.Name))
+		cooldown := time.Duration(defaultCooldownSec) * time.Second
+		toSend := nd.applyCooldownAndSuppression(findings, routeKey, cooldown, now)
+		if len(toSend) == 0 {
+			continue
+		}
+		actions = append(actions, DispatchAction{
+			Webhook:  wh,
+			Findings: toSend,
+			RouteKey: routeKey,
+			RuleName: "legacy",
+		})
+	}
+	return actions
+}
+
+// matchRuleFindings applies a rule's category-based filter to a set of findings.
+// This extracts the "findings" category logic from evaluateRule in scheduler.go.
+// For the "findings" category only — other rule categories (disk_space, smart, etc.)
+// require snapshot data and remain in evaluateRule until full wiring (#94).
+func matchRuleFindings(rule internal.NotificationRule, findings []internal.Finding) []internal.Finding {
+	cat := strings.ToLower(rule.Category)
+	cond := strings.ToLower(rule.Condition)
+	target := strings.ToLower(strings.TrimSpace(rule.Target))
+
+	if cat != "findings" {
+		// Non-findings categories require snapshot data; for now delegate to
+		// the full evaluateRule in scheduler.go. The dispatcher only handles
+		// pre-evaluated findings. Return the raw findings if the rule category
+		// is not "findings" — callers are expected to pre-evaluate rules for
+		// snapshot-based categories before calling EvaluateRules.
+		//
+		// In practice, the scheduler will call evaluateRule() first and pass
+		// the matched findings to EvaluateRules. For now, we filter the
+		// findings slice directly using severity/category semantics.
+		return filterByCategoryAndSeverity(cat, cond, target, findings)
+	}
+
+	return evalFindingsFilter(cond, target, findings)
+}
+
+// evalFindingsFilter implements the "findings" category matching logic.
+func evalFindingsFilter(cond, target string, findings []internal.Finding) []internal.Finding {
+	var out []internal.Finding
+	for _, f := range findings {
+		switch cond {
+		case "critical":
+			if f.Severity == internal.SeverityCritical {
+				out = append(out, f)
+			}
+		case "warning":
+			if f.Severity == internal.SeverityWarning || f.Severity == internal.SeverityCritical {
+				out = append(out, f)
+			}
+		case "category":
+			if strings.EqualFold(string(f.Category), target) {
+				out = append(out, f)
+			}
+		case "any":
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// filterByCategoryAndSeverity provides a generic category+severity filter for
+// non-"findings" rules operating on pre-existing findings.
+func filterByCategoryAndSeverity(cat, cond, target string, findings []internal.Finding) []internal.Finding {
+	var out []internal.Finding
+	for _, f := range findings {
+		// Category filter: only include findings from matching category.
+		if cat != "" && !strings.EqualFold(string(f.Category), cat) {
+			continue
+		}
+		// Condition-based severity filter.
+		switch cond {
+		case "critical":
+			if f.Severity != internal.SeverityCritical {
+				continue
+			}
+		case "warning":
+			if f.Severity != internal.SeverityWarning && f.Severity != internal.SeverityCritical {
+				continue
+			}
+		case "any", "":
+			// pass
+		default:
+			// Unknown condition — for non-findings categories this may be a
+			// threshold condition (e.g., "above", "down"). Let it through if
+			// the category already matched.
+		}
+		// Target filter.
+		if target != "" && !strings.EqualFold(strings.TrimSpace(f.RelatedDisk), target) &&
+			!strings.EqualFold(strings.TrimSpace(f.Title), target) {
+			// No target match — include anyway since target matching for
+			// non-findings categories is complex and context-dependent.
+			// Keep the finding; the scheduler's evaluateRule does the real
+			// target filtering before passing findings here.
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+// applyCooldownAndSuppression filters a set of findings through dedup,
+// alert suppression, and cooldown checks. Mirrors scheduler.applyCooldown.
+func (nd *NotificationDispatcher) applyCooldownAndSuppression(
+	findings []internal.Finding,
+	routeKey string,
+	cooldown time.Duration,
+	now time.Time,
+) []internal.Finding {
+	seen := make(map[string]struct{})
+	out := make([]internal.Finding, 0, len(findings))
+
+	for _, f := range findings {
+		fp := dispatcherFingerprint(f)
+		if fp == "" {
+			out = append(out, f)
+			continue
+		}
+
+		// Dedup within the same batch.
+		if _, exists := seen[fp]; exists {
+			continue
+		}
+		seen[fp] = struct{}{}
+
+		// Alert suppression (acknowledged / snoozed).
+		suppressed, _, err := nd.alertStore.IsAlertSuppressed(fp, now)
+		if err != nil {
+			nd.logger.Warn("alert suppression check failed", "fingerprint", fp, "error", err)
+		} else if suppressed {
+			continue
+		}
+
+		// Cooldown enforcement.
+		allowed, err := nd.store.CanSendNotification(fp, routeKey, cooldown, now)
+		if err != nil {
+			nd.logger.Warn("cooldown check failed; allowing notification",
+				"route", routeKey, "fingerprint", fp, "error", err)
+			out = append(out, f)
+			continue
+		}
+		if allowed {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// Dispatch sends a DispatchAction to its webhook and records the result.
+func (nd *NotificationDispatcher) Dispatch(action DispatchAction, hostname string, now time.Time) error {
+	if len(action.Findings) == 0 {
+		return nil
+	}
+
+	err := nd.sender.NotifyWebhook(action.Webhook, action.Findings, hostname)
+	if err != nil {
+		_ = nd.store.SaveNotificationLog(
+			action.Webhook.Name, action.Webhook.Type, "failed",
+			len(action.Findings), err.Error(),
+		)
+		return fmt.Errorf("dispatch to %s failed: %w", action.Webhook.Name, err)
+	}
+
+	// Record sent state for each finding.
+	fingerprints := make([]string, 0, len(action.Findings))
+	for _, f := range action.Findings {
+		fp := dispatcherFingerprint(f)
+		fingerprints = append(fingerprints, fp)
+		if saveErr := nd.store.SaveNotificationState(fp, action.RouteKey, "sent", now); saveErr != nil {
+			nd.logger.Warn("failed to save notification state",
+				"fingerprint", fp, "route", action.RouteKey, "error", saveErr)
+		}
+	}
+
+	_ = nd.store.SaveNotificationLog(
+		action.Webhook.Name, action.Webhook.Type, "sent",
+		len(action.Findings), "",
+	)
+
+	// Mark alerts as notified.
+	if err := nd.alertStore.MarkAlertsNotifiedByFingerprint(fingerprints, now); err != nil {
+		nd.logger.Warn("failed to mark alerts notified", "error", err)
+	}
+
+	return nil
+}
+
+// dispatcherFingerprint computes a stable fingerprint for a finding.
+// Mirrors findingFingerprint in scheduler.go — duplicated to avoid
+// coupling and allow independent evolution.
+func dispatcherFingerprint(f internal.Finding) string {
+	parts := []string{
+		strings.ToLower(strings.TrimSpace(string(f.Category))),
+		strings.ToLower(strings.TrimSpace(f.Title)),
+		strings.ToLower(strings.TrimSpace(f.RelatedDisk)),
+	}
+	raw := strings.Join(parts, "|")
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/scheduler/notify_test.go
+++ b/internal/scheduler/notify_test.go
@@ -1,0 +1,808 @@
+package scheduler
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// ── Test helpers ──
+
+// fakeSender records NotifyWebhook calls for assertion.
+type fakeSender struct {
+	calls []fakeSendCall
+	err   error // if non-nil, NotifyWebhook returns this error
+}
+
+type fakeSendCall struct {
+	Webhook  internal.WebhookConfig
+	Findings []internal.Finding
+	Hostname string
+}
+
+func (s *fakeSender) NotifyWebhook(wh internal.WebhookConfig, findings []internal.Finding, hostname string) error {
+	s.calls = append(s.calls, fakeSendCall{Webhook: wh, Findings: findings, Hostname: hostname})
+	return s.err
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func testWebhook(name string) internal.WebhookConfig {
+	return internal.WebhookConfig{
+		Name:    name,
+		URL:     "https://example.com/" + name,
+		Type:    "generic",
+		Enabled: true,
+	}
+}
+
+func criticalFinding(category internal.Category, title string) internal.Finding {
+	return internal.Finding{
+		ID:       "test-" + title,
+		Severity: internal.SeverityCritical,
+		Category: category,
+		Title:    title,
+	}
+}
+
+func warningFinding(category internal.Category, title string) internal.Finding {
+	return internal.Finding{
+		ID:       "test-" + title,
+		Severity: internal.SeverityWarning,
+		Category: category,
+		Title:    title,
+	}
+}
+
+func infoFinding(category internal.Category, title string) internal.Finding {
+	return internal.Finding{
+		ID:       "test-" + title,
+		Severity: internal.SeverityInfo,
+		Category: category,
+		Title:    title,
+	}
+}
+
+// ── Tests: Rule Matching ──
+
+func TestEvaluateRules_SeverityMatch_CriticalIncluded(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	findings := []internal.Finding{
+		criticalFinding(internal.CategoryDisk, "Disk failing"),
+	}
+	rules := []internal.NotificationRule{
+		{
+			ID:          "r1",
+			Name:        "critical-only",
+			Enabled:     true,
+			Webhook:     "alerts",
+			Category:    "findings",
+			Condition:   "critical",
+			CooldownSec: 60,
+		},
+	}
+	webhooks := []internal.WebhookConfig{testWebhook("alerts")}
+	now := time.Now()
+
+	actions := nd.EvaluateRules(findings, rules, webhooks, 900, now)
+
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(actions))
+	}
+	if len(actions[0].Findings) != 1 {
+		t.Fatalf("expected 1 finding in action, got %d", len(actions[0].Findings))
+	}
+	if actions[0].Findings[0].Title != "Disk failing" {
+		t.Errorf("expected finding title 'Disk failing', got %q", actions[0].Findings[0].Title)
+	}
+}
+
+func TestEvaluateRules_SeverityMismatch_WarningExcludedByCriticalRule(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	findings := []internal.Finding{
+		warningFinding(internal.CategoryDisk, "Disk space low"),
+	}
+	rules := []internal.NotificationRule{
+		{
+			ID:          "r1",
+			Name:        "critical-only",
+			Enabled:     true,
+			Webhook:     "alerts",
+			Category:    "findings",
+			Condition:   "critical",
+			CooldownSec: 60,
+		},
+	}
+	webhooks := []internal.WebhookConfig{testWebhook("alerts")}
+	now := time.Now()
+
+	actions := nd.EvaluateRules(findings, rules, webhooks, 900, now)
+
+	if len(actions) != 0 {
+		t.Fatalf("expected 0 actions (warning doesn't match critical rule), got %d", len(actions))
+	}
+}
+
+func TestEvaluateRules_WarningRuleIncludesCritical(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	findings := []internal.Finding{
+		criticalFinding(internal.CategoryDisk, "Disk failing"),
+		warningFinding(internal.CategoryDisk, "Disk space low"),
+		infoFinding(internal.CategoryDisk, "Disk info"),
+	}
+	rules := []internal.NotificationRule{
+		{
+			ID:          "r1",
+			Name:        "warnings-and-up",
+			Enabled:     true,
+			Webhook:     "alerts",
+			Category:    "findings",
+			Condition:   "warning",
+			CooldownSec: 60,
+		},
+	}
+	webhooks := []internal.WebhookConfig{testWebhook("alerts")}
+	now := time.Now()
+
+	actions := nd.EvaluateRules(findings, rules, webhooks, 900, now)
+
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(actions))
+	}
+	if len(actions[0].Findings) != 2 {
+		t.Fatalf("expected 2 findings (critical + warning), got %d", len(actions[0].Findings))
+	}
+}
+
+// ── Tests: Category Filtering ──
+
+func TestEvaluateRules_CategoryFilter_DiskIncluded_NetworkExcluded(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	findings := []internal.Finding{
+		criticalFinding(internal.CategoryDisk, "Disk failing"),
+		criticalFinding(internal.CategoryNetwork, "Network down"),
+	}
+	rules := []internal.NotificationRule{
+		{
+			ID:          "r1",
+			Name:        "disk-category",
+			Enabled:     true,
+			Webhook:     "alerts",
+			Category:    "findings",
+			Condition:   "category",
+			Target:      "disk",
+			CooldownSec: 60,
+		},
+	}
+	webhooks := []internal.WebhookConfig{testWebhook("alerts")}
+	now := time.Now()
+
+	actions := nd.EvaluateRules(findings, rules, webhooks, 900, now)
+
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(actions))
+	}
+	if len(actions[0].Findings) != 1 {
+		t.Fatalf("expected 1 finding (disk only), got %d", len(actions[0].Findings))
+	}
+	if actions[0].Findings[0].Category != internal.CategoryDisk {
+		t.Errorf("expected disk category, got %s", actions[0].Findings[0].Category)
+	}
+}
+
+// ── Tests: Check Type / Non-Findings Category Filter ──
+
+func TestEvaluateRules_NonFindingsCategory_SpeedCheckOnly(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	// Pre-evaluated findings from different categories.
+	findings := []internal.Finding{
+		warningFinding(internal.CategorySpeedTest, "Download speed below threshold"),
+		warningFinding(internal.CategoryService, "Service down: my-api"),
+	}
+	rules := []internal.NotificationRule{
+		{
+			ID:          "r1",
+			Name:        "speed-only",
+			Enabled:     true,
+			Webhook:     "alerts",
+			Category:    "speedtest", // non-findings category
+			Condition:   "any",
+			CooldownSec: 60,
+		},
+	}
+	webhooks := []internal.WebhookConfig{testWebhook("alerts")}
+	now := time.Now()
+
+	actions := nd.EvaluateRules(findings, rules, webhooks, 900, now)
+
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(actions))
+	}
+	if len(actions[0].Findings) != 1 {
+		t.Fatalf("expected 1 finding (speedtest only), got %d", len(actions[0].Findings))
+	}
+	if actions[0].Findings[0].Category != internal.CategorySpeedTest {
+		t.Errorf("expected speedtest category, got %s", actions[0].Findings[0].Category)
+	}
+}
+
+// ── Tests: Cooldown Enforcement ──
+
+func TestEvaluateRules_CooldownWithinWindow_Suppressed(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	now := time.Now()
+	finding := criticalFinding(internal.CategoryDisk, "Disk failing")
+	fp := dispatcherFingerprint(finding)
+	routeKey := "rule:r1"
+
+	// Pre-seed: notification was sent 30 seconds ago.
+	_ = store.SaveNotificationState(fp, routeKey, "sent", now.Add(-30*time.Second))
+
+	findings := []internal.Finding{finding}
+	rules := []internal.NotificationRule{
+		{
+			ID:          "r1",
+			Name:        "disk-alerts",
+			Enabled:     true,
+			Webhook:     "alerts",
+			Category:    "findings",
+			Condition:   "any",
+			CooldownSec: 60, // 60 seconds cooldown — we're within it
+		},
+	}
+	webhooks := []internal.WebhookConfig{testWebhook("alerts")}
+
+	actions := nd.EvaluateRules(findings, rules, webhooks, 900, now)
+
+	if len(actions) != 0 {
+		t.Fatalf("expected 0 actions (within cooldown), got %d", len(actions))
+	}
+}
+
+func TestEvaluateRules_CooldownExpired_Allowed(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	now := time.Now()
+	finding := criticalFinding(internal.CategoryDisk, "Disk failing")
+	fp := dispatcherFingerprint(finding)
+	routeKey := "rule:r1"
+
+	// Pre-seed: notification was sent 120 seconds ago.
+	_ = store.SaveNotificationState(fp, routeKey, "sent", now.Add(-120*time.Second))
+
+	findings := []internal.Finding{finding}
+	rules := []internal.NotificationRule{
+		{
+			ID:          "r1",
+			Name:        "disk-alerts",
+			Enabled:     true,
+			Webhook:     "alerts",
+			Category:    "findings",
+			Condition:   "any",
+			CooldownSec: 60, // 60 seconds cooldown — we're past it
+		},
+	}
+	webhooks := []internal.WebhookConfig{testWebhook("alerts")}
+
+	actions := nd.EvaluateRules(findings, rules, webhooks, 900, now)
+
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action (cooldown expired), got %d", len(actions))
+	}
+	if len(actions[0].Findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(actions[0].Findings))
+	}
+}
+
+// ── Tests: Alert Suppression ──
+
+func TestEvaluateRules_AcknowledgedAlert_NotDispatched(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	now := time.Now()
+	finding := criticalFinding(internal.CategoryDisk, "Disk failing")
+	fp := dispatcherFingerprint(finding)
+
+	// Pre-seed: this finding's alert has been acknowledged.
+	store.SuppressAlert(fp, "acknowledged")
+
+	findings := []internal.Finding{finding}
+	rules := []internal.NotificationRule{
+		{
+			ID:          "r1",
+			Name:        "disk-alerts",
+			Enabled:     true,
+			Webhook:     "alerts",
+			Category:    "findings",
+			Condition:   "any",
+			CooldownSec: 60,
+		},
+	}
+	webhooks := []internal.WebhookConfig{testWebhook("alerts")}
+
+	actions := nd.EvaluateRules(findings, rules, webhooks, 900, now)
+
+	if len(actions) != 0 {
+		t.Fatalf("expected 0 actions (acknowledged alert), got %d", len(actions))
+	}
+}
+
+func TestEvaluateRules_SnoozedAlert_NotDispatched(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	now := time.Now()
+	finding := warningFinding(internal.CategorySMART, "SMART attribute degraded")
+	fp := dispatcherFingerprint(finding)
+
+	// Pre-seed: this finding's alert has been snoozed.
+	store.SuppressAlert(fp, "snoozed")
+
+	findings := []internal.Finding{finding}
+	rules := []internal.NotificationRule{
+		{
+			ID:          "r1",
+			Name:        "smart-alerts",
+			Enabled:     true,
+			Webhook:     "alerts",
+			Category:    "findings",
+			Condition:   "any",
+			CooldownSec: 60,
+		},
+	}
+	webhooks := []internal.WebhookConfig{testWebhook("alerts")}
+
+	actions := nd.EvaluateRules(findings, rules, webhooks, 900, now)
+
+	if len(actions) != 0 {
+		t.Fatalf("expected 0 actions (snoozed alert), got %d", len(actions))
+	}
+}
+
+// ── Tests: Multiple Rules ──
+
+func TestEvaluateRules_MultipleRules_TwoWebhooks(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	findings := []internal.Finding{
+		criticalFinding(internal.CategoryDisk, "Disk failing"),
+	}
+	rules := []internal.NotificationRule{
+		{
+			ID:          "r1",
+			Name:        "discord-alerts",
+			Enabled:     true,
+			Webhook:     "discord",
+			Category:    "findings",
+			Condition:   "any",
+			CooldownSec: 60,
+		},
+		{
+			ID:          "r2",
+			Name:        "slack-alerts",
+			Enabled:     true,
+			Webhook:     "slack",
+			Category:    "findings",
+			Condition:   "any",
+			CooldownSec: 60,
+		},
+	}
+	webhooks := []internal.WebhookConfig{
+		testWebhook("discord"),
+		testWebhook("slack"),
+	}
+	now := time.Now()
+
+	actions := nd.EvaluateRules(findings, rules, webhooks, 900, now)
+
+	if len(actions) != 2 {
+		t.Fatalf("expected 2 actions (one per webhook), got %d", len(actions))
+	}
+	// Verify each action targets a different webhook.
+	names := map[string]bool{}
+	for _, a := range actions {
+		names[a.Webhook.Name] = true
+	}
+	if !names["discord"] || !names["slack"] {
+		t.Errorf("expected discord and slack webhooks, got %v", names)
+	}
+}
+
+// ── Tests: No Matching Webhook ──
+
+func TestEvaluateRules_NonexistentWebhook_SkippedGracefully(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	findings := []internal.Finding{
+		criticalFinding(internal.CategoryDisk, "Disk failing"),
+	}
+	rules := []internal.NotificationRule{
+		{
+			ID:          "r1",
+			Name:        "orphan-rule",
+			Enabled:     true,
+			Webhook:     "nonexistent-webhook",
+			Category:    "findings",
+			Condition:   "any",
+			CooldownSec: 60,
+		},
+	}
+	webhooks := []internal.WebhookConfig{testWebhook("alerts")}
+	now := time.Now()
+
+	actions := nd.EvaluateRules(findings, rules, webhooks, 900, now)
+
+	if len(actions) != 0 {
+		t.Fatalf("expected 0 actions (webhook doesn't exist), got %d", len(actions))
+	}
+}
+
+// ── Tests: Disabled Rules and Webhooks ──
+
+func TestEvaluateRules_DisabledRule_Skipped(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	findings := []internal.Finding{
+		criticalFinding(internal.CategoryDisk, "Disk failing"),
+	}
+	rules := []internal.NotificationRule{
+		{
+			ID:          "r1",
+			Name:        "disabled-rule",
+			Enabled:     false,
+			Webhook:     "alerts",
+			Category:    "findings",
+			Condition:   "any",
+			CooldownSec: 60,
+		},
+	}
+	webhooks := []internal.WebhookConfig{testWebhook("alerts")}
+	now := time.Now()
+
+	actions := nd.EvaluateRules(findings, rules, webhooks, 900, now)
+
+	if len(actions) != 0 {
+		t.Fatalf("expected 0 actions (disabled rule), got %d", len(actions))
+	}
+}
+
+func TestEvaluateRules_DisabledWebhook_Skipped(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	findings := []internal.Finding{
+		criticalFinding(internal.CategoryDisk, "Disk failing"),
+	}
+	rules := []internal.NotificationRule{
+		{
+			ID:          "r1",
+			Name:        "good-rule",
+			Enabled:     true,
+			Webhook:     "alerts",
+			Category:    "findings",
+			Condition:   "any",
+			CooldownSec: 60,
+		},
+	}
+	disabledWH := testWebhook("alerts")
+	disabledWH.Enabled = false
+	webhooks := []internal.WebhookConfig{disabledWH}
+	now := time.Now()
+
+	actions := nd.EvaluateRules(findings, rules, webhooks, 900, now)
+
+	if len(actions) != 0 {
+		t.Fatalf("expected 0 actions (disabled webhook), got %d", len(actions))
+	}
+}
+
+// ── Tests: Legacy Mode (No Rules) ──
+
+func TestEvaluateRules_NoRules_LegacyAllToAllEnabled(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	findings := []internal.Finding{
+		criticalFinding(internal.CategoryDisk, "Disk failing"),
+		warningFinding(internal.CategoryNetwork, "Network issue"),
+	}
+	webhooks := []internal.WebhookConfig{
+		testWebhook("discord"),
+		testWebhook("slack"),
+	}
+	now := time.Now()
+
+	actions := nd.EvaluateRules(findings, nil, webhooks, 900, now)
+
+	if len(actions) != 2 {
+		t.Fatalf("expected 2 actions (one per enabled webhook), got %d", len(actions))
+	}
+	for _, a := range actions {
+		if len(a.Findings) != 2 {
+			t.Errorf("expected 2 findings per action in legacy mode, got %d", len(a.Findings))
+		}
+	}
+}
+
+func TestEvaluateRules_NoRules_NoFindings_NoActions(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	webhooks := []internal.WebhookConfig{testWebhook("alerts")}
+	now := time.Now()
+
+	actions := nd.EvaluateRules(nil, nil, webhooks, 900, now)
+
+	if len(actions) != 0 {
+		t.Fatalf("expected 0 actions (no findings), got %d", len(actions))
+	}
+}
+
+// ── Tests: Dedup Within Batch ──
+
+func TestEvaluateRules_DuplicateFindings_Deduped(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	// Same finding duplicated.
+	finding := criticalFinding(internal.CategoryDisk, "Disk failing")
+	findings := []internal.Finding{finding, finding, finding}
+	rules := []internal.NotificationRule{
+		{
+			ID:          "r1",
+			Name:        "disk-alerts",
+			Enabled:     true,
+			Webhook:     "alerts",
+			Category:    "findings",
+			Condition:   "any",
+			CooldownSec: 60,
+		},
+	}
+	webhooks := []internal.WebhookConfig{testWebhook("alerts")}
+	now := time.Now()
+
+	actions := nd.EvaluateRules(findings, rules, webhooks, 900, now)
+
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(actions))
+	}
+	if len(actions[0].Findings) != 1 {
+		t.Fatalf("expected 1 finding (deduped), got %d", len(actions[0].Findings))
+	}
+}
+
+// ── Tests: Dispatch ──
+
+func TestDispatch_Success_RecordsState(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	now := time.Now()
+	action := DispatchAction{
+		Webhook:  testWebhook("alerts"),
+		Findings: []internal.Finding{criticalFinding(internal.CategoryDisk, "Disk failing")},
+		RouteKey: "rule:r1",
+		RuleName: "disk-alerts",
+	}
+
+	err := nd.Dispatch(action, "my-nas", now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify sender was called.
+	if len(sender.calls) != 1 {
+		t.Fatalf("expected 1 sender call, got %d", len(sender.calls))
+	}
+	if sender.calls[0].Hostname != "my-nas" {
+		t.Errorf("expected hostname 'my-nas', got %q", sender.calls[0].Hostname)
+	}
+
+	// Verify notification log was saved.
+	log, err := store.GetNotificationLog(10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(log) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(log))
+	}
+	if log[0].Status != "sent" {
+		t.Errorf("expected log status 'sent', got %q", log[0].Status)
+	}
+
+	// Verify notification state was saved (cooldown will apply next time).
+	fp := dispatcherFingerprint(action.Findings[0])
+	canSend, _ := store.CanSendNotification(fp, action.RouteKey, time.Minute, now)
+	if canSend {
+		t.Error("expected CanSendNotification to return false (just sent), but got true")
+	}
+}
+
+func TestDispatch_SenderError_LogsFailed(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{err: errors.New("connection refused")}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	now := time.Now()
+	action := DispatchAction{
+		Webhook:  testWebhook("alerts"),
+		Findings: []internal.Finding{criticalFinding(internal.CategoryDisk, "Disk failing")},
+		RouteKey: "rule:r1",
+		RuleName: "disk-alerts",
+	}
+
+	err := nd.Dispatch(action, "my-nas", now)
+	if err == nil {
+		t.Fatal("expected error from Dispatch, got nil")
+	}
+
+	// Verify notification log records the failure.
+	log, _ := store.GetNotificationLog(10)
+	if len(log) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(log))
+	}
+	if log[0].Status != "failed" {
+		t.Errorf("expected log status 'failed', got %q", log[0].Status)
+	}
+	if log[0].ErrorMessage != "connection refused" {
+		t.Errorf("expected error message 'connection refused', got %q", log[0].ErrorMessage)
+	}
+}
+
+func TestDispatch_EmptyFindings_NoOp(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	now := time.Now()
+	action := DispatchAction{
+		Webhook:  testWebhook("alerts"),
+		Findings: nil,
+		RouteKey: "rule:r1",
+	}
+
+	err := nd.Dispatch(action, "my-nas", now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sender.calls) != 0 {
+		t.Errorf("expected 0 sender calls, got %d", len(sender.calls))
+	}
+}
+
+// ── Tests: Webhook Name Case Insensitivity ──
+
+func TestEvaluateRules_WebhookNameCaseInsensitive(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	findings := []internal.Finding{
+		criticalFinding(internal.CategoryDisk, "Disk failing"),
+	}
+	rules := []internal.NotificationRule{
+		{
+			ID:          "r1",
+			Name:        "alerts-rule",
+			Enabled:     true,
+			Webhook:     "My Alerts",
+			Category:    "findings",
+			Condition:   "any",
+			CooldownSec: 60,
+		},
+	}
+	wh := testWebhook("my alerts") // lowercase
+	webhooks := []internal.WebhookConfig{wh}
+	now := time.Now()
+
+	actions := nd.EvaluateRules(findings, rules, webhooks, 900, now)
+
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action (case-insensitive match), got %d", len(actions))
+	}
+}
+
+// ── Tests: Default Cooldown ──
+
+func TestEvaluateRules_RuleWithZeroCooldown_UsesDefault(t *testing.T) {
+	store := storage.NewFakeStore()
+	sender := &fakeSender{}
+	nd := NewNotificationDispatcher(store, store, sender, testLogger())
+
+	now := time.Now()
+	finding := criticalFinding(internal.CategoryDisk, "Disk failing")
+	fp := dispatcherFingerprint(finding)
+	routeKey := "rule:r1"
+
+	// Pre-seed: notification was sent 100 seconds ago.
+	_ = store.SaveNotificationState(fp, routeKey, "sent", now.Add(-100*time.Second))
+
+	findings := []internal.Finding{finding}
+	rules := []internal.NotificationRule{
+		{
+			ID:          "r1",
+			Name:        "no-cooldown-rule",
+			Enabled:     true,
+			Webhook:     "alerts",
+			Category:    "findings",
+			Condition:   "any",
+			CooldownSec: 0, // zero → uses default
+		},
+	}
+	webhooks := []internal.WebhookConfig{testWebhook("alerts")}
+
+	// Default cooldown is 900 seconds — sent 100s ago, so still within cooldown.
+	actions := nd.EvaluateRules(findings, rules, webhooks, 900, now)
+
+	if len(actions) != 0 {
+		t.Fatalf("expected 0 actions (within default 900s cooldown), got %d", len(actions))
+	}
+}
+
+// ── Tests: dispatcherFingerprint ──
+
+func TestDispatcherFingerprint_Deterministic(t *testing.T) {
+	f := internal.Finding{
+		Category: internal.CategoryDisk,
+		Title:    "Disk failing",
+	}
+	fp1 := dispatcherFingerprint(f)
+	fp2 := dispatcherFingerprint(f)
+	if fp1 != fp2 {
+		t.Errorf("fingerprints should be deterministic: %q != %q", fp1, fp2)
+	}
+	if len(fp1) != 64 {
+		t.Errorf("expected 64-char hex fingerprint, got len=%d", len(fp1))
+	}
+}
+
+func TestDispatcherFingerprint_DifferentFindings_DifferentFingerprints(t *testing.T) {
+	f1 := criticalFinding(internal.CategoryDisk, "Disk A failing")
+	f2 := criticalFinding(internal.CategoryDisk, "Disk B failing")
+	fp1 := dispatcherFingerprint(f1)
+	fp2 := dispatcherFingerprint(f2)
+	if fp1 == fp2 {
+		t.Error("different findings should have different fingerprints")
+	}
+}

--- a/internal/storage/fake.go
+++ b/internal/storage/fake.go
@@ -36,6 +36,9 @@ type FakeStore struct {
 	alertSeq    int64
 	alertEvents []AlertEvent
 
+	// Alert suppression: fingerprint → reason (e.g., "acknowledged", "snoozed").
+	suppressedAlerts map[string]string
+
 	// Finding history keyed by category.
 	findingsByCategory map[string][]internal.Finding
 }
@@ -169,8 +172,25 @@ func (f *FakeStore) UnsnoozeAlert(_ int64, _ string, _ time.Time) (bool, error) 
 	return false, nil
 }
 
-func (f *FakeStore) IsAlertSuppressed(_ string, _ time.Time) (bool, string, error) {
+func (f *FakeStore) IsAlertSuppressed(fingerprint string, _ time.Time) (bool, string, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if f.suppressedAlerts != nil {
+		if reason, ok := f.suppressedAlerts[fingerprint]; ok {
+			return true, reason, nil
+		}
+	}
 	return false, "", nil
+}
+
+// SuppressAlert marks a fingerprint as suppressed (acknowledged/snoozed) for testing.
+func (f *FakeStore) SuppressAlert(fingerprint, reason string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.suppressedAlerts == nil {
+		f.suppressedAlerts = make(map[string]string)
+	}
+	f.suppressedAlerts[fingerprint] = reason
 }
 
 func (f *FakeStore) MarkAlertsNotifiedByFingerprint(_ []string, _ time.Time) error {


### PR DESCRIPTION
Closes #92

## Summary

- Extracted notification routing logic into a standalone `NotificationDispatcher` module (`internal/scheduler/notify.go`)
- Added `Sender` interface to abstract webhook delivery, enabling tests without real HTTP
- Enhanced `FakeStore.IsAlertSuppressed` to support pre-seeding suppressed fingerprints for testing
- 23 test cases in `notify_test.go` using `FakeStore` — zero real I/O

## What's in the module

**Types:**
- `NotificationDispatcher` — orchestrates rule evaluation, cooldown, suppression, dispatch
- `DispatchAction` — groups findings destined for a single webhook
- `Sender` — interface for webhook delivery (production: `notifier.Notifier`)

**Methods:**
- `EvaluateRules()` — matches findings to rules, applies cooldown + suppression, returns `[]DispatchAction`
- `Dispatch()` — sends a `DispatchAction` to its webhook, records state and logs

**Logic extracted from scheduler.go:**
- Rule matching: severity filter (`critical`, `warning`), category filter, check type filter
- Cooldown enforcement via `NotificationStore.CanSendNotification()`
- Alert suppression via `AlertStore.IsAlertSuppressed()`
- Dedup within batch via fingerprint tracking
- Legacy mode: no rules → all findings to all enabled webhooks

## Test coverage (23 tests)

1. Severity match: critical finding included by critical rule
2. Severity mismatch: warning excluded by critical-only rule
3. Warning rule includes both warning and critical
4. Category filter: disk included, network excluded
5. Non-findings category: speedtest rule includes only speedtest findings
6. Cooldown within window: suppressed
7. Cooldown expired: allowed
8. Acknowledged alert: not dispatched
9. Snoozed alert: not dispatched
10. Multiple rules with different webhooks: 2 dispatch actions
11. Nonexistent webhook: skipped gracefully
12. Disabled rule: skipped
13. Disabled webhook: skipped
14. Legacy mode: all findings to all enabled webhooks
15. Legacy mode: no findings → no actions
16. Duplicate findings: deduped
17. Webhook name case insensitive
18. Zero cooldown on rule: uses default
19. Dispatch success: records state and log
20. Dispatch sender error: logs failure
21. Dispatch empty findings: no-op
22. Fingerprint deterministic
23. Different findings → different fingerprints

## Important

**Additive only** — no code removed from or modified in `scheduler.go`. Wiring happens in #94.