### PR TITLE
fix(unraid): port change actually works — switch Web UI Port to Type=Variable (#128)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,10 @@ ENV NAS_DOCTOR_LISTEN=":8060" \
 
 EXPOSE 8060
 
+# Port-aware healthcheck: derives the port from NAS_DOCTOR_LISTEN so setting
+# the env var (e.g. ":8067", "8067", "0.0.0.0:8067") keeps the healthcheck
+# aligned with the actual listen address. Falls back to 8060 if unset/empty.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8060/api/v1/health || exit 1
+    CMD sh -c 'P="${NAS_DOCTOR_LISTEN##*:}"; P="${P:-8060}"; wget -q --tries=1 --spider "http://localhost:${P}/api/v1/health"' || exit 1
 
 ENTRYPOINT ["/app/nas-doctor"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ LABEL org.opencontainers.image.title="NAS Doctor" \
       org.opencontainers.image.vendor="mcdays94" \
       org.opencontainers.image.licenses="MIT" \
       net.unraid.docker.icon="https://raw.githubusercontent.com/mcdays94/nas-doctor/main/icons/icon3.png" \
-      net.unraid.docker.webui="http://[IP]:[PORT:8060]/" \
+      net.unraid.docker.webui="http://[IP]:8060/" \
       net.unraid.docker.managed="dockerman"
 
 COPY --from=builder /nas-doctor /app/nas-doctor

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Then open `http://your-nas:8060`. See platform-specific sections below for Unrai
 | **Name** | `nas-doctor` |
 | **Repository** | `ghcr.io/mcdays94/nas-doctor:latest` |
 | **Icon URL** | `https://raw.githubusercontent.com/mcdays94/nas-doctor/main/icons/icon3.png` |
-| **WebUI** | `http://[IP]:[PORT:8060]/` |
+| **WebUI** | `http://[IP]:8060/` (if you change the listen port below, update this to match) |
 | **Network Type** | `Host` |
 | **Privileged** | `On` (**required** — SMART access needs raw device access) |
 | **Extra Parameters** | `--pid=host` (**required** for Top Processes to see host processes) |
@@ -271,17 +271,20 @@ Then open `http://your-nas:8060`. See platform-specific sections below for Unrai
 | Device Nodes | `/dev` | `/dev` | RO | SMART and GPU device access |
 | Sysfs | `/sys` | `/sys` | RO | GPU telemetry and drive mapping |
 
-4. Add this **variable**:
+4. Add these **variables**:
 
 | Key | Value |
 |---|---|
 | `TZ` | Your timezone (e.g. `Europe/Lisbon`, `America/New_York`) |
+| `NAS_DOCTOR_LISTEN` | HTTP listen address, default `:8060`. Change to e.g. `:8067` if port 8060 is in use (the container runs in host networking, so this is how the port is set). |
 
 5. Click **Apply**
 
-Then open `http://your-unraid-ip:8060`.
+Then open `http://your-unraid-ip:8060` (or whichever port you set).
 
 > **Important**: Privileged mode and the Host Mounts volume (`/mnt:/host/mnt:ro`) are required. Without privileged, SMART data won't work. Without `/mnt`, per-disk space won't show.
+>
+> **Changing the port**: Because the container uses host networking, the "Web UI Port" field in the template sets `NAS_DOCTOR_LISTEN` (not a Docker port mapping). If you change it, also update the WebUI URL in Unraid (container settings → Advanced View → WebUI) so the icon opens the right port.
 
 ### Synology DSM — Container Manager
 

--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -43,7 +44,7 @@ var version = "dev"
 
 func main() {
 	// Flags
-	listenAddr := flag.String("listen", envOr("NAS_DOCTOR_LISTEN", ":8060"), "HTTP listen address")
+	listenAddr := flag.String("listen", normalizeListenAddr(envOr("NAS_DOCTOR_LISTEN", ":8060")), "HTTP listen address")
 	dataDir := flag.String("data", envOr("NAS_DOCTOR_DATA", "/tmp/nas-doctor-data"), "Data directory for SQLite DB")
 	intervalStr := flag.String("interval", envOr("NAS_DOCTOR_INTERVAL", "30m"), "Diagnostic scan interval")
 	configPath := flag.String("config", envOr("NAS_DOCTOR_CONFIG", ""), "Path to JSON config file")
@@ -472,6 +473,25 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// normalizeListenAddr accepts a listen address in either "port" (e.g. "8067"),
+// ":port" (e.g. ":8067"), or "host:port" (e.g. "0.0.0.0:8067", "[::1]:8060")
+// form and returns a form accepted by net.Listen. Bare port numbers are
+// prefixed with ":" so users who type "8067" into the Unraid template's
+// NAS_DOCTOR_LISTEN variable still get a working config.
+//
+// Empty input is returned unchanged so callers see the empty value and can
+// fall back to their own default.
+func normalizeListenAddr(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return s
+	}
+	if !strings.Contains(s, ":") {
+		return ":" + s
+	}
+	return s
 }
 
 func countSev(findings []internal.Finding, sev internal.Severity) int {

--- a/cmd/nas-doctor/main_test.go
+++ b/cmd/nas-doctor/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import "testing"
+
+// TestNormalizeListenAddr verifies the listen address normalization accepts
+// both bare port numbers (e.g. "8067") and full address forms (e.g. ":8067",
+// "0.0.0.0:8067"). This exists to reduce footguns for Unraid template users
+// who type a bare port number into the NAS_DOCTOR_LISTEN variable.
+func TestNormalizeListenAddr(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare port gets colon prefix", "8067", ":8067"},
+		{"colon-prefixed port unchanged", ":8067", ":8067"},
+		{"host:port unchanged", "0.0.0.0:8067", "0.0.0.0:8067"},
+		{"default port unchanged", ":8060", ":8060"},
+		{"ipv6-like host:port unchanged", "[::1]:8060", "[::1]:8060"},
+		{"empty string unchanged", "", ""},
+		{"whitespace is trimmed then normalized", "  8067  ", ":8067"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := normalizeListenAddr(c.in)
+			if got != c.want {
+				t.Errorf("normalizeListenAddr(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/unraid-template.xml
+++ b/unraid-template.xml
@@ -40,7 +40,7 @@ Features:
   <DonateText>Buy Me a Coffee</DonateText>
   <DonateLink>https://buymeacoffee.com/miguelcaetanodias</DonateLink>
   <Requires/>
-  <Config Name="Web UI Port" Target="8060" Default="8060" Mode="tcp" Description="Web dashboard and API port" Type="Port" Display="always" Required="true" Mask="false">8060</Config>
+  <Config Name="Web UI Port" Target="NAS_DOCTOR_LISTEN" Default=":8060" Mode="" Description="HTTP listen address (host networking). Change to e.g. :8067 to avoid port conflicts. If you type a bare number like 8067, it will be normalized to :8067 automatically. After changing, update the WebUI URL (container settings, Advanced View) to match." Type="Variable" Display="always" Required="true" Mask="false">:8060</Config>
   <Config Name="Data Directory" Target="/data" Default="/mnt/user/appdata/nas-doctor" Mode="rw" Description="Persistent data (SQLite database, config, backups)" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/nas-doctor</Config>
   <Config Name="Docker Socket" Target="/var/run/docker.sock" Default="/var/run/docker.sock" Mode="ro" Description="Docker socket for container monitoring" Type="Path" Display="always" Required="true" Mask="false">/var/run/docker.sock</Config>
   <Config Name="Emhttp Status" Target="/var/local/emhttp" Default="/var/local/emhttp" Mode="ro" Description="Unraid emhttp status (required for merged drive view)" Type="Path" Display="always" Required="true" Mask="false">/var/local/emhttp</Config>


### PR DESCRIPTION
Closes #128.

## Root cause

The Unraid template declared `<Network>host</Network>` AND used `Type="Port"` for the "Web UI Port" field. In host networking mode, Docker silently ignores `-p host:container` mappings — so the user's input did nothing. The template also never set `NAS_DOCTOR_LISTEN`, so the binary stayed on `:8060` regardless of what was typed into "Web UI Port".

## Changes

- **`unraid-template.xml`** — "Web UI Port" is now `Type="Variable"` with `Target="NAS_DOCTOR_LISTEN"` and `Default=":8060"`. User input now actually drives the listener in host-networking mode.
- **`cmd/nas-doctor/main.go`** — added `normalizeListenAddr()` so users who type a bare `8067` get `:8067` automatically (net.Listen requires the `:port` form). IPv6 / `host:port` / empty pass through unchanged.
- **`cmd/nas-doctor/main_test.go`** — 7-case table-driven test for the normalizer.
- **`Dockerfile`** — `net.unraid.docker.webui` label was using the `[PORT:8060]` macro, which only works with `Type="Port"`. Replaced with a literal `http://[IP]:8060/`. Users who change the port need to update the WebUI URL manually (documented in README).
- **`README.md`** — added `NAS_DOCTOR_LISTEN` row to the Unraid Docker UI variables table and a note explaining how to change the port under host networking.

## Verification

- `go build ./...` — passes
- `go test ./...` — all green, including the new `TestNormalizeListenAddr` (7/7 subtests)
- `xmllint --noout unraid-template.xml` — valid

## Suggested reply to the user (for #128 once this ships)

> Thanks for the report — you found a real template bug. The container runs in host networking mode, so the "Web UI Port" field in the template wasn't actually reaching the binary.
>
> **If you need this now, before the next release:** in the Unraid template, click *Add another Path, Port, Variable…*, choose **Variable**, and add:
> - Key: `NAS_DOCTOR_LISTEN`
> - Value: `:8067` (or whichever free port you want)
>
> Then restart the container. After the next release, the "Web UI Port" field in the template will do this for you automatically. Tracked in #128 and fixed by this PR.
>
> Note that because the container uses host networking, you'll also need to edit the WebUI URL in the container's Advanced View to match your new port, so the "open WebUI" button goes to the right place.

## Follow-ups for maintainer

- **`mcdays94/docker-templates`** needs a separate push after merge — Unraid Community Apps pulls the template from there, not from this repo. Unraid CA users won't pick up the fix until that sibling repo is updated.
- **File-boundary flag**: #135's worker (not yet dispatched) will also edit `unraid-template.xml`. #135 *adds* a new Config block; this PR *modifies* an existing Config block (line 43). Merges should be clean but worth being aware of if #135 lands in parallel.