### PR TITLE
fix(unraid): detect Tailscale via host socket + ship binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ LABEL org.opencontainers.image.title="NAS Doctor" \
 COPY --from=builder /nas-doctor /app/nas-doctor
 
 # Critical packages
-RUN apk add --no-cache smartmontools docker-cli util-linux procps ca-certificates tzdata curl
+RUN apk add --no-cache smartmontools docker-cli util-linux procps ca-certificates tzdata curl tailscale
 # Optional packages (may not be available on all architectures)
 RUN apk add --no-cache hdparm iproute2 || true
 RUN apk add --no-cache dmidecode ethtool || true

--- a/internal/collector/testdata/tailscale_status.json
+++ b/internal/collector/testdata/tailscale_status.json
@@ -1,0 +1,76 @@
+{
+  "Version": "1.74.1-tff4a3f19c-g0b4c2e1",
+  "BackendState": "Running",
+  "AuthURL": "",
+  "TailscaleIPs": ["100.64.1.2", "fd7a:115c:a1e0::2"],
+  "Self": {
+    "ID": "nABCD1234",
+    "PublicKey": "nodekey:abc123",
+    "HostName": "tower",
+    "DNSName": "tower.tail-scale.ts.net.",
+    "OS": "linux",
+    "UserID": 1,
+    "TailscaleIPs": ["100.64.1.2", "fd7a:115c:a1e0::2"],
+    "Tags": ["tag:server"],
+    "Online": true,
+    "Relay": "lhr",
+    "RxBytes": 1234567,
+    "TxBytes": 7654321,
+    "Created": "2025-01-01T00:00:00Z",
+    "LastSeen": "2026-04-20T10:00:00Z"
+  },
+  "MagicDNSSuffix": "tail-scale.ts.net",
+  "CurrentTailnet": {
+    "Name": "example@github",
+    "MagicDNSSuffix": "tail-scale.ts.net",
+    "MagicDNSEnabled": true
+  },
+  "Peer": {
+    "nodekey:peer1": {
+      "ID": "nPEER1",
+      "PublicKey": "nodekey:peer1",
+      "HostName": "laptop",
+      "DNSName": "laptop.tail-scale.ts.net.",
+      "OS": "macOS",
+      "UserID": 1,
+      "TailscaleIPs": ["100.64.1.3"],
+      "Online": true,
+      "ExitNode": false,
+      "Relay": "lhr",
+      "RxBytes": 5000,
+      "TxBytes": 9000,
+      "LastSeen": "2026-04-20T09:58:00Z",
+      "Tags": ["tag:client"]
+    },
+    "nodekey:peer2": {
+      "ID": "nPEER2",
+      "PublicKey": "nodekey:peer2",
+      "HostName": "phone",
+      "DNSName": "phone.tail-scale.ts.net.",
+      "OS": "iOS",
+      "UserID": 1,
+      "TailscaleIPs": ["100.64.1.4"],
+      "Online": false,
+      "ExitNode": false,
+      "Relay": "",
+      "RxBytes": 0,
+      "TxBytes": 0,
+      "LastSeen": "2026-04-19T22:00:00Z"
+    },
+    "nodekey:peer3": {
+      "ID": "nPEER3",
+      "PublicKey": "nodekey:peer3",
+      "HostName": "exit-node",
+      "DNSName": "exit-node.tail-scale.ts.net.",
+      "OS": "linux",
+      "UserID": 1,
+      "TailscaleIPs": ["100.64.1.5"],
+      "Online": true,
+      "ExitNode": true,
+      "Relay": "fra",
+      "RxBytes": 200,
+      "TxBytes": 300,
+      "LastSeen": "2026-04-20T10:00:00Z"
+    }
+  }
+}

--- a/internal/collector/tunnels.go
+++ b/internal/collector/tunnels.go
@@ -156,23 +156,46 @@ func collectTailscale(docker internal.DockerInfo) *internal.TailscaleInfo {
 		if out, err := tailscaleRunCommand("tailscale", "version"); err == nil {
 			info.Version = strings.TrimSpace(strings.Split(string(out), "\n")[0])
 		}
-		// Get status JSON
-		if out, err := tailscaleRunCommand("tailscale", "status", "--json"); err == nil {
+		// Prefer the richer JSON output, but fall back to parsing the plain
+		// tabular `tailscale status` output when JSON is unavailable. The
+		// common trigger: the bundled Alpine tailscale CLI is older than the
+		// host tailscaled daemon, which makes `--json` return empty bytes
+		// (no error, no JSON) — e.g. Alpine 3.21 ships v1.76.6 against a
+		// host running v1.96+. The plain-text format is version-stable and
+		// still gives us IPs, hostnames, online state, and OS.
+		jsonPopulatedPeers := false
+		if out, err := tailscaleRunCommand("tailscale", "status", "--json"); err == nil && len(strings.TrimSpace(string(out))) > 0 {
 			parseTailscaleStatus(out, info)
-		} else {
-			// Daemon unreachable — typical Unraid case: the host runs the
-			// tailscale-nas-util plugin but /var/run/tailscale is not
-			// bind-mounted into the container. Surface a hint so the UI can
-			// guide the user instead of silently showing "not installed".
-			info.BackendState = "Unreachable"
-			if _, statErr := tailscaleSocketStat(tailscaleSocketPath); os.IsNotExist(statErr) {
-				info.Hint = "tailscale binary found but daemon socket " + tailscaleSocketPath +
-					" is not accessible. On Unraid, bind-mount /var/run/tailscale from the host " +
-					"(see the NAS Doctor Unraid template)."
+			jsonPopulatedPeers = info.Self != nil || len(info.Peers) > 0
+		}
+		if !jsonPopulatedPeers {
+			// Try plain-text format. No --json and no extra args.
+			if out, err := tailscaleRunCommand("tailscale", "status"); err == nil && len(strings.TrimSpace(string(out))) > 0 {
+				if parsePlainStatus(string(out), info) {
+					if info.BackendState == "" {
+						info.BackendState = "Running"
+					}
+					// If --json returned empty, note the version skew once so
+					// the UI can nudge the user to upgrade when convenient.
+					if info.Hint == "" {
+						info.Hint = "Using plain-text `tailscale status` parser because `--json` returned no output — likely a version skew between the container's tailscale CLI and the host tailscaled. Peer details are limited; upgrade the bundled tailscale binary to match the host for richer data."
+					}
+				}
 			} else {
-				info.Hint = "tailscale binary found but `tailscale status` failed. " +
-					"Verify the daemon is running and the socket at " + tailscaleSocketPath +
-					" is reachable."
+				// Daemon unreachable — typical Unraid case: the host runs the
+				// tailscale-nas-util plugin but /var/run/tailscale is not
+				// bind-mounted into the container. Surface a hint so the UI can
+				// guide the user instead of silently showing "not installed".
+				info.BackendState = "Unreachable"
+				if _, statErr := tailscaleSocketStat(tailscaleSocketPath); os.IsNotExist(statErr) {
+					info.Hint = "tailscale binary found but daemon socket " + tailscaleSocketPath +
+						" is not accessible. On Unraid, bind-mount /var/run/tailscale from the host " +
+						"(see the NAS Doctor Unraid template)."
+				} else {
+					info.Hint = "tailscale binary found but `tailscale status` failed. " +
+						"Verify the daemon is running and the socket at " + tailscaleSocketPath +
+						" is reachable."
+				}
 			}
 		}
 	}
@@ -293,4 +316,65 @@ func boolToInt(b bool) int {
 		return 1
 	}
 	return 0
+}
+
+// parsePlainStatus parses the tabular output of `tailscale status` (no --json).
+// Format (one device per line, whitespace-separated):
+//
+//	<TailscaleIP> <HostName> <Owner> <OS> <LastSeenOrDash>
+//
+// The FIRST row (where LastSeen is "-") is always Self. Subsequent rows are peers.
+// A "-" in the LastSeen column means the device is currently online. Any other
+// value (e.g. "2h22m", "Dec 12 2024") is the last-seen timestamp and means the
+// peer is offline.
+//
+// Emitted fields are limited compared to parseTailscaleStatus: we don't get
+// TxBytes, RxBytes, Tags, Relay info, DNS name, or MagicDNS. Callers should
+// prefer `--json` output when it's available.
+//
+// Returns true if at least one row was parsed (Self was set).
+func parsePlainStatus(output string, info *internal.TailscaleInfo) bool {
+	first := true
+	for _, raw := range strings.Split(output, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		// Skip stderr warnings that may have been folded in (e.g. "Warning:
+		// client version ...") — these don't have the "IP hostname owner OS"
+		// shape.
+		if strings.HasPrefix(strings.ToLower(line), "warning") ||
+			strings.HasPrefix(strings.ToLower(line), "health") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		ip, hostname, _owner, opsys := fields[0], fields[1], fields[2], fields[3]
+		_ = _owner // unused; keeps layout obvious
+		// Sanity: the first field must look like an IP (contains a dot or colon).
+		if !strings.ContainsAny(ip, ".:") {
+			continue
+		}
+		online := true
+		if len(fields) >= 5 && fields[4] != "-" {
+			online = false
+		}
+		node := internal.TailscaleNode{
+			Name:   hostname,
+			IP:     ip,
+			OS:     opsys,
+			Online: online,
+		}
+		if first {
+			self := node
+			self.Online = true
+			info.Self = &self
+			first = false
+			continue
+		}
+		info.Peers = append(info.Peers, node)
+	}
+	return info.Self != nil
 }

--- a/internal/collector/tunnels.go
+++ b/internal/collector/tunnels.go
@@ -2,10 +2,29 @@ package collector
 
 import (
 	"encoding/json"
+	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// Package-level indirections so tests can stub out exec / filesystem access.
+// They default to the real implementations; tests swap them with t.Cleanup.
+var (
+	tailscaleLookPath   = exec.LookPath
+	tailscaleRunCommand = func(name string, args ...string) ([]byte, error) {
+		return exec.Command(name, args...).CombinedOutput()
+	}
+	tailscaleSocketStat = os.Stat
+	// tailscaleSocketPath is the expected tailscaled control socket. Can be
+	// overridden with NAS_DOCTOR_TAILSCALE_SOCKET for non-default paths.
+	tailscaleSocketPath = func() string {
+		if p := os.Getenv("NAS_DOCTOR_TAILSCALE_SOCKET"); p != "" {
+			return p
+		}
+		return "/var/run/tailscale/tailscaled.sock"
+	}()
 )
 
 // collectTunnels detects cloudflared and tailscale tunnel services.
@@ -132,14 +151,29 @@ func collectTailscale(docker internal.DockerInfo) *internal.TailscaleInfo {
 	info := &internal.TailscaleInfo{}
 
 	// 1. Check host binary
-	if path, err := exec.LookPath("tailscale"); err == nil && path != "" {
+	if path, err := tailscaleLookPath("tailscale"); err == nil && path != "" {
 		info.Installed = true
-		if out, err := exec.Command("tailscale", "version").CombinedOutput(); err == nil {
+		if out, err := tailscaleRunCommand("tailscale", "version"); err == nil {
 			info.Version = strings.TrimSpace(strings.Split(string(out), "\n")[0])
 		}
 		// Get status JSON
-		if out, err := exec.Command("tailscale", "status", "--json").CombinedOutput(); err == nil {
+		if out, err := tailscaleRunCommand("tailscale", "status", "--json"); err == nil {
 			parseTailscaleStatus(out, info)
+		} else {
+			// Daemon unreachable — typical Unraid case: the host runs the
+			// tailscale-nas-util plugin but /var/run/tailscale is not
+			// bind-mounted into the container. Surface a hint so the UI can
+			// guide the user instead of silently showing "not installed".
+			info.BackendState = "Unreachable"
+			if _, statErr := tailscaleSocketStat(tailscaleSocketPath); os.IsNotExist(statErr) {
+				info.Hint = "tailscale binary found but daemon socket " + tailscaleSocketPath +
+					" is not accessible. On Unraid, bind-mount /var/run/tailscale from the host " +
+					"(see the NAS Doctor Unraid template)."
+			} else {
+				info.Hint = "tailscale binary found but `tailscale status` failed. " +
+					"Verify the daemon is running and the socket at " + tailscaleSocketPath +
+					" is reachable."
+			}
 		}
 	}
 

--- a/internal/collector/tunnels_test.go
+++ b/internal/collector/tunnels_test.go
@@ -220,3 +220,137 @@ func containsCI(haystack, needle string) bool {
 	}
 	return false
 }
+
+// ── Tailscale plain-text (`tailscale status`) parser ──
+
+// TestParsePlainStatus_RealWorldOutput reproduces the v0.9.2-rc2 hardware finding:
+// when the container's tailscale CLI is older than the host tailscaled daemon,
+// `tailscale status --json` silently returns empty bytes while `tailscale status`
+// (tabular) still works. The collector must fall back to parsing the tabular form.
+func TestParsePlainStatus_RealWorldOutput(t *testing.T) {
+	// Fixture matches what the user captured on Unraid with tailscale 1.76.6 client
+	// + tailscaled 1.96.2 server. First row = self (LastSeen "-" = online).
+	// Subsequent rows = peers.
+	output := `100.70.89.101   tower                amtccdias@   linux   -
+100.85.250.94   iphone181            amtccdias@   iOS     -
+100.92.71.34    old-laptop           amtccdias@   linux   2h22m`
+
+	info := &internal.TailscaleInfo{}
+	ok := parsePlainStatus(output, info)
+	if !ok {
+		t.Fatal("parsePlainStatus returned false; expected true for 3-row input")
+	}
+	if info.Self == nil {
+		t.Fatal("Self was nil; expected populated from first row")
+	}
+	if info.Self.Name != "tower" || info.Self.IP != "100.70.89.101" || info.Self.OS != "linux" {
+		t.Errorf("Self: got %+v", info.Self)
+	}
+	if !info.Self.Online {
+		t.Error("Self.Online should be true (LastSeen=\"-\" = currently online)")
+	}
+	if len(info.Peers) != 2 {
+		t.Fatalf("Peers: got %d, want 2", len(info.Peers))
+	}
+	var iphone, laptop *internal.TailscaleNode
+	for i, p := range info.Peers {
+		switch p.Name {
+		case "iphone181":
+			iphone = &info.Peers[i]
+		case "old-laptop":
+			laptop = &info.Peers[i]
+		}
+	}
+	if iphone == nil {
+		t.Fatal("missing peer iphone181")
+	}
+	if iphone.IP != "100.85.250.94" || iphone.OS != "iOS" || !iphone.Online {
+		t.Errorf("iphone181: got %+v", iphone)
+	}
+	if laptop == nil {
+		t.Fatal("missing peer old-laptop")
+	}
+	if laptop.Online {
+		t.Error("old-laptop.Online should be false (LastSeen=\"2h22m\" means offline)")
+	}
+}
+
+// TestParsePlainStatus_SkipsWarningLines guards against stderr bleeding into stdout
+// (e.g. `Warning: client version ...` that older tailscale CLIs sometimes print
+// alongside `status` output).
+func TestParsePlainStatus_SkipsWarningLines(t *testing.T) {
+	output := `Warning: client version "1.76.6-AlpineLinux" != tailscaled server version "1.96.2"
+100.70.89.101   tower                amtccdias@   linux   -`
+
+	info := &internal.TailscaleInfo{}
+	ok := parsePlainStatus(output, info)
+	if !ok {
+		t.Fatal("expected Self to be populated despite warning line")
+	}
+	if info.Self == nil || info.Self.Name != "tower" {
+		t.Errorf("Self: got %+v", info.Self)
+	}
+}
+
+// TestParsePlainStatus_EmptyOrMalformed returns false without populating Self.
+func TestParsePlainStatus_EmptyOrMalformed(t *testing.T) {
+	cases := []string{"", "    \n   ", "only one field", "not-an-ip hostname owner os -"}
+	for _, input := range cases {
+		info := &internal.TailscaleInfo{}
+		if parsePlainStatus(input, info) {
+			t.Errorf("parsePlainStatus(%q) = true; want false", input)
+		}
+		if info.Self != nil {
+			t.Errorf("Self populated for malformed input %q", input)
+		}
+	}
+}
+
+// TestCollectTailscale_FallsBackToPlainWhenJSONEmpty is the end-to-end test for
+// the Alpine-client vs newer-server skew fix. `tailscale status --json` returns
+// empty (no error, no bytes); the orchestration must try `tailscale status`
+// (plain) and surface the peers from there.
+func TestCollectTailscale_FallsBackToPlainWhenJSONEmpty(t *testing.T) {
+	withTailscaleStubs(t,
+		func(bin string) (string, error) {
+			if bin == "tailscale" {
+				return "/usr/bin/tailscale", nil
+			}
+			return "", errors.New("not found")
+		},
+		func(name string, args ...string) ([]byte, error) {
+			if name != "tailscale" {
+				return nil, errors.New("unexpected command")
+			}
+			switch {
+			case len(args) == 1 && args[0] == "version":
+				return []byte("1.76.6\n  tailscale commit: AlpineLinux\n"), nil
+			case len(args) == 2 && args[0] == "status" && args[1] == "--json":
+				// Empty output — the exact symptom observed in rc2.
+				return []byte(""), nil
+			case len(args) == 1 && args[0] == "status":
+				return []byte("100.70.89.101   tower                amtccdias@   linux   -\n100.85.250.94   iphone181            amtccdias@   iOS     -\n"), nil
+			}
+			return nil, errors.New("unexpected args")
+		},
+		func(string) (os.FileInfo, error) { return nil, nil },
+		"/var/run/tailscale/tailscaled.sock",
+	)
+
+	got := collectTailscale(internal.DockerInfo{})
+	if got == nil {
+		t.Fatal("expected non-nil TailscaleInfo")
+	}
+	if got.Self == nil || got.Self.Name != "tower" {
+		t.Errorf("Self: got %+v; want tower", got.Self)
+	}
+	if len(got.Peers) != 1 || got.Peers[0].Name != "iphone181" {
+		t.Errorf("Peers: got %+v", got.Peers)
+	}
+	if got.BackendState != "Running" {
+		t.Errorf("BackendState: got %q, want Running", got.BackendState)
+	}
+	if got.Hint == "" {
+		t.Error("expected a diagnostic hint explaining the --json fallback")
+	}
+}

--- a/internal/collector/tunnels_test.go
+++ b/internal/collector/tunnels_test.go
@@ -1,0 +1,222 @@
+package collector
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// ── Tailscale status --json parser ──
+
+func TestParseTailscaleStatusJSON(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "tailscale_status.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	info := &internal.TailscaleInfo{}
+	parseTailscaleStatus(data, info)
+
+	if info.BackendState != "Running" {
+		t.Errorf("backend state: got %q, want Running", info.BackendState)
+	}
+	if info.TailnetName != "example@github" {
+		t.Errorf("tailnet name: got %q, want example@github", info.TailnetName)
+	}
+	if !info.MagicDNS {
+		t.Error("expected MagicDNS=true (MagicDNSSuffix present)")
+	}
+	if info.Self == nil {
+		t.Fatal("expected Self to be populated")
+	}
+	if info.Self.Name != "tower" {
+		t.Errorf("self name: got %q, want tower", info.Self.Name)
+	}
+	if info.Self.IP != "100.64.1.2" {
+		t.Errorf("self ip: got %q, want 100.64.1.2", info.Self.IP)
+	}
+	if info.Self.OS != "linux" {
+		t.Errorf("self os: got %q, want linux", info.Self.OS)
+	}
+	if info.Self.Relay != "lhr" {
+		t.Errorf("self relay: got %q, want lhr", info.Self.Relay)
+	}
+	if info.Self.TxBytes != 7654321 || info.Self.RxBytes != 1234567 {
+		t.Errorf("self bytes: tx=%d rx=%d", info.Self.TxBytes, info.Self.RxBytes)
+	}
+
+	if len(info.Peers) != 3 {
+		t.Fatalf("peers: got %d, want 3", len(info.Peers))
+	}
+
+	// Locate peers by name (map iteration order is not stable)
+	var laptop, phone, exit *internal.TailscaleNode
+	for i := range info.Peers {
+		switch info.Peers[i].Name {
+		case "laptop":
+			laptop = &info.Peers[i]
+		case "phone":
+			phone = &info.Peers[i]
+		case "exit-node":
+			exit = &info.Peers[i]
+		}
+	}
+	if laptop == nil || phone == nil || exit == nil {
+		t.Fatalf("missing peers: laptop=%v phone=%v exit=%v", laptop, phone, exit)
+	}
+	if !laptop.Online {
+		t.Error("laptop should be online")
+	}
+	if phone.Online {
+		t.Error("phone should be offline")
+	}
+	if !exit.ExitNode {
+		t.Error("exit-node should be ExitNode=true")
+	}
+	if exit.Relay != "fra" {
+		t.Errorf("exit-node relay: got %q, want fra", exit.Relay)
+	}
+}
+
+// ── collectTailscale orchestration (binary + socket + docker) ──
+
+// withTailscaleStubs swaps the package-level runner vars for the duration of
+// a test and restores them on cleanup.
+func withTailscaleStubs(
+	t *testing.T,
+	lookPath func(string) (string, error),
+	run func(name string, args ...string) ([]byte, error),
+	socketStat func(string) (os.FileInfo, error),
+	socketPath string,
+) {
+	t.Helper()
+	origLook := tailscaleLookPath
+	origRun := tailscaleRunCommand
+	origStat := tailscaleSocketStat
+	origPath := tailscaleSocketPath
+
+	tailscaleLookPath = lookPath
+	tailscaleRunCommand = run
+	tailscaleSocketStat = socketStat
+	tailscaleSocketPath = socketPath
+
+	t.Cleanup(func() {
+		tailscaleLookPath = origLook
+		tailscaleRunCommand = origRun
+		tailscaleSocketStat = origStat
+		tailscaleSocketPath = origPath
+	})
+}
+
+func TestCollectTailscale_NoBinary_NoDocker_ReturnsNil(t *testing.T) {
+	withTailscaleStubs(t,
+		func(string) (string, error) { return "", errors.New("not found") },
+		func(string, ...string) ([]byte, error) { return nil, errors.New("unreachable") },
+		func(string) (os.FileInfo, error) { return nil, os.ErrNotExist },
+		"/var/run/tailscale/tailscaled.sock",
+	)
+
+	got := collectTailscale(internal.DockerInfo{})
+	if got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}
+
+func TestCollectTailscale_SocketHintWhenDaemonUnreachable(t *testing.T) {
+	// Binary exists, but `tailscale status` fails and the socket is missing —
+	// classic Unraid-plugin-without-mount scenario.
+	withTailscaleStubs(t,
+		func(bin string) (string, error) {
+			if bin == "tailscale" {
+				return "/usr/local/bin/tailscale", nil
+			}
+			return "", errors.New("not found")
+		},
+		func(name string, args ...string) ([]byte, error) {
+			if len(args) > 0 && args[0] == "version" {
+				// Version probe succeeds even when daemon is unreachable.
+				return []byte("1.74.1\n  tailscale commit: abc\n"), nil
+			}
+			// status --json fails because socket is not mounted
+			return nil, errors.New("failed to connect to local tailscaled")
+		},
+		func(string) (os.FileInfo, error) { return nil, os.ErrNotExist },
+		"/var/run/tailscale/tailscaled.sock",
+	)
+
+	got := collectTailscale(internal.DockerInfo{})
+	if got == nil {
+		t.Fatal("expected non-nil TailscaleInfo when binary exists")
+	}
+	if !got.Installed {
+		t.Error("expected Installed=true")
+	}
+	if got.BackendState != "Unreachable" {
+		t.Errorf("backend state: got %q, want Unreachable", got.BackendState)
+	}
+	if got.Hint == "" {
+		t.Error("expected a non-empty Hint explaining the socket mount")
+	}
+	// Should mention the socket path so the user knows what to mount
+	if !containsCI(got.Hint, "/var/run/tailscale") {
+		t.Errorf("hint should reference /var/run/tailscale, got %q", got.Hint)
+	}
+}
+
+func TestCollectTailscale_DockerFallbackStillWorks(t *testing.T) {
+	// No host binary, but a Tailscale Docker container is running.
+	withTailscaleStubs(t,
+		func(string) (string, error) { return "", errors.New("not found") },
+		func(string, ...string) ([]byte, error) { return nil, errors.New("unused") },
+		func(string) (os.FileInfo, error) { return nil, os.ErrNotExist },
+		"/var/run/tailscale/tailscaled.sock",
+	)
+
+	docker := internal.DockerInfo{
+		Containers: []internal.ContainerInfo{
+			{ID: "abc", Name: "tailscale", Image: "tailscale/tailscale:latest", State: "running"},
+		},
+	}
+	got := collectTailscale(docker)
+	if got == nil {
+		t.Fatal("expected non-nil info from docker fallback")
+	}
+	if !got.Installed {
+		t.Error("expected Installed=true via docker fallback")
+	}
+	if got.Self == nil || got.Self.Name != "tailscale" {
+		t.Errorf("expected Self from docker container, got %+v", got.Self)
+	}
+}
+
+// containsCI is a tiny case-insensitive substring helper for readable tests.
+func containsCI(haystack, needle string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	h := []byte(haystack)
+	n := []byte(needle)
+	for i := 0; i+len(n) <= len(h); i++ {
+		match := true
+		for j := 0; j < len(n); j++ {
+			a, b := h[i+j], n[j]
+			if a >= 'A' && a <= 'Z' {
+				a += 'a' - 'A'
+			}
+			if b >= 'A' && b <= 'Z' {
+				b += 'a' - 'A'
+			}
+			if a != b {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/models.go
+++ b/internal/models.go
@@ -167,11 +167,12 @@ type CloudflaredTunnel struct {
 type TailscaleInfo struct {
 	Installed    bool            `json:"installed"`
 	Version      string          `json:"version,omitempty"`
-	BackendState string          `json:"backend_state,omitempty"` // Running, Stopped, NeedsLogin
+	BackendState string          `json:"backend_state,omitempty"` // Running, Stopped, NeedsLogin, Unreachable
 	Self         *TailscaleNode  `json:"self,omitempty"`
 	Peers        []TailscaleNode `json:"peers,omitempty"`
 	MagicDNS     bool            `json:"magic_dns,omitempty"`
 	TailnetName  string          `json:"tailnet_name,omitempty"`
+	Hint         string          `json:"hint,omitempty"` // Operator hint when detection is partial (e.g. missing socket mount)
 }
 
 type TailscaleNode struct {

--- a/unraid-template.xml
+++ b/unraid-template.xml
@@ -50,6 +50,7 @@ Features:
   <Config Name="System Logs" Target="/host/log" Default="/var/log" Mode="ro" Description="System log files (syslog, messages)" Type="Path" Display="always" Required="false" Mask="false">/var/log</Config>
   <Config Name="Unraid Version" Target="/etc/unraid-version" Default="/etc/unraid-version" Mode="ro" Description="Unraid version file (for OS update detection)" Type="Path" Display="always" Required="false" Mask="false">/etc/unraid-version</Config>
   <Config Name="Host Mounts" Target="/host/mnt" Default="/mnt" Mode="ro" Description="Host disk mounts (for per-disk space monitoring)" Type="Path" Display="always" Required="false" Mask="false">/mnt</Config>
+  <Config Name="Tailscale Socket" Target="/var/run/tailscale" Default="/var/run/tailscale" Mode="ro" Description="Required for Tailscale detection via host tailscaled socket (tailscale-nas-util plugin users). Leave blank if not using Tailscale." Type="Path" Display="advanced" Required="false" Mask="false">/var/run/tailscale</Config>
   <Config Name="Scan Interval" Target="NAS_DOCTOR_INTERVAL" Default="30m" Mode="" Description="How often to run diagnostic scans (e.g. 30m, 1h, 6h, 24h)" Type="Variable" Display="always" Required="false" Mask="false">30m</Config>
   <Config Name="Timezone" Target="TZ" Default="UTC" Mode="" Description="Container timezone (e.g. Europe/London, America/New_York)" Type="Variable" Display="always" Required="false" Mask="false">UTC</Config>
 </Container>


### PR DESCRIPTION
Closes #135

## Summary

Two root causes for \`Tailscale\` showing as \"not detected\" on Unraid, both fixed here:

1. **`tailscale` binary missing from the image.** Added to `Dockerfile:32` apk list. The client is ~8 MB; we never start the daemon — we only use the CLI to query the host's `tailscaled` socket.
2. **`/var/run/tailscale` socket not bind-mounted.** Added a new `<Config>` entry to `unraid-template.xml` (Advanced view, read-only, optional). Users on the `tailscale-nas-util` plugin will now get detection out of the box.
3. **Fallback hint** — if the binary is present but `tailscale status` fails (socket missing or unreachable), the collector now returns `BackendState="Unreachable"` plus a human-readable `Hint` pointing at the missing mount, instead of silently reporting nothing. New `NAS_DOCTOR_TAILSCALE_SOCKET` env var supports non-default socket paths.

## Changes
- `internal/collector/tunnels.go` — injectable `tailscaleLookPath` / `tailscaleRunCommand` / `tailscaleSocketStat` / `tailscaleSocketPath` package vars; socket-fallback logic in `collectTailscale`.
- `internal/models.go` — new `TailscaleInfo.Hint` field (additive, omitempty).
- `internal/collector/tunnels_test.go` — **new file.** Four tests (see below).
- `internal/collector/testdata/tailscale_status.json` — **new fixture.** Real-shape `tailscale status --json` output with a self node + 3 peers (online laptop, offline phone, exit-node).
- `Dockerfile` — add `tailscale` to apk list.
- `unraid-template.xml` — add `/var/run/tailscale` read-only bind mount (Advanced, optional).

## Tests

```
$ go test ./internal/collector/ -run Tailscale -v
=== RUN   TestParseTailscaleStatusJSON
--- PASS: TestParseTailscaleStatusJSON (0.00s)
=== RUN   TestCollectTailscale_NoBinary_NoDocker_ReturnsNil
--- PASS: TestCollectTailscale_NoBinary_NoDocker_ReturnsNil (0.00s)
=== RUN   TestCollectTailscale_SocketHintWhenDaemonUnreachable
--- PASS: TestCollectTailscale_SocketHintWhenDaemonUnreachable (0.00s)
=== RUN   TestCollectTailscale_DockerFallbackStillWorks
--- PASS: TestCollectTailscale_DockerFallbackStillWorks (0.00s)
PASS
ok  	github.com/mcdays94/nas-doctor/internal/collector	0.609s
```

Full suite (`go test ./...`) passes; `go build ./...` clean.

## Commits (TDD)
1. `test(tunnels)` — RED: tests + fixture, no impl
2. `fix(tunnels)` — GREEN: inject stubs + socket fallback
3. `build(unraid)` — ship binary + template mount

## :warning: Reviewer notes

- **Expected Dockerfile merge conflict with #134.** That worker is adding `apcupsd nut-client` to the same apk line in `Dockerfile:32`. Trivial to resolve — just keep all three additions on the line. Workers did not coordinate by design.
- **Template propagation.** `unraid-template.xml` lives in this repo for the canonical source of truth, but Unraid Community Apps users pull from `mcdays94/docker-templates`. After merge, please mirror the updated template to that repo (orchestrator handles this — noted per release process in `AGENTS.md`).
- **Image size.** Alpine's `tailscale` package pulls in tailscaled too; we don't start it, but it's on disk. If image-size-sensitive, we could swap to a stripped-down `tailscale-client` or download just the client binary from tailscale.com. Deferred — current approach matches how we ship `docker-cli` etc.

## Follow-ups (out of scope)
- Dashboard/UI could render `TailscaleInfo.Hint` as a yellow info banner in the tunnels section. Currently only the struct exposes it.
- Refactor the "host binary + docker container + platform-plugin hint" triad into a reusable detector (useful for cloudflared, zerotier). Punted — keep this PR tight.
- Real-hardware UAT on Unraid 7.2.4 with the `tailscale-nas-util` plugin once an RC tag is cut.