### PR TITLE
fix(dashboard): re-render when scan completes to reset button state

### DIFF
--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -125,8 +125,19 @@ polling._pollStatus = function() {
     }
 
     if (scanRunning !== _wasScanRunning) {
+      var wasRunning = _wasScanRunning;
       _wasScanRunning = scanRunning;
+      _scanInProgress = scanRunning;
       polling._startPoll();
+      if (wasRunning && !scanRunning) {
+        _lastScanTime = scanTime;
+        util.fetchJSON("/api/v1/snapshot/latest").then(function(snap) {
+          _snapshotData = snap;
+          if (_renderFn) _renderFn();
+        }).catch(function() {});
+      } else if (_renderFn) {
+        _renderFn();
+      }
     }
   }).catch(function() {});
   _lastFetchTime = Date.now();


### PR DESCRIPTION
The polling loop detected scan_running transitions but only adjusted the poll interval — it never triggered a re-render or snapshot fetch. This left the Scanning button visible until manual refresh.

Now when scan_running transitions from true to false:
1. Syncs _scanInProgress with server state
2. Fetches the new snapshot immediately
3. Re-renders the dashboard (resetting the button to Run Scan)