### PR TITLE
fix(stats): disambiguate per-core CPU chart label (#140)

### DIFF
--- a/internal/api/api_process_history_test.go
+++ b/internal/api/api_process_history_test.go
@@ -141,10 +141,16 @@ func TestStatsHTMLContainsProcessHistorySection(t *testing.T) {
 		name   string
 		substr string
 	}{
-		{"section title", "Process CPU History"},
+		{"section title", "Process CPU Load"},
 		{"API fetch", "/api/v1/history/processes"},
 		{"chart canvas", "chart-process-cpu"},
 		{"NasChart.line call", "NasChart.line"},
+		// Per-core disambiguation — see issue #140. The chart plots `ps aux %CPU`
+		// which is a per-core value (N cores busy ≈ N×100%), so the label must
+		// not imply a normalized 0-100 scale.
+		{"per-core chart label", "% of 1 core"},
+		{"per-core y-axis label", "% / core"},
+		{"explanatory caption", "100% = one CPU core fully busy"},
 	}
 	for _, tc := range checks {
 		t.Run(tc.name, func(t *testing.T) {
@@ -152,6 +158,11 @@ func TestStatsHTMLContainsProcessHistorySection(t *testing.T) {
 				t.Errorf("stats.html missing %q — expected substring: %q", tc.name, tc.substr)
 			}
 		})
+	}
+
+	// Ensure the ambiguous old label is gone.
+	if strings.Contains(tmpl, "CPU Usage (%) by Process") {
+		t.Errorf("stats.html still contains ambiguous label %q; should disambiguate per-core semantics (issue #140)", "CPU Usage (%) by Process")
 	}
 }
 

--- a/internal/api/templates/stats.html
+++ b/internal/api/templates/stats.html
@@ -490,8 +490,8 @@ fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d
     ranked = ranked.slice(0, 8);
     if (ranked.length === 0) return '';
     var title = highlightProc
-      ? esc(highlightProc) + (highlightCtr ? ' (' + esc(highlightCtr) + ')' : ' (host)') + ' — CPU History'
-      : 'Process CPU History (top ' + ranked.length + ' by cumulative CPU)';
+      ? esc(highlightProc) + (highlightCtr ? ' (' + esc(highlightCtr) + ')' : ' (host)') + ' — CPU Load (per-core %)'
+      : 'Process CPU Load (top ' + ranked.length + ' by cumulative core-time)';
     var h = '<div class="system-section" id="process-history">';
     h += '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">';
     h += '<div class="system-section-title" style="margin-bottom:0">' + title + '</div>';
@@ -503,8 +503,9 @@ fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d
       h += '<button onclick="window._loadProcessRange(' + rng.h + ')" style="font-size:10px;padding:2px 8px;border-radius:4px;border:1px solid var(--border);background:' + (active ? 'var(--bg-elevated)' : 'transparent') + ';color:' + (active ? 'var(--text2)' : 'var(--text3)') + ';cursor:pointer">' + rng.l + '</button>';
     }
     h += '</div></div>';
-    h += '<div class="chart-card"><div class="chart-label">CPU Usage (%) by Process</div>';
-    h += '<canvas id="chart-process-cpu" width="600" height="200" style="width:100%;height:200px"></canvas></div>';
+    h += '<div class="chart-card"><div class="chart-label">CPU Load per Process (% of 1 core; up to N×100% on multi-core)</div>';
+    h += '<canvas id="chart-process-cpu" width="600" height="200" style="width:100%;height:200px"></canvas>';
+    h += '<div style="font-size:11px;color:var(--text3);margin-top:4px">100% = one CPU core fully busy. A process using N cores can reach N×100%.</div></div>';
     // Legend
     h += '<div style="display:flex;gap:12px;flex-wrap:wrap;margin-bottom:20px;padding:0 4px">';
     for (var j = 0; j < ranked.length; j++) {
@@ -569,7 +570,7 @@ fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d
       if (isNaN(d.getTime())) return '';
       return ('0'+d.getHours()).slice(-2) + ':' + ('0'+d.getMinutes()).slice(-2);
     });
-    try { NasChart.line("chart-process-cpu", { datasets: datasets, labels: labels, yLabel: "%" }); } catch(e) {}
+    try { NasChart.line("chart-process-cpu", { datasets: datasets, labels: labels, yLabel: "% / core" }); } catch(e) {}
   }
 
   var capacityForecast = null;


### PR DESCRIPTION
Closes #140

## Summary

The `/stats` Process CPU History chart plots `ps aux %CPU`, which is **per-core** by Linux convention — an 8-threaded process pegging 8 cores legitimately reports ~800%. The previous label `CPU Usage (%) by Process` falsely implied a normalized 0-100 scale, making values >100% look like bugs.

**This is a label-only fix.** Data, computation, collector, scheduler, and storage are unchanged — they were correct all along. The dashboard already treats container CPU the same way (`cm.cpu_percent > 200 ? 'td-crit'`).

## Changes

`internal/api/templates/stats.html`:
- Section title/subtitle: `Process CPU History` → `Process CPU Load (top N by cumulative core-time)`
- Highlight subtitle: `— CPU History` → `— CPU Load (per-core %)`
- Chart label: `CPU Usage (%) by Process` → `CPU Load per Process (% of 1 core; up to N×100% on multi-core)`
- Y-axis: `%` → `% / core`
- Added explanatory caption under the chart: *"100% = one CPU core fully busy. A process using N cores can reach N×100%."*

`internal/api/api_process_history_test.go`:
- Extended `TestStatsHTMLContainsProcessHistorySection` with assertions for the new labels and a guard that the old ambiguous label is gone.

## Test output

```
=== RUN   TestStatsHTMLContainsProcessHistorySection
--- PASS: TestStatsHTMLContainsProcessHistorySection (0.00s)
    --- PASS: TestStatsHTMLContainsProcessHistorySection/section_title (0.00s)
    --- PASS: TestStatsHTMLContainsProcessHistorySection/API_fetch (0.00s)
    --- PASS: TestStatsHTMLContainsProcessHistorySection/chart_canvas (0.00s)
    --- PASS: TestStatsHTMLContainsProcessHistorySection/NasChart.line_call (0.00s)
    --- PASS: TestStatsHTMLContainsProcessHistorySection/per-core_chart_label (0.00s)
    --- PASS: TestStatsHTMLContainsProcessHistorySection/per-core_y-axis_label (0.00s)
    --- PASS: TestStatsHTMLContainsProcessHistorySection/explanatory_caption (0.00s)
PASS
```

Full pre-flight:
```
go build ./...  # ok
go test ./...   # all packages pass (api, collector, scheduler, storage, cmd)
```

## Out of scope (follow-up candidates)

- **Normalized view toggle** — an alternate chart mode that divides CPU% by `system.cpu_cores` so both charts read 0-100. Mentioned by issue author as a future enhancement, deliberately deferred — this PR is a pure label fix.