### PR TITLE
refactor(scheduler): wire ServiceChecker + RetentionManager, extract rules.go

### DIFF
--- a/internal/scheduler/checks_test.go
+++ b/internal/scheduler/checks_test.go
@@ -644,19 +644,22 @@ func TestCheckKey_Deterministic(t *testing.T) {
 	}
 }
 
-func TestCheckKey_MatchesSchedulerKey(t *testing.T) {
-	// Verify that CheckKey produces the same result as the original
-	// serviceCheckKey function in scheduler.go.
+func TestCheckKey_Consistency(t *testing.T) {
+	// Verify that CheckKey is deterministic and produces the expected
+	// SHA-256 hash format for a given input.
 	check := internal.ServiceCheckConfig{
 		Name:   "My Service",
 		Type:   "HTTP",
 		Target: "https://example.com",
 		Port:   443,
 	}
-	newKey := CheckKey(check)
-	oldKey := serviceCheckKey(check)
-	if newKey != oldKey {
-		t.Fatalf("CheckKey and serviceCheckKey produce different results:\n  new: %s\n  old: %s", newKey, oldKey)
+	key1 := CheckKey(check)
+	key2 := CheckKey(check)
+	if key1 != key2 {
+		t.Fatalf("CheckKey is not deterministic:\n  first:  %s\n  second: %s", key1, key2)
+	}
+	if len(key1) != 64 {
+		t.Fatalf("expected 64-char hex key, got len=%d", len(key1))
 	}
 }
 

--- a/internal/scheduler/rules.go
+++ b/internal/scheduler/rules.go
@@ -1,0 +1,512 @@
+package scheduler
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// evaluateRule checks a single notification rule against the snapshot and
+// returns matching findings (real or synthetic).
+func evaluateRule(rule internal.NotificationRule, snap *internal.Snapshot) []internal.Finding {
+	cat := strings.ToLower(rule.Category)
+	cond := strings.ToLower(rule.Condition)
+	target := strings.ToLower(strings.TrimSpace(rule.Target))
+	val := parseFloat(rule.Value)
+
+	switch cat {
+	case "findings":
+		return evalFindings(cond, target, snap.Findings)
+	case "disk_space":
+		return evalDiskSpace(cond, target, val, snap.Disks)
+	case "disk_temp":
+		return evalDiskTemp(cond, target, int(val), snap.SMART)
+	case "smart":
+		return evalSMART(cond, target, int64(val), snap.SMART)
+	case "service":
+		return evalService(cond, target, val, snap.Services)
+	case "parity":
+		return evalParity(cond, val, snap.Parity)
+	case "ups":
+		return evalUPS(cond, val, snap.UPS)
+	case "docker":
+		return evalDocker(cond, target, snap.Docker)
+	case "system":
+		return evalSystem(cond, val, snap.System)
+	case "zfs":
+		return evalZFS(cond, target, val, snap.ZFS)
+	case "tunnels":
+		return evalTunnels(cond, target, snap.Tunnels)
+	case "update":
+		return evalUpdate(snap.Update)
+	}
+	return nil
+}
+
+func parseFloat(s string) float64 {
+	v, _ := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	return v
+}
+
+func synth(id string, sev internal.Severity, cat internal.Category, title, desc string) internal.Finding {
+	return internal.Finding{ID: id, Severity: sev, Category: cat, Title: title, Description: desc}
+}
+
+func matchTarget(target, candidate string) bool {
+	if target == "" {
+		return true
+	}
+	return strings.EqualFold(target, strings.TrimSpace(candidate))
+}
+
+// -- Category evaluators --
+
+func evalFindings(cond, target string, findings []internal.Finding) []internal.Finding {
+	var out []internal.Finding
+	for _, f := range findings {
+		switch cond {
+		case "critical":
+			if f.Severity == internal.SeverityCritical {
+				out = append(out, f)
+			}
+		case "warning":
+			if f.Severity == internal.SeverityWarning || f.Severity == internal.SeverityCritical {
+				out = append(out, f)
+			}
+		case "category":
+			if strings.EqualFold(string(f.Category), target) {
+				out = append(out, f)
+			}
+		case "any":
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func evalDiskSpace(cond, target string, val float64, disks []internal.DiskInfo) []internal.Finding {
+	if val <= 0 {
+		return nil
+	}
+	var out []internal.Finding
+	for _, d := range disks {
+		if !matchTarget(target, d.MountPoint) && !matchTarget(target, d.Label) {
+			continue
+		}
+		free := 100.0 - d.UsedPct
+		if free < val {
+			out = append(out, synth("rule:disk-space:"+d.MountPoint, internal.SeverityWarning, internal.CategoryDisk,
+				"Disk space low: "+d.MountPoint, fmt.Sprintf("Free space %.1f%% is below threshold %.0f%%", free, val)))
+		}
+	}
+	return out
+}
+
+func evalDiskTemp(cond, target string, val int, smart []internal.SMARTInfo) []internal.Finding {
+	if val <= 0 {
+		return nil
+	}
+	var out []internal.Finding
+	switch cond {
+	case "above", "single_above":
+		for _, s := range smart {
+			if !matchTarget(target, s.Serial) && !matchTarget(target, s.Device) {
+				continue
+			}
+			if s.Temperature > val {
+				out = append(out, synth("rule:disk-temp:"+s.Serial, internal.SeverityWarning, internal.CategoryThermal,
+					"Disk temperature high: "+s.Device, fmt.Sprintf("%d°C exceeds threshold %d°C", s.Temperature, val)))
+			}
+		}
+	case "avg_above":
+		if len(smart) == 0 {
+			return nil
+		}
+		sum := 0
+		for _, s := range smart {
+			sum += s.Temperature
+		}
+		avg := sum / len(smart)
+		if avg > val {
+			out = append(out, synth("rule:avg-disk-temp", internal.SeverityWarning, internal.CategoryThermal,
+				"Average disk temperature high", fmt.Sprintf("Average %d°C exceeds threshold %d°C", avg, val)))
+		}
+	}
+	return out
+}
+
+func evalSMART(cond, target string, val int64, smart []internal.SMARTInfo) []internal.Finding {
+	var out []internal.Finding
+	for _, s := range smart {
+		if !matchTarget(target, s.Serial) && !matchTarget(target, s.Device) {
+			continue
+		}
+		switch cond {
+		case "health_fails":
+			if !s.HealthPassed {
+				out = append(out, synth("rule:smart-fail:"+s.Serial, internal.SeverityCritical, internal.CategorySMART,
+					"SMART health failed: "+s.Device, s.Model+" (S/N: "+s.Serial+")"))
+			}
+		case "reallocated_above":
+			if val > 0 && s.Reallocated > val {
+				out = append(out, synth("rule:smart-realloc:"+s.Serial, internal.SeverityCritical, internal.CategorySMART,
+					"Reallocated sectors high: "+s.Device, fmt.Sprintf("%d exceeds threshold %d", s.Reallocated, val)))
+			}
+		case "pending_above":
+			if val > 0 && s.Pending > val {
+				out = append(out, synth("rule:smart-pending:"+s.Serial, internal.SeverityWarning, internal.CategorySMART,
+					"Pending sectors: "+s.Device, fmt.Sprintf("%d exceeds threshold %d", s.Pending, val)))
+			}
+		case "crc_above":
+			if val > 0 && s.UDMACRC > val {
+				out = append(out, synth("rule:smart-crc:"+s.Serial, internal.SeverityWarning, internal.CategorySMART,
+					"UDMA CRC errors: "+s.Device, fmt.Sprintf("%d exceeds threshold %d", s.UDMACRC, val)))
+			}
+		case "power_hours_above":
+			if val > 0 && s.PowerOnHours > val {
+				out = append(out, synth("rule:smart-age:"+s.Serial, internal.SeverityInfo, internal.CategorySMART,
+					"Drive age warning: "+s.Device, fmt.Sprintf("%.1f years (%.0f hours threshold)", float64(s.PowerOnHours)/8766, float64(val))))
+			}
+		}
+	}
+	return out
+}
+
+func evalService(cond, target string, val float64, services []internal.ServiceCheckResult) []internal.Finding {
+	var out []internal.Finding
+	for _, sc := range services {
+		if !matchTarget(target, sc.Name) && !matchTarget(target, sc.Key) {
+			continue
+		}
+		switch cond {
+		case "down":
+			if sc.Status == "down" {
+				out = append(out, synth("rule:svc-down:"+sc.Key, internal.SeverityWarning, internal.CategoryService,
+					"Service down: "+sc.Name, fmt.Sprintf("%s (%s) — %s", sc.Target, sc.Type, sc.Error)))
+			}
+		case "degraded":
+			if sc.Status == "degraded" {
+				out = append(out, synth("rule:svc-degraded:"+sc.Key, internal.SeverityWarning, internal.CategoryService,
+					"Service degraded: "+sc.Name, fmt.Sprintf("%s (%s) — %s", sc.Target, sc.Type, sc.Error)))
+			}
+		case "latency_above":
+			if val > 0 && float64(sc.ResponseMS) > val {
+				out = append(out, synth("rule:svc-latency:"+sc.Key, internal.SeverityWarning, internal.CategoryService,
+					"Service latency high: "+sc.Name, fmt.Sprintf("%dms exceeds threshold %.0fms", sc.ResponseMS, val)))
+			}
+		case "download_below":
+			if sc.Type == internal.ServiceCheckSpeed && val > 0 && sc.DownloadMbps < val {
+				out = append(out, synth("rule:svc-dl:"+sc.Key, internal.SeverityWarning, internal.CategorySpeedTest,
+					"Download speed below threshold: "+sc.Name, fmt.Sprintf("%.0f Mbps < %.0f Mbps threshold", sc.DownloadMbps, val)))
+			}
+		case "upload_below":
+			if sc.Type == internal.ServiceCheckSpeed && val > 0 && sc.UploadMbps < val {
+				out = append(out, synth("rule:svc-ul:"+sc.Key, internal.SeverityWarning, internal.CategorySpeedTest,
+					"Upload speed below threshold: "+sc.Name, fmt.Sprintf("%.0f Mbps < %.0f Mbps threshold", sc.UploadMbps, val)))
+			}
+		}
+	}
+	return out
+}
+
+func evalParity(cond string, val float64, parity *internal.ParityInfo) []internal.Finding {
+	if parity == nil || len(parity.History) == 0 {
+		return nil
+	}
+	last := parity.History[len(parity.History)-1]
+	switch cond {
+	case "errors":
+		if last.Errors > 0 {
+			return []internal.Finding{synth("rule:parity-err:"+last.Date, internal.SeverityCritical, internal.CategoryParity,
+				"Parity check errors: "+last.Date, fmt.Sprintf("%d errors found", last.Errors))}
+		}
+	case "speed_below":
+		if val > 0 && last.SpeedMBs < val {
+			return []internal.Finding{synth("rule:parity-slow:"+last.Date, internal.SeverityWarning, internal.CategoryParity,
+				"Parity check slow", fmt.Sprintf("%.1f MB/s below threshold %.0f MB/s", last.SpeedMBs, val))}
+		}
+	}
+	return nil
+}
+
+func evalUPS(cond string, val float64, ups *internal.UPSInfo) []internal.Finding {
+	if ups == nil || !ups.Available {
+		return nil
+	}
+	switch cond {
+	case "on_battery":
+		if ups.OnBattery {
+			return []internal.Finding{synth("rule:ups-battery", internal.SeverityCritical, internal.CategoryUPS,
+				"UPS on battery", fmt.Sprintf("Battery %.0f%%, runtime %.0f min", ups.BatteryPct, ups.RuntimeMins))}
+		}
+	case "battery_below":
+		if val > 0 && ups.BatteryPct < val {
+			return []internal.Finding{synth("rule:ups-low", internal.SeverityCritical, internal.CategoryUPS,
+				"UPS battery low", fmt.Sprintf("%.0f%% below threshold %.0f%%", ups.BatteryPct, val))}
+		}
+	case "load_above":
+		if val > 0 && ups.LoadPct > val {
+			return []internal.Finding{synth("rule:ups-load", internal.SeverityWarning, internal.CategoryUPS,
+				"UPS load high", fmt.Sprintf("%.0f%% exceeds threshold %.0f%%", ups.LoadPct, val))}
+		}
+	}
+	return nil
+}
+
+func evalDocker(cond, target string, docker internal.DockerInfo) []internal.Finding {
+	var out []internal.Finding
+	for _, c := range docker.Containers {
+		if !matchTarget(target, c.Name) {
+			continue
+		}
+		switch cond {
+		case "stopped":
+			if c.State != "running" {
+				out = append(out, synth("rule:docker-stop:"+c.Name, internal.SeverityWarning, internal.CategoryDocker,
+					"Container stopped: "+c.Name, c.Image+" — state: "+c.State))
+			}
+		}
+	}
+	return out
+}
+
+func evalSystem(cond string, val float64, sys internal.SystemInfo) []internal.Finding {
+	if val <= 0 {
+		return nil
+	}
+	switch cond {
+	case "cpu_above":
+		if sys.CPUUsage > val {
+			return []internal.Finding{synth("rule:sys-cpu", internal.SeverityWarning, internal.CategorySystem,
+				"CPU usage high", fmt.Sprintf("%.1f%% exceeds threshold %.0f%%", sys.CPUUsage, val))}
+		}
+	case "mem_above":
+		if sys.MemPercent > val {
+			return []internal.Finding{synth("rule:sys-mem", internal.SeverityWarning, internal.CategorySystem,
+				"Memory usage high", fmt.Sprintf("%.1f%% exceeds threshold %.0f%%", sys.MemPercent, val))}
+		}
+	case "load_above":
+		if sys.LoadAvg1 > val {
+			return []internal.Finding{synth("rule:sys-load", internal.SeverityWarning, internal.CategorySystem,
+				"Load average high", fmt.Sprintf("%.2f exceeds threshold %.0f", sys.LoadAvg1, val))}
+		}
+	case "iowait_above":
+		if sys.IOWait > val {
+			return []internal.Finding{synth("rule:sys-iowait", internal.SeverityWarning, internal.CategorySystem,
+				"I/O wait high", fmt.Sprintf("%.1f%% exceeds threshold %.0f%%", sys.IOWait, val))}
+		}
+	}
+	return nil
+}
+
+func evalZFS(cond, target string, val float64, zfs *internal.ZFSInfo) []internal.Finding {
+	if zfs == nil || !zfs.Available {
+		return nil
+	}
+	var out []internal.Finding
+	for _, pool := range zfs.Pools {
+		if !matchTarget(target, pool.Name) {
+			continue
+		}
+		switch cond {
+		case "degraded":
+			if !strings.EqualFold(pool.State, "ONLINE") {
+				out = append(out, synth("rule:zfs-degraded:"+pool.Name, internal.SeverityCritical, internal.CategoryZFS,
+					"ZFS pool degraded: "+pool.Name, "State: "+pool.State))
+			}
+		case "scrub_errors":
+			if pool.ScanErrors > 0 {
+				out = append(out, synth("rule:zfs-scrub-err:"+pool.Name, internal.SeverityCritical, internal.CategoryZFS,
+					"ZFS scrub errors: "+pool.Name, fmt.Sprintf("%d errors found", pool.ScanErrors)))
+			}
+		case "usage_above":
+			if val > 0 && pool.UsedPct > val {
+				out = append(out, synth("rule:zfs-usage:"+pool.Name, internal.SeverityWarning, internal.CategoryZFS,
+					"ZFS pool usage high: "+pool.Name, fmt.Sprintf("%.1f%% exceeds threshold %.0f%%", pool.UsedPct, val)))
+			}
+		}
+	}
+	return out
+}
+
+func evalTunnels(cond, target string, tunnels *internal.TunnelInfo) []internal.Finding {
+	if tunnels == nil {
+		return nil
+	}
+	var out []internal.Finding
+	switch cond {
+	case "cloudflared_down":
+		if tunnels.Cloudflared != nil {
+			for _, t := range tunnels.Cloudflared.Tunnels {
+				if !matchTarget(target, t.Name) {
+					continue
+				}
+				if t.Status != "healthy" {
+					out = append(out, synth("rule:cf-down:"+t.Name, internal.SeverityWarning, internal.CategoryNetwork,
+						"Cloudflared tunnel down: "+t.Name, "Status: "+t.Status))
+				}
+			}
+		}
+	case "tailscale_offline":
+		if tunnels.Tailscale != nil {
+			all := tunnels.Tailscale.Peers
+			for _, nd := range all {
+				if !matchTarget(target, nd.Name) {
+					continue
+				}
+				if !nd.Online {
+					out = append(out, synth("rule:ts-offline:"+nd.Name, internal.SeverityWarning, internal.CategoryNetwork,
+						"Tailscale node offline: "+nd.Name, "IP: "+nd.IP))
+				}
+			}
+		}
+	}
+	return out
+}
+
+func evalUpdate(update *internal.UpdateInfo) []internal.Finding {
+	if update != nil && update.UpdateAvailable {
+		return []internal.Finding{synth("rule:update", internal.SeverityInfo, internal.CategorySystem,
+			"Platform update available", fmt.Sprintf("%s → %s", update.InstalledVersion, update.LatestVersion))}
+	}
+	return nil
+}
+
+// -- Suppression helpers --
+
+func matchesHostname(hosts []string, hostname string) bool {
+	if len(hosts) == 0 {
+		return true
+	}
+	h := strings.ToLower(strings.TrimSpace(hostname))
+	for _, c := range hosts {
+		if strings.ToLower(strings.TrimSpace(c)) == h {
+			return true
+		}
+	}
+	return false
+}
+
+func severityRank(sev internal.Severity) int {
+	switch sev {
+	case internal.SeverityCritical:
+		return 3
+	case internal.SeverityWarning:
+		return 2
+	case internal.SeverityInfo:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func inQuietHours(cfg QuietHours, now time.Time) bool {
+	if !cfg.Enabled {
+		return false
+	}
+	start, err := parseHHMM(cfg.StartHHMM)
+	if err != nil {
+		return false
+	}
+	end, err := parseHHMM(cfg.EndHHMM)
+	if err != nil {
+		return false
+	}
+	if start == end {
+		return false
+	}
+
+	loc := time.UTC
+	if cfg.Timezone != "" {
+		if loaded, err := time.LoadLocation(cfg.Timezone); err == nil {
+			loc = loaded
+		}
+	}
+	localNow := now.In(loc)
+	mins := localNow.Hour()*60 + localNow.Minute()
+
+	if start < end {
+		return mins >= start && mins < end
+	}
+	return mins >= start || mins < end
+}
+
+func parseHHMM(v string) (int, error) {
+	parts := strings.Split(strings.TrimSpace(v), ":")
+	if len(parts) != 2 {
+		return 0, fmt.Errorf("invalid time")
+	}
+	h, err := time.Parse("15:04", fmt.Sprintf("%s:%s", parts[0], parts[1]))
+	if err != nil {
+		return 0, err
+	}
+	return h.Hour()*60 + h.Minute(), nil
+}
+
+func inMaintenanceWindow(windows []MaintenanceWindow, hostname string, now time.Time) bool {
+	for _, w := range windows {
+		if !w.Enabled {
+			continue
+		}
+		if !matchesHostname(w.Hostnames, hostname) {
+			continue
+		}
+		start, err1 := time.Parse(time.RFC3339, strings.TrimSpace(w.StartISO))
+		end, err2 := time.Parse(time.RFC3339, strings.TrimSpace(w.EndISO))
+		if err1 != nil || err2 != nil || !end.After(start) {
+			continue
+		}
+		if (now.Equal(start) || now.After(start)) && now.Before(end) {
+			return true
+		}
+	}
+	return false
+}
+
+// -- Fingerprinting & counting --
+
+func findingFingerprint(f internal.Finding) string {
+	parts := []string{
+		strings.ToLower(strings.TrimSpace(string(f.Category))),
+		strings.ToLower(strings.TrimSpace(f.Title)),
+		strings.ToLower(strings.TrimSpace(f.RelatedDisk)),
+	}
+	raw := strings.Join(parts, "|")
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
+func countSeverity(findings []internal.Finding, sev internal.Severity) int {
+	count := 0
+	for _, f := range findings {
+		if f.Severity == sev {
+			count++
+		}
+	}
+	return count
+}
+
+// -- SMART trend helpers --
+
+func estimateTrendCost(urgency string) string {
+	switch urgency {
+	case "immediate":
+		return "$80-350 for replacement drive"
+	case "short-term":
+		return "$5-15 (cable) or drive replacement planning"
+	default:
+		return "none"
+	}
+}
+
+func minInt64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -2,17 +2,8 @@
 package scheduler
 
 import (
-	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"log/slog"
-	"net"
-	"net/http"
-	"net/url"
-	"os/exec"
-	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -94,7 +85,8 @@ type Scheduler struct {
 	retention         RetentionConfig
 	alerting          AlertingConfig
 	serviceChecks     []internal.ServiceCheckConfig
-	lastCheckRun      map[string]time.Time // per-check last execution time
+	checker           *ServiceChecker
+	retentionMgr      *RetentionManager
 
 	logForwarder *logfwd.Forwarder
 
@@ -115,7 +107,7 @@ func New(
 	logger *slog.Logger,
 	interval time.Duration,
 ) *Scheduler {
-	return &Scheduler{
+	s := &Scheduler{
 		collector:         col,
 		store:             store,
 		notifier:          notif,
@@ -134,10 +126,12 @@ func New(
 			DefaultCooldownSec: 900,
 		},
 		serviceChecks: []internal.ServiceCheckConfig{},
-		lastCheckRun:  make(map[string]time.Time),
 		stop:          make(chan struct{}),
 		restart:       make(chan time.Duration, 1),
 	}
+	s.checker = NewServiceChecker(store, logger)
+	s.retentionMgr = NewRetentionManager(store, store, logger)
+	return s
 }
 
 // Start begins the periodic collection loop. It runs the first collection
@@ -428,72 +422,28 @@ func (s *Scheduler) UpdateRetention(cfg RetentionConfig) {
 	)
 }
 
-// pruneData runs all data lifecycle maintenance tasks.
+// pruneData runs all data lifecycle maintenance tasks via RetentionManager.
 func (s *Scheduler) pruneData() {
 	s.mu.RLock()
 	ret := s.retention
 	s.mu.RUnlock()
 
-	snapshotAge := time.Duration(ret.SnapshotDays) * 24 * time.Hour
-	notifyAge := time.Duration(ret.NotifyLogDays) * 24 * time.Hour
-	needsVacuum := false
-
-	// 1. Prune old snapshots (cascades to smart_history, system_history)
-	if pruned, err := s.store.PruneSnapshots(snapshotAge, 10); err != nil {
-		s.logger.Warn("prune snapshots failed", "error", err)
-	} else if pruned > 0 {
-		s.logger.Info("pruned old snapshots", "count", pruned, "retention_days", ret.SnapshotDays)
-		needsVacuum = true
-	}
-
-	// 2. Prune orphaned findings (safety net)
-	if pruned, err := s.store.PruneOrphanedFindings(); err != nil {
-		s.logger.Warn("prune orphaned findings failed", "error", err)
-	} else if pruned > 0 {
-		s.logger.Info("pruned orphaned findings", "count", pruned)
-		needsVacuum = true
-	}
-
-	// 3. Prune notification log
-	if pruned, err := s.store.PruneNotificationLog(notifyAge); err != nil {
-		s.logger.Warn("prune notification log failed", "error", err)
-	} else if pruned > 0 {
-		s.logger.Info("pruned notification log", "count", pruned)
-		needsVacuum = true
-	}
-
-	// 3b. Prune service check history
-	if pruned, err := s.store.PruneServiceCheckHistory(notifyAge); err != nil {
-		s.logger.Warn("prune service check history failed", "error", err)
-	} else if pruned > 0 {
-		s.logger.Info("pruned service check history", "count", pruned)
-		needsVacuum = true
-	}
-
-	// 4. Prune resolved alerts (same retention as notifications)
-	if pruned, err := s.store.PruneAlerts(notifyAge); err != nil {
-		s.logger.Warn("prune alerts failed", "error", err)
-	} else if pruned > 0 {
-		s.logger.Info("pruned old alerts", "count", pruned)
-		needsVacuum = true
-	}
-
-	// 5. Check DB size cap — if over the limit, aggressively delete oldest data
-	if ret.MaxDBSizeMB > 0 {
-		if pruned, err := s.store.PruneToSizeMB(float64(ret.MaxDBSizeMB)); err != nil {
-			s.logger.Warn("prune to size failed", "error", err)
-		} else if pruned > 0 {
-			s.logger.Warn("DB size exceeded cap, pruned snapshots",
-				"pruned", pruned, "cap_mb", ret.MaxDBSizeMB)
-			needsVacuum = false // PruneToSizeMB already vacuums
-		}
-	}
-
-	// 6. VACUUM to reclaim space (only if we pruned and didn't already vacuum)
-	if needsVacuum {
-		if err := s.store.Vacuum(); err != nil {
-			s.logger.Warn("vacuum failed", "error", err)
-		}
+	result := s.retentionMgr.RunRetention(RetentionManagerConfig{
+		SnapshotMaxAge:     time.Duration(ret.SnapshotDays) * 24 * time.Hour,
+		SnapshotKeepMin:    10,
+		ServiceCheckMaxAge: time.Duration(ret.NotifyLogDays) * 24 * time.Hour,
+		NotificationMaxAge: time.Duration(ret.NotifyLogDays) * 24 * time.Hour,
+		AlertMaxAge:        time.Duration(ret.NotifyLogDays) * 24 * time.Hour,
+		MaxDBSizeMB:        float64(ret.MaxDBSizeMB),
+	})
+	if result.SnapshotsPruned > 0 || result.ServiceChecksPruned > 0 || result.NotificationsPruned > 0 || result.AlertsPruned > 0 {
+		s.logger.Info("retention complete",
+			"snapshots", result.SnapshotsPruned,
+			"service_checks", result.ServiceChecksPruned,
+			"notifications", result.NotificationsPruned,
+			"alerts", result.AlertsPruned,
+			"orphans", result.OrphansPruned,
+		)
 	}
 }
 
@@ -571,7 +521,7 @@ func (s *Scheduler) UpdateServiceChecks(checks []internal.ServiceCheckConfig) {
 		if check.Name == "" || check.Target == "" {
 			continue
 		}
-		if !isSupportedServiceCheckType(check.Type) {
+		if !IsSupportedCheckType(check.Type) {
 			continue
 		}
 		if check.TimeoutSec <= 0 {
@@ -620,41 +570,21 @@ func (s *Scheduler) checkBackup() {
 		return
 	}
 
-	intervalH := cfg.IntervalH
-	if intervalH <= 0 {
-		intervalH = 168 // weekly
-	}
-
-	if !cfg.LastBackup.IsZero() && time.Since(cfg.LastBackup) < time.Duration(intervalH)*time.Hour {
-		return // not time yet
-	}
-
-	result, err := s.store.CreateBackup(cfg.Path, s.logger)
+	result, err := s.retentionMgr.RunBackup(BackupManagerConfig{
+		Enabled:   cfg.Enabled,
+		Path:      cfg.Path,
+		KeepCount: cfg.KeepCount,
+		IntervalH: cfg.IntervalH,
+	}, cfg.LastBackup, time.Now())
 	if err != nil {
 		s.logger.Warn("auto backup failed", "error", err)
 		return
 	}
-
-	// Prune old backups
-	backupDir := cfg.Path
-	if backupDir == "" {
-		// Extract directory from result path
-		backupDir = filepath.Dir(result.Path)
+	if result != nil {
+		s.mu.Lock()
+		s.backup.LastBackup = result.Timestamp
+		s.mu.Unlock()
 	}
-
-	keepCount := cfg.KeepCount
-	if keepCount <= 0 {
-		keepCount = 4
-	}
-	if pruned, err := storage.PruneBackups(backupDir, keepCount, s.logger); err != nil {
-		s.logger.Warn("backup prune failed", "error", err)
-	} else if pruned > 0 {
-		s.logger.Info("pruned old backups", "count", pruned)
-	}
-
-	s.mu.Lock()
-	s.backup.LastBackup = result.Timestamp
-	s.mu.Unlock()
 }
 
 func (s *Scheduler) buildSMARTTrendFindings(snap *internal.Snapshot) []internal.Finding {
@@ -766,24 +696,6 @@ func (s *Scheduler) buildSMARTTrendFindings(snap *internal.Snapshot) []internal.
 	return findings
 }
 
-func estimateTrendCost(urgency string) string {
-	switch urgency {
-	case "immediate":
-		return "$80-350 for replacement drive"
-	case "short-term":
-		return "$5-15 (cable) or drive replacement planning"
-	default:
-		return "none"
-	}
-}
-
-func minInt64(a, b int64) int64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func (s *Scheduler) runServiceChecks(now time.Time) ([]internal.ServiceCheckResult, error) {
 	s.mu.RLock()
 	checks := make([]internal.ServiceCheckConfig, len(s.serviceChecks))
@@ -794,14 +706,22 @@ func (s *Scheduler) runServiceChecks(now time.Time) ([]internal.ServiceCheckResu
 		return []internal.ServiceCheckResult{}, nil
 	}
 
-	results := make([]internal.ServiceCheckResult, 0, len(checks))
-	for _, check := range checks {
-		if !check.Enabled {
-			continue
+	// Filter to enabled-only for the full-scan path (RunCheck executes all passed checks).
+	var enabled []internal.ServiceCheckConfig
+	for _, c := range checks {
+		if c.Enabled {
+			enabled = append(enabled, c)
 		}
+	}
+	if len(enabled) == 0 {
+		return []internal.ServiceCheckResult{}, nil
+	}
 
-		result := executeServiceCheck(check, now)
+	results := make([]internal.ServiceCheckResult, 0, len(enabled))
+	for _, check := range enabled {
+		result := s.checker.RunCheck(check, now)
 
+		// Track consecutive failures from store history.
 		state, ok, err := s.store.GetLatestServiceCheckState(result.Key)
 		if err != nil {
 			s.logger.Warn("failed to read previous service check state", "check", result.Name, "error", err)
@@ -826,11 +746,6 @@ func (s *Scheduler) runServiceChecks(now time.Time) ([]internal.ServiceCheckResu
 	return results, nil
 }
 
-const defaultCheckIntervalSec = 300 // 5 minutes
-
-// runDueServiceChecks is called every 30s by the independent service check
-// loop. It checks each configured check's per-check interval and only
-// executes those whose interval has elapsed since their last run.
 // collectContainerStats runs a lightweight Docker stats collection and saves to DB.
 // This runs every 5 minutes independently of the main scan (which runs every 6h)
 // to provide enough data points for the container metrics charts.
@@ -884,321 +799,7 @@ func (s *Scheduler) runDueServiceChecks() {
 	checks := make([]internal.ServiceCheckConfig, len(s.serviceChecks))
 	copy(checks, s.serviceChecks)
 	s.mu.RUnlock()
-
-	now := time.Now()
-	var due []internal.ServiceCheckConfig
-	for _, check := range checks {
-		if !check.Enabled {
-			continue
-		}
-		key := serviceCheckKey(check)
-		interval := check.IntervalSec
-		if interval <= 0 {
-			interval = defaultCheckIntervalSec
-		}
-		s.mu.RLock()
-		last, exists := s.lastCheckRun[key]
-		s.mu.RUnlock()
-		if !exists || now.Sub(last) >= time.Duration(interval)*time.Second {
-			due = append(due, check)
-		}
-	}
-	if len(due) == 0 {
-		return
-	}
-
-	results := make([]internal.ServiceCheckResult, 0, len(due))
-	for _, check := range due {
-		result := executeServiceCheck(check, now)
-		key := result.Key
-
-		state, ok, err := s.store.GetLatestServiceCheckState(key)
-		if err != nil {
-			s.logger.Warn("service check state read failed", "check", result.Name, "error", err)
-		}
-		if result.Status == "down" {
-			if ok && state.Status == "down" {
-				result.ConsecutiveFailures = state.ConsecutiveFailures + 1
-			} else {
-				result.ConsecutiveFailures = 1
-			}
-		}
-		results = append(results, result)
-
-		s.mu.Lock()
-		s.lastCheckRun[key] = now
-		s.mu.Unlock()
-	}
-
-	if err := s.store.SaveServiceCheckResults(results); err != nil {
-		s.logger.Warn("failed to save service check results", "error", err)
-	}
-}
-
-func executeServiceCheck(check internal.ServiceCheckConfig, now time.Time) internal.ServiceCheckResult {
-	typeName := strings.ToLower(strings.TrimSpace(check.Type))
-	timeoutSec := check.TimeoutSec
-	if timeoutSec <= 0 {
-		timeoutSec = 5
-	}
-	threshold := check.FailureThreshold
-	if threshold <= 0 {
-		threshold = 1
-	}
-	severity := check.FailureSeverity
-	if severity == "" {
-		severity = internal.SeverityWarning
-	}
-
-	result := internal.ServiceCheckResult{
-		Key:              serviceCheckKey(check),
-		Name:             strings.TrimSpace(check.Name),
-		Type:             typeName,
-		Target:           strings.TrimSpace(check.Target),
-		Status:           "down",
-		CheckedAt:        now.UTC().Format(time.RFC3339),
-		FailureThreshold: threshold,
-		FailureSeverity:  severity,
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSec)*time.Second)
-	defer cancel()
-
-	start := time.Now()
-	switch typeName {
-	case internal.ServiceCheckHTTP:
-		urlValue := normalizeHTTPURL(check.Target)
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlValue, nil)
-		if err != nil {
-			result.Error = err.Error()
-			break
-		}
-		req.Header.Set("User-Agent", "nas-doctor-service-check/1.0")
-		for k, v := range check.Headers {
-			req.Header.Set(k, v)
-		}
-		resp, err := (&http.Client{Timeout: time.Duration(timeoutSec) * time.Second}).Do(req)
-		result.ResponseMS = time.Since(start).Milliseconds()
-		if err != nil {
-			result.Error = err.Error()
-			break
-		}
-		_ = resp.Body.Close()
-		minStatus := check.ExpectedMin
-		maxStatus := check.ExpectedMax
-		if minStatus <= 0 {
-			minStatus = 200
-		}
-		if maxStatus <= 0 {
-			maxStatus = 399
-		}
-		if maxStatus < minStatus {
-			maxStatus = minStatus
-		}
-		if resp.StatusCode < minStatus || resp.StatusCode > maxStatus {
-			result.Error = fmt.Sprintf("unexpected HTTP status %d", resp.StatusCode)
-			break
-		}
-		result.Status = "up"
-
-	case internal.ServiceCheckDNS:
-		host := normalizeDNSHost(check.Target)
-		if host == "" {
-			result.Error = "empty DNS target"
-			break
-		}
-		addrs, err := net.DefaultResolver.LookupHost(ctx, host)
-		result.ResponseMS = time.Since(start).Milliseconds()
-		if err != nil {
-			result.Error = err.Error()
-			break
-		}
-		if len(addrs) == 0 {
-			result.Error = "no DNS records found"
-			break
-		}
-		result.Status = "up"
-
-	case internal.ServiceCheckTCP, internal.ServiceCheckSMB, internal.ServiceCheckNFS:
-		addr, err := normalizeTCPAddress(check)
-		if err != nil {
-			result.Error = err.Error()
-			break
-		}
-		dialer := net.Dialer{Timeout: time.Duration(timeoutSec) * time.Second}
-		conn, err := dialer.DialContext(ctx, "tcp", addr)
-		result.ResponseMS = time.Since(start).Milliseconds()
-		if err != nil {
-			result.Error = err.Error()
-			break
-		}
-		_ = conn.Close()
-		result.Status = "up"
-
-	case internal.ServiceCheckPing:
-		host := normalizeDNSHost(check.Target)
-		if host == "" {
-			result.Error = "empty ping target"
-			break
-		}
-		countArg := "-c"
-		timeoutArg := "-W"
-		timeoutVal := fmt.Sprintf("%d", timeoutSec)
-		if runtime.GOOS == "darwin" {
-			timeoutArg = "-t"
-		}
-		cmd := exec.CommandContext(ctx, "ping", countArg, "1", timeoutArg, timeoutVal, host)
-		out, err := cmd.CombinedOutput()
-		result.ResponseMS = time.Since(start).Milliseconds()
-		if err != nil {
-			result.Error = "host unreachable"
-			break
-		}
-		// Parse round-trip time from ping output if available
-		outStr := string(out)
-		if idx := strings.Index(outStr, "time="); idx >= 0 {
-			sub := outStr[idx+5:]
-			if sp := strings.IndexAny(sub, " m\n"); sp > 0 {
-				if ms, parseErr := strconv.ParseFloat(sub[:sp], 64); parseErr == nil {
-					result.ResponseMS = int64(ms)
-				}
-			}
-		}
-		result.Status = "up"
-
-	case internal.ServiceCheckSpeed:
-		// Run a speed test and compare against contracted speeds
-		stResult := collector.RunSpeedTest()
-		if stResult == nil {
-			result.Error = "no speedtest tool available (install speedtest or speedtest-cli)"
-			break
-		}
-
-		result.DownloadMbps = stResult.DownloadMbps
-		result.UploadMbps = stResult.UploadMbps
-		result.LatencyMs = stResult.LatencyMs
-		result.ResponseMS = int64(stResult.LatencyMs)
-
-		// Apply margin of error (default 10%)
-		margin := check.MarginPct
-		if margin <= 0 {
-			margin = 10
-		}
-		marginFactor := 1 - (margin / 100)
-
-		dlThreshold := check.ContractedDownMbps * marginFactor
-		ulThreshold := check.ContractedUpMbps * marginFactor
-
-		dlOK := check.ContractedDownMbps <= 0 || stResult.DownloadMbps >= dlThreshold
-		ulOK := check.ContractedUpMbps <= 0 || stResult.UploadMbps >= ulThreshold
-		result.DownloadOK = &dlOK
-		result.UploadOK = &ulOK
-
-		switch {
-		case dlOK && ulOK:
-			result.Status = "up"
-		case dlOK || ulOK:
-			result.Status = "degraded"
-			which := "upload"
-			if !dlOK {
-				which = "download"
-			}
-			result.Error = fmt.Sprintf("%s below contracted speed (%.0f/%.0f Mbps, threshold %.0f with %.0f%% margin)",
-				which, stResult.DownloadMbps, stResult.UploadMbps,
-				check.ContractedDownMbps, margin)
-		default:
-			result.Error = fmt.Sprintf("both download and upload below contracted speed (%.0f/%.0f Mbps, contracted %.0f/%.0f with %.0f%% margin)",
-				stResult.DownloadMbps, stResult.UploadMbps,
-				check.ContractedDownMbps, check.ContractedUpMbps, margin)
-		}
-
-	default:
-		result.Error = "unsupported service check type"
-	}
-
-	if result.ResponseMS == 0 {
-		result.ResponseMS = time.Since(start).Milliseconds()
-	}
-	if result.Status == "up" {
-		result.Error = ""
-	}
-	return result
-}
-
-func isSupportedServiceCheckType(checkType string) bool {
-	switch strings.ToLower(strings.TrimSpace(checkType)) {
-	case internal.ServiceCheckHTTP, internal.ServiceCheckTCP, internal.ServiceCheckDNS, internal.ServiceCheckSMB, internal.ServiceCheckNFS, internal.ServiceCheckPing, internal.ServiceCheckSpeed:
-		return true
-	default:
-		return false
-	}
-}
-
-func normalizeHTTPURL(rawTarget string) string {
-	target := strings.TrimSpace(rawTarget)
-	if target == "" {
-		return target
-	}
-	if strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://") {
-		return target
-	}
-	return "http://" + target
-}
-
-func normalizeDNSHost(rawTarget string) string {
-	target := strings.TrimSpace(rawTarget)
-	if target == "" {
-		return ""
-	}
-	if strings.Contains(target, "://") {
-		if parsed, err := url.Parse(target); err == nil {
-			if host := strings.TrimSpace(parsed.Hostname()); host != "" {
-				return host
-			}
-		}
-	}
-	if host, _, err := net.SplitHostPort(target); err == nil {
-		return host
-	}
-	return target
-}
-
-func normalizeTCPAddress(check internal.ServiceCheckConfig) (string, error) {
-	target := strings.TrimSpace(check.Target)
-	if target == "" {
-		return "", fmt.Errorf("empty target")
-	}
-	if strings.Contains(target, "://") {
-		parsed, err := url.Parse(target)
-		if err == nil && parsed.Host != "" {
-			target = parsed.Host
-		}
-	}
-
-	if _, _, err := net.SplitHostPort(target); err == nil {
-		return target, nil
-	}
-
-	port := check.Port
-	if port <= 0 {
-		switch strings.ToLower(strings.TrimSpace(check.Type)) {
-		case internal.ServiceCheckSMB:
-			port = 445
-		case internal.ServiceCheckNFS:
-			port = 2049
-		}
-	}
-	if port <= 0 {
-		return "", fmt.Errorf("missing port")
-	}
-	host := normalizeDNSHost(target)
-	return net.JoinHostPort(host, fmt.Sprintf("%d", port)), nil
-}
-
-func serviceCheckKey(check internal.ServiceCheckConfig) string {
-	raw := strings.ToLower(strings.TrimSpace(check.Name)) + "|" + strings.ToLower(strings.TrimSpace(check.Type)) + "|" + strings.ToLower(strings.TrimSpace(check.Target)) + "|" + fmt.Sprintf("%d", check.Port)
-	sum := sha256.Sum256([]byte(raw))
-	return hex.EncodeToString(sum[:])
+	s.checker.RunDueChecks(checks, time.Now())
 }
 
 func (s *Scheduler) dispatchNotifications(notif *notifier.Notifier, snap *internal.Snapshot, hostname string, now time.Time) {
@@ -1298,372 +899,6 @@ func (s *Scheduler) recordSent(findings []internal.Finding, routeKey string, now
 	}
 }
 
-// evaluateRule checks a single notification rule against the snapshot and
-// returns matching findings (real or synthetic).
-func evaluateRule(rule internal.NotificationRule, snap *internal.Snapshot) []internal.Finding {
-	cat := strings.ToLower(rule.Category)
-	cond := strings.ToLower(rule.Condition)
-	target := strings.ToLower(strings.TrimSpace(rule.Target))
-	val := parseFloat(rule.Value)
-
-	switch cat {
-	case "findings":
-		return evalFindings(cond, target, snap.Findings)
-	case "disk_space":
-		return evalDiskSpace(cond, target, val, snap.Disks)
-	case "disk_temp":
-		return evalDiskTemp(cond, target, int(val), snap.SMART)
-	case "smart":
-		return evalSMART(cond, target, int64(val), snap.SMART)
-	case "service":
-		return evalService(cond, target, val, snap.Services)
-	case "parity":
-		return evalParity(cond, val, snap.Parity)
-	case "ups":
-		return evalUPS(cond, val, snap.UPS)
-	case "docker":
-		return evalDocker(cond, target, snap.Docker)
-	case "system":
-		return evalSystem(cond, val, snap.System)
-	case "zfs":
-		return evalZFS(cond, target, val, snap.ZFS)
-	case "tunnels":
-		return evalTunnels(cond, target, snap.Tunnels)
-	case "update":
-		return evalUpdate(snap.Update)
-	}
-	return nil
-}
-
-func parseFloat(s string) float64 {
-	v, _ := strconv.ParseFloat(strings.TrimSpace(s), 64)
-	return v
-}
-
-func synth(id string, sev internal.Severity, cat internal.Category, title, desc string) internal.Finding {
-	return internal.Finding{ID: id, Severity: sev, Category: cat, Title: title, Description: desc}
-}
-
-func matchTarget(target, candidate string) bool {
-	if target == "" {
-		return true
-	}
-	return strings.EqualFold(target, strings.TrimSpace(candidate))
-}
-
-// ── Category evaluators ──
-
-func evalFindings(cond, target string, findings []internal.Finding) []internal.Finding {
-	var out []internal.Finding
-	for _, f := range findings {
-		switch cond {
-		case "critical":
-			if f.Severity == internal.SeverityCritical {
-				out = append(out, f)
-			}
-		case "warning":
-			if f.Severity == internal.SeverityWarning || f.Severity == internal.SeverityCritical {
-				out = append(out, f)
-			}
-		case "category":
-			if strings.EqualFold(string(f.Category), target) {
-				out = append(out, f)
-			}
-		case "any":
-			out = append(out, f)
-		}
-	}
-	return out
-}
-
-func evalDiskSpace(cond, target string, val float64, disks []internal.DiskInfo) []internal.Finding {
-	if val <= 0 {
-		return nil
-	}
-	var out []internal.Finding
-	for _, d := range disks {
-		if !matchTarget(target, d.MountPoint) && !matchTarget(target, d.Label) {
-			continue
-		}
-		free := 100.0 - d.UsedPct
-		if free < val {
-			out = append(out, synth("rule:disk-space:"+d.MountPoint, internal.SeverityWarning, internal.CategoryDisk,
-				"Disk space low: "+d.MountPoint, fmt.Sprintf("Free space %.1f%% is below threshold %.0f%%", free, val)))
-		}
-	}
-	return out
-}
-
-func evalDiskTemp(cond, target string, val int, smart []internal.SMARTInfo) []internal.Finding {
-	if val <= 0 {
-		return nil
-	}
-	var out []internal.Finding
-	switch cond {
-	case "above", "single_above":
-		for _, s := range smart {
-			if !matchTarget(target, s.Serial) && !matchTarget(target, s.Device) {
-				continue
-			}
-			if s.Temperature > val {
-				out = append(out, synth("rule:disk-temp:"+s.Serial, internal.SeverityWarning, internal.CategoryThermal,
-					"Disk temperature high: "+s.Device, fmt.Sprintf("%d°C exceeds threshold %d°C", s.Temperature, val)))
-			}
-		}
-	case "avg_above":
-		if len(smart) == 0 {
-			return nil
-		}
-		sum := 0
-		for _, s := range smart {
-			sum += s.Temperature
-		}
-		avg := sum / len(smart)
-		if avg > val {
-			out = append(out, synth("rule:avg-disk-temp", internal.SeverityWarning, internal.CategoryThermal,
-				"Average disk temperature high", fmt.Sprintf("Average %d°C exceeds threshold %d°C", avg, val)))
-		}
-	}
-	return out
-}
-
-func evalSMART(cond, target string, val int64, smart []internal.SMARTInfo) []internal.Finding {
-	var out []internal.Finding
-	for _, s := range smart {
-		if !matchTarget(target, s.Serial) && !matchTarget(target, s.Device) {
-			continue
-		}
-		switch cond {
-		case "health_fails":
-			if !s.HealthPassed {
-				out = append(out, synth("rule:smart-fail:"+s.Serial, internal.SeverityCritical, internal.CategorySMART,
-					"SMART health failed: "+s.Device, s.Model+" (S/N: "+s.Serial+")"))
-			}
-		case "reallocated_above":
-			if val > 0 && s.Reallocated > val {
-				out = append(out, synth("rule:smart-realloc:"+s.Serial, internal.SeverityCritical, internal.CategorySMART,
-					"Reallocated sectors high: "+s.Device, fmt.Sprintf("%d exceeds threshold %d", s.Reallocated, val)))
-			}
-		case "pending_above":
-			if val > 0 && s.Pending > val {
-				out = append(out, synth("rule:smart-pending:"+s.Serial, internal.SeverityWarning, internal.CategorySMART,
-					"Pending sectors: "+s.Device, fmt.Sprintf("%d exceeds threshold %d", s.Pending, val)))
-			}
-		case "crc_above":
-			if val > 0 && s.UDMACRC > val {
-				out = append(out, synth("rule:smart-crc:"+s.Serial, internal.SeverityWarning, internal.CategorySMART,
-					"UDMA CRC errors: "+s.Device, fmt.Sprintf("%d exceeds threshold %d", s.UDMACRC, val)))
-			}
-		case "power_hours_above":
-			if val > 0 && s.PowerOnHours > val {
-				out = append(out, synth("rule:smart-age:"+s.Serial, internal.SeverityInfo, internal.CategorySMART,
-					"Drive age warning: "+s.Device, fmt.Sprintf("%.1f years (%.0f hours threshold)", float64(s.PowerOnHours)/8766, float64(val))))
-			}
-		}
-	}
-	return out
-}
-
-func evalService(cond, target string, val float64, services []internal.ServiceCheckResult) []internal.Finding {
-	var out []internal.Finding
-	for _, sc := range services {
-		if !matchTarget(target, sc.Name) && !matchTarget(target, sc.Key) {
-			continue
-		}
-		switch cond {
-		case "down":
-			if sc.Status == "down" {
-				out = append(out, synth("rule:svc-down:"+sc.Key, internal.SeverityWarning, internal.CategoryService,
-					"Service down: "+sc.Name, fmt.Sprintf("%s (%s) — %s", sc.Target, sc.Type, sc.Error)))
-			}
-		case "degraded":
-			if sc.Status == "degraded" {
-				out = append(out, synth("rule:svc-degraded:"+sc.Key, internal.SeverityWarning, internal.CategoryService,
-					"Service degraded: "+sc.Name, fmt.Sprintf("%s (%s) — %s", sc.Target, sc.Type, sc.Error)))
-			}
-		case "latency_above":
-			if val > 0 && float64(sc.ResponseMS) > val {
-				out = append(out, synth("rule:svc-latency:"+sc.Key, internal.SeverityWarning, internal.CategoryService,
-					"Service latency high: "+sc.Name, fmt.Sprintf("%dms exceeds threshold %.0fms", sc.ResponseMS, val)))
-			}
-		case "download_below":
-			if sc.Type == internal.ServiceCheckSpeed && val > 0 && sc.DownloadMbps < val {
-				out = append(out, synth("rule:svc-dl:"+sc.Key, internal.SeverityWarning, internal.CategorySpeedTest,
-					"Download speed below threshold: "+sc.Name, fmt.Sprintf("%.0f Mbps < %.0f Mbps threshold", sc.DownloadMbps, val)))
-			}
-		case "upload_below":
-			if sc.Type == internal.ServiceCheckSpeed && val > 0 && sc.UploadMbps < val {
-				out = append(out, synth("rule:svc-ul:"+sc.Key, internal.SeverityWarning, internal.CategorySpeedTest,
-					"Upload speed below threshold: "+sc.Name, fmt.Sprintf("%.0f Mbps < %.0f Mbps threshold", sc.UploadMbps, val)))
-			}
-		}
-	}
-	return out
-}
-
-func evalParity(cond string, val float64, parity *internal.ParityInfo) []internal.Finding {
-	if parity == nil || len(parity.History) == 0 {
-		return nil
-	}
-	last := parity.History[len(parity.History)-1]
-	switch cond {
-	case "errors":
-		if last.Errors > 0 {
-			return []internal.Finding{synth("rule:parity-err:"+last.Date, internal.SeverityCritical, internal.CategoryParity,
-				"Parity check errors: "+last.Date, fmt.Sprintf("%d errors found", last.Errors))}
-		}
-	case "speed_below":
-		if val > 0 && last.SpeedMBs < val {
-			return []internal.Finding{synth("rule:parity-slow:"+last.Date, internal.SeverityWarning, internal.CategoryParity,
-				"Parity check slow", fmt.Sprintf("%.1f MB/s below threshold %.0f MB/s", last.SpeedMBs, val))}
-		}
-	}
-	return nil
-}
-
-func evalUPS(cond string, val float64, ups *internal.UPSInfo) []internal.Finding {
-	if ups == nil || !ups.Available {
-		return nil
-	}
-	switch cond {
-	case "on_battery":
-		if ups.OnBattery {
-			return []internal.Finding{synth("rule:ups-battery", internal.SeverityCritical, internal.CategoryUPS,
-				"UPS on battery", fmt.Sprintf("Battery %.0f%%, runtime %.0f min", ups.BatteryPct, ups.RuntimeMins))}
-		}
-	case "battery_below":
-		if val > 0 && ups.BatteryPct < val {
-			return []internal.Finding{synth("rule:ups-low", internal.SeverityCritical, internal.CategoryUPS,
-				"UPS battery low", fmt.Sprintf("%.0f%% below threshold %.0f%%", ups.BatteryPct, val))}
-		}
-	case "load_above":
-		if val > 0 && ups.LoadPct > val {
-			return []internal.Finding{synth("rule:ups-load", internal.SeverityWarning, internal.CategoryUPS,
-				"UPS load high", fmt.Sprintf("%.0f%% exceeds threshold %.0f%%", ups.LoadPct, val))}
-		}
-	}
-	return nil
-}
-
-func evalDocker(cond, target string, docker internal.DockerInfo) []internal.Finding {
-	var out []internal.Finding
-	for _, c := range docker.Containers {
-		if !matchTarget(target, c.Name) {
-			continue
-		}
-		switch cond {
-		case "stopped":
-			if c.State != "running" {
-				out = append(out, synth("rule:docker-stop:"+c.Name, internal.SeverityWarning, internal.CategoryDocker,
-					"Container stopped: "+c.Name, c.Image+" — state: "+c.State))
-			}
-		}
-	}
-	return out
-}
-
-func evalSystem(cond string, val float64, sys internal.SystemInfo) []internal.Finding {
-	if val <= 0 {
-		return nil
-	}
-	switch cond {
-	case "cpu_above":
-		if sys.CPUUsage > val {
-			return []internal.Finding{synth("rule:sys-cpu", internal.SeverityWarning, internal.CategorySystem,
-				"CPU usage high", fmt.Sprintf("%.1f%% exceeds threshold %.0f%%", sys.CPUUsage, val))}
-		}
-	case "mem_above":
-		if sys.MemPercent > val {
-			return []internal.Finding{synth("rule:sys-mem", internal.SeverityWarning, internal.CategorySystem,
-				"Memory usage high", fmt.Sprintf("%.1f%% exceeds threshold %.0f%%", sys.MemPercent, val))}
-		}
-	case "load_above":
-		if sys.LoadAvg1 > val {
-			return []internal.Finding{synth("rule:sys-load", internal.SeverityWarning, internal.CategorySystem,
-				"Load average high", fmt.Sprintf("%.2f exceeds threshold %.0f", sys.LoadAvg1, val))}
-		}
-	case "iowait_above":
-		if sys.IOWait > val {
-			return []internal.Finding{synth("rule:sys-iowait", internal.SeverityWarning, internal.CategorySystem,
-				"I/O wait high", fmt.Sprintf("%.1f%% exceeds threshold %.0f%%", sys.IOWait, val))}
-		}
-	}
-	return nil
-}
-
-func evalZFS(cond, target string, val float64, zfs *internal.ZFSInfo) []internal.Finding {
-	if zfs == nil || !zfs.Available {
-		return nil
-	}
-	var out []internal.Finding
-	for _, pool := range zfs.Pools {
-		if !matchTarget(target, pool.Name) {
-			continue
-		}
-		switch cond {
-		case "degraded":
-			if !strings.EqualFold(pool.State, "ONLINE") {
-				out = append(out, synth("rule:zfs-degraded:"+pool.Name, internal.SeverityCritical, internal.CategoryZFS,
-					"ZFS pool degraded: "+pool.Name, "State: "+pool.State))
-			}
-		case "scrub_errors":
-			if pool.ScanErrors > 0 {
-				out = append(out, synth("rule:zfs-scrub-err:"+pool.Name, internal.SeverityCritical, internal.CategoryZFS,
-					"ZFS scrub errors: "+pool.Name, fmt.Sprintf("%d errors found", pool.ScanErrors)))
-			}
-		case "usage_above":
-			if val > 0 && pool.UsedPct > val {
-				out = append(out, synth("rule:zfs-usage:"+pool.Name, internal.SeverityWarning, internal.CategoryZFS,
-					"ZFS pool usage high: "+pool.Name, fmt.Sprintf("%.1f%% exceeds threshold %.0f%%", pool.UsedPct, val)))
-			}
-		}
-	}
-	return out
-}
-
-func evalTunnels(cond, target string, tunnels *internal.TunnelInfo) []internal.Finding {
-	if tunnels == nil {
-		return nil
-	}
-	var out []internal.Finding
-	switch cond {
-	case "cloudflared_down":
-		if tunnels.Cloudflared != nil {
-			for _, t := range tunnels.Cloudflared.Tunnels {
-				if !matchTarget(target, t.Name) {
-					continue
-				}
-				if t.Status != "healthy" {
-					out = append(out, synth("rule:cf-down:"+t.Name, internal.SeverityWarning, internal.CategoryNetwork,
-						"Cloudflared tunnel down: "+t.Name, "Status: "+t.Status))
-				}
-			}
-		}
-	case "tailscale_offline":
-		if tunnels.Tailscale != nil {
-			all := tunnels.Tailscale.Peers
-			for _, nd := range all {
-				if !matchTarget(target, nd.Name) {
-					continue
-				}
-				if !nd.Online {
-					out = append(out, synth("rule:ts-offline:"+nd.Name, internal.SeverityWarning, internal.CategoryNetwork,
-						"Tailscale node offline: "+nd.Name, "IP: "+nd.IP))
-				}
-			}
-		}
-	}
-	return out
-}
-
-func evalUpdate(update *internal.UpdateInfo) []internal.Finding {
-	if update != nil && update.UpdateAvailable {
-		return []internal.Finding{synth("rule:update", internal.SeverityInfo, internal.CategorySystem,
-			"Platform update available", fmt.Sprintf("%s → %s", update.InstalledVersion, update.LatestVersion))}
-	}
-	return nil
-}
-
 func (s *Scheduler) logSuppressed(notif *notifier.Notifier, findings []internal.Finding, hostname string, cfg AlertingConfig, status string) {
 	for _, wh := range notif.Webhooks() {
 		if !wh.Enabled || len(findings) == 0 {
@@ -1706,114 +941,4 @@ func (s *Scheduler) applyCooldown(findings []internal.Finding, routeKey string, 
 		}
 	}
 	return out
-}
-
-func matchesHostname(hosts []string, hostname string) bool {
-	if len(hosts) == 0 {
-		return true
-	}
-	h := strings.ToLower(strings.TrimSpace(hostname))
-	for _, c := range hosts {
-		if strings.ToLower(strings.TrimSpace(c)) == h {
-			return true
-		}
-	}
-	return false
-}
-
-func severityRank(sev internal.Severity) int {
-	switch sev {
-	case internal.SeverityCritical:
-		return 3
-	case internal.SeverityWarning:
-		return 2
-	case internal.SeverityInfo:
-		return 1
-	default:
-		return 0
-	}
-}
-
-func inQuietHours(cfg QuietHours, now time.Time) bool {
-	if !cfg.Enabled {
-		return false
-	}
-	start, err := parseHHMM(cfg.StartHHMM)
-	if err != nil {
-		return false
-	}
-	end, err := parseHHMM(cfg.EndHHMM)
-	if err != nil {
-		return false
-	}
-	if start == end {
-		return false
-	}
-
-	loc := time.UTC
-	if cfg.Timezone != "" {
-		if loaded, err := time.LoadLocation(cfg.Timezone); err == nil {
-			loc = loaded
-		}
-	}
-	localNow := now.In(loc)
-	mins := localNow.Hour()*60 + localNow.Minute()
-
-	if start < end {
-		return mins >= start && mins < end
-	}
-	return mins >= start || mins < end
-}
-
-func parseHHMM(v string) (int, error) {
-	parts := strings.Split(strings.TrimSpace(v), ":")
-	if len(parts) != 2 {
-		return 0, fmt.Errorf("invalid time")
-	}
-	h, err := time.Parse("15:04", fmt.Sprintf("%s:%s", parts[0], parts[1]))
-	if err != nil {
-		return 0, err
-	}
-	return h.Hour()*60 + h.Minute(), nil
-}
-
-func inMaintenanceWindow(windows []MaintenanceWindow, hostname string, now time.Time) bool {
-	for _, w := range windows {
-		if !w.Enabled {
-			continue
-		}
-		if !matchesHostname(w.Hostnames, hostname) {
-			continue
-		}
-		start, err1 := time.Parse(time.RFC3339, strings.TrimSpace(w.StartISO))
-		end, err2 := time.Parse(time.RFC3339, strings.TrimSpace(w.EndISO))
-		if err1 != nil || err2 != nil || !end.After(start) {
-			continue
-		}
-		if (now.Equal(start) || now.After(start)) && now.Before(end) {
-			return true
-		}
-	}
-	return false
-}
-
-func findingFingerprint(f internal.Finding) string {
-	parts := []string{
-		strings.ToLower(strings.TrimSpace(string(f.Category))),
-		strings.ToLower(strings.TrimSpace(f.Title)),
-		strings.ToLower(strings.TrimSpace(f.RelatedDisk)),
-	}
-	raw := strings.Join(parts, "|")
-	sum := sha256.Sum256([]byte(raw))
-	return hex.EncodeToString(sum[:])
-}
-
-func countSeverity(findings []internal.Finding, sev internal.Severity) int {
-	count := 0
-	for _, f := range findings {
-		if f.Severity == sev {
-			count++
-		}
-	}
-	return count
 }

--- a/internal/scheduler/service_checks_test.go
+++ b/internal/scheduler/service_checks_test.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/storage"
 )
 
 func TestExecuteServiceCheckHTTPUp(t *testing.T) {
@@ -24,7 +26,8 @@ func TestExecuteServiceCheckHTTPUp(t *testing.T) {
 		Enabled: true,
 	}
 
-	result := executeServiceCheck(check, time.Now().UTC())
+	sc := NewServiceChecker(storage.NewFakeStore(), slog.Default())
+	result := sc.RunCheck(check, time.Now().UTC())
 	if result.Status != "up" {
 		t.Fatalf("expected status up, got %s (error=%q)", result.Status, result.Error)
 	}
@@ -49,7 +52,8 @@ func TestExecuteServiceCheckHTTPUnexpectedStatus(t *testing.T) {
 		Enabled: true,
 	}
 
-	result := executeServiceCheck(check, time.Now().UTC())
+	sc := NewServiceChecker(storage.NewFakeStore(), slog.Default())
+	result := sc.RunCheck(check, time.Now().UTC())
 	if result.Status != "down" {
 		t.Fatalf("expected status down, got %s", result.Status)
 	}
@@ -59,12 +63,12 @@ func TestExecuteServiceCheckHTTPUnexpectedStatus(t *testing.T) {
 }
 
 func TestNormalizeTCPAddressSMBDefaultPort(t *testing.T) {
-	addr, err := normalizeTCPAddress(internal.ServiceCheckConfig{
+	addr, err := NormalizeTCPAddress(internal.ServiceCheckConfig{
 		Type:   internal.ServiceCheckSMB,
 		Target: "nas.local",
 	})
 	if err != nil {
-		t.Fatalf("normalizeTCPAddress failed: %v", err)
+		t.Fatalf("NormalizeTCPAddress failed: %v", err)
 	}
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {


### PR DESCRIPTION
Closes #94

## Summary
- **Extract `rules.go`** — Moved all pure notification rule evaluation functions (`evaluateRule`, `evalFindings`, `evalDiskSpace`, `evalDiskTemp`, `evalSMART`, `evalService`, `evalParity`, `evalUPS`, `evalDocker`, `evalSystem`, `evalZFS`, `evalTunnels`, `evalUpdate`), suppression helpers (`matchesHostname`, `severityRank`, `inQuietHours`, `parseHHMM`, `inMaintenanceWindow`), fingerprinting (`findingFingerprint`, `countSeverity`), and SMART trend helpers (`estimateTrendCost`, `minInt64`) out of scheduler.go into a dedicated rules.go file.
- **Wire `ServiceChecker`** — Replaced inline `executeServiceCheck()`, `isSupportedServiceCheckType()`, `normalizeHTTPURL()`, `normalizeDNSHost()`, `normalizeTCPAddress()`, `serviceCheckKey()`, and the `lastCheckRun` map with delegation to the `ServiceChecker` module (#91). `runDueServiceChecks()` now calls `checker.RunDueChecks()` and `runServiceChecks()` uses `checker.RunCheck()`.
- **Wire `RetentionManager`** — Replaced inline `pruneData()` body with delegation to `retentionMgr.RunRetention()` and replaced `checkBackup()` body with `retentionMgr.RunBackup()` (#93).
- **Updated tests** — `service_checks_test.go` now uses `ServiceChecker.RunCheck()` instead of the deleted `executeServiceCheck()`, and uses `NormalizeTCPAddress()` instead of `normalizeTCPAddress()`. `checks_test.go` updated to remove cross-reference test against deleted `serviceCheckKey()`.

## Impact
- `scheduler.go`: 1,819 → 944 lines (−48%)
- New `rules.go`: 512 lines (pure functions, zero struct dependencies)
- All existing tests pass (`go test ./...` ✅)
- `go build ./...` ✅, `go vet ./...` ✅