### PR TITLE
feat(dashboard): add Top Processes section with container tags

### DIFF
--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -72,6 +72,7 @@ type DashboardSections struct {
 	MergedDrives     bool `json:"merged_drives"`     // Combine SMART + storage into one card per drive
 	Backup           bool `json:"backup"`
 	SpeedTest        bool `json:"speed_test"`
+	Processes        bool `json:"processes"`
 	DashColumns      int  `json:"dash_columns"` // Dashboard column count: 0=auto (default 2), 1, 2, 3, 4
 }
 

--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -1011,6 +1011,58 @@ sections.kubernetes = function(sn) {
   return h;
 };
 
+/* ── Section: Processes ───────────────────────────────────────── */
+sections.processes = function(sn) {
+  var esc = util.esc;
+  var h = '';
+  h += '<div class="section-block" data-section="processes">';
+  var procs = (sn && sn.system && sn.system.top_processes) ? sn.system.top_processes : [];
+  if (procs.length > 0) {
+    var showCount = Math.min(procs.length, 10);
+    h += '<div>';
+    h += '<div class="section-title">Top Processes (' + procs.length + ')</div>';
+    h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);overflow:hidden">';
+    h += '<table style="width:100%;font-size:12px;border-collapse:collapse">';
+    h += '<tr style="color:var(--text-quaternary);font-size:10px;text-transform:uppercase;letter-spacing:0.5px">';
+    h += '<th style="text-align:left;padding:6px 8px;border-bottom:1px solid var(--border);width:28px">#</th>';
+    h += '<th style="text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)">Process</th>';
+    h += '<th style="text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)">Container</th>';
+    h += '<th style="text-align:right;padding:6px 8px;border-bottom:1px solid var(--border)">CPU%</th>';
+    h += '<th style="text-align:right;padding:6px 8px;border-bottom:1px solid var(--border)">Mem%</th>';
+    h += '<th style="text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)">User</th>';
+    h += '</tr>';
+    for (var pi = 0; pi < showCount; pi++) {
+      var p = procs[pi];
+      var cpuClass = p.cpu_percent >= 50 ? 'td-crit' : p.cpu_percent >= 20 ? 'td-warn' : '';
+      var memClass = p.mem_percent >= 50 ? 'td-crit' : p.mem_percent >= 20 ? 'td-warn' : '';
+      var containerTag = '';
+      if (p.container_name) {
+        containerTag = '<span style="display:inline-block;font-size:10px;padding:1px 6px;border-radius:999px;background:rgba(94,106,210,0.15);color:var(--accent);white-space:nowrap">' + esc(p.container_name) + '</span>';
+      } else {
+        containerTag = '<span style="display:inline-block;font-size:10px;padding:1px 6px;border-radius:999px;background:rgba(128,128,128,0.12);color:var(--text-quaternary);white-space:nowrap">host</span>';
+      }
+      var cmdDisplay = esc(p.command || '');
+      if (cmdDisplay.length > 40) cmdDisplay = cmdDisplay.substring(0, 40) + '\u2026';
+      h += '<tr>';
+      h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border);color:var(--text-quaternary)">' + (pi + 1) + '</td>';
+      h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border)"><div style="font-weight:500;max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="' + esc(p.command || '') + '">' + cmdDisplay + '</div></td>';
+      h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border)">' + containerTag + '</td>';
+      h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border);text-align:right;font-family:var(--font-mono);font-size:11px" class="' + cpuClass + '">' + (p.cpu_percent || 0).toFixed(1) + '</td>';
+      h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border);text-align:right;font-family:var(--font-mono);font-size:11px" class="' + memClass + '">' + (p.mem_percent || 0).toFixed(1) + '</td>';
+      h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border);color:var(--text-tertiary);font-size:11px">' + esc(p.user || '') + '</td>';
+      h += '</tr>';
+    }
+    h += '</table>';
+    h += '</div>';
+    if (procs.length > showCount) {
+      h += '<div style="text-align:center;padding:6px 0;font-size:11px;color:var(--text-quaternary)">' + (procs.length - showCount) + ' more processes not shown</div>';
+    }
+    h += '</div>';
+  }
+  h += '</div>';
+  return h;
+};
+
 /* ── Section: Parity ─────────────────────────────────────────── */
 sections.parity = function(sn) {
   var esc = util.esc;
@@ -1321,6 +1373,7 @@ function distributeSections() {
     "ups": sec.ups !== false,
     "backup": sec.backup !== false,
     "services": true,
+    "processes": sec.processes !== false,
     "network": sec.network !== false,
     "speedtest": sec.speedtest !== false,
     "tunnels": sec.tunnels !== false,

--- a/internal/api/dashboard_processes_test.go
+++ b/internal/api/dashboard_processes_test.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDashboardJSContainsProcessesSection verifies that the shared dashboard JS
+// module includes a sections.processes renderer function.
+func TestDashboardJSContainsProcessesSection(t *testing.T) {
+	js := DashboardJS
+
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		{"renderer function defined", "sections.processes = function(sn)"},
+		{"data-section attribute", `data-section="processes"`},
+		{"reads top_processes", "sn.system.top_processes"},
+		{"section title", "Top Processes ("},
+		{"CPU column header", "CPU%"},
+		{"Mem column header", "Mem%"},
+		{"container column", "Container"},
+		{"user column", "User"},
+		{"host badge for non-container procs", ">host</span>"},
+		{"container name badge styling", "container_name"},
+	}
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(js, tc.substr) {
+				t.Errorf("DashboardJS missing %q — expected substring: %q", tc.name, tc.substr)
+			}
+		})
+	}
+}
+
+// TestDashboardJSSectionMapIncludesProcesses verifies the sectionMap in
+// distributeSections() includes the processes entry.
+func TestDashboardJSSectionMapIncludesProcesses(t *testing.T) {
+	js := DashboardJS
+	if !strings.Contains(js, `"processes": sec.processes !== false`) {
+		t.Error("sectionMap in DashboardJS missing processes entry")
+	}
+}
+
+// TestDashboardSectionsProcessesField verifies the DashboardSections struct
+// serializes the processes field correctly.
+func TestDashboardSectionsProcessesField(t *testing.T) {
+	// Default: processes is false (Go zero value)
+	sec := DashboardSections{}
+	b, err := json.Marshal(sec)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if _, ok := m["processes"]; !ok {
+		t.Error("DashboardSections JSON missing 'processes' field")
+	}
+
+	// When set to true
+	sec.Processes = true
+	b, _ = json.Marshal(sec)
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if v, ok := m["processes"]; !ok || v != true {
+		t.Errorf("expected processes=true, got %v", v)
+	}
+}
+
+// TestThemeTemplatesIncludeProcessesSection verifies both midnight.html and
+// clean.html call sec.processes(sn) in their staging area.
+func TestThemeTemplatesIncludeProcessesSection(t *testing.T) {
+	templates := []string{"midnight.html", "clean.html"}
+	for _, tmpl := range templates {
+		t.Run(tmpl, func(t *testing.T) {
+			path := filepath.Join("templates", tmpl)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("failed to read %s: %v", path, err)
+			}
+			content := string(data)
+			if !strings.Contains(content, "sec.processes(sn)") {
+				t.Errorf("%s missing sec.processes(sn) call in staging area", tmpl)
+			}
+		})
+	}
+}
+
+// TestSettingsHTMLIncludesProcessesToggle verifies settings.html has the
+// processes section toggle and save/load wiring.
+func TestSettingsHTMLIncludesProcessesToggle(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read settings.html: %v", err)
+	}
+	content := string(data)
+
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		{"toggle element", `id="sec-processes"`},
+		{"secIds mapping", `"processes":"sec-processes"`},
+		{"save payload", `processes: document.getElementById("sec-processes").classList.contains("on")`},
+	}
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(content, tc.substr) {
+				t.Errorf("settings.html missing %q — expected: %q", tc.name, tc.substr)
+			}
+		})
+	}
+}

--- a/internal/api/templates/clean.html
+++ b/internal/api/templates/clean.html
@@ -409,6 +409,7 @@ tbody tr:hover{background:rgba(0,0,0,0.03)}
     h += sec.network(sn);
     h += sec.speedtest(sn);
     h += sec.serviceChecks(sn);
+    h += sec.processes(sn);
     h += sec.tunnels(sn);
     h += sec.proxmox(sn);
     h += sec.kubernetes(sn);

--- a/internal/api/templates/midnight.html
+++ b/internal/api/templates/midnight.html
@@ -353,6 +353,7 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
     h += sec.network(sn);
     h += sec.speedtest(sn);
     h += sec.serviceChecks(sn);
+    h += sec.processes(sn);
     h += sec.tunnels(sn);
     h += sec.proxmox(sn);
     h += sec.kubernetes(sn);

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -728,6 +728,7 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
       <div class="toggle-wrap"><div class="toggle on" id="sec-kubernetes" onclick="this.classList.toggle('on');saveSettings()"><div class="toggle-knob"></div></div><span class="toggle-label">Kubernetes</span></div>
       <div class="toggle-wrap"><div class="toggle on" id="sec-backup" onclick="this.classList.toggle('on');saveSettings()"><div class="toggle-knob"></div></div><span class="toggle-label">Backup Monitoring</span></div>
       <div class="toggle-wrap"><div class="toggle on" id="sec-speedtest" onclick="this.classList.toggle('on');saveSettings()"><div class="toggle-knob"></div></div><span class="toggle-label">Speed Test</span></div>
+      <div class="toggle-wrap"><div class="toggle on" id="sec-processes" onclick="this.classList.toggle('on');saveSettings()"><div class="toggle-knob"></div></div><span class="toggle-label">Top Processes</span></div>
       <div style="margin-top:12px;padding-top:12px;border-top:1px solid var(--border)">
         <div class="toggle-wrap"><div class="toggle on" id="sec-merged-containers" onclick="this.classList.toggle('on');saveSettings()"><div class="toggle-knob"></div></div><span class="toggle-label">Merged Container View <span style="font-size:11px;color:var(--text2)">(combine Docker list + resource metrics into one section)</span></span></div>
         <div class="toggle-wrap" style="margin-top:8px"><div class="toggle on" id="sec-merged-drives" onclick="this.classList.toggle('on');saveSettings()"><div class="toggle-knob"></div></div><span class="toggle-label">Merged Drive View <span style="font-size:11px;color:var(--text2)">(combine SMART + storage into one card per drive)</span></span></div>
@@ -1128,8 +1129,8 @@ function loadSettings() {
       renderServiceChecks();
       /* Dashboard section toggles */
       var sec = data.sections || {};
-      var secMap = {findings:1,disk_space:1,smart:1,docker:1,container_metrics:1,zfs:1,ups:1,parity:1,network:1,tunnels:1,proxmox:1,kubernetes:1,backup:1,speedtest:1,merged_containers:1,merged_drives:1,dash_columns:1};
-      var secIds = {"findings":"sec-findings","disk_space":"sec-disk","smart":"sec-smart","docker":"sec-docker","container_metrics":"sec-container-metrics","zfs":"sec-zfs","gpu":"sec-gpu","ups":"sec-ups","parity":"sec-parity","network":"sec-network","tunnels":"sec-tunnels","proxmox":"sec-proxmox","kubernetes":"sec-kubernetes","backup":"sec-backup","speedtest":"sec-speedtest","merged_containers":"sec-merged-containers","merged_drives":"sec-merged-drives","dash_columns":"sec-dash-columns"};
+      var secMap = {findings:1,disk_space:1,smart:1,docker:1,container_metrics:1,zfs:1,ups:1,parity:1,network:1,tunnels:1,proxmox:1,kubernetes:1,backup:1,speedtest:1,processes:1,merged_containers:1,merged_drives:1,dash_columns:1};
+      var secIds = {"findings":"sec-findings","disk_space":"sec-disk","smart":"sec-smart","docker":"sec-docker","container_metrics":"sec-container-metrics","zfs":"sec-zfs","gpu":"sec-gpu","ups":"sec-ups","parity":"sec-parity","network":"sec-network","tunnels":"sec-tunnels","proxmox":"sec-proxmox","kubernetes":"sec-kubernetes","backup":"sec-backup","speedtest":"sec-speedtest","processes":"sec-processes","merged_containers":"sec-merged-containers","merged_drives":"sec-merged-drives","dash_columns":"sec-dash-columns"};
       for (var sk in secIds) { var el = document.getElementById(secIds[sk]); if (el) { if (sec[sk] === false) el.classList.remove("on"); else el.classList.add("on"); } }
       var dashColsSel = document.getElementById("sec-dash-columns");
       if (dashColsSel && sec.dash_columns !== undefined) dashColsSel.value = sec.dash_columns || 0;
@@ -1218,6 +1219,7 @@ function buildSettingsPayload() {
       kubernetes: document.getElementById("sec-kubernetes").classList.contains("on"),
       backup: document.getElementById("sec-backup").classList.contains("on"),
       speedtest: document.getElementById("sec-speedtest").classList.contains("on"),
+      processes: document.getElementById("sec-processes").classList.contains("on"),
       merged_drives: document.getElementById("sec-merged-drives").classList.contains("on"),
       dash_columns: parseInt(document.getElementById("sec-dash-columns").value) || 0
     },


### PR DESCRIPTION
Closes #110

## Summary
- Adds a new **Top Processes** dashboard section that displays the top 10 processes sorted by CPU usage
- Container processes show an accent-colored badge with the container name; host processes show a grey "host" badge
- CPU% and Mem% columns use warning (≥20%) and critical (≥50%) color thresholds

## Changes
- **`internal/api/dashboard.go`**: New `sections.processes()` renderer with table layout matching the service checks pattern; added `"processes"` to `sectionMap` in `distributeSections()`
- **`internal/api/api_extended.go`**: Added `Processes bool` field to `DashboardSections` struct
- **`internal/api/templates/midnight.html`**: Added `sec.processes(sn)` to staging area
- **`internal/api/templates/clean.html`**: Added `sec.processes(sn)` to staging area
- **`internal/api/templates/settings.html`**: Added visibility toggle, secMap/secIds entries, and save payload field
- **`internal/api/dashboard_processes_test.go`**: 16 test assertions covering renderer content, sectionMap, struct serialization, theme templates, and settings wiring

## Test count
- **16 new test assertions** across 5 test functions
- All existing tests continue to pass
- `go build ./...` clean