### PR TITLE
fix(service-checks): purge orphaned history on config update (#133)

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -523,6 +523,10 @@ func (s *Scheduler) UpdateAlerting(cfg AlertingConfig) {
 }
 
 // UpdateServiceChecks replaces service check configuration used in each run.
+// It also purges service_checks_history rows whose keys are no longer in the
+// config — otherwise stale checks keep appearing on the /service-checks page
+// (issue #133). Because this runs both on startup (from main.go) and on every
+// settings save, it also cleans up orphans left over from upgraded installs.
 func (s *Scheduler) UpdateServiceChecks(checks []internal.ServiceCheckConfig) {
 	normalized := make([]internal.ServiceCheckConfig, 0, len(checks))
 	for _, check := range checks {
@@ -550,6 +554,19 @@ func (s *Scheduler) UpdateServiceChecks(checks []internal.ServiceCheckConfig) {
 	s.mu.Lock()
 	s.serviceChecks = normalized
 	s.mu.Unlock()
+
+	// Purge orphaned history for any check that was removed from the config.
+	if s.store != nil {
+		keepKeys := make([]string, 0, len(normalized))
+		for _, c := range normalized {
+			keepKeys = append(keepKeys, CheckKey(c))
+		}
+		if pruned, err := s.store.DeleteServiceChecksNotIn(keepKeys); err != nil {
+			s.logger.Warn("prune orphaned service check history", "error", err)
+		} else if pruned > 0 {
+			s.logger.Info("pruned orphaned service check history", "rows", pruned)
+		}
+	}
 
 	s.logger.Info("service check config updated", "checks", len(normalized))
 }

--- a/internal/scheduler/service_checks_purge_test.go
+++ b/internal/scheduler/service_checks_purge_test.go
@@ -1,0 +1,134 @@
+package scheduler
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// newSchedulerForTest builds a minimal scheduler suitable for exercising
+// config-management methods like UpdateServiceChecks. Collector/notifier are
+// nil — the methods under test must not touch them.
+func newSchedulerForTest(store storage.Store) *Scheduler {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	return &Scheduler{
+		store:             store,
+		logger:            logger,
+		interval:          time.Hour,
+		speedTestInterval: 4 * time.Hour,
+		serviceChecks:     []internal.ServiceCheckConfig{},
+		stop:              make(chan struct{}),
+		restart:           make(chan time.Duration, 1),
+	}
+}
+
+func seedHistory(t *testing.T, store storage.Store, keys ...string) {
+	t.Helper()
+	now := time.Now().UTC()
+	results := make([]internal.ServiceCheckResult, 0, len(keys))
+	for i, k := range keys {
+		results = append(results, internal.ServiceCheckResult{
+			Key:              k,
+			Name:             k,
+			Type:             "http",
+			Target:           "http://" + k,
+			Status:           "up",
+			FailureThreshold: 1,
+			FailureSeverity:  internal.SeverityWarning,
+			CheckedAt:        now.Add(time.Duration(i) * time.Second).Format(time.RFC3339),
+		})
+	}
+	if err := store.SaveServiceCheckResults(results); err != nil {
+		t.Fatalf("SaveServiceCheckResults: %v", err)
+	}
+}
+
+func historyKeys(t *testing.T, store storage.Store) map[string]bool {
+	t.Helper()
+	entries, err := store.ListLatestServiceChecks(100)
+	if err != nil {
+		t.Fatalf("ListLatestServiceChecks: %v", err)
+	}
+	keys := make(map[string]bool)
+	for _, e := range entries {
+		keys[e.Key] = true
+	}
+	return keys
+}
+
+// UpdateServiceChecks must purge history rows whose keys are no longer
+// present in the incoming config. Issue #133.
+func TestUpdateServiceChecks_PurgesOrphanedHistory(t *testing.T) {
+	store := storage.NewFakeStore()
+
+	// User ran checks for A, B, C in the past.
+	checkA := internal.ServiceCheckConfig{Name: "A", Type: "http", Target: "http://a.example"}
+	checkB := internal.ServiceCheckConfig{Name: "B", Type: "http", Target: "http://b.example"}
+	checkC := internal.ServiceCheckConfig{Name: "C", Type: "http", Target: "http://c.example"}
+	seedHistory(t, store, CheckKey(checkA), CheckKey(checkB), CheckKey(checkC))
+
+	before := historyKeys(t, store)
+	if len(before) != 3 {
+		t.Fatalf("precondition: expected 3 keys seeded, got %d (%v)", len(before), before)
+	}
+
+	// User deleted B and C in settings; only A remains.
+	sched := newSchedulerForTest(store)
+	sched.UpdateServiceChecks([]internal.ServiceCheckConfig{checkA})
+
+	after := historyKeys(t, store)
+	if !after[CheckKey(checkA)] {
+		t.Error("expected history for A to be retained")
+	}
+	if after[CheckKey(checkB)] {
+		t.Error("expected history for B to be purged (orphan)")
+	}
+	if after[CheckKey(checkC)] {
+		t.Error("expected history for C to be purged (orphan)")
+	}
+}
+
+// When the user removes every service check, all history must be purged too.
+func TestUpdateServiceChecks_PurgesAllWhenConfigEmpty(t *testing.T) {
+	store := storage.NewFakeStore()
+
+	checkA := internal.ServiceCheckConfig{Name: "A", Type: "http", Target: "http://a.example"}
+	checkB := internal.ServiceCheckConfig{Name: "B", Type: "http", Target: "http://b.example"}
+	seedHistory(t, store, CheckKey(checkA), CheckKey(checkB))
+
+	sched := newSchedulerForTest(store)
+	sched.UpdateServiceChecks(nil)
+
+	after := historyKeys(t, store)
+	if len(after) != 0 {
+		t.Errorf("expected all history purged, got %d keys: %v", len(after), after)
+	}
+}
+
+// Invalid or blank checks in the config must not leave their (non-existent)
+// keys as a signal to keep orphans around — but valid ones must keep theirs.
+func TestUpdateServiceChecks_KeysDerivedFromNormalizedConfig(t *testing.T) {
+	store := storage.NewFakeStore()
+
+	valid := internal.ServiceCheckConfig{Name: "Valid", Type: "http", Target: "http://v.example"}
+	seedHistory(t, store, CheckKey(valid), "stale-orphan-key")
+
+	sched := newSchedulerForTest(store)
+	sched.UpdateServiceChecks([]internal.ServiceCheckConfig{
+		valid,
+		{Name: "", Type: "http", Target: ""}, // dropped by normalization
+		{Name: "Bad", Type: "bogus", Target: "x"},
+	})
+
+	after := historyKeys(t, store)
+	if !after[CheckKey(valid)] {
+		t.Error("valid check history must be retained")
+	}
+	if after["stale-orphan-key"] {
+		t.Error("orphan history must be purged")
+	}
+}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -1674,6 +1674,37 @@ func (d *DB) DeleteServiceCheckByKey(key string) (int, error) {
 	return int(n), nil
 }
 
+// DeleteServiceChecksNotIn removes all history rows whose check_key is NOT in
+// the provided keepKeys slice. This is how orphaned history is cleaned up
+// after a service check is removed from the configuration. Passing a nil or
+// empty slice deletes every row in service_checks_history.
+func (d *DB) DeleteServiceChecksNotIn(keepKeys []string) (int, error) {
+	if len(keepKeys) == 0 {
+		result, err := d.db.Exec("DELETE FROM service_checks_history")
+		if err != nil {
+			return 0, err
+		}
+		n, _ := result.RowsAffected()
+		return int(n), nil
+	}
+
+	// Build placeholder list (?, ?, ?) and args slice.
+	placeholders := make([]string, len(keepKeys))
+	args := make([]interface{}, len(keepKeys))
+	for i, k := range keepKeys {
+		placeholders[i] = "?"
+		args[i] = k
+	}
+	query := "DELETE FROM service_checks_history WHERE check_key NOT IN (" +
+		strings.Join(placeholders, ",") + ")"
+	result, err := d.db.Exec(query, args...)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := result.RowsAffected()
+	return int(n), nil
+}
+
 // GetFindingHistory returns how a specific finding category has changed over time.
 func (d *DB) GetFindingHistory(category string, limit int) ([]internal.Finding, error) {
 	rows, err := d.db.Query(`

--- a/internal/storage/db_service_checks_test.go
+++ b/internal/storage/db_service_checks_test.go
@@ -1,0 +1,124 @@
+package storage
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+func newTestDB(t *testing.T) *DB {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	db, err := Open(dbPath, logger)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func seedServiceChecks(t *testing.T, db *DB, keys ...string) {
+	t.Helper()
+	now := time.Now().UTC()
+	results := make([]internal.ServiceCheckResult, 0, len(keys))
+	for i, k := range keys {
+		results = append(results, internal.ServiceCheckResult{
+			Key:              k,
+			Name:             k + "-name",
+			Type:             "http",
+			Target:           "http://example.com/" + k,
+			Status:           "up",
+			ResponseMS:       10,
+			FailureThreshold: 1,
+			FailureSeverity:  internal.SeverityWarning,
+			CheckedAt:        now.Add(time.Duration(i) * time.Second).Format(time.RFC3339),
+		})
+	}
+	if err := db.SaveServiceCheckResults(results); err != nil {
+		t.Fatalf("SaveServiceCheckResults: %v", err)
+	}
+}
+
+func TestDB_DeleteServiceChecksNotIn_KeepsSpecifiedKeys(t *testing.T) {
+	db := newTestDB(t)
+
+	seedServiceChecks(t, db, "a", "b", "b", "c", "c", "c")
+
+	deleted, err := db.DeleteServiceChecksNotIn([]string{"a", "b"})
+	if err != nil {
+		t.Fatalf("DeleteServiceChecksNotIn: %v", err)
+	}
+	// 3 rows for "c" should be removed.
+	if deleted != 3 {
+		t.Errorf("expected 3 rows deleted (for key c), got %d", deleted)
+	}
+
+	entries, err := db.ListLatestServiceChecks(100)
+	if err != nil {
+		t.Fatalf("ListLatestServiceChecks: %v", err)
+	}
+	gotKeys := make(map[string]bool)
+	for _, e := range entries {
+		gotKeys[e.Key] = true
+	}
+	if !gotKeys["a"] || !gotKeys["b"] {
+		t.Errorf("expected keys a & b retained, got %v", gotKeys)
+	}
+	if gotKeys["c"] {
+		t.Error("key c should have been purged")
+	}
+}
+
+func TestDB_DeleteServiceChecksNotIn_EmptyKeepList_DeletesAll(t *testing.T) {
+	db := newTestDB(t)
+
+	seedServiceChecks(t, db, "a", "b", "c")
+
+	deleted, err := db.DeleteServiceChecksNotIn(nil)
+	if err != nil {
+		t.Fatalf("DeleteServiceChecksNotIn(nil): %v", err)
+	}
+	if deleted != 3 {
+		t.Errorf("expected 3 rows deleted with nil keep list, got %d", deleted)
+	}
+
+	entries, _ := db.ListLatestServiceChecks(100)
+	if len(entries) != 0 {
+		t.Errorf("expected 0 remaining entries, got %d", len(entries))
+	}
+
+	// Same behaviour for non-nil empty slice.
+	seedServiceChecks(t, db, "x")
+	deleted, err = db.DeleteServiceChecksNotIn([]string{})
+	if err != nil {
+		t.Fatalf("DeleteServiceChecksNotIn([]): %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("expected 1 row deleted with empty slice, got %d", deleted)
+	}
+}
+
+func TestDB_DeleteServiceChecksNotIn_NoOpWhenAllRetained(t *testing.T) {
+	db := newTestDB(t)
+
+	seedServiceChecks(t, db, "a", "b")
+
+	deleted, err := db.DeleteServiceChecksNotIn([]string{"a", "b", "c"})
+	if err != nil {
+		t.Fatalf("DeleteServiceChecksNotIn: %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("expected 0 rows deleted, got %d", deleted)
+	}
+
+	entries, _ := db.ListLatestServiceChecks(100)
+	if len(entries) != 2 {
+		t.Errorf("expected 2 remaining entries, got %d", len(entries))
+	}
+}

--- a/internal/storage/fake.go
+++ b/internal/storage/fake.go
@@ -351,6 +351,36 @@ func (f *FakeStore) DeleteServiceCheckByKey(key string) (int, error) {
 	return deleted, nil
 }
 
+// DeleteServiceChecksNotIn removes every history row whose key is NOT in
+// keepKeys. A nil/empty keepKeys deletes all rows.
+func (f *FakeStore) DeleteServiceChecksNotIn(keepKeys []string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if len(keepKeys) == 0 {
+		deleted := len(f.serviceChecks)
+		f.serviceChecks = nil
+		return deleted, nil
+	}
+
+	keep := make(map[string]struct{}, len(keepKeys))
+	for _, k := range keepKeys {
+		keep[k] = struct{}{}
+	}
+
+	var kept []internal.ServiceCheckResult
+	deleted := 0
+	for _, r := range f.serviceChecks {
+		if _, ok := keep[r.Key]; ok {
+			kept = append(kept, r)
+		} else {
+			deleted++
+		}
+	}
+	f.serviceChecks = kept
+	return deleted, nil
+}
+
 // ── HistoryStore ──
 
 func (f *FakeStore) GetDiskHistory(_ string, _ int) ([]DiskHistoryPoint, error) {

--- a/internal/storage/fake_test.go
+++ b/internal/storage/fake_test.go
@@ -264,6 +264,98 @@ func TestFakeStore_DeleteServiceCheckByKey(t *testing.T) {
 	}
 }
 
+func TestFakeStore_DeleteServiceChecksNotIn_KeepsSpecifiedKeys(t *testing.T) {
+	store := NewFakeStore()
+
+	now := time.Now().UTC()
+	store.SaveServiceCheckResults([]internal.ServiceCheckResult{
+		{Key: "a", Name: "A", CheckedAt: now.Format(time.RFC3339)},
+		{Key: "b", Name: "B", CheckedAt: now.Format(time.RFC3339)},
+		{Key: "b", Name: "B", CheckedAt: now.Add(time.Minute).Format(time.RFC3339)},
+		{Key: "c", Name: "C", CheckedAt: now.Format(time.RFC3339)},
+		{Key: "c", Name: "C", CheckedAt: now.Add(time.Minute).Format(time.RFC3339)},
+	})
+
+	deleted, err := store.DeleteServiceChecksNotIn([]string{"a", "b"})
+	if err != nil {
+		t.Fatalf("DeleteServiceChecksNotIn: %v", err)
+	}
+	if deleted != 2 {
+		t.Errorf("expected 2 rows deleted (for key c), got %d", deleted)
+	}
+
+	entries, _ := store.ListLatestServiceChecks(10)
+	gotKeys := make(map[string]bool)
+	for _, e := range entries {
+		gotKeys[e.Key] = true
+	}
+	if len(gotKeys) != 2 || !gotKeys["a"] || !gotKeys["b"] {
+		t.Errorf("expected remaining keys {a,b}, got %v", gotKeys)
+	}
+	if gotKeys["c"] {
+		t.Error("key c should have been purged")
+	}
+}
+
+func TestFakeStore_DeleteServiceChecksNotIn_EmptyKeepList_DeletesAll(t *testing.T) {
+	store := NewFakeStore()
+
+	now := time.Now().UTC()
+	store.SaveServiceCheckResults([]internal.ServiceCheckResult{
+		{Key: "a", Name: "A", CheckedAt: now.Format(time.RFC3339)},
+		{Key: "b", Name: "B", CheckedAt: now.Format(time.RFC3339)},
+		{Key: "c", Name: "C", CheckedAt: now.Format(time.RFC3339)},
+	})
+
+	deleted, err := store.DeleteServiceChecksNotIn(nil)
+	if err != nil {
+		t.Fatalf("DeleteServiceChecksNotIn(nil): %v", err)
+	}
+	if deleted != 3 {
+		t.Errorf("expected 3 rows deleted, got %d", deleted)
+	}
+
+	entries, _ := store.ListLatestServiceChecks(10)
+	if len(entries) != 0 {
+		t.Errorf("expected 0 remaining entries, got %d", len(entries))
+	}
+
+	// Also verify empty (non-nil) slice deletes all.
+	store.SaveServiceCheckResults([]internal.ServiceCheckResult{
+		{Key: "x", Name: "X", CheckedAt: now.Format(time.RFC3339)},
+	})
+	deleted, err = store.DeleteServiceChecksNotIn([]string{})
+	if err != nil {
+		t.Fatalf("DeleteServiceChecksNotIn([]): %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("expected 1 row deleted with empty slice, got %d", deleted)
+	}
+}
+
+func TestFakeStore_DeleteServiceChecksNotIn_NoOpWhenAllKeysKept(t *testing.T) {
+	store := NewFakeStore()
+
+	now := time.Now().UTC()
+	store.SaveServiceCheckResults([]internal.ServiceCheckResult{
+		{Key: "a", Name: "A", CheckedAt: now.Format(time.RFC3339)},
+		{Key: "b", Name: "B", CheckedAt: now.Format(time.RFC3339)},
+	})
+
+	deleted, err := store.DeleteServiceChecksNotIn([]string{"a", "b", "c"})
+	if err != nil {
+		t.Fatalf("DeleteServiceChecksNotIn: %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("expected 0 rows deleted, got %d", deleted)
+	}
+
+	entries, _ := store.ListLatestServiceChecks(10)
+	if len(entries) != 2 {
+		t.Errorf("expected 2 remaining entries, got %d", len(entries))
+	}
+}
+
 func TestFakeStore_SaveAndGetProcessStats(t *testing.T) {
 	store := NewFakeStore()
 

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -43,6 +43,10 @@ type ServiceCheckStore interface {
 	GetServiceCheckHistory(checkKey string, limit int) ([]ServiceCheckEntry, error)
 	PruneServiceCheckHistory(olderThan time.Duration) (int, error)
 	DeleteServiceCheckByKey(key string) (int, error)
+	// DeleteServiceChecksNotIn removes every row from service_checks_history
+	// whose check_key is NOT in keepKeys. Passing nil or an empty slice
+	// deletes all rows. Returns the number of rows deleted.
+	DeleteServiceChecksNotIn(keepKeys []string) (int, error)
 }
 
 // HistoryStore handles time-series history for disks, system, GPU, containers, and speed tests.


### PR DESCRIPTION
Closes #133.

## Root cause

When a user removed a service check in Settings, only the config was
deleted. `service_checks_history` was never purged, so every check that
ever ran kept appearing on `/service-checks` — flagged client-side with a
tiny `isOrphan` badge most users miss.

## Fix

- New `ServiceCheckStore.DeleteServiceChecksNotIn(keepKeys) (int, error)`:
  - `*DB`: parameterised `DELETE FROM service_checks_history WHERE check_key NOT IN (?, ?, …)` with a special-case `DELETE FROM …` when `keepKeys` is empty (SQLite rejects empty `NOT IN ()`).
  - `*FakeStore`: map-based filter, same contract.
- Wire the purge into `scheduler.UpdateServiceChecks`. Because `UpdateServiceChecks` is already invoked both on settings save (`api_extended.go:599`) **and** on every process start via `main.go:applySchedulerSettingsFromStore` → line 593, this single call site covers both the RED/GREEN user flow and the one-shot cleanup for users upgrading with pre-existing orphans.
- Uses `scheduler.CheckKey(c)` to build the keep-set from the normalized (post-validation) config — invalid/blank entries are dropped, so they never accidentally preserve orphan rows.

Errors are logged at WARN and do not block the rest of settings save; the data is non-critical.

## Tests (9 new, all passing)

```
=== RUN   TestDB_DeleteServiceChecksNotIn_KeepsSpecifiedKeys
--- PASS: TestDB_DeleteServiceChecksNotIn_KeepsSpecifiedKeys (0.01s)
=== RUN   TestDB_DeleteServiceChecksNotIn_EmptyKeepList_DeletesAll
--- PASS: TestDB_DeleteServiceChecksNotIn_EmptyKeepList_DeletesAll (0.01s)
=== RUN   TestDB_DeleteServiceChecksNotIn_NoOpWhenAllRetained
--- PASS: TestDB_DeleteServiceChecksNotIn_NoOpWhenAllRetained (0.01s)
=== RUN   TestFakeStore_DeleteServiceChecksNotIn_KeepsSpecifiedKeys
--- PASS: TestFakeStore_DeleteServiceChecksNotIn_KeepsSpecifiedKeys (0.00s)
=== RUN   TestFakeStore_DeleteServiceChecksNotIn_EmptyKeepList_DeletesAll
--- PASS: TestFakeStore_DeleteServiceChecksNotIn_EmptyKeepList_DeletesAll (0.00s)
=== RUN   TestFakeStore_DeleteServiceChecksNotIn_NoOpWhenAllKeysKept
--- PASS: TestFakeStore_DeleteServiceChecksNotIn_NoOpWhenAllKeysKept (0.00s)
=== RUN   TestUpdateServiceChecks_PurgesOrphanedHistory
--- PASS: TestUpdateServiceChecks_PurgesOrphanedHistory (0.00s)
=== RUN   TestUpdateServiceChecks_PurgesAllWhenConfigEmpty
--- PASS: TestUpdateServiceChecks_PurgesAllWhenConfigEmpty (0.00s)
=== RUN   TestUpdateServiceChecks_KeysDerivedFromNormalizedConfig
--- PASS: TestUpdateServiceChecks_KeysDerivedFromNormalizedConfig (0.00s)
```

Full \`go build ./...\` and \`go test ./...\` pass (no regressions).

## Follow-ups / deferred

- **Client-side \`isOrphan\` badge** (\`service_checks.html:206\`) — kept as a belt-and-suspenders safety net. If an upgrade path leaves a stale row and the scheduler's prune somehow misses it, users still have a manual delete button. Low cost to keep; can be removed in a follow-up PR after this lands in a release and we're confident no orphans survive.
- **\`DeleteServiceCheckByKey\`** — now redundant except as the handler for that orphan-delete button. Keeping until the badge is removed.