### PR TITLE
feat(collector): add container attribution to process collection

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -87,6 +87,13 @@ func (c *Collector) Collect() (*internal.Snapshot, error) {
 	}
 	snap.Docker = docker
 
+	// Enrich top processes with container attribution (requires Docker data)
+	if docker.Available && len(docker.Containers) > 0 && len(sys.TopProcesses) > 0 {
+		containerIDMap := buildContainerIDMap(docker.Containers)
+		enrichProcessContainers(sys.TopProcesses, containerIDMap, "/proc")
+		snap.System.TopProcesses = sys.TopProcesses
+	}
+
 	// Network
 	c.logger.Info("collecting network info")
 	net, err := collectNetwork()

--- a/internal/collector/system.go
+++ b/internal/collector/system.go
@@ -232,6 +232,53 @@ func collectTopProcesses(n int) []internal.ProcessInfo {
 	return procs
 }
 
+// extractContainerID reads /proc/<pid>/cgroup and extracts the Docker
+// container ID. procRoot allows overriding the proc filesystem root for
+// testing (default: "/proc").
+func extractContainerID(pid int, procRoot string) string {
+	path := fmt.Sprintf("%s/%d/cgroup", procRoot, pid)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "" // file doesn't exist (macOS) or permission denied
+	}
+	return parseContainerIDFromCgroup(string(data))
+}
+
+// buildContainerIDMap creates a lookup map from Docker short container IDs
+// to container names, using the ContainerInfo slice from collectDocker().
+func buildContainerIDMap(containers []internal.ContainerInfo) map[string]string {
+	m := make(map[string]string, len(containers))
+	for _, c := range containers {
+		if c.ID != "" {
+			m[c.ID] = c.Name
+		}
+	}
+	return m
+}
+
+// enrichProcessContainers populates ContainerID and ContainerName on each
+// ProcessInfo by reading cgroup data and matching against the container map.
+// The containerMap keys are short Docker IDs (typically 12 chars from docker ps);
+// we match by checking if the full 64-char cgroup ID starts with a short ID.
+// procRoot allows overriding the proc filesystem root for testing.
+func enrichProcessContainers(procs []internal.ProcessInfo, containerMap map[string]string, procRoot string) {
+	for i := range procs {
+		fullID := extractContainerID(procs[i].PID, procRoot)
+		if fullID == "" {
+			continue
+		}
+		procs[i].ContainerID = fullID
+
+		// Try to find the container name by prefix-matching short IDs
+		for shortID, name := range containerMap {
+			if strings.HasPrefix(fullID, shortID) {
+				procs[i].ContainerName = name
+				break
+			}
+		}
+	}
+}
+
 // parseContainerIDFromCgroup extracts a Docker container ID (64-char hex)
 // from the contents of a /proc/PID/cgroup file. Supports:
 //   - cgroup v1 (Unraid): "12:devices:/docker/<64-hex>"

--- a/internal/collector/system.go
+++ b/internal/collector/system.go
@@ -232,6 +232,55 @@ func collectTopProcesses(n int) []internal.ProcessInfo {
 	return procs
 }
 
+// parseContainerIDFromCgroup extracts a Docker container ID (64-char hex)
+// from the contents of a /proc/PID/cgroup file. Supports:
+//   - cgroup v1 (Unraid): "12:devices:/docker/<64-hex>"
+//   - cgroup v2 (TrueNAS SCALE): "0::/system.slice/docker-<64-hex>.scope"
+//
+// Returns empty string if no Docker container ID is found.
+func parseContainerIDFromCgroup(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// cgroup v1: look for "/docker/<id>" anywhere in the line
+		if idx := strings.Index(line, "/docker/"); idx != -1 {
+			candidate := line[idx+len("/docker/"):]
+			if id := extractHexID(candidate); id != "" {
+				return id
+			}
+		}
+
+		// cgroup v2: look for "docker-<id>.scope" anywhere in the line
+		if idx := strings.Index(line, "docker-"); idx != -1 {
+			candidate := line[idx+len("docker-"):]
+			// Strip ".scope" suffix if present
+			candidate = strings.TrimSuffix(candidate, ".scope")
+			if id := extractHexID(candidate); id != "" {
+				return id
+			}
+		}
+	}
+	return ""
+}
+
+// extractHexID returns the first 64 hex characters from s, or "" if
+// s doesn't start with a valid 64-char hex string.
+func extractHexID(s string) string {
+	if len(s) < 64 {
+		return ""
+	}
+	candidate := s[:64]
+	for _, c := range candidate {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return ""
+		}
+	}
+	return candidate
+}
+
 func execCmd(name string, args ...string) (string, error) {
 	cmd := exec.Command(name, args...)
 	out, err := cmd.CombinedOutput()

--- a/internal/collector/system_test.go
+++ b/internal/collector/system_test.go
@@ -1,7 +1,11 @@
 package collector
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/mcdays94/nas-doctor/internal"
 )
 
 func TestParseContainerIDFromCgroup(t *testing.T) {
@@ -69,5 +73,145 @@ func TestParseContainerIDFromCgroup(t *testing.T) {
 				t.Errorf("parseContainerIDFromCgroup() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestExtractContainerID(t *testing.T) {
+	// Create a fake /proc/<pid>/cgroup file in a temp directory
+	tmpDir := t.TempDir()
+
+	// Fake PID 42 with cgroup v1 docker content
+	pid42Dir := filepath.Join(tmpDir, "42")
+	if err := os.MkdirAll(pid42Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cgroupContent := "12:devices:/docker/abc123def456789abc123def456789abc123def456789abc123def456789abcd\n"
+	if err := os.WriteFile(filepath.Join(pid42Dir, "cgroup"), []byte(cgroupContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake PID 99 with non-container cgroup
+	pid99Dir := filepath.Join(tmpDir, "99")
+	if err := os.MkdirAll(pid99Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pid99Dir, "cgroup"), []byte("0::/init.scope\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		pid  int
+		want string
+	}{
+		{
+			name: "docker container process",
+			pid:  42,
+			want: "abc123def456789abc123def456789abc123def456789abc123def456789abcd",
+		},
+		{
+			name: "non-container process",
+			pid:  99,
+			want: "",
+		},
+		{
+			name: "nonexistent PID (graceful)",
+			pid:  99999,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractContainerID(tt.pid, tmpDir)
+			if got != tt.want {
+				t.Errorf("extractContainerID(%d) = %q, want %q", tt.pid, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildContainerIDMap(t *testing.T) {
+	containers := []internal.ContainerInfo{
+		{ID: "abc123def456", Name: "nginx"},
+		{ID: "fedcba987654", Name: "postgres"},
+		{ID: "", Name: "broken"}, // edge: empty ID
+	}
+
+	m := buildContainerIDMap(containers)
+
+	if got := m["abc123def456"]; got != "nginx" {
+		t.Errorf("map[abc123def456] = %q, want %q", got, "nginx")
+	}
+	if got := m["fedcba987654"]; got != "postgres" {
+		t.Errorf("map[fedcba987654] = %q, want %q", got, "postgres")
+	}
+	if _, ok := m[""]; ok {
+		t.Error("empty ID should not be in the map")
+	}
+}
+
+func TestEnrichProcessContainers(t *testing.T) {
+	// Create fake proc filesystem
+	tmpDir := t.TempDir()
+
+	fullID := "abc123def456789abc123def456789abc123def456789abc123def456789abcd"
+
+	// PID 10: in a docker container
+	pid10Dir := filepath.Join(tmpDir, "10")
+	if err := os.MkdirAll(pid10Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pid10Dir, "cgroup"),
+		[]byte("12:devices:/docker/"+fullID+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// PID 20: host process
+	pid20Dir := filepath.Join(tmpDir, "20")
+	if err := os.MkdirAll(pid20Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pid20Dir, "cgroup"),
+		[]byte("0::/init.scope\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	procs := []internal.ProcessInfo{
+		{PID: 10, User: "root", CPU: 25.0, Mem: 10.0, Command: "nginx"},
+		{PID: 20, User: "root", CPU: 5.0, Mem: 2.0, Command: "sshd"},
+		{PID: 30, User: "root", CPU: 1.0, Mem: 0.5, Command: "kworker"}, // no cgroup file
+	}
+
+	// containerMap: short IDs map to names, but we also need to test prefix matching.
+	// Docker ps returns short IDs (12 char), cgroup has full 64-char IDs.
+	containerMap := map[string]string{
+		"abc123def456": "my-nginx",
+	}
+
+	enrichProcessContainers(procs, containerMap, tmpDir)
+
+	// PID 10 should be attributed to my-nginx
+	if procs[0].ContainerID != fullID {
+		t.Errorf("PID 10 ContainerID = %q, want %q", procs[0].ContainerID, fullID)
+	}
+	if procs[0].ContainerName != "my-nginx" {
+		t.Errorf("PID 10 ContainerName = %q, want %q", procs[0].ContainerName, "my-nginx")
+	}
+
+	// PID 20 should have no container
+	if procs[1].ContainerID != "" {
+		t.Errorf("PID 20 ContainerID = %q, want empty", procs[1].ContainerID)
+	}
+	if procs[1].ContainerName != "" {
+		t.Errorf("PID 20 ContainerName = %q, want empty", procs[1].ContainerName)
+	}
+
+	// PID 30 should have no container (missing cgroup file)
+	if procs[2].ContainerID != "" {
+		t.Errorf("PID 30 ContainerID = %q, want empty", procs[2].ContainerID)
+	}
+	if procs[2].ContainerName != "" {
+		t.Errorf("PID 30 ContainerName = %q, want empty", procs[2].ContainerName)
 	}
 }

--- a/internal/collector/system_test.go
+++ b/internal/collector/system_test.go
@@ -1,0 +1,73 @@
+package collector
+
+import (
+	"testing"
+)
+
+func TestParseContainerIDFromCgroup(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "cgroup v1 docker path",
+			content: "12:devices:/docker/abc123def456789abc123def456789abc123def456789abc123def456789abcd\n",
+			want:    "abc123def456789abc123def456789abc123def456789abc123def456789abcd",
+		},
+		{
+			name: "cgroup v1 multi-line with docker on one line",
+			content: `11:cpuset:/docker/abc123def456789abc123def456789abc123def456789abc123def456789abcd
+10:memory:/docker/abc123def456789abc123def456789abc123def456789abc123def456789abcd
+9:devices:/docker/abc123def456789abc123def456789abc123def456789abc123def456789abcd
+`,
+			want: "abc123def456789abc123def456789abc123def456789abc123def456789abcd",
+		},
+		{
+			name:    "cgroup v2 systemd docker scope",
+			content: "0::/system.slice/docker-abc123def456789abc123def456789abc123def456789abc123def456789abcd.scope\n",
+			want:    "abc123def456789abc123def456789abc123def456789abc123def456789abcd",
+		},
+		{
+			name:    "non-container process",
+			content: "0::/user.slice/user-1000.slice/session-1.scope\n",
+			want:    "",
+		},
+		{
+			name:    "empty content",
+			content: "",
+			want:    "",
+		},
+		{
+			name:    "kernel thread or init",
+			content: "0::/init.scope\n",
+			want:    "",
+		},
+		{
+			name: "cgroup v1 with nested docker path",
+			content: `12:blkio:/docker/fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210
+11:memory:/docker/fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210
+`,
+			want: "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210",
+		},
+		{
+			name:    "containerd/cri-o format (not docker)",
+			content: "0::/kubepods/burstable/pod12345/cri-containerd-abc123\n",
+			want:    "",
+		},
+		{
+			name:    "docker compose with buildkit",
+			content: "0::/system.slice/docker-aabbccdd00112233445566778899aabbccddeeff00112233445566778899aabb.scope\n",
+			want:    "aabbccdd00112233445566778899aabbccddeeff00112233445566778899aabb",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseContainerIDFromCgroup(tt.content)
+			if got != tt.want {
+				t.Errorf("parseContainerIDFromCgroup() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/models.go
+++ b/internal/models.go
@@ -268,11 +268,13 @@ type SystemInfo struct {
 }
 
 type ProcessInfo struct {
-	PID     int     `json:"pid"`
-	User    string  `json:"user"`
-	CPU     float64 `json:"cpu_percent"`
-	Mem     float64 `json:"mem_percent"`
-	Command string  `json:"command"`
+	PID           int     `json:"pid"`
+	User          string  `json:"user"`
+	CPU           float64 `json:"cpu_percent"`
+	Mem           float64 `json:"mem_percent"`
+	Command       string  `json:"command"`
+	ContainerName string  `json:"container_name"`
+	ContainerID   string  `json:"container_id"`
 }
 
 // ---------- Disk ----------

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -242,6 +242,24 @@ func (d *DB) migrate() error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_service_checks_key_ts ON service_checks_history(check_key, checked_at DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_service_checks_ts ON service_checks_history(checked_at DESC)`,
+		// --- Process history ---
+		`CREATE TABLE IF NOT EXISTS process_history (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			snapshot_id TEXT NOT NULL,
+			pid INTEGER NOT NULL,
+			user TEXT,
+			name TEXT NOT NULL,
+			command TEXT,
+			container_name TEXT DEFAULT '',
+			container_id TEXT DEFAULT '',
+			cpu_pct REAL,
+			mem_pct REAL,
+			timestamp DATETIME NOT NULL,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_process_history_ts ON process_history(timestamp DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_process_history_name ON process_history(name, container_name, timestamp DESC)`,
+
 		// Disk usage history for capacity forecasting
 		`CREATE TABLE IF NOT EXISTS disk_usage_history (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -543,6 +561,89 @@ func (d *DB) GetContainerHistory(hours int) ([]ContainerHistoryPoint, error) {
 	for rows.Next() {
 		var p ContainerHistoryPoint
 		if err := rows.Scan(&p.Timestamp, &p.Name, &p.Image, &p.CPUPct, &p.MemMB, &p.MemPct, &p.NetIn, &p.NetOut, &p.BlockRead, &p.BlockWrite); err != nil {
+			return nil, err
+		}
+		points = append(points, p)
+	}
+	return points, rows.Err()
+}
+
+// ProcessHistoryPoint represents a single time-series data point for a process.
+type ProcessHistoryPoint struct {
+	Timestamp     time.Time `json:"timestamp"`
+	PID           int       `json:"pid"`
+	User          string    `json:"user"`
+	Name          string    `json:"name"`
+	Command       string    `json:"command"`
+	ContainerName string    `json:"container_name"`
+	ContainerID   string    `json:"container_id"`
+	CPUPct        float64   `json:"cpu_percent"`
+	MemPct        float64   `json:"mem_percent"`
+}
+
+// processName extracts a short process name from a full command string.
+// e.g. "/usr/bin/python3 app.py" → "python3", "nginx: worker" → "nginx:"
+func processName(command string) string {
+	if command == "" {
+		return ""
+	}
+	// Take the first field (the executable path/name).
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return ""
+	}
+	exe := fields[0]
+	// Strip leading path: /usr/bin/python3 → python3
+	if idx := strings.LastIndex(exe, "/"); idx >= 0 && idx < len(exe)-1 {
+		exe = exe[idx+1:]
+	}
+	return exe
+}
+
+// SaveProcessStats saves a standalone process stats snapshot.
+// Used by the lightweight process stats collection loop (similar to SaveContainerStats).
+func (d *DB) SaveProcessStats(procs []internal.ProcessInfo) error {
+	if len(procs) == 0 {
+		return nil
+	}
+	now := time.Now()
+	snapshotID := fmt.Sprintf("pstats-%d", now.UnixMilli())
+	for _, p := range procs {
+		name := processName(p.Command)
+		if name == "" {
+			continue // skip processes with empty name
+		}
+		_, err := d.db.Exec(
+			`INSERT INTO process_history (snapshot_id, pid, user, name, command, container_name, container_id, cpu_pct, mem_pct, timestamp)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			snapshotID, p.PID, p.User, name, p.Command, "", "", p.CPU, p.Mem, now,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetProcessHistory returns process history for the given time range.
+func (d *DB) GetProcessHistory(hours int) ([]ProcessHistoryPoint, error) {
+	cutoff := time.Now().Add(-time.Duration(hours) * time.Hour)
+	rows, err := d.db.Query(
+		`SELECT timestamp, pid, COALESCE(user, ''), name, COALESCE(command, ''), COALESCE(container_name, ''), COALESCE(container_id, ''), cpu_pct, mem_pct
+		 FROM process_history
+		 WHERE timestamp >= ?
+		 ORDER BY name ASC, container_name ASC, timestamp ASC`,
+		cutoff,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var points []ProcessHistoryPoint
+	for rows.Next() {
+		var p ProcessHistoryPoint
+		if err := rows.Scan(&p.Timestamp, &p.PID, &p.User, &p.Name, &p.Command, &p.ContainerName, &p.ContainerID, &p.CPUPct, &p.MemPct); err != nil {
 			return nil, err
 		}
 		points = append(points, p)
@@ -1638,7 +1739,7 @@ func (d *DB) PruneSnapshots(olderThan time.Duration, keepMin int) (int, error) {
 
 	// Explicitly delete from history tables for the snapshots being pruned,
 	// in case foreign_keys or CASCADE is not fully honoured at runtime.
-	for _, table := range []string{"smart_history", "system_history", "disk_usage_history", "gpu_history", "container_stats_history", "speedtest_history"} {
+	for _, table := range []string{"smart_history", "system_history", "disk_usage_history", "gpu_history", "container_stats_history", "speedtest_history", "process_history"} {
 		_, err := tx.Exec(fmt.Sprintf(
 			`DELETE FROM %s WHERE snapshot_id IN (%s)`, table, pruneQuery,
 		), keepMin, cutoff)
@@ -2018,7 +2119,7 @@ func (d *DB) PruneToSizeMB(targetMB float64) (int, error) {
 		if err != nil {
 			return totalPruned, err
 		}
-		for _, table := range []string{"smart_history", "system_history", "disk_usage_history", "gpu_history", "container_stats_history", "speedtest_history"} {
+		for _, table := range []string{"smart_history", "system_history", "disk_usage_history", "gpu_history", "container_stats_history", "speedtest_history", "process_history"} {
 			d.db.Exec(fmt.Sprintf(`DELETE FROM %s WHERE snapshot_id IN (
 				SELECT id FROM snapshots ORDER BY timestamp ASC LIMIT ?
 			)`, table), batchSize)

--- a/internal/storage/db_process_test.go
+++ b/internal/storage/db_process_test.go
@@ -1,0 +1,157 @@
+package storage
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+func TestDB_ProcessHistory_SaveAndQuery(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	db, err := Open(dbPath, logger)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	procs := []internal.ProcessInfo{
+		{PID: 100, User: "root", CPU: 50.0, Mem: 20.0, Command: "/usr/bin/python3 server.py"},
+		{PID: 200, User: "www", CPU: 30.0, Mem: 10.0, Command: "nginx: master process"},
+		{PID: 300, User: "nobody", CPU: 10.0, Mem: 5.0, Command: "/usr/sbin/sshd"},
+	}
+
+	if err := db.SaveProcessStats(procs); err != nil {
+		t.Fatalf("SaveProcessStats: %v", err)
+	}
+
+	history, err := db.GetProcessHistory(1) // last 1 hour
+	if err != nil {
+		t.Fatalf("GetProcessHistory: %v", err)
+	}
+
+	if len(history) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(history))
+	}
+
+	// Should be ordered by name ASC, then timestamp ASC.
+	// nginx: < python3 < sshd
+	expectedNames := []string{"nginx:", "python3", "sshd"}
+	for i, name := range expectedNames {
+		if history[i].Name != name {
+			t.Errorf("row %d: expected name=%q, got %q", i, name, history[i].Name)
+		}
+	}
+
+	// Verify specific fields for python3.
+	var python ProcessHistoryPoint
+	for _, h := range history {
+		if h.Name == "python3" {
+			python = h
+			break
+		}
+	}
+	if python.PID != 100 {
+		t.Errorf("expected PID 100, got %d", python.PID)
+	}
+	if python.User != "root" {
+		t.Errorf("expected user root, got %s", python.User)
+	}
+	if python.CPUPct != 50.0 {
+		t.Errorf("expected CPU 50.0, got %f", python.CPUPct)
+	}
+	if python.MemPct != 20.0 {
+		t.Errorf("expected Mem 20.0, got %f", python.MemPct)
+	}
+	if python.Command != "/usr/bin/python3 server.py" {
+		t.Errorf("expected full command preserved, got %s", python.Command)
+	}
+}
+
+func TestDB_ProcessHistory_SkipsEmptyName(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	db, err := Open(dbPath, logger)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	procs := []internal.ProcessInfo{
+		{PID: 1, User: "root", CPU: 1.0, Mem: 1.0, Command: ""},     // empty command → skip
+		{PID: 2, User: "root", CPU: 2.0, Mem: 2.0, Command: "bash"}, // valid
+	}
+
+	if err := db.SaveProcessStats(procs); err != nil {
+		t.Fatalf("SaveProcessStats: %v", err)
+	}
+
+	history, err := db.GetProcessHistory(1)
+	if err != nil {
+		t.Fatalf("GetProcessHistory: %v", err)
+	}
+
+	if len(history) != 1 {
+		t.Fatalf("expected 1 row (empty-name skipped), got %d", len(history))
+	}
+	if history[0].Name != "bash" {
+		t.Errorf("expected name=bash, got %s", history[0].Name)
+	}
+}
+
+func TestDB_ProcessHistory_EmptyInput(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	db, err := Open(dbPath, logger)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	// Nil and empty slices should not error.
+	if err := db.SaveProcessStats(nil); err != nil {
+		t.Fatalf("SaveProcessStats(nil): %v", err)
+	}
+	if err := db.SaveProcessStats([]internal.ProcessInfo{}); err != nil {
+		t.Fatalf("SaveProcessStats([]): %v", err)
+	}
+
+	history, err := db.GetProcessHistory(1)
+	if err != nil {
+		t.Fatalf("GetProcessHistory: %v", err)
+	}
+	if len(history) != 0 {
+		t.Errorf("expected 0 rows, got %d", len(history))
+	}
+}
+
+func TestProcessName(t *testing.T) {
+	tests := []struct {
+		command string
+		want    string
+	}{
+		{"/usr/bin/python3 app.py", "python3"},
+		{"nginx: worker process", "nginx:"},
+		{"/usr/sbin/sshd -D", "sshd"},
+		{"bash", "bash"},
+		{"/bin/sh", "sh"},
+		{"", ""},
+		{"   ", ""},
+	}
+
+	for _, tc := range tests {
+		got := processName(tc.command)
+		if got != tc.want {
+			t.Errorf("processName(%q) = %q, want %q", tc.command, got, tc.want)
+		}
+	}
+}

--- a/internal/storage/fake.go
+++ b/internal/storage/fake.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -38,6 +39,9 @@ type FakeStore struct {
 
 	// Alert suppression: fingerprint → reason (e.g., "acknowledged", "snoozed").
 	suppressedAlerts map[string]string
+
+	// Process history.
+	processHistory []ProcessHistoryPoint
 
 	// Finding history keyed by category.
 	findingsByCategory map[string][]internal.Finding
@@ -407,6 +411,65 @@ func (f *FakeStore) SaveContainerStats(_ *internal.DockerInfo) error {
 func (f *FakeStore) GetContainerHistory(_ int) ([]ContainerHistoryPoint, error) {
 	// TODO: implement for testing
 	return nil, nil
+}
+
+func (f *FakeStore) SaveProcessStats(procs []internal.ProcessInfo) error {
+	if len(procs) == 0 {
+		return nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	now := time.Now()
+	for _, p := range procs {
+		name := extractProcessName(p.Command)
+		if name == "" {
+			continue
+		}
+		f.processHistory = append(f.processHistory, ProcessHistoryPoint{
+			Timestamp: now,
+			PID:       p.PID,
+			User:      p.User,
+			Name:      name,
+			Command:   p.Command,
+			CPUPct:    p.CPU,
+			MemPct:    p.Mem,
+		})
+	}
+	return nil
+}
+
+func (f *FakeStore) GetProcessHistory(_ int) ([]ProcessHistoryPoint, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	// Return a copy sorted by name ASC, container_name ASC, timestamp ASC.
+	out := make([]ProcessHistoryPoint, len(f.processHistory))
+	copy(out, f.processHistory)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		if out[i].ContainerName != out[j].ContainerName {
+			return out[i].ContainerName < out[j].ContainerName
+		}
+		return out[i].Timestamp.Before(out[j].Timestamp)
+	})
+	return out, nil
+}
+
+// extractProcessName extracts a short name from a command string (same logic as processName in db.go).
+func extractProcessName(command string) string {
+	if command == "" {
+		return ""
+	}
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return ""
+	}
+	exe := fields[0]
+	if idx := strings.LastIndex(exe, "/"); idx >= 0 && idx < len(exe)-1 {
+		exe = exe[idx+1:]
+	}
+	return exe
 }
 
 func (f *FakeStore) SaveSpeedTest(_ string, _ *internal.SpeedTestResult) error {

--- a/internal/storage/fake_test.go
+++ b/internal/storage/fake_test.go
@@ -264,6 +264,105 @@ func TestFakeStore_DeleteServiceCheckByKey(t *testing.T) {
 	}
 }
 
+func TestFakeStore_SaveAndGetProcessStats(t *testing.T) {
+	store := NewFakeStore()
+
+	procs := []internal.ProcessInfo{
+		{PID: 1001, User: "root", CPU: 25.0, Mem: 10.0, Command: "/usr/bin/python3 app.py"},
+		{PID: 1002, User: "www", CPU: 15.0, Mem: 5.0, Command: "nginx: worker process"},
+		{PID: 1003, User: "nobody", CPU: 5.0, Mem: 2.0, Command: "/usr/sbin/sshd -D"},
+	}
+
+	if err := store.SaveProcessStats(procs); err != nil {
+		t.Fatalf("SaveProcessStats: %v", err)
+	}
+
+	history, err := store.GetProcessHistory(1) // last 1 hour
+	if err != nil {
+		t.Fatalf("GetProcessHistory: %v", err)
+	}
+	if len(history) != 3 {
+		t.Fatalf("expected 3 process history points, got %d", len(history))
+	}
+
+	// Verify results are sorted by name ASC.
+	names := make([]string, len(history))
+	for i, h := range history {
+		names[i] = h.Name
+	}
+	if names[0] != "nginx:" || names[1] != "python3" || names[2] != "sshd" {
+		t.Errorf("unexpected name order: %v", names)
+	}
+
+	// Verify content of the python3 entry.
+	var python ProcessHistoryPoint
+	for _, h := range history {
+		if h.Name == "python3" {
+			python = h
+			break
+		}
+	}
+	if python.PID != 1001 {
+		t.Errorf("expected PID 1001, got %d", python.PID)
+	}
+	if python.User != "root" {
+		t.Errorf("expected user root, got %s", python.User)
+	}
+	if python.CPUPct != 25.0 {
+		t.Errorf("expected CPU 25.0, got %f", python.CPUPct)
+	}
+	if python.MemPct != 10.0 {
+		t.Errorf("expected Mem 10.0, got %f", python.MemPct)
+	}
+	if python.Command != "/usr/bin/python3 app.py" {
+		t.Errorf("expected full command, got %s", python.Command)
+	}
+}
+
+func TestFakeStore_SaveProcessStats_SkipsEmptyCommand(t *testing.T) {
+	store := NewFakeStore()
+
+	procs := []internal.ProcessInfo{
+		{PID: 1, User: "root", CPU: 1.0, Mem: 1.0, Command: ""},
+		{PID: 2, User: "root", CPU: 2.0, Mem: 2.0, Command: "valid-process"},
+	}
+
+	if err := store.SaveProcessStats(procs); err != nil {
+		t.Fatalf("SaveProcessStats: %v", err)
+	}
+
+	history, err := store.GetProcessHistory(1)
+	if err != nil {
+		t.Fatalf("GetProcessHistory: %v", err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("expected 1 process (empty command skipped), got %d", len(history))
+	}
+	if history[0].Name != "valid-process" {
+		t.Errorf("expected valid-process, got %s", history[0].Name)
+	}
+}
+
+func TestFakeStore_SaveProcessStats_Empty(t *testing.T) {
+	store := NewFakeStore()
+
+	// Saving empty slice should not error.
+	if err := store.SaveProcessStats(nil); err != nil {
+		t.Fatalf("SaveProcessStats(nil): %v", err)
+	}
+	if err := store.SaveProcessStats([]internal.ProcessInfo{}); err != nil {
+		t.Fatalf("SaveProcessStats([]): %v", err)
+	}
+
+	history, err := store.GetProcessHistory(1)
+	if err != nil {
+		t.Fatalf("GetProcessHistory: %v", err)
+	}
+	if len(history) != 0 {
+		t.Errorf("expected 0 process history points, got %d", len(history))
+	}
+}
+
 func TestFakeStore_LifecycleMethods(t *testing.T) {
 	store := NewFakeStore()
 

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -59,6 +59,8 @@ type HistoryStore interface {
 	GetGPUHistory(hours int) ([]GPUHistoryPoint, error)
 	SaveContainerStats(docker *internal.DockerInfo) error
 	GetContainerHistory(hours int) ([]ContainerHistoryPoint, error)
+	SaveProcessStats(procs []internal.ProcessInfo) error
+	GetProcessHistory(hours int) ([]ProcessHistoryPoint, error)
 	SaveSpeedTest(snapshotID string, result *internal.SpeedTestResult) error
 	GetSpeedTestHistory(hours int) ([]SpeedTestHistoryPoint, error)
 }


### PR DESCRIPTION
Closes #107

## Summary
- Add `ContainerName` and `ContainerID` fields to `ProcessInfo` struct
- Implement cgroup parser supporting both **cgroup v1** (Unraid: `/docker/<id>`) and **cgroup v2** (TrueNAS SCALE: `docker-<id>.scope`)
- Enrich top processes with container attribution by reading `/proc/PID/cgroup` and prefix-matching against Docker container short IDs
- Wire enrichment into `Collect()` as a post-processing step after Docker collection

## Key design decisions
- **Separated pure parsing from I/O**: `parseContainerIDFromCgroup(content string)` is a pure function that takes cgroup file content as a string — fully testable without filesystem access. `extractContainerID(pid, procRoot)` handles the I/O layer with an injectable proc root for testing.
- **Post-processing enrichment**: Rather than changing `collectSystem()`'s signature, container attribution runs as a post-processing step in `Collect()` after Docker data is available. This mirrors the existing SMART→Unraid array slot enrichment pattern.
- **Prefix matching for short IDs**: Docker `ps` returns 12-char short IDs, but cgroup paths contain full 64-char hex IDs. `enrichProcessContainers()` uses `strings.HasPrefix` to match.
- **Graceful degradation**: Missing `/proc/PID/cgroup` (macOS), non-container processes, and unknown container IDs all result in empty strings — no errors, no panics.

## Tests added (15 total)
- `TestParseContainerIDFromCgroup` — 9 table-driven subtests (v1, v2, multi-line, non-container, empty, kernel, nested, containerd, compose)
- `TestExtractContainerID` — 3 subtests using temp dir as fake /proc (container process, non-container, nonexistent PID)
- `TestBuildContainerIDMap` — validates ID→name map construction and empty-ID filtering
- `TestEnrichProcessContainers` — end-to-end enrichment with fake proc filesystem (container, host, missing cgroup)

## Files changed
- `internal/models.go` — Added `ContainerName`, `ContainerID` to `ProcessInfo`
- `internal/collector/system.go` — Added `parseContainerIDFromCgroup()`, `extractHexID()`, `extractContainerID()`, `buildContainerIDMap()`, `enrichProcessContainers()`
- `internal/collector/collector.go` — Wired enrichment after Docker collection
- `internal/collector/system_test.go` — New file with 15 tests