### PR TITLE
fix: process history timestamps + demo deploy trigger

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -1,14 +1,9 @@
 name: Deploy Demo Worker
 
 on:
-  release:
-    types: [published]
   push:
-    branches: [main]
-    paths:
-      - 'demo-worker/**'
-      - 'internal/api/templates/**'
-      - '.github/workflows/demo-deploy.yml'
+    tags:
+      - 'latest'
   workflow_dispatch:
 
 env:

--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -252,7 +252,7 @@ func main() {
 					p.Mem = 0.1
 				}
 			}
-			if err := store.SaveProcessStats(procSnap.System.TopProcesses); err != nil {
+			if err := store.SaveProcessStatsAt(procSnap.System.TopProcesses, ts); err != nil {
 				logger.Warn("failed to save demo process history", "m", m, "error", err)
 			}
 		}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -600,14 +600,19 @@ func processName(command string) string {
 	return exe
 }
 
-// SaveProcessStats saves a standalone process stats snapshot.
-// Used by the lightweight process stats collection loop (similar to SaveContainerStats).
+// SaveProcessStats saves a standalone process stats snapshot at the current time.
 func (d *DB) SaveProcessStats(procs []internal.ProcessInfo) error {
+	return d.SaveProcessStatsAt(procs, time.Now())
+}
+
+// SaveProcessStatsAt saves a standalone process stats snapshot at the given timestamp.
+// Used by the lightweight process stats collection loop (similar to SaveContainerStats)
+// and by demo mode for seeding historical data.
+func (d *DB) SaveProcessStatsAt(procs []internal.ProcessInfo, ts time.Time) error {
 	if len(procs) == 0 {
 		return nil
 	}
-	now := time.Now()
-	snapshotID := fmt.Sprintf("pstats-%d", now.UnixMilli())
+	snapshotID := fmt.Sprintf("pstats-%d", ts.UnixMilli())
 	for _, p := range procs {
 		name := processName(p.Command)
 		if name == "" {
@@ -616,7 +621,7 @@ func (d *DB) SaveProcessStats(procs []internal.ProcessInfo) error {
 		_, err := d.db.Exec(
 			`INSERT INTO process_history (snapshot_id, pid, user, name, command, container_name, container_id, cpu_pct, mem_pct, timestamp)
 			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			snapshotID, p.PID, p.User, name, p.Command, "", "", p.CPU, p.Mem, now,
+			snapshotID, p.PID, p.User, name, p.Command, p.ContainerName, p.ContainerID, p.CPU, p.Mem, ts,
 		)
 		if err != nil {
 			return err

--- a/internal/storage/fake.go
+++ b/internal/storage/fake.go
@@ -414,25 +414,30 @@ func (f *FakeStore) GetContainerHistory(_ int) ([]ContainerHistoryPoint, error) 
 }
 
 func (f *FakeStore) SaveProcessStats(procs []internal.ProcessInfo) error {
+	return f.SaveProcessStatsAt(procs, time.Now())
+}
+
+func (f *FakeStore) SaveProcessStatsAt(procs []internal.ProcessInfo, ts time.Time) error {
 	if len(procs) == 0 {
 		return nil
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	now := time.Now()
 	for _, p := range procs {
 		name := extractProcessName(p.Command)
 		if name == "" {
 			continue
 		}
 		f.processHistory = append(f.processHistory, ProcessHistoryPoint{
-			Timestamp: now,
-			PID:       p.PID,
-			User:      p.User,
-			Name:      name,
-			Command:   p.Command,
-			CPUPct:    p.CPU,
-			MemPct:    p.Mem,
+			Timestamp:     ts,
+			PID:           p.PID,
+			User:          p.User,
+			Name:          name,
+			Command:       p.Command,
+			ContainerName: p.ContainerName,
+			ContainerID:   p.ContainerID,
+			CPUPct:        p.CPU,
+			MemPct:        p.Mem,
 		})
 	}
 	return nil

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -60,6 +60,7 @@ type HistoryStore interface {
 	SaveContainerStats(docker *internal.DockerInfo) error
 	GetContainerHistory(hours int) ([]ContainerHistoryPoint, error)
 	SaveProcessStats(procs []internal.ProcessInfo) error
+	SaveProcessStatsAt(procs []internal.ProcessInfo, ts time.Time) error
 	GetProcessHistory(hours int) ([]ProcessHistoryPoint, error)
 	SaveSpeedTest(snapshotID string, result *internal.SpeedTestResult) error
 	GetSpeedTestHistory(hours int) ([]SpeedTestHistoryPoint, error)


### PR DESCRIPTION
Fixes two bugs:
1. **Process history timestamps**: SaveProcessStats hardcoded time.Now(), so demo seeding created 576 rows all with the same timestamp. Added SaveProcessStatsAt() that accepts a timestamp. Also fixed empty container_name/container_id fields.
2. **Demo deploy trigger**: Changed from deploying on every push to main (path-filtered) to only deploying when the 'latest' tag is pushed or manually triggered.