### PR TITLE
fix: clean theme rendering + remove ember references

### DIFF
--- a/internal/api/templates/alerts.html
+++ b/internal/api/templates/alerts.html
@@ -474,8 +474,8 @@ function escapeHtml(str) {
 
 /* ========== Theme ========== */
 function applyTheme(theme) {
-  document.body.classList.remove("theme-midnight", "theme-clean", "theme-ember");
-  if (theme === "clean" || theme === "ember") {
+  document.body.classList.remove("theme-midnight", "theme-clean");
+  if (theme === "clean") {
     document.body.classList.add("theme-" + theme);
   } else {
     document.body.classList.add("theme-midnight");

--- a/internal/api/templates/clean.html
+++ b/internal/api/templates/clean.html
@@ -11,6 +11,20 @@
 <style>
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
 
+/* CSS custom properties — maps the shared dashboard module's var() tokens to clean-theme values */
+:root{
+  --bg-base:#ffffff;--bg-panel:#ffffff;--bg-elevated:#f5f5f5;
+  --brand:#171717;--accent:#0068d6;--hover:#0050aa;
+  --border:rgba(0,0,0,0.08);--border-hover:rgba(0,0,0,0.15);
+  --btn-bg:rgba(0,0,0,0.02);--btn-bg-hover:rgba(0,0,0,0.05);
+  --text-primary:#171717;--text-secondary:#4d4d4d;--text-tertiary:#808080;--text-quaternary:#b3b3b3;
+  --green:#16a34a;--green-bg:rgba(22,163,74,0.08);
+  --amber:#d97706;--amber-bg:rgba(217,119,6,0.08);
+  --red:#dc2626;--red-bg:rgba(220,38,38,0.08);
+  --radius:8px;--sp:8px;
+  --font-mono:'SF Mono',ui-monospace,monospace;
+}
+
 html{font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:16px;line-height:1.5;color:#171717;background:#fff;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
 body{min-height:100vh;background:#fff}
 .container{max-width:1200px;margin:0 auto;padding:0 24px 80px}
@@ -136,9 +150,36 @@ body{min-height:100vh;background:#fff}
 .finding-detail-value.val-italic { font-style: italic; }
 .finding-evidence-list { list-style: none; display: flex; flex-direction: column; gap: 2px; font-family: 'SF Mono', monospace; font-size: 11px; color: #808080; }
 .finding-details { margin-top: 8px; padding-top: 8px; border-top: 1px solid rgba(0,0,0,0.06); display: flex; flex-direction: column; gap: 6px; }
-.finding-meta { display: flex; gap: 12px; margin-top: 8px; flex-wrap: wrap; }
+.finding-meta{display:flex;flex-wrap:wrap;gap:12px;font-size:11px;color:#808080;margin-top:6px}
+.finding-meta span{display:flex;align-items:center;gap:3px}
+.finding-meta strong{color:#4d4d4d;font-weight:500}
 .finding-meta-item { font-size: 12px; color: #666666; }
 .finding-meta-item strong { font-weight: 500; color: #4d4d4d; }
+
+/* ---- Findings (shared module classes) ---- */
+/* The shared dashboard module generates .finding / .finding-critical etc. */
+.finding{border:1px solid rgba(0,0,0,0.08);border-radius:8px;padding:14px 16px;transition:all 200ms ease;position:relative;overflow:hidden;background:#fff;cursor:pointer}
+.swipe-dismiss-bg{position:absolute;top:0;right:0;bottom:0;width:100%;display:flex;align-items:center;justify-content:flex-end;padding-right:20px;background:rgba(220,38,38,0.1);color:#dc2626;font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;opacity:0;pointer-events:none;z-index:-1;border-radius:8px}
+.finding:hover{border-color:rgba(0,0,0,0.15)}
+.finding-critical{background:rgba(220,38,38,0.03);border-color:rgba(220,38,38,0.15)}
+.finding-critical:hover{background:rgba(220,38,38,0.06);border-color:rgba(220,38,38,0.25)}
+.finding-warning{background:rgba(217,119,6,0.03);border-color:rgba(217,119,6,0.15)}
+.finding-warning:hover{background:rgba(217,119,6,0.06);border-color:rgba(217,119,6,0.25)}
+.finding-info{background:rgba(0,104,214,0.03);border-color:rgba(0,104,214,0.15)}
+.finding-info:hover{background:rgba(0,104,214,0.06);border-color:rgba(0,104,214,0.25)}
+.finding-ok{background:rgba(22,163,74,0.03);border-color:rgba(22,163,74,0.15)}
+.finding-ok:hover{background:rgba(22,163,74,0.06);border-color:rgba(22,163,74,0.25)}
+.finding.active .finding-expandable{max-height:500px;opacity:1}
+.sev-dot{display:inline-block;width:7px;height:7px;border-radius:50%;margin-right:6px;vertical-align:middle;flex-shrink:0}
+.sev-dot-critical{background:#dc2626}
+.sev-dot-warning{background:#d97706}
+.sev-dot-info{background:#0068d6}
+.sev-dot-ok{background:#16a34a}
+.finding-tag{font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;padding:2px 7px;border-radius:4px}
+.finding-tag.sev-critical{color:#dc2626;background:rgba(220,38,38,0.08)}
+.finding-tag.sev-warning{color:#d97706;background:rgba(217,119,6,0.08)}
+.finding-tag.sev-info{color:#0068d6;background:rgba(0,104,214,0.08)}
+.finding-tag.sev-ok{color:#16a34a;background:rgba(22,163,74,0.08)}
 
 /* ---- Disk bars (compact) ---- */
 .disk-list { display: flex; flex-direction: column; gap: 10px; }
@@ -151,6 +192,9 @@ body{min-height:100vh;background:#fff}
 .disk-bar-fill.color-green { background: #16a34a; }
 .disk-bar-fill.color-amber { background: #d97706; }
 .disk-bar-fill.color-red   { background: #dc2626; }
+
+/* Shared module uses disk-bar-bg instead of disk-bar-track */
+.disk-bar-bg{height:6px;background:#ebebeb;border-radius:9999px;overflow:hidden}
 
 /* ---- Tables ---- */
 .table-container { background: #ffffff; border-radius: 8px; box-shadow: 0px 0px 0px 1px rgba(0,0,0,0.08); overflow-x: auto; }
@@ -168,6 +212,15 @@ body{min-height:100vh;background:#fff}
 .table-wrap tr:last-child td { border-bottom: none; }
 .table-wrap tbody tr:nth-child(even) { background: rgba(0,0,0,0.01); }
 .table-wrap tbody tr:hover { background: rgba(0,0,0,0.03); }
+
+/* ---- Bare table defaults (shared module generates tables outside .table-wrap) ---- */
+table{width:100%;border-collapse:collapse}
+thead{background:#fafafa}
+th{font-size:11px;font-weight:500;color:#808080;text-transform:uppercase;letter-spacing:0.4px;padding:8px 12px;text-align:left;border-bottom:1px solid rgba(0,0,0,0.08)}
+td{font-size:13px;color:#171717;padding:8px 12px;border-bottom:1px solid rgba(0,0,0,0.04)}
+tr:last-child td{border-bottom:none}
+tbody tr:nth-child(even){background:rgba(0,0,0,0.01)}
+tbody tr:hover{background:rgba(0,0,0,0.03)}
 
 /* ---- Buttons ---- */
 .btn { display: inline-flex; align-items: center; gap: 6px; padding: 6px 14px; font-size: 13px; font-weight: 500; font-family: inherit; border-radius: 6px; border: none; cursor: pointer; transition: opacity 0.15s; }

--- a/internal/api/templates/disk_detail.html
+++ b/internal/api/templates/disk_detail.html
@@ -30,18 +30,6 @@ body.theme-clean{
   --red:#dc2626;--red-bg:rgba(220,38,38,0.08);
   --border:rgba(0,0,0,0.08);
 }
-body.theme-ember{
-  --bg-base:#07080a;--bg-surface:#101111;--bg-elevated:#1a1b1c;
-  --text-primary:#f9f9f9;--text-secondary:#d0d0d0;--text-tertiary:#9c9c9d;
-  --accent:#55b3ff;--accent-hover:#7ec8ff;
-  --green:#5fc992;--green-bg:rgba(95,201,146,0.1);
-  --amber:#FACC15;--amber-bg:rgba(250,204,21,0.1);
-  --red:#FF6363;--red-bg:rgba(255,99,99,0.1);
-  --border:rgba(255,255,255,0.06);
-}
-body.theme-ember{font-family:'Inter',-apple-system,BlinkMacSystemFont,sans-serif}
-body.theme-ember .drive-title,body.theme-ember .section-title{font-family:'Literata','Georgia',serif}
-body.theme-ember .badge,body.theme-ember .attr-raw,body.theme-ember .attr-value{font-family:'JetBrains Mono',ui-monospace,'SF Mono',monospace}
 html{background:var(--bg-base);color:var(--text-primary);font-family:"Inter",system-ui,-apple-system,sans-serif;font-feature-settings:"cv01","ss03";font-size:14px;line-height:1.5;-webkit-font-smoothing:antialiased}
 body{min-height:100vh;padding:calc(var(--sp)*3);transition:background 0.2s,color 0.2s}
 a{color:var(--accent);text-decoration:none}
@@ -161,7 +149,7 @@ a:hover{color:var(--accent-hover)}
 fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d.hostname)document.title="NAS Doctor — "+d.hostname;}).catch(function(){});
 /* Theme detection */
 (function(){
-  function applyTheme(t){document.body.classList.remove("theme-midnight","theme-clean","theme-ember");document.body.classList.add("theme-"+(t||"midnight"));}
+  function applyTheme(t){document.body.classList.remove("theme-midnight","theme-clean");document.body.classList.add("theme-"+(t||"midnight"));}
   try{var s=localStorage.getItem("nas-doctor-theme");if(s)applyTheme(s);}catch(e){}
   fetch("/api/v1/settings").then(function(r){return r.json()}).then(function(d){if(d.theme){applyTheme(d.theme);try{localStorage.setItem("nas-doctor-theme",d.theme)}catch(e){}}}).catch(function(){});
 })();

--- a/internal/api/templates/fleet.html
+++ b/internal/api/templates/fleet.html
@@ -122,9 +122,6 @@ body.theme-clean .mini-stat{background:rgba(0,0,0,0.04)}
 .empty{text-align:center;padding:60px 20px;color:var(--text2)}
 .empty-title{font-size:16px;font-weight:600;color:var(--text);margin-bottom:8px}
 
-/* Ember overrides */
-body.theme-ember .node-name,.theme-ember .fleet-stat-val,.theme-ember .section-hdr{font-family:var(--font-serif)}
-body.theme-ember .meta-val,.theme-ember .metric-pct,.theme-ember .finding-cat{font-family:var(--font-mono)}
 </style>
 </head>
 <body>
@@ -149,7 +146,7 @@ body.theme-ember .meta-val,.theme-ember .metric-pct,.theme-ember .finding-cat{fo
 </div>
 <script>
 (function(){
-  function applyTheme(t){document.body.classList.remove("theme-midnight","theme-clean","theme-ember");document.body.classList.add("theme-"+(t||"midnight"));}
+  function applyTheme(t){document.body.classList.remove("theme-midnight","theme-clean");document.body.classList.add("theme-"+(t||"midnight"));}
   try{var s=localStorage.getItem("nas-doctor-theme");if(s)applyTheme(s);}catch(e){}
   fetch("/api/v1/settings").then(function(r){return r.json()}).then(function(d){if(d.theme){applyTheme(d.theme);try{localStorage.setItem("nas-doctor-theme",d.theme)}catch(e){}}}).catch(function(){});
   fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d.hostname)document.title="NAS Doctor \u2014 "+d.hostname;}).catch(function(){});

--- a/internal/api/templates/parity.html
+++ b/internal/api/templates/parity.html
@@ -67,7 +67,7 @@
 <script src="/js/charts.js"></script>
 <script>
 (function(){
-  function applyTheme(t){document.body.classList.remove("theme-midnight","theme-clean","theme-ember");document.body.classList.add("theme-"+(t||"midnight"));}
+  function applyTheme(t){document.body.classList.remove("theme-midnight","theme-clean");document.body.classList.add("theme-"+(t||"midnight"));}
   try{var s=localStorage.getItem("nas-doctor-theme");if(s)applyTheme(s);}catch(e){}
   fetch("/api/v1/settings").then(function(r){return r.json()}).then(function(d){if(d.theme){applyTheme(d.theme);try{localStorage.setItem("nas-doctor-theme",d.theme)}catch(e){}}}).catch(function(){});
   fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d.hostname)document.title="NAS Doctor — "+d.hostname;}).catch(function(){});

--- a/internal/api/templates/replacement_planner.html
+++ b/internal/api/templates/replacement_planner.html
@@ -71,9 +71,6 @@ body.theme-clean .life-bar{background:rgba(0,0,0,0.06)}
 
 .data-ver{font-size:10px;color:var(--text3);text-align:right;margin-top:12px}
 
-/* Ember */
-body.theme-ember .rp-stat-val,.theme-ember .cost-title,.theme-ember .section-hdr{font-family:var(--font-serif)}
-body.theme-ember .cost-row .val,.theme-ember .health-ring{font-family:var(--font-mono)}
 </style>
 </head>
 <body>
@@ -98,7 +95,7 @@ body.theme-ember .cost-row .val,.theme-ember .health-ring{font-family:var(--font
 </div>
 <script>
 (function(){
-  function applyTheme(t){document.body.classList.remove("theme-midnight","theme-clean","theme-ember");document.body.classList.add("theme-"+(t||"midnight"));}
+  function applyTheme(t){document.body.classList.remove("theme-midnight","theme-clean");document.body.classList.add("theme-"+(t||"midnight"));}
   try{var s=localStorage.getItem("nas-doctor-theme");if(s)applyTheme(s);}catch(e){}
   fetch("/api/v1/settings").then(function(r){return r.json()}).then(function(d){if(d.theme){applyTheme(d.theme);try{localStorage.setItem("nas-doctor-theme",d.theme)}catch(e){}}}).catch(function(){});
   fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d.hostname)document.title="NAS Doctor \u2014 "+d.hostname;}).catch(function(){});

--- a/internal/api/templates/service_checks.html
+++ b/internal/api/templates/service_checks.html
@@ -136,7 +136,7 @@
 <script src="/js/charts.js"></script>
 <script>
 (function(){
-  function applyTheme(t){document.body.classList.remove("theme-midnight","theme-clean","theme-ember");document.body.classList.add("theme-"+(t||"midnight"));}
+  function applyTheme(t){document.body.classList.remove("theme-midnight","theme-clean");document.body.classList.add("theme-"+(t||"midnight"));}
   try{var s=localStorage.getItem("nas-doctor-theme");if(s)applyTheme(s);}catch(e){}
   fetch("/api/v1/settings").then(function(r){return r.json()}).then(function(d){if(d.theme){applyTheme(d.theme);try{localStorage.setItem("nas-doctor-theme",d.theme)}catch(e){}}}).catch(function(){});
   fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d.hostname)document.title="NAS Doctor — "+d.hostname;}).catch(function(){});

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -20,7 +20,6 @@
 .swatch{width:24px;height:24px;border-radius:6px;border:1px solid rgba(255,255,255,0.1);flex-shrink:0}
 .swatch-midnight{background:linear-gradient(135deg,#0f1011 50%,#5e6ad2 50%)}
 .swatch-clean{background:linear-gradient(135deg,#ffffff 50%,#000000 50%)}
-.swatch-ember{background:linear-gradient(135deg,#1a1a1a 50%,#f97316 50%)}
 .theme-name{font-size:13px;font-weight:500;color:var(--text)}
 /* cron preview mono */
 #scan-cron-preview{font-family:var(--font-mono);font-size:11px}
@@ -121,11 +120,7 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
         <div class="swatch swatch-clean"></div>
         <span class="theme-name">Clean</span>
       </div>
-      <div class="theme-option" data-theme="ember" onclick="selectTheme(this)">
-        <input type="radio" name="theme" value="ember">
-        <div class="swatch swatch-ember"></div>
-        <span class="theme-name">Ember</span>
-      </div>
+
     </div>
     <div style="margin-top:20px">
       <label>App Icon</label>
@@ -1795,8 +1790,8 @@ function escapeHtml(str) {
 
 /* ---------- Apply saved theme ---------- */
 function applyTheme(theme) {
-  document.body.classList.remove("theme-midnight", "theme-clean", "theme-ember");
-  if (theme === "clean" || theme === "ember") {
+  document.body.classList.remove("theme-midnight", "theme-clean");
+  if (theme === "clean") {
     document.body.classList.add("theme-" + theme);
   } else {
     document.body.classList.add("theme-midnight");

--- a/internal/api/templates/stats.html
+++ b/internal/api/templates/stats.html
@@ -14,7 +14,6 @@ body{padding:0}
 /* Additional tokens for stats page */
 :root,body.theme-midnight{--elevated:#242526;--text3:#5a5f6a}
 body.theme-clean{--elevated:#fafafa;--text3:#b3b3b3}
-body.theme-ember{--elevated:#1a1b1c;--text3:#5a5b5c}
 body.theme-clean .drive,.theme-clean .summary-box,.theme-clean .chart-card,.theme-clean .smart-table{box-shadow:0 0 0 1px rgba(0,0,0,0.08)}
 body.theme-clean .drive:hover{box-shadow:0 0 0 1px rgba(0,0,0,0.15)}
 .summary{display:flex;gap:12px;margin-bottom:24px;flex-wrap:wrap}
@@ -110,11 +109,6 @@ body.theme-clean .drive-detail-inner{border-top-color:rgba(0,0,0,0.08)}
 body.theme-clean .bb-box{background:var(--elevated);border-color:rgba(0,0,0,0.08)}
 body.theme-clean .badge{border:1px solid rgba(0,0,0,0.06)}
 body.theme-clean a{color:var(--accent)}
-
-/* Ember theme overrides */
-body.theme-ember .drive-name,body.theme-ember .smart-section-title,body.theme-ember .summary-val{font-family:'Literata','Georgia',serif}
-body.theme-ember .drive-model,body.theme-ember .detail-value,body.theme-ember .mono{font-family:'JetBrains Mono',ui-monospace,monospace}
-body.theme-ember .drive-clickable:hover{border-color:rgba(255,255,255,0.12)}
 
 /* Sort pill inline (stats page doesn't use shared.css for dashboards) */
 .sort-bar{display:inline-flex;gap:1px;padding:0;border-radius:6px;background:none;border:none}
@@ -425,10 +419,10 @@ fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d
   (function(){
     try {
       var t = localStorage.getItem("nas-doctor-theme");
-      if (t === "clean" || t === "ember") document.body.classList.add("theme-"+t);
+      if (t === "clean") document.body.classList.add("theme-"+t);
     } catch(e) {}
     fetch("/api/v1/settings").then(function(r){return r.json()}).then(function(d){
-      if (d.theme === "clean" || d.theme === "ember") {
+      if (d.theme === "clean") {
         document.body.className = "theme-"+d.theme;
       }
       try { localStorage.setItem("nas-doctor-theme", d.theme); } catch(e){}


### PR DESCRIPTION
## Summary

Fixes two QA bugs found during local testing:

### Bug 1: Clean theme rendering broken
The shared dashboard module (`dashboard.go`) generates HTML using CSS custom properties (`var(--bg-panel)`, `var(--border)`, etc.) and specific class names (`.finding`, `.finding-critical`, `.sev-dot`, `.disk-bar-bg`, etc.) that originated from the midnight theme. When clean.html was refactored to use the shared module, it lacked:

- **CSS custom properties** — Added `:root` variables mapping the shared module's `var()` tokens to clean-theme light colors
- **Finding card classes** — Added `.finding`, `.finding-critical/warning/info/ok`, `.sev-dot-*`, `.finding-tag.sev-*` rules with clean-theme styling
- **Disk bar class** — Added `.disk-bar-bg` (module uses this instead of clean's `.disk-bar-track`)
- **Bare table defaults** — Added `table`, `thead`, `th`, `td` element selectors (module generates tables outside `.table-wrap`)
- **Finding meta** — Added `.finding-meta span` and `.finding-meta strong` rules

### Bug 2: Ember theme references in 8 template files
The ember theme was previously deleted (template + routes) but references remained in settings, parity, service_checks, stats, replacement_planner, fleet, alerts, and disk_detail templates. Removed:
- Ember CSS rules (`body.theme-ember {...}`)
- Ember from `applyTheme()` `classList.remove()` calls
- Ember theme option from settings selector
- Ember from theme-switching JS conditionals

## Verification
- `go build ./...` passes ✅
- No `\bember\b` string in any template file ✅
- Clean theme will now render findings with styled cards, severity badges, drive capacity bars, and service checks tables properly