### PR TITLE
fix(analyzer): escalate lifespan-exhausted drives to Replace Soon (#143)

### DIFF
--- a/internal/analyzer/replacement.go
+++ b/internal/analyzer/replacement.go
@@ -212,6 +212,12 @@ func determineUrgency(dp DrivePlan) (ReplacementUrgency, string) {
 	if dp.HealthScore < 60 {
 		return UrgencyReplaceSoon, "Degraded health — plan replacement within 3 months"
 	}
+	if dp.LifeUsedPct >= 100 {
+		return UrgencyReplaceSoon, fmt.Sprintf("%.0f%% of expected life used — exceeded design lifespan", dp.LifeUsedPct)
+	}
+	if dp.RemainingYears < 0.25 {
+		return UrgencyReplaceSoon, fmt.Sprintf("~%.1f months remaining at current degradation rate", dp.RemainingYears*12)
+	}
 	if dp.RemainingYears < 1.0 && dp.HealthScore < 80 {
 		return UrgencyReplaceSoon, fmt.Sprintf("~%.1f years remaining at current degradation rate", dp.RemainingYears)
 	}

--- a/internal/analyzer/replacement_test.go
+++ b/internal/analyzer/replacement_test.go
@@ -1,0 +1,45 @@
+package analyzer
+
+import "testing"
+
+func TestDetermineUrgency_LifeUsedOver100_EscalatesToReplaceSoon(t *testing.T) {
+	dp := DrivePlan{
+		HealthPassed:   true,
+		HealthScore:    92,
+		LifeUsedPct:    127,
+		RemainingYears: 0.08,
+		FailureMult:    2.5,
+	}
+	got, _ := determineUrgency(dp)
+	if got != UrgencyReplaceSoon {
+		t.Errorf("127%% life used should be ReplaceSoon, got %s", got)
+	}
+}
+
+func TestDetermineUrgency_RemainingUnder3Months_EscalatesToReplaceSoon(t *testing.T) {
+	dp := DrivePlan{
+		HealthPassed:   true,
+		HealthScore:    95,
+		LifeUsedPct:    90,
+		RemainingYears: 0.2, // ~2.4 months
+		FailureMult:    1.5,
+	}
+	got, _ := determineUrgency(dp)
+	if got != UrgencyReplaceSoon {
+		t.Errorf("<3 months remaining should be ReplaceSoon, got %s", got)
+	}
+}
+
+func TestDetermineUrgency_HealthyDriveWithGoodLife_StaysHealthy(t *testing.T) {
+	dp := DrivePlan{
+		HealthPassed:   true,
+		HealthScore:    95,
+		LifeUsedPct:    45,
+		RemainingYears: 4.5,
+		FailureMult:    0.8,
+	}
+	got, _ := determineUrgency(dp)
+	if got != UrgencyHealthy {
+		t.Errorf("healthy drive should stay Healthy, got %s", got)
+	}
+}


### PR DESCRIPTION
Closes #143

## Summary

Drives with 100%+ life used, <1 month remaining, and 7+ years of age were classified as `Monitor` because a high SMART `HealthScore` short-circuited the urgency checks. The existing `(RemainingYears<1 AND HealthScore<80)` conjunction in `determineUrgency()` required *both* aging AND degraded health — so a drive with 127% life used but score=92 fell through to `Monitor`. This caused the Replacement Planner to report "Total Urgent Replacements $0" even when multiple drives were clearly end-of-life.

## Changes

`internal/analyzer/replacement.go` — add two rules in the `Replace Soon` bucket, before the existing AND-conjunction:

```go
if dp.LifeUsedPct >= 100 {
    return UrgencyReplaceSoon, "... exceeded design lifespan"
}
if dp.RemainingYears < 0.25 {
    return UrgencyReplaceSoon, "~X.X months remaining ..."
}
```

`internal/analyzer/replacement_test.go` — new file, three test cases from the issue:
- `TestDetermineUrgency_LifeUsedOver100_EscalatesToReplaceSoon` — the reproduction case (score=92, LifeUsed=127%)
- `TestDetermineUrgency_RemainingUnder3Months_EscalatesToReplaceSoon` — trajectory-based escalation
- `TestDetermineUrgency_HealthyDriveWithGoodLife_StaysHealthy` — regression guard

## Kept vs dropped: `RemainingYears<1.0 && HealthScore<80`

**Kept.** It still catches a distinct case not covered by the two new rules: a degraded-but-not-exhausted drive with a mid-term trajectory, specifically `HealthScore ∈ [60,80) AND LifeUsedPct<100 AND RemainingYears ∈ [0.25, 1.0)`. Dropping it would demote those drives to `Monitor`, which is a behavior change outside the scope of this bug.

## Test output

```
=== RUN   TestDetermineUrgency_LifeUsedOver100_EscalatesToReplaceSoon
--- PASS: TestDetermineUrgency_LifeUsedOver100_EscalatesToReplaceSoon (0.00s)
=== RUN   TestDetermineUrgency_RemainingUnder3Months_EscalatesToReplaceSoon
--- PASS: TestDetermineUrgency_RemainingUnder3Months_EscalatesToReplaceSoon (0.00s)
=== RUN   TestDetermineUrgency_HealthyDriveWithGoodLife_StaysHealthy
--- PASS: TestDetermineUrgency_HealthyDriveWithGoodLife_StaysHealthy (0.00s)
PASS
ok  	github.com/mcdays94/nas-doctor/internal/analyzer	0.508s
```

Full suite (`go build ./...` + `go test ./...`): all green.

## Follow-ups (out of scope, noted in issue)

- Thresholds (100%, 0.25y, 1.0y) could be made configurable via settings for power users.
- A future refactor could collapse the urgency rules into a scored/weighted model rather than stacked early-returns.