### PR TITLE
fix(unraid): install apcupsd + nut-client so UPS detection works (#134)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ LABEL org.opencontainers.image.title="NAS Doctor" \
 COPY --from=builder /nas-doctor /app/nas-doctor
 
 # Critical packages
-RUN apk add --no-cache smartmontools docker-cli util-linux procps ca-certificates tzdata curl apcupsd nut-client
+RUN apk add --no-cache smartmontools docker-cli util-linux procps ca-certificates tzdata curl apcupsd nut
 # Optional packages (may not be available on all architectures)
 RUN apk add --no-cache hdparm iproute2 || true
 RUN apk add --no-cache dmidecode ethtool || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ LABEL org.opencontainers.image.title="NAS Doctor" \
 COPY --from=builder /nas-doctor /app/nas-doctor
 
 # Critical packages
-RUN apk add --no-cache smartmontools docker-cli util-linux procps ca-certificates tzdata curl
+RUN apk add --no-cache smartmontools docker-cli util-linux procps ca-certificates tzdata curl apcupsd nut-client
 # Optional packages (may not be available on all architectures)
 RUN apk add --no-cache hdparm iproute2 || true
 RUN apk add --no-cache dmidecode ethtool || true

--- a/internal/collector/ups.go
+++ b/internal/collector/ups.go
@@ -35,19 +35,52 @@ func (execRunner) Output(name string, args ...string) ([]byte, error) {
 // defaultRunner is used by the exported collectUPS / collectNUT / collectApcupsd entrypoints.
 var defaultRunner UPSRunner = execRunner{}
 
-// collectUPS tries NUT first, then apcupsd. Returns Available=false if neither is available.
+// collectUPS tries NUT first, then apcupsd.
+//
+// Both collectors return a non-nil diagnostic hint ({Status:"unreachable"}) when their
+// client binary is present but the daemon isn't reachable — this is *useful* UX when
+// it's the only signal, but on a typical Unraid box both binaries are installed and
+// only apcupsd actually reaches its daemon. We must therefore treat an "unreachable"
+// hint as "try the next source" rather than a successful detection. The hint is only
+// surfaced if EVERY source returned one.
+//
+// Returns Available=false if neither binary is installed.
 func collectUPS() (*internal.UPSInfo, error) {
+	return collectUPSWith(defaultRunner)
+}
+
+// collectUPSWith is the testable form of collectUPS — takes an injected UPSRunner.
+func collectUPSWith(r UPSRunner) (*internal.UPSInfo, error) {
+	var hint *internal.UPSInfo
+
 	// Try NUT first (works on TrueNAS, Synology, generic Linux, FreeBSD, macOS with brew)
-	if info, err := collectNUTWith(defaultRunner); err == nil && info != nil {
-		return info, nil
+	if info, err := collectNUTWith(r); err == nil && info != nil {
+		if !isUnreachableHint(info) {
+			return info, nil // NUT actually returned data
+		}
+		hint = info // remember; may surface if apcupsd also fails
 	}
 
 	// Try apcupsd (common on Unraid, available on all Linux/FreeBSD/macOS)
-	if info, err := collectApcupsdWith(defaultRunner); err == nil && info != nil {
-		return info, nil
+	if info, err := collectApcupsdWith(r); err == nil && info != nil {
+		if !isUnreachableHint(info) {
+			return info, nil // apcupsd actually returned data
+		}
+		if hint == nil {
+			hint = info // only NUT is missing; use apcupsd's hint
+		}
 	}
 
+	if hint != nil {
+		return hint, nil // neither source reached a daemon — show the first hint
+	}
 	return &internal.UPSInfo{Available: false}, nil
+}
+
+// isUnreachableHint reports whether the given UPSInfo is a diagnostic hint
+// emitted by unreachableHint() rather than a real data payload.
+func isUnreachableHint(info *internal.UPSInfo) bool {
+	return info != nil && info.Status == "unreachable"
 }
 
 // ── NUT (Network UPS Tools) via `upsc` ──────────────────────────────

--- a/internal/collector/ups.go
+++ b/internal/collector/ups.go
@@ -17,15 +17,33 @@ import (
 	"github.com/mcdays94/nas-doctor/internal"
 )
 
+// UPSRunner abstracts binary discovery (LookPath) and command execution (Output)
+// so the UPS collectors can be exercised from tests without real exec calls.
+type UPSRunner interface {
+	LookPath(name string) (string, error)
+	Output(name string, args ...string) ([]byte, error)
+}
+
+// execRunner is the production UPSRunner backed by os/exec.
+type execRunner struct{}
+
+func (execRunner) LookPath(name string) (string, error) { return exec.LookPath(name) }
+func (execRunner) Output(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}
+
+// defaultRunner is used by the exported collectUPS / collectNUT / collectApcupsd entrypoints.
+var defaultRunner UPSRunner = execRunner{}
+
 // collectUPS tries NUT first, then apcupsd. Returns Available=false if neither is available.
 func collectUPS() (*internal.UPSInfo, error) {
 	// Try NUT first (works on TrueNAS, Synology, generic Linux, FreeBSD, macOS with brew)
-	if info, err := collectNUT(); err == nil && info != nil {
+	if info, err := collectNUTWith(defaultRunner); err == nil && info != nil {
 		return info, nil
 	}
 
 	// Try apcupsd (common on Unraid, available on all Linux/FreeBSD/macOS)
-	if info, err := collectApcupsd(); err == nil && info != nil {
+	if info, err := collectApcupsdWith(defaultRunner); err == nil && info != nil {
 		return info, nil
 	}
 
@@ -34,8 +52,10 @@ func collectUPS() (*internal.UPSInfo, error) {
 
 // ── NUT (Network UPS Tools) via `upsc` ──────────────────────────────
 
-func collectNUT() (*internal.UPSInfo, error) {
-	if _, err := exec.LookPath("upsc"); err != nil {
+func collectNUT() (*internal.UPSInfo, error) { return collectNUTWith(defaultRunner) }
+
+func collectNUTWith(r UPSRunner) (*internal.UPSInfo, error) {
+	if _, err := r.LookPath("upsc"); err != nil {
 		return nil, err
 	}
 
@@ -48,12 +68,16 @@ func collectNUT() (*internal.UPSInfo, error) {
 		if nutHost != "" {
 			listArgs = append(listArgs, nutHost)
 		}
-		listOut, err := exec.Command("upsc", listArgs...).Output()
+		listOut, err := r.Output("upsc", listArgs...)
 		if err != nil {
 			// Some older NUT versions use -L (capital). Try fallback.
-			listOut, err = exec.Command("upsc", "-L").Output()
+			listOut, err = r.Output("upsc", "-L")
 			if err != nil {
-				return nil, err
+				// Binary is present but we can't reach a NUT server. Surface a
+				// diagnostic hint so the user sees *something* in the dashboard
+				// rather than a silent "no UPS" — especially important on
+				// container-networked setups where the daemon is on the host.
+				return unreachableHint("nut", err), nil
 			}
 		}
 
@@ -79,9 +103,9 @@ func collectNUT() (*internal.UPSInfo, error) {
 		upsID = upsName + "@" + nutHost
 	}
 
-	out, err := exec.Command("upsc", upsID).Output()
+	out, err := r.Output("upsc", upsID)
 	if err != nil {
-		return nil, err
+		return unreachableHint("nut", err), nil
 	}
 
 	return parseNUT(upsName, string(out)), nil
@@ -185,8 +209,10 @@ func nutStatusToHuman(status string) string {
 
 // ── apcupsd via `apcaccess` ─────────────────────────────────────────
 
-func collectApcupsd() (*internal.UPSInfo, error) {
-	if _, err := exec.LookPath("apcaccess"); err != nil {
+func collectApcupsd() (*internal.UPSInfo, error) { return collectApcupsdWith(defaultRunner) }
+
+func collectApcupsdWith(r UPSRunner) (*internal.UPSInfo, error) {
+	if _, err := r.LookPath("apcaccess"); err != nil {
 		return nil, err
 	}
 
@@ -196,12 +222,40 @@ func collectApcupsd() (*internal.UPSInfo, error) {
 		args = append(args, "-h", host)
 	}
 
-	out, err := exec.Command("apcaccess", args...).Output()
+	out, err := r.Output("apcaccess", args...)
 	if err != nil {
-		return nil, err
+		// Binary present but daemon unreachable — typical on Unraid when the
+		// apcupsd plugin isn't running or the container isn't on host network.
+		// Surface a diagnostic so the UPS section shows a helpful hint instead
+		// of silently disappearing.
+		return unreachableHint("apcupsd", err), nil
 	}
 
 	return parseApcaccess(string(out)), nil
+}
+
+// unreachableHint builds a UPSInfo that tells the user the client binary is
+// present but the daemon can't be reached (wrong host/port, service down, or
+// non-host-networked container). Available=true so the dashboard renders a row.
+func unreachableHint(source string, cause error) *internal.UPSInfo {
+	var hint string
+	switch source {
+	case "apcupsd":
+		hint = "apcupsd client present but daemon unreachable — check the host apcupsd plugin is running and listening on 127.0.0.1:3551, or set NAS_DOCTOR_APCUPSD_HOST"
+	case "nut":
+		hint = "NUT client present but server unreachable — check upsd is running, or set NAS_DOCTOR_NUT_HOST for remote setups"
+	default:
+		hint = "UPS client present but daemon unreachable"
+	}
+	if cause != nil {
+		hint += " (" + strings.TrimSpace(cause.Error()) + ")"
+	}
+	return &internal.UPSInfo{
+		Available:   true,
+		Source:      source,
+		Status:      "unreachable",
+		StatusHuman: hint,
+	}
 }
 
 // parseApcaccess parses `apcaccess` output (KEY : VALUE pairs).

--- a/internal/collector/ups_test.go
+++ b/internal/collector/ups_test.go
@@ -328,3 +328,86 @@ func TestNutStatusToHuman(t *testing.T) {
 		}
 	}
 }
+
+// ── collectUPS orchestration (fallback chain) ──
+
+// TestCollectUPS_NUTUnreachable_FallsThroughToApcupsd reproduces the Unraid
+// hardware bug observed in v0.9.2-rc2: both binaries are installed (Dockerfile fix
+// from #134 did its job), but the host runs apcupsd (not NUT), so upsc fails to
+// reach a daemon while apcaccess succeeds. The collector must surface apcupsd's
+// real data, not NUT's "unreachable" hint.
+func TestCollectUPS_NUTUnreachable_FallsThroughToApcupsd(t *testing.T) {
+	r := fakeRunner{
+		lookPath: func(name string) (string, error) { return "/usr/bin/" + name, nil },
+		output: func(name string, args ...string) ([]byte, error) {
+			if name == "upsc" {
+				return nil, errors.New("Error: Connection failure: Connection refused")
+			}
+			// apcaccess succeeds with real data
+			return []byte(sampleApcaccess), nil
+		},
+	}
+	info, err := collectUPSWith(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected non-nil UPSInfo")
+	}
+	if info.Source != "apcupsd" {
+		t.Errorf("source: got %q, want apcupsd (NUT unreachable, apcupsd should win)", info.Source)
+	}
+	if info.Status == "unreachable" {
+		t.Error("status should be real data, not the unreachable hint")
+	}
+	if info.Name == "" {
+		t.Error("expected UPSNAME populated from apcaccess output")
+	}
+}
+
+// TestCollectUPS_BothUnreachable_ReturnsNUTHint guards the fall-back of last resort:
+// when both daemons are unreachable, we surface the FIRST hint (NUT, since it was
+// tried first) so the user has something actionable in the dashboard.
+func TestCollectUPS_BothUnreachable_ReturnsNUTHint(t *testing.T) {
+	r := fakeRunner{
+		lookPath: func(name string) (string, error) { return "/usr/bin/" + name, nil },
+		output: func(name string, args ...string) ([]byte, error) {
+			return nil, errors.New("connection refused")
+		},
+	}
+	info, err := collectUPSWith(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected hint UPSInfo, got nil")
+	}
+	if info.Source != "nut" {
+		t.Errorf("source: got %q, want nut (first-tried hint wins)", info.Source)
+	}
+	if info.Status != "unreachable" {
+		t.Errorf("status: got %q, want unreachable", info.Status)
+	}
+}
+
+// TestCollectUPS_NeitherBinaryInstalled_ReturnsUnavailable preserves the
+// "nothing here" signal for platforms that truly have no UPS support.
+func TestCollectUPS_NeitherBinaryInstalled_ReturnsUnavailable(t *testing.T) {
+	r := fakeRunner{
+		lookPath: func(string) (string, error) { return "", errors.New("not found") },
+		output: func(string, ...string) ([]byte, error) {
+			t.Fatal("output should not be called when no binary installed")
+			return nil, nil
+		},
+	}
+	info, err := collectUPSWith(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected UPSInfo{Available:false}, got nil")
+	}
+	if info.Available {
+		t.Errorf("expected Available=false when no binaries, got %+v", info)
+	}
+}

--- a/internal/collector/ups_test.go
+++ b/internal/collector/ups_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -198,6 +199,109 @@ MODEL    : Smart-UPS 1500
 	}
 	if info.StatusHuman != "On Battery" {
 		t.Errorf("status human: got %q", info.StatusHuman)
+	}
+}
+
+// ── Detection: binary missing / daemon unreachable ──
+
+// fakeRunner is an injectable UPSRunner for tests — no real exec/LookPath required.
+type fakeRunner struct {
+	lookPath func(string) (string, error)
+	output   func(name string, args ...string) ([]byte, error)
+}
+
+func (f fakeRunner) LookPath(name string) (string, error) { return f.lookPath(name) }
+func (f fakeRunner) Output(name string, args ...string) ([]byte, error) {
+	return f.output(name, args...)
+}
+
+func TestCollectApcupsd_BinaryMissing_ReturnsNil(t *testing.T) {
+	r := fakeRunner{
+		lookPath: func(string) (string, error) { return "", errors.New("not found") },
+		output: func(string, ...string) ([]byte, error) {
+			t.Fatal("output should not be called when binary missing")
+			return nil, nil
+		},
+	}
+	info, err := collectApcupsdWith(r)
+	if err == nil {
+		t.Error("expected error when apcaccess missing")
+	}
+	if info != nil {
+		t.Errorf("expected nil UPSInfo, got %+v", info)
+	}
+}
+
+func TestCollectNUT_BinaryMissing_ReturnsNil(t *testing.T) {
+	r := fakeRunner{
+		lookPath: func(string) (string, error) { return "", errors.New("not found") },
+		output: func(string, ...string) ([]byte, error) {
+			t.Fatal("output should not be called when binary missing")
+			return nil, nil
+		},
+	}
+	info, err := collectNUTWith(r)
+	if err == nil {
+		t.Error("expected error when upsc missing")
+	}
+	if info != nil {
+		t.Errorf("expected nil UPSInfo, got %+v", info)
+	}
+}
+
+func TestCollectApcupsd_BinaryPresent_DaemonUnreachable_ReturnsHint(t *testing.T) {
+	// Simulate the Unraid failure mode: image has apcaccess, but the host daemon
+	// is unreachable on 127.0.0.1:3551 (e.g. apcupsd plugin not running or
+	// container not using host networking).
+	r := fakeRunner{
+		lookPath: func(name string) (string, error) { return "/usr/sbin/" + name, nil },
+		output: func(name string, args ...string) ([]byte, error) {
+			return nil, errors.New("Error contacting apcupsd @ 127.0.0.1:3551: Connection refused")
+		},
+	}
+	info, err := collectApcupsdWith(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected UPSInfo with diagnostic hint, got nil")
+	}
+	if !info.Available {
+		t.Error("expected Available=true so users see the diagnostic in the dashboard")
+	}
+	if info.Source != "apcupsd" {
+		t.Errorf("source: got %q, want apcupsd", info.Source)
+	}
+	if info.Status != "unreachable" {
+		t.Errorf("status: got %q, want unreachable", info.Status)
+	}
+	if info.StatusHuman == "" {
+		t.Error("expected a human-readable hint explaining the unreachable daemon")
+	}
+}
+
+func TestCollectNUT_BinaryPresent_DaemonUnreachable_ReturnsHint(t *testing.T) {
+	r := fakeRunner{
+		lookPath: func(name string) (string, error) { return "/usr/bin/" + name, nil },
+		output: func(name string, args ...string) ([]byte, error) {
+			return nil, errors.New("Error: Connection failure: Connection refused")
+		},
+	}
+	info, err := collectNUTWith(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected UPSInfo with diagnostic hint, got nil")
+	}
+	if !info.Available {
+		t.Error("expected Available=true so users see the diagnostic in the dashboard")
+	}
+	if info.Source != "nut" {
+		t.Errorf("source: got %q, want nut", info.Source)
+	}
+	if info.Status != "unreachable" {
+		t.Errorf("status: got %q, want unreachable", info.Status)
 	}
 }
 


### PR DESCRIPTION
Closes #134

## Summary
- **Dockerfile**: add `apcupsd` and `nut-client` to the critical `apk add` line so `apcaccess` and `upsc` are actually present in the runtime image. Prior to this, `exec.LookPath` failed immediately on every platform and the UPS section silently disappeared.
- **internal/collector/ups.go**: extract `LookPath` + `exec.Command` behind a new `UPSRunner` interface so the detection paths can be unit-tested, and add a diagnostic hint when the client binary is present but the daemon rejects the connection (the typical Unraid failure mode: plugin not running, or container not on host networking).
- **internal/collector/ups_test.go**: 4 new tests covering the binary-missing and binary-present-daemon-unreachable branches for both apcupsd and NUT.

When unreachable, the collector now returns `UPSInfo{Available: true, Source: "apcupsd"|"nut", Status: "unreachable", StatusHuman: "<actionable hint>"}` so the dashboard keeps the section visible with a helpful message (incl. the relevant `NAS_DOCTOR_APCUPSD_HOST` / `NAS_DOCTOR_NUT_HOST` env var for remote setups) instead of hiding UPS entirely.

## Test output

```
$ go build ./...
(clean)

$ go vet ./...
(clean)

$ go test ./... -count=1
ok   github.com/mcdays94/nas-doctor/cmd/nas-doctor            0.700s
ok   github.com/mcdays94/nas-doctor/internal/api              1.058s
ok   github.com/mcdays94/nas-doctor/internal/collector        0.548s
ok   github.com/mcdays94/nas-doctor/internal/scheduler        3.020s
ok   github.com/mcdays94/nas-doctor/internal/storage          1.759s

$ go test ./internal/collector/... -run 'Collect(Apcupsd|NUT)_' -v
=== RUN   TestCollectApcupsd_BinaryMissing_ReturnsNil
--- PASS
=== RUN   TestCollectNUT_BinaryMissing_ReturnsNil
--- PASS
=== RUN   TestCollectApcupsd_BinaryPresent_DaemonUnreachable_ReturnsHint
--- PASS
=== RUN   TestCollectNUT_BinaryPresent_DaemonUnreachable_ReturnsHint
--- PASS
PASS
```

## Follow-ups / notes for the reviewer

- **Merge conflict expected with #135**: a concurrent worker is adding `tailscale` to the same `apk add` line on `Dockerfile:32`. Whichever PR lands second will need a 1-line rebase to combine both additions into a single `apk add` line.
- **README env-var docs**: `NAS_DOCTOR_APCUPSD_HOST` and `NAS_DOCTOR_NUT_HOST` are mentioned in the `ups.go` doc comment and surfaced in the new unreachable hint, but not yet in the README — that's a doc-only follow-up and was out of scope for this fix.
- **On-hardware verification**: the container image rebuild from this PR should be validated on the UAT instance before cutting a stable tag (per AGENTS.md release process). Expected check: `docker exec nas-doctor-uat apcaccess -h 127.0.0.1:3551` succeeds on Unraid 7.2.4 RC.