### PR TITLE
fix(demo-deploy): exclude pre-release tags from version fallback

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -32,7 +32,7 @@ jobs:
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VER="${GITHUB_REF_NAME#v}"
           else
-            VER=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1 | sed 's/^v//')
+            VER=$(git tag -l 'v[0-9]*' --sort=-v:refname | grep -vE -- '-(rc|beta|alpha)[0-9]*$' | head -1 | sed 's/^v//')
           fi
           VER="${VER:-0.0.0}"
           echo "value=$VER" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Closes #144

## Summary

The demo Worker's version label was resolving to `0.9.1-rc2` instead of `0.9.1` because `git tag -l ... --sort=-v:refname` sorts pre-release tags (e.g. `v0.9.1-rc2`) as string-greater-than their release counterparts (`v0.9.1`). `head -1` therefore picked the wrong tag in the fallback branch of `.github/workflows/demo-deploy.yml`.

## Change

One-line fix in `demo-deploy.yml` — add a `grep -vE` to exclude `-rc*` / `-beta*` / `-alpha*` suffixes before `head -1`:

```diff
- VER=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1 | sed 's/^v//')
+ VER=$(git tag -l 'v[0-9]*' --sort=-v:refname | grep -vE -- '-(rc|beta|alpha)[0-9]*$' | head -1 | sed 's/^v//')
```

The explicit-tag branch (`refs/tags/v*`) is unchanged — it's already correct.

## Manual validation

Ran locally against the actual repo tags:

```
$ git tag -l 'v[0-9]*' --sort=-v:refname | head -5
v0.9.1-rc2
v0.9.1-rc1
v0.9.1
v0.9.0-rc10
v0.9.0-rc9

# Current (buggy) command:
$ git tag -l 'v[0-9]*' --sort=-v:refname | head -1 | sed 's/^v//'
0.9.1-rc2

# Proposed fix:
$ git tag -l 'v[0-9]*' --sort=-v:refname | grep -vE -- '-(rc|beta|alpha)[0-9]*$' | head -1 | sed 's/^v//'
0.9.1
```

## Sanity checks

- `go build ./...` — pass
- `go test ./...` — pass (no Go code touched)

## Deployment note

Merging this PR will **not** automatically redeploy the demo Worker — `demo-deploy.yml` is triggered by `push: tags: ['latest']` (or `workflow_dispatch`). To roll out the corrected version label, after merge run:

```
git push -f origin latest
```

…or trigger the workflow manually from the Actions tab.