### PR TITLE
fix(settings): add Cost per TB input widget (#131)

### DIFF
--- a/internal/api/settings_cost_per_tb_test.go
+++ b/internal/api/settings_cost_per_tb_test.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// newSettingsTestServer builds a minimal Server for exercising the settings
+// handlers against an in-memory FakeStore.
+func newSettingsTestServer() *Server {
+	return &Server{
+		store:     storage.NewFakeStore(),
+		logger:    slog.Default(),
+		version:   "test",
+		startTime: time.Now(),
+	}
+}
+
+// TestSettingsHTMLIncludesCostPerTBInput verifies the settings page template
+// contains the cost-per-TB input widget with proper load/save wiring.
+//
+// Regression for #131 — backend Settings.CostPerTB was wired in commit 2a3eb3e
+// but the UI input was never added, making the field unreachable from the app.
+func TestSettingsHTMLIncludesCostPerTBInput(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read settings.html: %v", err)
+	}
+	content := string(data)
+
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		{"input element", `id="cost-per-tb"`},
+		{"card anchor", `id="card-replacement-cost"`},
+		{"sidebar nav link", `href="#card-replacement-cost"`},
+		{"load from data", `data.cost_per_tb`},
+		{"save payload key", `cost_per_tb:`},
+	}
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(content, tc.substr) {
+				t.Errorf("settings.html missing %q — expected substring: %q", tc.name, tc.substr)
+			}
+		})
+	}
+}
+
+// TestSettings_CostPerTB_RoundTrip verifies the cost_per_tb setting is
+// persisted through a PUT/GET cycle against the real settings handlers.
+func TestSettings_CostPerTB_RoundTrip(t *testing.T) {
+	srv := newSettingsTestServer()
+
+	// PUT /api/v1/settings with cost_per_tb=22.5 and minimum valid fields
+	// (handleUpdateSettings requires scan_interval + theme).
+	putBody := map[string]interface{}{
+		"scan_interval": "30m",
+		"theme":         "midnight",
+		"cost_per_tb":   22.5,
+	}
+	buf, _ := json.Marshal(putBody)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(buf))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.handleUpdateSettings(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT /api/v1/settings returned %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// GET /api/v1/settings — cost_per_tb should round-trip.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	rec2 := httptest.NewRecorder()
+	srv.handleGetSettings(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/settings returned %d", rec2.Code)
+	}
+	body, _ := io.ReadAll(rec2.Body)
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("invalid JSON response: %v", err)
+	}
+	got, ok := parsed["cost_per_tb"].(float64)
+	if !ok {
+		t.Fatalf("cost_per_tb missing or wrong type in response: %v", parsed["cost_per_tb"])
+	}
+	if got != 22.5 {
+		t.Errorf("cost_per_tb round-trip: got %v, want 22.5", got)
+	}
+}

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -60,6 +60,7 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
     <a href="#card-fleet" class="btn btn-secondary btn-sm" style="text-decoration:none">Fleet</a>
     <a href="#card-sections" class="btn btn-secondary btn-sm" style="text-decoration:none">Dashboard</a>
     <a href="#card-retention" class="btn btn-secondary btn-sm" style="text-decoration:none">Data</a>
+    <a href="#card-replacement-cost" class="btn btn-secondary btn-sm" style="text-decoration:none">Replacement Cost</a>
     <a href="#card-speedtest" class="btn btn-secondary btn-sm" style="text-decoration:none">Speed Test</a>
     <a href="#card-backup" class="btn btn-secondary btn-sm" style="text-decoration:none">Backup</a>
   </div>
@@ -671,6 +672,23 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
     </div>
   </div>
 
+  <!-- 5b. Drive Replacement Cost -->
+  <div class="card" id="card-replacement-cost">
+    <div class="card-title">Drive Replacement Cost</div>
+    <div class="card-desc">Used by the <a href="/replacement-planner" style="color:var(--accent)">Replacement Planner</a> to estimate per-drive and fleet replacement costs. Leave at 0 to hide cost estimates.</div>
+    <div class="form-row">
+      <div>
+        <label for="cost-per-tb">Cost per TB</label>
+        <input type="number" id="cost-per-tb" min="0" max="10000" step="0.01" placeholder="e.g. 22.50" style="text-align:center">
+        <p style="font-size:11px;color:var(--text2);margin-top:4px">Enter the current market cost of HDD storage per terabyte, in your preferred currency. Applied uniformly across all drives.</p>
+      </div>
+      <div>
+        <label>&nbsp;</label>
+        <div style="font-size:12px;color:var(--text2);line-height:1.8;padding-top:8px">Example: at 22.50/TB, replacing a 12TB drive costs ~270.</div>
+      </div>
+    </div>
+  </div>
+
   <!-- 6. Fleet / Multi-Server -->
   <div class="card" id="card-fleet">
     <div class="card-title">Fleet Monitoring</div>
@@ -1137,6 +1155,9 @@ function loadSettings() {
       if (dashColsSel && sec.dash_columns !== undefined) dashColsSel.value = sec.dash_columns || 0;
       /* API Key */
       document.getElementById("api-key-display").value = data.api_key || "";
+      /* Drive replacement cost per TB */
+      var costEl = document.getElementById("cost-per-tb");
+      if (costEl) costEl.value = (data.cost_per_tb && data.cost_per_tb > 0) ? data.cost_per_tb : "";
       /* Proxmox VE */
       var pve = data.proxmox || {};
       if (pve.enabled) document.getElementById("pve-toggle").classList.add("on"); else document.getElementById("pve-toggle").classList.remove("on");
@@ -1247,7 +1268,8 @@ function buildSettingsPayload() {
     },
     api_key: document.getElementById("api-key-display").value.trim(),
     fleet: fleetServers || base.fleet || [],
-    dismissed_findings: base.dismissed_findings || []
+    dismissed_findings: base.dismissed_findings || [],
+    cost_per_tb: parseFloat(document.getElementById("cost-per-tb") && document.getElementById("cost-per-tb").value) || 0
   };
 }
 


### PR DESCRIPTION
Closes #131

## Summary

- Backend `Settings.CostPerTB` and the `/replacement-planner` consumer were fully wired in commit `2a3eb3e`, but the settings UI widget was never added. Users saw **"Set Cost per TB in Settings"** on the planner page with no way to actually set it.
- Adds a small **"Drive Replacement Cost"** card to `/settings` with a number input (`0–10000`, `step 0.01`), a sidebar nav link, and load/save JS wiring.
- Leaving the value at `0` keeps cost estimates hidden on the planner (pre-existing behavior via `CostConfigured`).

## Changes

- `internal/api/templates/settings.html`:
  - New `card-replacement-cost` card between Data (retention) and Fleet
  - Sidebar nav link **Replacement Cost**
  - `loadSettings()`: populates input from `data.cost_per_tb`
  - `buildSettingsPayload()`: sends `cost_per_tb` in the PUT payload
- `internal/api/settings_cost_per_tb_test.go` (new):
  - `TestSettingsHTMLIncludesCostPerTBInput` — template-presence assertions for the input, card anchor, nav link, and both load/save hooks
  - `TestSettings_CostPerTB_RoundTrip` — PUT then GET against the real settings handlers verifies the value persists

## Verification

- `go build ./...` ✅
- `go test ./...` ✅ (all existing + 2 new tests pass)
- README.md:111 already claims the feature exists — the claim is now accurate, so no doc change needed.
- Manual visual check still worth doing: set a non-zero value, confirm `/replacement-planner` stops showing the "Set Cost per TB in Settings" prompt.

## Notes for the reviewer

- Edits are confined to a new section of `settings.html`; no overlap with PR #126's `generateAPIKey`/`copyAPIKey` work near line 2667, so the merge should be clean.
- The spec suggested a soft clamp (0–10000) — implemented at the input level via HTML `min`/`max`. Did not add server-side validation in `handleUpdateSettings` since float parsing is already defensive and `cost_per_tb,omitempty` naturally handles 0.