### PR TITLE
feat(scheduler): add RetentionManager module with tests

### DIFF
--- a/internal/scheduler/retention.go
+++ b/internal/scheduler/retention.go
@@ -1,0 +1,194 @@
+// Package scheduler — retention.go implements the RetentionManager, a standalone
+// module that owns all data lifecycle operations (pruning, vacuuming, backups).
+//
+// This module is additive: the existing pruneData() and checkBackup() in
+// scheduler.go remain untouched. Wiring happens in a follow-up issue (#94).
+package scheduler
+
+import (
+	"log/slog"
+	"path/filepath"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// RetentionManagerConfig holds configurable data lifecycle settings.
+// Unlike the scheduler's RetentionConfig (which uses int days), this uses
+// time.Duration for precision and testability.
+type RetentionManagerConfig struct {
+	SnapshotMaxAge     time.Duration
+	SnapshotKeepMin    int
+	ServiceCheckMaxAge time.Duration
+	NotificationMaxAge time.Duration
+	AlertMaxAge        time.Duration
+	MaxDBSizeMB        float64
+}
+
+// RetentionResult summarizes what a single RunRetention call pruned.
+type RetentionResult struct {
+	SnapshotsPruned     int
+	ServiceChecksPruned int
+	NotificationsPruned int
+	AlertsPruned        int
+	OrphansPruned       int
+	SizePruned          int
+	Vacuumed            bool
+}
+
+// RetentionManager owns all data lifecycle operations. It depends only on
+// storage.LifecycleStore (for pruning/vacuum) and storage.ServiceCheckStore
+// (for service check history pruning), keeping it decoupled from the
+// full Scheduler.
+type RetentionManager struct {
+	store  storage.LifecycleStore
+	svc    storage.ServiceCheckStore
+	logger *slog.Logger
+}
+
+// NewRetentionManager creates a RetentionManager.
+// If svc is nil, service check pruning is skipped.
+func NewRetentionManager(store storage.LifecycleStore, svc storage.ServiceCheckStore, logger *slog.Logger) *RetentionManager {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &RetentionManager{
+		store:  store,
+		svc:    svc,
+		logger: logger,
+	}
+}
+
+// RunRetention executes all pruning operations in the same order as the
+// existing scheduler.pruneData() method:
+//
+//  1. Prune old snapshots (respects keep-minimum)
+//  2. Prune orphaned findings
+//  3. Prune notification log
+//  4. Prune service check history (3b)
+//  5. Prune resolved alerts
+//  6. DB size cap enforcement
+//  7. VACUUM (if anything was pruned and PruneToSizeMB didn't already vacuum)
+func (rm *RetentionManager) RunRetention(cfg RetentionManagerConfig) RetentionResult {
+	var result RetentionResult
+	needsVacuum := false
+
+	// 1. Prune old snapshots
+	if pruned, err := rm.store.PruneSnapshots(cfg.SnapshotMaxAge, cfg.SnapshotKeepMin); err != nil {
+		rm.logger.Warn("prune snapshots failed", "error", err)
+	} else if pruned > 0 {
+		rm.logger.Info("pruned old snapshots", "count", pruned)
+		result.SnapshotsPruned = pruned
+		needsVacuum = true
+	}
+
+	// 2. Prune orphaned findings
+	if pruned, err := rm.store.PruneOrphanedFindings(); err != nil {
+		rm.logger.Warn("prune orphaned findings failed", "error", err)
+	} else if pruned > 0 {
+		rm.logger.Info("pruned orphaned findings", "count", pruned)
+		result.OrphansPruned = pruned
+		needsVacuum = true
+	}
+
+	// 3. Prune notification log
+	if pruned, err := rm.store.PruneNotificationLog(cfg.NotificationMaxAge); err != nil {
+		rm.logger.Warn("prune notification log failed", "error", err)
+	} else if pruned > 0 {
+		rm.logger.Info("pruned notification log", "count", pruned)
+		result.NotificationsPruned = pruned
+		needsVacuum = true
+	}
+
+	// 3b. Prune service check history
+	if rm.svc != nil {
+		if pruned, err := rm.svc.PruneServiceCheckHistory(cfg.ServiceCheckMaxAge); err != nil {
+			rm.logger.Warn("prune service check history failed", "error", err)
+		} else if pruned > 0 {
+			rm.logger.Info("pruned service check history", "count", pruned)
+			result.ServiceChecksPruned = pruned
+			needsVacuum = true
+		}
+	}
+
+	// 4. Prune resolved alerts
+	if pruned, err := rm.store.PruneAlerts(cfg.AlertMaxAge); err != nil {
+		rm.logger.Warn("prune alerts failed", "error", err)
+	} else if pruned > 0 {
+		rm.logger.Info("pruned old alerts", "count", pruned)
+		result.AlertsPruned = pruned
+		needsVacuum = true
+	}
+
+	// 5. DB size cap
+	if cfg.MaxDBSizeMB > 0 {
+		if pruned, err := rm.store.PruneToSizeMB(cfg.MaxDBSizeMB); err != nil {
+			rm.logger.Warn("prune to size failed", "error", err)
+		} else if pruned > 0 {
+			rm.logger.Warn("DB size exceeded cap, pruned snapshots",
+				"pruned", pruned, "cap_mb", cfg.MaxDBSizeMB)
+			result.SizePruned = pruned
+			needsVacuum = false // PruneToSizeMB already vacuums
+		}
+	}
+
+	// 6. VACUUM to reclaim space
+	if needsVacuum {
+		if err := rm.store.Vacuum(); err != nil {
+			rm.logger.Warn("vacuum failed", "error", err)
+		} else {
+			result.Vacuumed = true
+		}
+	}
+
+	return result
+}
+
+// BackupManagerConfig holds backup scheduling settings for RunBackup.
+type BackupManagerConfig struct {
+	Enabled   bool
+	Path      string // backup directory
+	KeepCount int
+	IntervalH int
+}
+
+// RunBackup creates a database backup if due (based on lastBackup + interval),
+// then prunes old backups to keep KeepCount. Returns the backup result or nil
+// if not due / disabled.
+func (rm *RetentionManager) RunBackup(cfg BackupManagerConfig, lastBackup time.Time, now time.Time) (*storage.BackupResult, error) {
+	if !cfg.Enabled {
+		return nil, nil
+	}
+
+	intervalH := cfg.IntervalH
+	if intervalH <= 0 {
+		intervalH = 168 // weekly default
+	}
+
+	if !lastBackup.IsZero() && now.Sub(lastBackup) < time.Duration(intervalH)*time.Hour {
+		return nil, nil // not time yet
+	}
+
+	result, err := rm.store.CreateBackup(cfg.Path, rm.logger)
+	if err != nil {
+		return nil, err
+	}
+
+	// Prune old backups
+	backupDir := cfg.Path
+	if backupDir == "" {
+		backupDir = filepath.Dir(result.Path)
+	}
+
+	keepCount := cfg.KeepCount
+	if keepCount <= 0 {
+		keepCount = 4
+	}
+	if pruned, err := storage.PruneBackups(backupDir, keepCount, rm.logger); err != nil {
+		rm.logger.Warn("backup prune failed", "error", err)
+	} else if pruned > 0 {
+		rm.logger.Info("pruned old backups", "count", pruned)
+	}
+
+	return result, nil
+}

--- a/internal/scheduler/retention_test.go
+++ b/internal/scheduler/retention_test.go
@@ -1,0 +1,477 @@
+package scheduler
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// helper: create a logger that discards output.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// helper: create a snapshot at a given time offset from now.
+func makeSnapshot(id string, age time.Duration) *internal.Snapshot {
+	return &internal.Snapshot{
+		ID:        id,
+		Timestamp: time.Now().Add(-age),
+	}
+}
+
+// helper: default config with generous retention (nothing pruned).
+func defaultCfg() RetentionManagerConfig {
+	return RetentionManagerConfig{
+		SnapshotMaxAge:     90 * 24 * time.Hour,
+		SnapshotKeepMin:    10,
+		ServiceCheckMaxAge: 30 * 24 * time.Hour,
+		NotificationMaxAge: 30 * 24 * time.Hour,
+		AlertMaxAge:        30 * 24 * time.Hour,
+		MaxDBSizeMB:        500,
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 1: Snapshot pruning — old snapshots removed, keep-minimum respected
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRunRetention_SnapshotPruning_KeepMinRespected(t *testing.T) {
+	store := storage.NewFakeStore()
+	for i := 0; i < 15; i++ {
+		if err := store.SaveSnapshot(makeSnapshot(
+			fmt.Sprintf("snap-%02d", i),
+			100*24*time.Hour+time.Duration(i)*time.Minute,
+		)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rm := NewRetentionManager(store, store, discardLogger())
+	cfg := defaultCfg()
+	cfg.SnapshotKeepMin = 10
+
+	result := rm.RunRetention(cfg)
+
+	if result.SnapshotsPruned != 5 {
+		t.Fatalf("expected 5 snapshots pruned, got %d", result.SnapshotsPruned)
+	}
+	if store.SnapshotCount() != 10 {
+		t.Fatalf("expected 10 remaining snapshots, got %d", store.SnapshotCount())
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 2: Snapshot pruning — all within age → nothing pruned
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRunRetention_SnapshotPruning_AllRecent(t *testing.T) {
+	store := storage.NewFakeStore()
+	for i := 0; i < 5; i++ {
+		if err := store.SaveSnapshot(makeSnapshot(
+			fmt.Sprintf("snap-%02d", i),
+			time.Duration(i)*time.Hour,
+		)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rm := NewRetentionManager(store, store, discardLogger())
+	result := rm.RunRetention(defaultCfg())
+
+	if result.SnapshotsPruned != 0 {
+		t.Fatalf("expected 0 snapshots pruned, got %d", result.SnapshotsPruned)
+	}
+	if store.SnapshotCount() != 5 {
+		t.Fatalf("expected 5 remaining, got %d", store.SnapshotCount())
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 3: Service check pruning — old entries removed
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRunRetention_ServiceCheckPruning(t *testing.T) {
+	store := storage.NewFakeStore()
+
+	oldTime := time.Now().Add(-60 * 24 * time.Hour).Format(time.RFC3339)
+	recentTime := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
+
+	_ = store.SaveServiceCheckResults([]internal.ServiceCheckResult{
+		{Key: "check-1", Name: "Old check", CheckedAt: oldTime, Status: "up"},
+		{Key: "check-2", Name: "Recent check", CheckedAt: recentTime, Status: "up"},
+	})
+
+	rm := NewRetentionManager(store, store, discardLogger())
+	cfg := defaultCfg()
+	cfg.ServiceCheckMaxAge = 30 * 24 * time.Hour
+
+	result := rm.RunRetention(cfg)
+
+	if result.ServiceChecksPruned != 1 {
+		t.Fatalf("expected 1 service check pruned, got %d", result.ServiceChecksPruned)
+	}
+	if store.ServiceCheckCount() != 1 {
+		t.Fatalf("expected 1 remaining, got %d", store.ServiceCheckCount())
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 4: Notification log pruning — old entries removed
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRunRetention_NotificationLogPruning(t *testing.T) {
+	store := storage.NewFakeStore()
+
+	store.AddNotificationLogEntry(storage.NotificationLogEntry{
+		ID: 1, CreatedAt: time.Now().Add(-60 * 24 * time.Hour),
+	})
+	store.AddNotificationLogEntry(storage.NotificationLogEntry{
+		ID: 2, CreatedAt: time.Now().Add(-1 * time.Hour),
+	})
+
+	rm := NewRetentionManager(store, store, discardLogger())
+	cfg := defaultCfg()
+	cfg.NotificationMaxAge = 30 * 24 * time.Hour
+
+	result := rm.RunRetention(cfg)
+
+	if result.NotificationsPruned != 1 {
+		t.Fatalf("expected 1 notification pruned, got %d", result.NotificationsPruned)
+	}
+	if store.NotificationLogCount() != 1 {
+		t.Fatalf("expected 1 remaining, got %d", store.NotificationLogCount())
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 5: Alert pruning — resolved alerts older than max age removed
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRunRetention_AlertPruning(t *testing.T) {
+	store := storage.NewFakeStore()
+
+	store.AddAlert(storage.AlertRecord{
+		ID: 1, Status: storage.AlertStatusResolved,
+		ResolvedAt: time.Now().Add(-60 * 24 * time.Hour).Format(time.RFC3339),
+	})
+	store.AddAlert(storage.AlertRecord{
+		ID: 2, Status: storage.AlertStatusResolved,
+		ResolvedAt: time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+	})
+	store.AddAlert(storage.AlertRecord{
+		ID: 3, Status: storage.AlertStatusOpen,
+	})
+
+	rm := NewRetentionManager(store, store, discardLogger())
+	cfg := defaultCfg()
+	cfg.AlertMaxAge = 30 * 24 * time.Hour
+
+	result := rm.RunRetention(cfg)
+
+	if result.AlertsPruned != 1 {
+		t.Fatalf("expected 1 alert pruned, got %d", result.AlertsPruned)
+	}
+	if store.AlertCount() != 2 {
+		t.Fatalf("expected 2 remaining, got %d", store.AlertCount())
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 6: Orphan cleanup — orphaned findings removed
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRunRetention_OrphanCleanup(t *testing.T) {
+	store := storage.NewFakeStore()
+	store.AddOrphanedFindings(7)
+
+	rm := NewRetentionManager(store, store, discardLogger())
+	result := rm.RunRetention(defaultCfg())
+
+	if result.OrphansPruned != 7 {
+		t.Fatalf("expected 7 orphans pruned, got %d", result.OrphansPruned)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 7: Size-based pruning — triggers when DB exceeds target size
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRunRetention_SizeBasedPruning(t *testing.T) {
+	store := storage.NewFakeStore()
+	store.DBSizeMB = 600
+
+	for i := 0; i < 20; i++ {
+		_ = store.SaveSnapshot(makeSnapshot(fmt.Sprintf("snap-%02d", i), time.Duration(i)*time.Hour))
+	}
+
+	rm := NewRetentionManager(store, store, discardLogger())
+	cfg := defaultCfg()
+	cfg.MaxDBSizeMB = 500
+
+	result := rm.RunRetention(cfg)
+
+	if result.SizePruned == 0 {
+		t.Fatal("expected size-based pruning, got 0")
+	}
+	if store.SnapshotCount() >= 20 {
+		t.Fatalf("expected fewer than 20 snapshots, got %d", store.SnapshotCount())
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 8: Vacuum runs after age-based pruning
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRunRetention_VacuumAfterPruning(t *testing.T) {
+	store := storage.NewFakeStore()
+	store.AddNotificationLogEntry(storage.NotificationLogEntry{
+		ID: 1, CreatedAt: time.Now().Add(-60 * 24 * time.Hour),
+	})
+
+	rm := NewRetentionManager(store, store, discardLogger())
+	cfg := defaultCfg()
+	cfg.NotificationMaxAge = 30 * 24 * time.Hour
+
+	result := rm.RunRetention(cfg)
+
+	if !result.Vacuumed {
+		t.Fatal("expected vacuum to run after pruning")
+	}
+	if !store.VacuumCalled {
+		t.Fatal("expected FakeStore.Vacuum() to be called")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 9: Vacuum skipped when size-based pruning occurred
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRunRetention_VacuumSkippedAfterSizePruning(t *testing.T) {
+	store := storage.NewFakeStore()
+	store.DBSizeMB = 600
+
+	for i := 0; i < 20; i++ {
+		_ = store.SaveSnapshot(makeSnapshot(fmt.Sprintf("snap-%02d", i), time.Duration(i)*time.Minute))
+	}
+
+	rm := NewRetentionManager(store, store, discardLogger())
+	cfg := defaultCfg()
+	cfg.MaxDBSizeMB = 500
+
+	result := rm.RunRetention(cfg)
+
+	if result.Vacuumed {
+		t.Fatal("expected vacuum NOT to run after size-based pruning")
+	}
+	if result.SizePruned == 0 {
+		t.Fatal("expected size-based pruning to occur")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 10: Combined retention — all operations run, results correct
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRunRetention_CombinedAllOperations(t *testing.T) {
+	store := storage.NewFakeStore()
+
+	for i := 0; i < 5; i++ {
+		_ = store.SaveSnapshot(makeSnapshot(
+			fmt.Sprintf("snap-%02d", i),
+			100*24*time.Hour+time.Duration(i)*time.Minute,
+		))
+	}
+
+	oldTime := time.Now().Add(-60 * 24 * time.Hour).Format(time.RFC3339)
+	_ = store.SaveServiceCheckResults([]internal.ServiceCheckResult{
+		{Key: "svc-old", Name: "Old", CheckedAt: oldTime, Status: "up"},
+	})
+
+	store.AddNotificationLogEntry(storage.NotificationLogEntry{
+		ID: 1, CreatedAt: time.Now().Add(-60 * 24 * time.Hour),
+	})
+
+	store.AddAlert(storage.AlertRecord{
+		ID: 1, Status: storage.AlertStatusResolved,
+		ResolvedAt: time.Now().Add(-60 * 24 * time.Hour).Format(time.RFC3339),
+	})
+
+	store.AddOrphanedFindings(3)
+
+	rm := NewRetentionManager(store, store, discardLogger())
+	cfg := RetentionManagerConfig{
+		SnapshotMaxAge:     90 * 24 * time.Hour,
+		SnapshotKeepMin:    2,
+		ServiceCheckMaxAge: 30 * 24 * time.Hour,
+		NotificationMaxAge: 30 * 24 * time.Hour,
+		AlertMaxAge:        30 * 24 * time.Hour,
+		MaxDBSizeMB:        0,
+	}
+
+	result := rm.RunRetention(cfg)
+
+	if result.SnapshotsPruned != 3 {
+		t.Errorf("snapshots: expected 3, got %d", result.SnapshotsPruned)
+	}
+	if result.ServiceChecksPruned != 1 {
+		t.Errorf("service checks: expected 1, got %d", result.ServiceChecksPruned)
+	}
+	if result.NotificationsPruned != 1 {
+		t.Errorf("notifications: expected 1, got %d", result.NotificationsPruned)
+	}
+	if result.AlertsPruned != 1 {
+		t.Errorf("alerts: expected 1, got %d", result.AlertsPruned)
+	}
+	if result.OrphansPruned != 3 {
+		t.Errorf("orphans: expected 3, got %d", result.OrphansPruned)
+	}
+	if !result.Vacuumed {
+		t.Error("expected vacuum to run")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 11: No-op retention — everything within bounds → zero counts
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRunRetention_NoOp(t *testing.T) {
+	store := storage.NewFakeStore()
+
+	for i := 0; i < 3; i++ {
+		_ = store.SaveSnapshot(makeSnapshot(fmt.Sprintf("snap-%02d", i), time.Duration(i)*time.Hour))
+	}
+	recentTime := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
+	_ = store.SaveServiceCheckResults([]internal.ServiceCheckResult{
+		{Key: "svc-1", Name: "Recent", CheckedAt: recentTime, Status: "up"},
+	})
+	store.AddNotificationLogEntry(storage.NotificationLogEntry{
+		ID: 1, CreatedAt: time.Now().Add(-1 * time.Hour),
+	})
+
+	rm := NewRetentionManager(store, store, discardLogger())
+	result := rm.RunRetention(defaultCfg())
+
+	if result.SnapshotsPruned != 0 || result.ServiceChecksPruned != 0 ||
+		result.NotificationsPruned != 0 || result.AlertsPruned != 0 ||
+		result.OrphansPruned != 0 || result.SizePruned != 0 {
+		t.Errorf("expected all zeros, got %+v", result)
+	}
+	if result.Vacuumed {
+		t.Error("expected vacuum NOT to run")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 12: RunBackup — disabled returns nil
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRunBackup_Disabled(t *testing.T) {
+	store := storage.NewFakeStore()
+	rm := NewRetentionManager(store, store, discardLogger())
+
+	result, err := rm.RunBackup(BackupManagerConfig{Enabled: false}, time.Time{}, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil, got %+v", result)
+	}
+	if store.BackupCalls != 0 {
+		t.Fatalf("expected 0 backup calls, got %d", store.BackupCalls)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 13: RunBackup — not due yet
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRunBackup_NotDueYet(t *testing.T) {
+	store := storage.NewFakeStore()
+	rm := NewRetentionManager(store, store, discardLogger())
+
+	lastBackup := time.Now().Add(-1 * time.Hour)
+	cfg := BackupManagerConfig{Enabled: true, IntervalH: 24}
+
+	result, err := rm.RunBackup(cfg, lastBackup, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Fatal("expected nil when not due")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 14: RunBackup — due, creates backup
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRunBackup_Due(t *testing.T) {
+	store := storage.NewFakeStore()
+	rm := NewRetentionManager(store, store, discardLogger())
+
+	lastBackup := time.Now().Add(-48 * time.Hour)
+	cfg := BackupManagerConfig{Enabled: true, IntervalH: 24, Path: t.TempDir()}
+
+	result, err := rm.RunBackup(cfg, lastBackup, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected backup result")
+	}
+	if store.BackupCalls != 1 {
+		t.Fatalf("expected 1 backup call, got %d", store.BackupCalls)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 15: RunBackup — first ever backup (zero lastBackup)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRunBackup_FirstEver(t *testing.T) {
+	store := storage.NewFakeStore()
+	rm := NewRetentionManager(store, store, discardLogger())
+
+	cfg := BackupManagerConfig{Enabled: true, IntervalH: 168, Path: t.TempDir()}
+
+	result, err := rm.RunBackup(cfg, time.Time{}, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected backup on first run")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 16: NewRetentionManager with nil logger
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestNewRetentionManager_NilLogger(t *testing.T) {
+	store := storage.NewFakeStore()
+	rm := NewRetentionManager(store, store, nil)
+	if rm.logger == nil {
+		t.Fatal("expected non-nil logger")
+	}
+	_ = rm.RunRetention(defaultCfg()) // smoke test: should not panic
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 17: RunRetention with nil service check store
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRunRetention_NilServiceCheckStore(t *testing.T) {
+	store := storage.NewFakeStore()
+	rm := NewRetentionManager(store, nil, discardLogger())
+
+	result := rm.RunRetention(defaultCfg())
+
+	if result.ServiceChecksPruned != 0 {
+		t.Fatalf("expected 0 with nil svc store, got %d", result.ServiceChecksPruned)
+	}
+}

--- a/internal/storage/fake.go
+++ b/internal/storage/fake.go
@@ -38,6 +38,15 @@ type FakeStore struct {
 
 	// Finding history keyed by category.
 	findingsByCategory map[string][]internal.Finding
+
+	// LifecycleStore test hooks.
+	VacuumCalled bool    // observable by tests
+	DBSizeMB     float64 // simulated DB file size for GetDBStats/PruneToSizeMB
+	BackupCalls  int     // number of CreateBackup invocations
+
+	// Orphaned findings: findings whose snapshot ID doesn't match any snapshot.
+	// Seeded by tests via AddOrphanedFindings().
+	orphanedFindingCount int
 }
 
 // NewFakeStore creates a ready-to-use in-memory store.
@@ -278,9 +287,28 @@ func (f *FakeStore) GetServiceCheckHistory(checkKey string, limit int) ([]Servic
 	return entries, nil
 }
 
-func (f *FakeStore) PruneServiceCheckHistory(_ time.Duration) (int, error) {
-	// TODO: implement for testing
-	return 0, nil
+// PruneServiceCheckHistory removes service check entries older than olderThan.
+func (f *FakeStore) PruneServiceCheckHistory(olderThan time.Duration) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	cutoff := time.Now().Add(-olderThan)
+	var kept []internal.ServiceCheckResult
+	pruned := 0
+	for _, r := range f.serviceChecks {
+		checkedAt, err := time.Parse(time.RFC3339, r.CheckedAt)
+		if err != nil {
+			kept = append(kept, r)
+			continue
+		}
+		if checkedAt.Before(cutoff) {
+			pruned++
+		} else {
+			kept = append(kept, r)
+		}
+	}
+	f.serviceChecks = kept
+	return pruned, nil
 }
 
 func (f *FakeStore) DeleteServiceCheckByKey(key string) (int, error) {
@@ -469,46 +497,132 @@ func (f *FakeStore) GetFindingHistory(category string, limit int) ([]internal.Fi
 
 // ── LifecycleStore ──
 
-func (f *FakeStore) PruneSnapshots(_ time.Duration, _ int) (int, error) {
-	// TODO: implement for testing
-	return 0, nil
+// PruneSnapshots removes snapshots older than olderThan, but always keeps at
+// least keepMin snapshots (the most recent ones). Returns the count removed.
+func (f *FakeStore) PruneSnapshots(olderThan time.Duration, keepMin int) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.snapshots) == 0 {
+		return 0, nil
+	}
+	cutoff := time.Now().Add(-olderThan)
+	sorted := make([]*internal.Snapshot, len(f.snapshots))
+	copy(sorted, f.snapshots)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Timestamp.After(sorted[j].Timestamp)
+	})
+	keep := make(map[string]bool)
+	for i := 0; i < keepMin && i < len(sorted); i++ {
+		keep[sorted[i].ID] = true
+	}
+	var kept []*internal.Snapshot
+	pruned := 0
+	for _, s := range f.snapshots {
+		if !keep[s.ID] && s.Timestamp.Before(cutoff) {
+			pruned++
+		} else {
+			kept = append(kept, s)
+		}
+	}
+	f.snapshots = kept
+	return pruned, nil
 }
 
-func (f *FakeStore) PruneNotificationLog(_ time.Duration) (int, error) {
-	// TODO: implement for testing
-	return 0, nil
+// PruneNotificationLog removes notification log entries older than olderThan.
+func (f *FakeStore) PruneNotificationLog(olderThan time.Duration) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cutoff := time.Now().Add(-olderThan)
+	var kept []NotificationLogEntry
+	pruned := 0
+	for _, entry := range f.notificationLog {
+		if entry.CreatedAt.Before(cutoff) {
+			pruned++
+		} else {
+			kept = append(kept, entry)
+		}
+	}
+	f.notificationLog = kept
+	return pruned, nil
 }
 
-func (f *FakeStore) PruneAlerts(_ time.Duration) (int, error) {
-	// TODO: implement for testing
-	return 0, nil
+// PruneAlerts removes resolved alerts older than olderThan.
+func (f *FakeStore) PruneAlerts(olderThan time.Duration) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cutoff := time.Now().Add(-olderThan)
+	var kept []AlertRecord
+	pruned := 0
+	for _, a := range f.alerts {
+		if a.Status == "resolved" && a.ResolvedAt != "" {
+			resolvedAt, err := time.Parse(time.RFC3339, a.ResolvedAt)
+			if err == nil && resolvedAt.Before(cutoff) {
+				pruned++
+				continue
+			}
+		}
+		kept = append(kept, a)
+	}
+	f.alerts = kept
+	return pruned, nil
 }
 
+// PruneOrphanedFindings removes orphaned findings and returns the count.
 func (f *FakeStore) PruneOrphanedFindings() (int, error) {
-	// TODO: implement for testing
-	return 0, nil
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := f.orphanedFindingCount
+	f.orphanedFindingCount = 0
+	return n, nil
 }
 
-func (f *FakeStore) PruneToSizeMB(_ float64) (int, error) {
-	// TODO: implement for testing
-	return 0, nil
+// PruneToSizeMB removes the oldest snapshots until the simulated DB size is
+// at or below targetMB.
+func (f *FakeStore) PruneToSizeMB(targetMB float64) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.DBSizeMB <= targetMB || len(f.snapshots) == 0 {
+		return 0, nil
+	}
+	sort.Slice(f.snapshots, func(i, j int) bool {
+		return f.snapshots[i].Timestamp.Before(f.snapshots[j].Timestamp)
+	})
+	perSnapshot := f.DBSizeMB / float64(len(f.snapshots))
+	pruned := 0
+	for f.DBSizeMB > targetMB && len(f.snapshots) > 0 {
+		f.snapshots = f.snapshots[1:]
+		f.DBSizeMB -= perSnapshot
+		pruned++
+	}
+	return pruned, nil
 }
 
+// Vacuum records that vacuum was called.
 func (f *FakeStore) Vacuum() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.VacuumCalled = true
 	return nil
 }
 
+// GetDBStats returns statistics about the in-memory store contents.
 func (f *FakeStore) GetDBStats() (*DBStats, error) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	return &DBStats{
+		FileSizeMB:       f.DBSizeMB,
 		SnapshotCount:    len(f.snapshots),
 		ServiceCheckRows: len(f.serviceChecks),
 		NotifyLogRows:    len(f.notificationLog),
+		AlertRows:        len(f.alerts),
 	}, nil
 }
 
+// CreateBackup records the call and returns a fake result.
 func (f *FakeStore) CreateBackup(_ string, _ *slog.Logger) (*BackupResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.BackupCalls++
 	return &BackupResult{
 		Path:      "/tmp/fake-backup.db.gz",
 		SizeMB:    0.1,
@@ -522,4 +636,62 @@ func (f *FakeStore) Close() error {
 
 func (f *FakeStore) DataDir() string {
 	return "/tmp/fake-store"
+}
+
+// ── Test helpers (not part of Store interface) ──
+
+// AddOrphanedFindings seeds orphaned finding count for PruneOrphanedFindings.
+func (f *FakeStore) AddOrphanedFindings(count int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.orphanedFindingCount += count
+}
+
+// AddAlert adds an alert record for testing.
+func (f *FakeStore) AddAlert(a AlertRecord) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.alerts = append(f.alerts, a)
+}
+
+// AddNotificationLogEntry adds a notification log entry with a specific timestamp.
+func (f *FakeStore) AddNotificationLogEntry(entry NotificationLogEntry) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.notificationLog = append(f.notificationLog, entry)
+}
+
+// SnapshotCount returns the current number of snapshots.
+func (f *FakeStore) SnapshotCount() int {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return len(f.snapshots)
+}
+
+// AlertCount returns the current number of alerts.
+func (f *FakeStore) AlertCount() int {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return len(f.alerts)
+}
+
+// NotificationLogCount returns the current number of notification log entries.
+func (f *FakeStore) NotificationLogCount() int {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return len(f.notificationLog)
+}
+
+// ServiceCheckCount returns the current number of service check entries.
+func (f *FakeStore) ServiceCheckCount() int {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return len(f.serviceChecks)
+}
+
+// ResetVacuum resets the VacuumCalled flag.
+func (f *FakeStore) ResetVacuum() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.VacuumCalled = false
 }


### PR DESCRIPTION
Closes #93

## Summary

- Extract retention/pruning logic into standalone `RetentionManager` module (`internal/scheduler/retention.go`)
- Flesh out `FakeStore` LifecycleStore methods for proper in-memory testing (`internal/storage/fake.go`)
- 17 test cases covering all pruning operations, backup scheduling, and edge cases

## Changes

### `internal/scheduler/retention.go` (new)
- `RetentionManager` struct with `RunRetention()` and `RunBackup()` methods
- `RetentionManagerConfig` — uses `time.Duration` for precision (vs int days in scheduler)
- `RetentionResult` — counts of pruned items per category + vacuum status
- `BackupManagerConfig` — standalone backup scheduling config
- Preserves exact operation order from `scheduler.pruneData()`:
  1. Snapshot pruning (age + keep-min)
  2. Orphaned finding cleanup
  3. Notification log pruning
  4. Service check history pruning
  5. Resolved alert pruning
  6. DB size cap enforcement
  7. Conditional VACUUM (skipped if PruneToSizeMB ran)

### `internal/scheduler/retention_test.go` (new, 17 tests)
1. Snapshot pruning with keep-minimum respected
2. All-recent snapshots — nothing pruned
3. Service check history pruning
4. Notification log pruning
5. Alert pruning (resolved only)
6. Orphan cleanup
7. Size-based pruning
8. Vacuum after age-based pruning
9. Vacuum skipped after size-based pruning
10. Combined: all operations in one run
11. No-op: everything within bounds
12. Backup disabled
13. Backup not due yet
14. Backup due — creates backup
15. First-ever backup (zero lastBackup)
16. Nil logger safety
17. Nil service check store safety

### `internal/storage/fake.go` (updated)
- Implement `PruneSnapshots` (age filter + keep-min)
- Implement `PruneServiceCheckHistory` (time-based)
- Implement `PruneNotificationLog` (time-based)
- Implement `PruneAlerts` (resolved + time-based)
- Implement `PruneOrphanedFindings` (counter-based)
- Implement `PruneToSizeMB` (proportional removal)
- `Vacuum()` records call via `VacuumCalled` field
- `CreateBackup()` tracks call count via `BackupCalls`
- Add test helpers: `AddAlert`, `AddOrphanedFindings`, `AddNotificationLogEntry`, `SnapshotCount`, `AlertCount`, etc.

## Important

**Additive only** — `scheduler.go` is NOT modified. Wiring happens in #94.