### PR TITLE
fix(demo): serve dashboard.js + process history + remove ember capture

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -59,7 +59,6 @@ jobs:
           mkdir -p demo-worker/captured/_pages demo-worker/captured/api
           curl -sf http://localhost:8060/ -o demo-worker/captured/_pages/midnight.html
           curl -sf http://localhost:8060/theme/clean -o demo-worker/captured/_pages/clean.html
-          curl -sf http://localhost:8060/theme/ember -o demo-worker/captured/_pages/ember.html
           curl -sf http://localhost:8060/settings -o demo-worker/captured/_pages/settings.html
           curl -sf http://localhost:8060/alerts -o demo-worker/captured/_pages/alerts.html
           curl -sf http://localhost:8060/fleet -o demo-worker/captured/_pages/fleet.html
@@ -70,6 +69,7 @@ jobs:
 
           # Capture static assets
           curl -sf http://localhost:8060/js/charts.js -o demo-worker/captured/charts.js
+          curl -sf http://localhost:8060/js/dashboard.js -o demo-worker/captured/dashboard.js
           curl -sf http://localhost:8060/css/shared.css -o demo-worker/captured/shared.css
 
           # Capture ALL API responses (these seed the KV namespace)
@@ -80,6 +80,7 @@ jobs:
           curl -sf 'http://localhost:8060/api/v1/history/gpu?hours=24' -o demo-worker/captured/api/gpu_history.json
           curl -sf 'http://localhost:8060/api/v1/history/containers?hours=24' -o demo-worker/captured/api/container_history.json
           curl -sf http://localhost:8060/api/v1/history/system -o demo-worker/captured/api/system_history.json
+          curl -sf 'http://localhost:8060/api/v1/history/processes?hours=24' -o demo-worker/captured/api/process_history.json
           curl -sf http://localhost:8060/api/v1/alerts -o demo-worker/captured/api/alerts.json
           curl -sf http://localhost:8060/api/v1/service-checks -o demo-worker/captured/api/service_checks.json
           curl -sf http://localhost:8060/api/v1/fleet -o demo-worker/captured/api/fleet.json

--- a/demo-worker/feeder/src/index.ts
+++ b/demo-worker/feeder/src/index.ts
@@ -20,7 +20,7 @@ type Platform = (typeof PLATFORMS)[number];
 const ENDPOINTS = [
   "status", "snapshot", "sparklines", "fleet", "service_checks",
   "alerts", "incidents", "notifications_log", "gpu_history",
-  "container_history", "system_history", "settings", "db_stats",
+  "container_history", "system_history", "process_history", "settings", "db_stats",
   "disks", "smart_trends", "replacement_plan", "capacity_forecast",
 ];
 
@@ -750,7 +750,7 @@ function refreshData(endpoint: string, data: unknown): unknown {
     case "sparklines": return refreshSparklines(data as Record<string, unknown>);
     case "fleet": return refreshFleet(data as unknown[]);
     case "service_checks": return refreshServiceChecks(data as unknown[]);
-    case "system_history": case "gpu_history": case "container_history": return refreshHistory(data as unknown[]);
+    case "system_history": case "gpu_history": case "container_history": case "process_history": return refreshHistory(data as unknown[]);
     default: return data;
   }
 }

--- a/demo-worker/src/index.ts
+++ b/demo-worker/src/index.ts
@@ -82,6 +82,10 @@ export default {
       const t = await fetchAsset(env, url, request, "charts.js");
       if (t !== null) return new Response(t, { headers: { "Content-Type": "application/javascript", "Cache-Control": "public, max-age=3600" } });
     }
+    if (path === "/js/dashboard.js") {
+      const t = await fetchAsset(env, url, request, "dashboard.js");
+      if (t !== null) return new Response(t, { headers: { "Content-Type": "application/javascript", "Cache-Control": "public, max-age=3600" } });
+    }
     if (path === "/css/shared.css") {
       const t = await fetchAsset(env, url, request, "shared.css");
       if (t !== null) return new Response(t, { headers: { "Content-Type": "text/css", "Cache-Control": "public, max-age=3600" } });
@@ -124,6 +128,7 @@ async function handleAPI(path: string, url: URL, platform: Platform, env: Env): 
     "/api/v1/history/gpu": "gpu_history",
     "/api/v1/history/containers": "container_history",
     "/api/v1/history/system": "system_history",
+    "/api/v1/history/processes": "process_history",
     "/api/v1/alerts": "alerts",
     "/api/v1/service-checks": "service_checks",
     "/api/v1/service-checks/history": "service_checks", // reuse full list as history


### PR DESCRIPTION
The demo site was broken because the Worker didn't serve /js/dashboard.js (added in the hardening sprint). Also adds process_history API route and CI capture, and removes the stale ember page capture.