### PR TITLE
feat(rules): add process alert rule category

### DIFF
--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -354,6 +354,7 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
               <option value="system">System</option>
               <option value="zfs">ZFS</option>
               <option value="tunnels">Tunnels</option>
+              <option value="process">Process</option>
               <option value="update">Platform Update</option>
             </select>
           </div>
@@ -1437,7 +1438,7 @@ function testRule() {
   var ruleName = (document.getElementById("nr-name") || {}).value || "Unnamed rule";
 
   // Map category to a Finding category constant
-  var catMap = {findings:"system",disk_space:"disk",disk_temp:"smart",smart:"smart",service:"service",parity:"parity",ups:"ups",docker:"docker",system:"system",zfs:"zfs",tunnels:"network",update:"system"};
+  var catMap = {findings:"system",disk_space:"disk",disk_temp:"smart",smart:"smart",service:"service",parity:"parity",ups:"ups",docker:"docker",system:"system",zfs:"zfs",tunnels:"network",process:"system",update:"system"};
   var findingCat = catMap[cat] || "system";
 
   // Build a severity based on the condition
@@ -1470,8 +1471,8 @@ function testRule() {
     battery_below: "UPS battery low — " + (val || "20") + "%",
     load_above: "Load above threshold — " + (val || "80") + "%",
     stopped: "Container stopped: " + targetLabel,
-    cpu_above: "CPU usage high — " + (val || "90") + "%",
-    mem_above: "Memory usage high — " + (val || "90") + "%",
+    cpu_above: cat === "process" ? "High CPU: " + targetLabel + " — " + (val || "80") + "%" : "CPU usage high — " + (val || "90") + "%",
+    mem_above: cat === "process" ? "High memory: " + targetLabel + " — " + (val || "80") + "%" : "Memory usage high — " + (val || "90") + "%",
     iowait_above: "I/O wait high — " + (val || "20") + "%",
     degraded_pool: "ZFS pool degraded: " + targetLabel,
     scrub_errors: "ZFS scrub errors on " + targetLabel,
@@ -2363,6 +2364,7 @@ var CONDITION_MAP = {
   system:     [{v:"cpu_above",l:"CPU above %"},{v:"mem_above",l:"Memory above %"},{v:"load_above",l:"Load average above"},{v:"iowait_above",l:"I/O wait above %"}],
   zfs:        [{v:"degraded",l:"Pool degraded"},{v:"scrub_errors",l:"Scrub errors detected"},{v:"usage_above",l:"Pool usage above %"}],
   tunnels:    [{v:"cloudflared_down",l:"Cloudflared tunnel down"},{v:"tailscale_offline",l:"Tailscale node offline"}],
+  process:    [{v:"cpu_above",l:"CPU usage above %"},{v:"mem_above",l:"Memory usage above %"}],
   update:     [{v:"available",l:"Platform update available"}]
 };
 var NEEDS_VALUE = {free_below:1,above:1,avg_above:1,reallocated_above:1,pending_above:1,crc_above:1,power_hours_above:1,latency_above:1,speed_below:1,battery_below:1,load_above:1,cpu_above:1,mem_above:1,iowait_above:1,usage_above:1,download_below:1,upload_below:1};
@@ -2521,6 +2523,16 @@ function populateTargetDropdown(cat) {
   } else if (cat === "tunnels" && sn.tunnels) {
     if (sn.tunnels.cloudflared) { for (var i = 0; i < sn.tunnels.cloudflared.tunnels.length; i++) { var t = sn.tunnels.cloudflared.tunnels[i]; sel.innerHTML += '<option value="' + escapeHtml(t.name) + '">' + escapeHtml("CF: " + t.name) + '</option>'; } }
     if (sn.tunnels.tailscale && sn.tunnels.tailscale.peers) { for (var i = 0; i < sn.tunnels.tailscale.peers.length; i++) { var nd = sn.tunnels.tailscale.peers[i]; sel.innerHTML += '<option value="' + escapeHtml(nd.name) + '">' + escapeHtml("TS: " + nd.name) + '</option>'; } }
+  } else if (cat === "process" && sn.system && sn.system.top_processes) {
+    var seen = {};
+    for (var i = 0; i < sn.system.top_processes.length; i++) {
+      var p = sn.system.top_processes[i];
+      var pName = (p.command || "").split(" ")[0].split("/").pop();
+      if (!pName || seen[pName]) continue;
+      seen[pName] = true;
+      var label = pName + (p.container_name ? " (" + p.container_name + ")" : "");
+      sel.innerHTML += '<option value="' + escapeHtml(pName) + '">' + escapeHtml(label) + '</option>';
+    }
   } else if (cat === "findings") {
     // For "category" condition, target = finding category
     var cats = ["system","disk","smart","docker","network","service","memory","thermal","logs","parity","zfs","ups"];

--- a/internal/scheduler/rules.go
+++ b/internal/scheduler/rules.go
@@ -44,6 +44,8 @@ func evaluateRule(rule internal.NotificationRule, snap *internal.Snapshot) []int
 		return evalTunnels(cond, target, snap.Tunnels)
 	case "update":
 		return evalUpdate(snap.Update)
+	case "process":
+		return evalProcess(cond, target, val, snap)
 	}
 	return nil
 }
@@ -375,6 +377,62 @@ func evalUpdate(update *internal.UpdateInfo) []internal.Finding {
 			"Platform update available", fmt.Sprintf("%s → %s", update.InstalledVersion, update.LatestVersion))}
 	}
 	return nil
+}
+
+func evalProcess(cond, target string, val float64, snap *internal.Snapshot) []internal.Finding {
+	if val <= 0 {
+		return nil
+	}
+	procs := snap.System.TopProcesses
+	if len(procs) == 0 {
+		return nil
+	}
+	var out []internal.Finding
+	for _, proc := range procs {
+		// Extract the short process name (basename of command).
+		name := processName(proc.Command)
+
+		// Target filtering: if target is set, only match that process name.
+		if target != "" && !strings.EqualFold(target, name) {
+			continue
+		}
+
+		containerLabel := proc.ContainerName
+		if containerLabel == "" {
+			containerLabel = "host"
+		}
+		processKey := name + ":" + proc.ContainerName
+
+		switch cond {
+		case "cpu_above":
+			if proc.CPU > val {
+				out = append(out, synth("rule:process-cpu:"+processKey, internal.SeverityWarning, internal.CategorySystem,
+					fmt.Sprintf("High CPU: %s (%s)", name, containerLabel),
+					fmt.Sprintf("Process %s is using %.1f%% CPU (threshold: %.0f%%)", name, proc.CPU, val)))
+			}
+		case "mem_above":
+			if proc.Mem > val {
+				out = append(out, synth("rule:process-mem:"+processKey, internal.SeverityWarning, internal.CategorySystem,
+					fmt.Sprintf("High memory: %s (%s)", name, containerLabel),
+					fmt.Sprintf("Process %s is using %.1f%% memory (threshold: %.0f%%)", name, proc.Mem, val)))
+			}
+		}
+	}
+	return out
+}
+
+// processName extracts the short name from a command string.
+// e.g. "/usr/bin/python3 script.py" → "python3", "java -Xmx1g" → "java", "python" → "python"
+func processName(cmd string) string {
+	// Take only the first token (before any space / arguments).
+	if idx := strings.IndexByte(cmd, ' '); idx > 0 {
+		cmd = cmd[:idx]
+	}
+	// Take basename (after last /).
+	if idx := strings.LastIndexByte(cmd, '/'); idx >= 0 {
+		cmd = cmd[idx+1:]
+	}
+	return cmd
 }
 
 // -- Suppression helpers --

--- a/internal/scheduler/rules_test.go
+++ b/internal/scheduler/rules_test.go
@@ -1,0 +1,152 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+func TestEvalProcess(t *testing.T) {
+	tests := []struct {
+		name      string
+		cond      string
+		target    string
+		val       float64
+		procs     []internal.ProcessInfo
+		wantCount int
+		wantTitle string // if wantCount==1, check title substring
+	}{
+		{
+			name: "cpu_above_triggered",
+			cond: "cpu_above", target: "", val: 80,
+			procs: []internal.ProcessInfo{
+				{PID: 1, Command: "python", CPU: 95.0, Mem: 10.0, ContainerName: "home-assistant"},
+			},
+			wantCount: 1,
+			wantTitle: "High CPU: python",
+		},
+		{
+			name: "cpu_below_threshold_no_finding",
+			cond: "cpu_above", target: "", val: 80,
+			procs: []internal.ProcessInfo{
+				{PID: 1, Command: "python", CPU: 50.0, Mem: 10.0},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "mem_above_triggered",
+			cond: "mem_above", target: "", val: 70,
+			procs: []internal.ProcessInfo{
+				{PID: 2, Command: "java", CPU: 10.0, Mem: 85.0, ContainerName: "minecraft"},
+			},
+			wantCount: 1,
+			wantTitle: "High memory: java",
+		},
+		{
+			name: "target_filter_matches",
+			cond: "cpu_above", target: "python", val: 50,
+			procs: []internal.ProcessInfo{
+				{PID: 1, Command: "python", CPU: 90.0, Mem: 10.0},
+				{PID: 2, Command: "java", CPU: 95.0, Mem: 10.0}, // higher CPU but wrong name
+			},
+			wantCount: 1,
+			wantTitle: "High CPU: python",
+		},
+		{
+			name: "target_empty_checks_all",
+			cond: "cpu_above", target: "", val: 50,
+			procs: []internal.ProcessInfo{
+				{PID: 1, Command: "python", CPU: 90.0, Mem: 10.0},
+				{PID: 2, Command: "java", CPU: 60.0, Mem: 10.0},
+				{PID: 3, Command: "nginx", CPU: 30.0, Mem: 10.0}, // below threshold
+			},
+			wantCount: 2,
+		},
+		{
+			name: "no_processes_no_findings",
+			cond: "cpu_above", target: "", val: 50,
+			procs:     nil,
+			wantCount: 0,
+		},
+		{
+			name: "host_process_label",
+			cond: "cpu_above", target: "", val: 50,
+			procs: []internal.ProcessInfo{
+				{PID: 1, Command: "python", CPU: 90.0, Mem: 10.0, ContainerName: ""},
+			},
+			wantCount: 1,
+			wantTitle: "High CPU: python (host)",
+		},
+		{
+			name: "container_label_in_title",
+			cond: "mem_above", target: "", val: 50,
+			procs: []internal.ProcessInfo{
+				{PID: 1, Command: "node", CPU: 10.0, Mem: 75.0, ContainerName: "grafana"},
+			},
+			wantCount: 1,
+			wantTitle: "High memory: node (grafana)",
+		},
+		{
+			name: "target_filter_case_insensitive",
+			cond: "cpu_above", target: "Python", val: 50,
+			procs: []internal.ProcessInfo{
+				{PID: 1, Command: "python", CPU: 90.0, Mem: 10.0},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "unknown_condition_no_findings",
+			cond: "disk_above", target: "", val: 50,
+			procs: []internal.ProcessInfo{
+				{PID: 1, Command: "python", CPU: 90.0, Mem: 90.0},
+			},
+			wantCount: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			snap := &internal.Snapshot{
+				System: internal.SystemInfo{
+					TopProcesses: tc.procs,
+				},
+			}
+			findings := evalProcess(tc.cond, tc.target, tc.val, snap)
+			if len(findings) != tc.wantCount {
+				t.Fatalf("expected %d findings, got %d: %+v", tc.wantCount, len(findings), findings)
+			}
+			if tc.wantCount == 1 && tc.wantTitle != "" {
+				if findings[0].Title != tc.wantTitle {
+					t.Errorf("expected title %q, got %q", tc.wantTitle, findings[0].Title)
+				}
+			}
+		})
+	}
+}
+
+// TestEvaluateRule_ProcessCategory verifies the top-level evaluateRule dispatch
+// routes "process" category to evalProcess.
+func TestEvaluateRule_ProcessCategory(t *testing.T) {
+	rule := internal.NotificationRule{
+		ID:        "test-1",
+		Name:      "High CPU process",
+		Enabled:   true,
+		Category:  "process",
+		Condition: "cpu_above",
+		Value:     "80",
+	}
+	snap := &internal.Snapshot{
+		System: internal.SystemInfo{
+			TopProcesses: []internal.ProcessInfo{
+				{PID: 1, Command: "ffmpeg", CPU: 95.0, Mem: 5.0, ContainerName: "plex"},
+			},
+		},
+	}
+	findings := evaluateRule(rule, snap)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding from evaluateRule with process category, got %d", len(findings))
+	}
+	if findings[0].Category != internal.CategorySystem {
+		t.Errorf("expected category %q, got %q", internal.CategorySystem, findings[0].Category)
+	}
+}

--- a/internal/scheduler/rules_test.go
+++ b/internal/scheduler/rules_test.go
@@ -23,7 +23,7 @@ func TestEvalProcess(t *testing.T) {
 				{PID: 1, Command: "python", CPU: 95.0, Mem: 10.0, ContainerName: "home-assistant"},
 			},
 			wantCount: 1,
-			wantTitle: "High CPU: python",
+			wantTitle: "High CPU: python (home-assistant)",
 		},
 		{
 			name: "cpu_below_threshold_no_finding",
@@ -40,7 +40,7 @@ func TestEvalProcess(t *testing.T) {
 				{PID: 2, Command: "java", CPU: 10.0, Mem: 85.0, ContainerName: "minecraft"},
 			},
 			wantCount: 1,
-			wantTitle: "High memory: java",
+			wantTitle: "High memory: java (minecraft)",
 		},
 		{
 			name: "target_filter_matches",
@@ -50,7 +50,7 @@ func TestEvalProcess(t *testing.T) {
 				{PID: 2, Command: "java", CPU: 95.0, Mem: 10.0}, // higher CPU but wrong name
 			},
 			wantCount: 1,
-			wantTitle: "High CPU: python",
+			wantTitle: "High CPU: python (host)",
 		},
 		{
 			name: "target_empty_checks_all",


### PR DESCRIPTION
Closes #112

## Summary
- Add `process` category to `evaluateRule()` in `rules.go` with `evalProcess()` implementation
- Support `cpu_above` and `mem_above` conditions that check `System.TopProcesses` in the snapshot
- Optional target filtering by process name (case-insensitive); empty target checks all processes
- Findings include container label ("host" if not in a container) for context
- Add "Process" to settings.html notification rule builder with conditions, target dropdown, and test webhook support

## Changes

### `internal/scheduler/rules.go`
- New `case "process"` in `evaluateRule()` switch
- `evalProcess(cond, target string, val float64, snap *internal.Snapshot)` — evaluates CPU/memory thresholds against top processes
- `processName(cmd string)` helper — extracts short name from command path (e.g., `/usr/bin/python3 script.py` → `python3`)

### `internal/scheduler/rules_test.go` (new file)
- 10 table-driven tests for `evalProcess()` covering: threshold triggering, no-trigger, target filtering, empty target (all processes), no processes, host vs container labels, case-insensitive matching, unknown conditions
- 1 integration test for `evaluateRule()` dispatch to process category

### `internal/api/templates/settings.html`
- "Process" option in category `<select>`
- `CONDITION_MAP.process` with `cpu_above` and `mem_above`
- `populateTargetDropdown()` populates process names from snapshot
- Finding category mapping and test webhook titles for process rules

## Test count
11 new tests added, all passing. Full scheduler test suite (77 tests) green.

## Notes
- The issue mentions consecutive detection (3 snapshots / 15 min sustained), but this requires a storage query against `process_history` which depends on #109 landing. The current implementation does single-snapshot threshold checking, which is the standard pattern for all other rule evaluators. Consecutive detection can be added as a follow-up once process_history storage is available.