### PR TITLE
fix: API key generation works over plain HTTP

### DIFF
--- a/internal/api/settings_apikey_test.go
+++ b/internal/api/settings_apikey_test.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestSettingsHTML_GenerateAPIKey_HasSecureFallback verifies that
+// generateAPIKey() in settings.html does not unconditionally call
+// crypto.randomUUID() — which throws on non-secure contexts (plain HTTP
+// on LAN) — and instead falls back to crypto.getRandomValues(). See #126.
+func TestSettingsHTML_GenerateAPIKey_HasSecureFallback(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read settings.html: %v", err)
+	}
+	content := string(data)
+
+	// Must reference getRandomValues (the fallback for non-secure contexts)
+	if !strings.Contains(content, "crypto.getRandomValues") {
+		t.Error("generateAPIKey() must include a crypto.getRandomValues() fallback for non-secure contexts")
+	}
+
+	// Locate generateAPIKey() body and assert the guard is present
+	genRE := regexp.MustCompile(`(?s)function\s+generateAPIKey\s*\(\s*\)\s*\{(.*?)\n\}`)
+	m := genRE.FindStringSubmatch(content)
+	if len(m) < 2 {
+		t.Fatal("could not locate generateAPIKey() function body in settings.html")
+	}
+	body := m[1]
+
+	// randomUUID must not be called unconditionally — it must be guarded by a
+	// typeof check or a feature-detection conditional.
+	guardRE := regexp.MustCompile(`typeof\s+crypto\.randomUUID`)
+	if !guardRE.MatchString(body) {
+		t.Error("generateAPIKey() must guard crypto.randomUUID with a typeof check so it does not throw in non-secure contexts")
+	}
+
+	// The getRandomValues fallback must live inside the function body.
+	if !strings.Contains(body, "getRandomValues") {
+		t.Error("generateAPIKey() must contain the getRandomValues() fallback inside its body")
+	}
+}
+
+// TestSettingsHTML_CopyAPIKey_HasClipboardFallback verifies that
+// copyAPIKey() in settings.html has a fallback for browsers where
+// navigator.clipboard is unavailable (non-secure context). See #126.
+func TestSettingsHTML_CopyAPIKey_HasClipboardFallback(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read settings.html: %v", err)
+	}
+	content := string(data)
+
+	copyRE := regexp.MustCompile(`(?s)function\s+copyAPIKey\s*\(\s*\)\s*\{(.*?)\n\}`)
+	m := copyRE.FindStringSubmatch(content)
+	if len(m) < 2 {
+		t.Fatal("could not locate copyAPIKey() function body in settings.html")
+	}
+	body := m[1]
+
+	// Must guard navigator.clipboard access rather than calling it directly.
+	guardRE := regexp.MustCompile(`navigator\.clipboard\s*&&|typeof\s+navigator\.clipboard|typeof\s+navigator`)
+	if !guardRE.MatchString(body) {
+		t.Error("copyAPIKey() must guard navigator.clipboard with a conditional to handle non-secure contexts")
+	}
+
+	// The execCommand fallback can live in a helper — assert it exists
+	// somewhere in the template so the copy button still works over HTTP.
+	if !strings.Contains(content, "execCommand") {
+		t.Error("settings.html must contain a document.execCommand('copy') fallback for non-secure contexts")
+	}
+}

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -2665,7 +2665,27 @@ function toggleAPIKeyVisibility() {
   el.type = el.type === "password" ? "text" : "password";
 }
 function generateAPIKey() {
-  var key = 'nd-' + crypto.randomUUID().replace(/-/g, '');
+  // crypto.randomUUID() requires a secure context (HTTPS or localhost); it is
+  // undefined when NAS Doctor is served over plain HTTP on a LAN, which causes
+  // the button to silently do nothing. Fall back to crypto.getRandomValues(),
+  // which is available in non-secure contexts too. See issue #126.
+  var key;
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    try { key = 'nd-' + crypto.randomUUID().replace(/-/g, ''); } catch (e) { key = null; }
+  }
+  if (!key && typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+    var bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    var hex = "";
+    for (var i = 0; i < bytes.length; i++) {
+      hex += ("0" + bytes[i].toString(16)).slice(-2);
+    }
+    key = 'nd-' + hex;
+  }
+  if (!key) {
+    showToast("Your browser doesn't support secure random generation", "error");
+    return;
+  }
   document.getElementById("api-key-display").value = key;
   saveSettings();
   showToast("API key generated — save it somewhere safe", "success");
@@ -2673,7 +2693,36 @@ function generateAPIKey() {
 function copyAPIKey() {
   var el = document.getElementById("api-key-display");
   if (!el.value) { showToast("No API key to copy", "error"); return; }
-  navigator.clipboard.writeText(el.value).then(function() { showToast("Copied to clipboard", "success"); });
+  // navigator.clipboard also requires a secure context; fall back to the
+  // legacy execCommand('copy') path when it's unavailable. See issue #126.
+  if (typeof navigator !== "undefined" && navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+    navigator.clipboard.writeText(el.value).then(function() {
+      showToast("Copied to clipboard", "success");
+    }, function() {
+      fallbackCopyAPIKey(el);
+    });
+    return;
+  }
+  fallbackCopyAPIKey(el);
+}
+function fallbackCopyAPIKey(el) {
+  var prevType = el.type;
+  try {
+    el.type = "text";
+    el.focus();
+    el.select();
+    el.setSelectionRange(0, el.value.length);
+    var ok = false;
+    try { ok = document.execCommand("copy"); } catch (e) { ok = false; }
+    if (ok) {
+      showToast("Copied to clipboard", "success");
+    } else {
+      showToast("Copy failed — select the key and copy manually", "error");
+    }
+  } finally {
+    el.type = prevType;
+    if (typeof el.blur === "function") el.blur();
+  }
 }
 function revokeAPIKey() {
   if (!confirm("Revoke the API key? All fleet instances using this key will lose access.")) return;


### PR DESCRIPTION
Closes #126

## Root cause

`generateAPIKey()` in `internal/api/templates/settings.html` called `crypto.randomUUID()` unconditionally. That API (and `navigator.clipboard.writeText` used by `copyAPIKey()`) is only available in a **secure context** — HTTPS or `localhost`. When NAS Doctor is accessed over plain HTTP on a LAN (the default on Unraid, Synology, TrueNAS, etc.) those APIs are `undefined`, so clicking *Generate* or *Copy* threw silently and looked like the button did nothing.

## Fix

- `generateAPIKey()`: guard `crypto.randomUUID` with `typeof` and fall back to `crypto.getRandomValues()` (still cryptographically secure, available in all contexts, including plain HTTP).
- `copyAPIKey()`: guard `navigator.clipboard` and fall back to `document.execCommand('copy')` via a new `fallbackCopyAPIKey()` helper.
- Both paths surface a clear error toast if the browser supports neither API rather than failing silently.

## Tests

Added `internal/api/settings_apikey_test.go` with two template-presence tests asserting:
- `generateAPIKey()` body contains a `typeof crypto.randomUUID` guard and a `getRandomValues` fallback.
- `copyAPIKey()` guards `navigator.clipboard` and an `execCommand` fallback exists in the template.

RED → GREEN confirmed locally. `go build ./...` and `go test ./...` both pass.

## Scope

Single file behavior change in `internal/api/templates/settings.html` + one new test file. No Go runtime changes, no schema changes, no config changes.