### PR TITLE
feat(scheduler): collect process stats every 5min in scheduler loop

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -217,3 +217,24 @@ func (c *Collector) CollectDockerStats() (*internal.DockerInfo, error) {
 	}
 	return &info, nil
 }
+
+// CollectTopProcesses returns the top n processes by CPU usage.
+// Used by the scheduler's process stats loop for standalone collection.
+func (c *Collector) CollectTopProcesses(n int) []internal.ProcessInfo {
+	return collectTopProcesses(n)
+}
+
+// EnrichProcessContainers populates ContainerID and ContainerName on each
+// ProcessInfo by reading cgroup data and matching against known containers.
+// procRoot allows overriding the /proc filesystem root for testing (pass ""
+// for the default "/proc").
+func EnrichProcessContainers(procs []internal.ProcessInfo, containers []internal.ContainerInfo, procRoot string) {
+	if len(procs) == 0 || len(containers) == 0 {
+		return
+	}
+	containerIDMap := buildContainerIDMap(containers)
+	if procRoot == "" {
+		procRoot = "/proc"
+	}
+	enrichProcessContainers(procs, containerIDMap, procRoot)
+}

--- a/internal/collector/system_test.go
+++ b/internal/collector/system_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -148,6 +149,64 @@ func TestBuildContainerIDMap(t *testing.T) {
 	}
 	if _, ok := m[""]; ok {
 		t.Error("empty ID should not be in the map")
+	}
+}
+
+func TestCollectTopProcesses_Exported(t *testing.T) {
+	// The exported CollectTopProcesses method should delegate to collectTopProcesses.
+	// On macOS/CI where ps output may differ, we just verify it returns a non-nil
+	// slice and respects the limit.
+	c := New(internal.HostPaths{}, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	procs := c.CollectTopProcesses(5)
+	// On any platform with at least 1 process, we should get results
+	if procs == nil {
+		t.Fatal("CollectTopProcesses returned nil")
+	}
+	if len(procs) > 5 {
+		t.Errorf("CollectTopProcesses(5) returned %d processes, want <= 5", len(procs))
+	}
+}
+
+func TestEnrichProcessContainers_Exported(t *testing.T) {
+	// Create fake proc filesystem
+	tmpDir := t.TempDir()
+	fullID := "abc123def456789abc123def456789abc123def456789abc123def456789abcd"
+
+	pid10Dir := filepath.Join(tmpDir, "10")
+	if err := os.MkdirAll(pid10Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pid10Dir, "cgroup"),
+		[]byte("12:devices:/docker/"+fullID+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	procs := []internal.ProcessInfo{
+		{PID: 10, User: "root", CPU: 25.0, Mem: 10.0, Command: "nginx"},
+	}
+	containers := []internal.ContainerInfo{
+		{ID: "abc123def456", Name: "my-nginx"},
+	}
+
+	// Use the exported function
+	EnrichProcessContainers(procs, containers, tmpDir)
+
+	if procs[0].ContainerID != fullID {
+		t.Errorf("ContainerID = %q, want %q", procs[0].ContainerID, fullID)
+	}
+	if procs[0].ContainerName != "my-nginx" {
+		t.Errorf("ContainerName = %q, want %q", procs[0].ContainerName, "my-nginx")
+	}
+}
+
+func TestEnrichProcessContainers_Exported_NilContainers(t *testing.T) {
+	// Passing empty containers should be a no-op (no panic)
+	procs := []internal.ProcessInfo{
+		{PID: 10, Command: "test"},
+	}
+	EnrichProcessContainers(procs, nil, "/proc")
+	if procs[0].ContainerID != "" {
+		t.Errorf("ContainerID should remain empty, got %q", procs[0].ContainerID)
 	}
 }
 

--- a/internal/scheduler/process_stats_test.go
+++ b/internal/scheduler/process_stats_test.go
@@ -1,0 +1,132 @@
+package scheduler
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/collector"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// newTestScheduler creates a minimal Scheduler suitable for unit tests.
+// It uses a real Collector (which calls ps/proc) and a FakeStore.
+func newTestScheduler() (*Scheduler, *storage.FakeStore) {
+	store := storage.NewFakeStore()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	col := collector.New(internal.HostPaths{}, logger)
+
+	s := New(col, store, nil, nil, logger, 0)
+	return s, store
+}
+
+func TestCollectProcessStats_SavesProcessesToStore(t *testing.T) {
+	s, store := newTestScheduler()
+
+	// Seed a cached snapshot so collectProcessStats has somewhere to update
+	s.latest = &internal.Snapshot{
+		System: internal.SystemInfo{},
+		Docker: internal.DockerInfo{Available: false},
+	}
+
+	s.collectProcessStats()
+
+	// Verify process history was saved to the store
+	history, err := store.GetProcessHistory(1)
+	if err != nil {
+		t.Fatalf("GetProcessHistory failed: %v", err)
+	}
+	if len(history) == 0 {
+		t.Fatal("expected process history entries after collectProcessStats, got 0")
+	}
+	// At least one process should have a non-empty name
+	foundNamed := false
+	for _, p := range history {
+		if p.Name != "" {
+			foundNamed = true
+			break
+		}
+	}
+	if !foundNamed {
+		t.Error("expected at least one process with a non-empty name")
+	}
+}
+
+func TestCollectProcessStats_UpdatesCachedSnapshot(t *testing.T) {
+	s, _ := newTestScheduler()
+
+	// Seed a cached snapshot with empty TopProcesses
+	s.latest = &internal.Snapshot{
+		System: internal.SystemInfo{TopProcesses: nil},
+		Docker: internal.DockerInfo{Available: false},
+	}
+
+	s.collectProcessStats()
+
+	s.mu.RLock()
+	procs := s.latest.System.TopProcesses
+	s.mu.RUnlock()
+
+	if len(procs) == 0 {
+		t.Fatal("expected cached TopProcesses to be updated, got empty")
+	}
+}
+
+func TestCollectProcessStats_NilLatest_NoPanic(t *testing.T) {
+	s, _ := newTestScheduler()
+
+	// latest is nil — collectProcessStats should handle gracefully
+	s.latest = nil
+
+	// Should not panic
+	s.collectProcessStats()
+}
+
+func TestCollectProcessStats_RespectsLimit(t *testing.T) {
+	s, _ := newTestScheduler()
+
+	s.latest = &internal.Snapshot{
+		System: internal.SystemInfo{},
+		Docker: internal.DockerInfo{Available: false},
+	}
+
+	s.collectProcessStats()
+
+	s.mu.RLock()
+	procs := s.latest.System.TopProcesses
+	s.mu.RUnlock()
+
+	// The implementation should collect at most 15 processes
+	if len(procs) > 15 {
+		t.Errorf("expected at most 15 processes, got %d", len(procs))
+	}
+}
+
+func TestCollectProcessStats_UsesContainerData(t *testing.T) {
+	s, _ := newTestScheduler()
+
+	// Seed a cached snapshot with Docker containers available
+	// (container attribution won't actually match any real process on the
+	// test host, but we verify the code path doesn't panic)
+	s.latest = &internal.Snapshot{
+		System: internal.SystemInfo{},
+		Docker: internal.DockerInfo{
+			Available: true,
+			Containers: []internal.ContainerInfo{
+				{ID: "abc123def456", Name: "test-container"},
+			},
+		},
+	}
+
+	// Should not panic even though no processes will match
+	s.collectProcessStats()
+
+	s.mu.RLock()
+	procs := s.latest.System.TopProcesses
+	s.mu.RUnlock()
+
+	if len(procs) == 0 {
+		t.Fatal("expected some processes even when no container matches")
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -176,8 +176,9 @@ func (s *Scheduler) Start() {
 		}
 	}()
 
-	// Independent container stats loop — collects Docker metrics every 5 minutes
-	// for chart history (full scans happen every 6h which is too infrequent for charts)
+	// Independent container & process stats loop — collects Docker metrics and
+	// top processes every 5 minutes for chart history (full scans happen at the
+	// configured interval which is too infrequent for granular charts).
 	go func() {
 		time.Sleep(30 * time.Second) // let first scan finish
 		ticker := time.NewTicker(5 * time.Minute)
@@ -186,6 +187,7 @@ func (s *Scheduler) Start() {
 			select {
 			case <-ticker.C:
 				s.collectContainerStats()
+				s.collectProcessStats()
 			case <-s.stop:
 				return
 			}
@@ -332,6 +334,15 @@ func (s *Scheduler) RunOnce() {
 	// Store
 	if err := s.store.SaveSnapshot(snap); err != nil {
 		s.logger.Error("failed to save snapshot", "error", err)
+	}
+
+	// Also persist process stats to the dedicated history table (same data
+	// that the 5-minute loop collects, but captured during full scans too
+	// so there are no gaps in the chart timeline).
+	if len(snap.System.TopProcesses) > 0 {
+		if err := s.store.SaveProcessStats(snap.System.TopProcesses); err != nil {
+			s.logger.Warn("failed to save process stats during full scan", "error", err)
+		}
 	}
 
 	// Update Prometheus metrics
@@ -762,6 +773,41 @@ func (s *Scheduler) collectContainerStats() {
 	s.mu.Lock()
 	if s.latest != nil {
 		s.latest.Docker = *docker
+	}
+	s.mu.Unlock()
+}
+
+// collectProcessStats runs a lightweight top-processes collection and saves to DB.
+// This runs every 5 minutes alongside collectContainerStats to provide enough
+// data points for the process resource usage charts.
+func (s *Scheduler) collectProcessStats() {
+	procs := s.collector.CollectTopProcesses(15)
+	if len(procs) == 0 {
+		return
+	}
+
+	// Enrich with container attribution from cached Docker data
+	s.mu.RLock()
+	var containers []internal.ContainerInfo
+	if s.latest != nil && s.latest.Docker.Available {
+		containers = s.latest.Docker.Containers
+	}
+	s.mu.RUnlock()
+
+	if len(containers) > 0 {
+		collector.EnrichProcessContainers(procs, containers, "")
+	}
+
+	// Persist to process_history table
+	if err := s.store.SaveProcessStats(procs); err != nil {
+		s.logger.Warn("failed to save process stats", "error", err)
+		return
+	}
+
+	// Update cached snapshot with fresh process data
+	s.mu.Lock()
+	if s.latest != nil {
+		s.latest.System.TopProcesses = procs
 	}
 	s.mu.Unlock()
 }


### PR DESCRIPTION
Closes #109

## Summary
- **Export collector methods**: Added `CollectTopProcesses(n int)` on `Collector` and package-level `EnrichProcessContainers()` for standalone process collection with container attribution
- **Add `collectProcessStats()` to scheduler**: Collects top 15 processes by CPU, enriches with container names from cached Docker data, persists to `process_history` table, and updates cached snapshot
- **Wire into 5-minute loop**: Process collection runs alongside container stats every 5 minutes in the existing goroutine
- **Full scan persistence**: Process stats from `RunOnce()` also saved to `process_history` so chart timelines have no gaps

## Changes
| File | Change |
|---|---|
| `internal/collector/collector.go` | Export `CollectTopProcesses()` method and `EnrichProcessContainers()` function |
| `internal/collector/system_test.go` | +3 tests for exported methods (limit enforcement, attribution, nil safety) |
| `internal/scheduler/scheduler.go` | Add `collectProcessStats()`, wire into 5-min loop, add `SaveProcessStats` in `RunOnce()` |
| `internal/scheduler/process_stats_test.go` | +5 tests covering persistence, cache update, nil safety, limit, container path |

## Tests
- 8 new tests (3 collector + 5 scheduler), all passing
- Full test suite green (`go test ./...`)
- Build verified (`go build ./...`)