### PR TITLE
feat(dashboard): click-through from processes section to stats history

### DIFF
--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -1020,7 +1020,7 @@ sections.processes = function(sn) {
   if (procs.length > 0) {
     var showCount = Math.min(procs.length, 10);
     h += '<div>';
-    h += '<div class="section-title">Top Processes (' + procs.length + ')</div>';
+    h += '<div class="section-title" style="display:flex;align-items:center;justify-content:space-between"><span>Top Processes (' + procs.length + ')</span><a href="/stats#process-history" style="font-size:11px;color:var(--text-quaternary);text-decoration:none;font-weight:400;margin-left:16px;white-space:nowrap">View history &rarr;</a></div>';
     h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);overflow:hidden">';
     h += '<table style="width:100%;font-size:12px;border-collapse:collapse">';
     h += '<tr style="color:var(--text-quaternary);font-size:10px;text-transform:uppercase;letter-spacing:0.5px">';

--- a/internal/api/templates/stats.html
+++ b/internal/api/templates/stats.html
@@ -478,7 +478,7 @@ fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d
     ranked.sort(function(a, b) { return b.total - a.total; });
     ranked = ranked.slice(0, 8);
     if (ranked.length === 0) return '';
-    var h = '<div class="system-section"><div class="system-section-title">Process CPU History (top ' + ranked.length + ' by cumulative CPU)</div>';
+    var h = '<div class="system-section" id="process-history"><div class="system-section-title">Process CPU History (top ' + ranked.length + ' by cumulative CPU)</div>';
     h += '<div class="chart-card"><div class="chart-label">CPU Usage (%) by Process</div>';
     h += '<canvas id="chart-process-cpu" width="600" height="200" style="width:100%;height:200px"></canvas></div>';
     // Legend


### PR DESCRIPTION
Adds a 'View history →' link in the Top Processes section header that navigates to /stats#process-history, scrolling directly to the process CPU history chart.