### PR TITLE
fix(retention): disk_usage_history breaks snapshot pruning (#141)

### DIFF
--- a/internal/scheduler/retention.go
+++ b/internal/scheduler/retention.go
@@ -22,18 +22,30 @@ type RetentionManagerConfig struct {
 	ServiceCheckMaxAge time.Duration
 	NotificationMaxAge time.Duration
 	AlertMaxAge        time.Duration
-	MaxDBSizeMB        float64
+	// DiskUsageMaxAge bounds how long snapshot-independent capacity-forecast
+	// rows (disk_usage_history) are retained. Zero falls back to the default
+	// (365 days) — see defaultDiskUsageMaxAge.
+	DiskUsageMaxAge time.Duration
+	MaxDBSizeMB     float64
 }
+
+// defaultDiskUsageMaxAge is the hardcoded retention for disk_usage_history
+// rows used by capacity forecasting. One year of daily samples per mount
+// point is a reasonable upper bound for linear-regression inputs. A future
+// PR (tracked alongside #127) will surface this as a user-configurable
+// advanced setting.
+const defaultDiskUsageMaxAge = 365 * 24 * time.Hour
 
 // RetentionResult summarizes what a single RunRetention call pruned.
 type RetentionResult struct {
-	SnapshotsPruned     int
-	ServiceChecksPruned int
-	NotificationsPruned int
-	AlertsPruned        int
-	OrphansPruned       int
-	SizePruned          int
-	Vacuumed            bool
+	SnapshotsPruned        int
+	ServiceChecksPruned    int
+	NotificationsPruned    int
+	AlertsPruned           int
+	OrphansPruned          int
+	DiskUsageHistoryPruned int64
+	SizePruned             int
+	Vacuumed               bool
 }
 
 // RetentionManager owns all data lifecycle operations. It depends only on
@@ -109,6 +121,21 @@ func (rm *RetentionManager) RunRetention(cfg RetentionManagerConfig) RetentionRe
 			result.ServiceChecksPruned = pruned
 			needsVacuum = true
 		}
+	}
+
+	// 3c. Prune disk_usage_history (snapshot-independent, own retention horizon).
+	// Falls back to defaultDiskUsageMaxAge (365d) when unset so callers that
+	// haven't plumbed this through yet still get sensible defaults.
+	diskUsageMaxAge := cfg.DiskUsageMaxAge
+	if diskUsageMaxAge <= 0 {
+		diskUsageMaxAge = defaultDiskUsageMaxAge
+	}
+	if pruned, err := rm.store.PruneDiskUsageHistory(time.Now().Add(-diskUsageMaxAge)); err != nil {
+		rm.logger.Warn("prune disk usage history failed", "error", err)
+	} else if pruned > 0 {
+		rm.logger.Info("pruned disk usage history", "count", pruned)
+		result.DiskUsageHistoryPruned = pruned
+		needsVacuum = true
 	}
 
 	// 4. Prune resolved alerts

--- a/internal/scheduler/retention_test.go
+++ b/internal/scheduler/retention_test.go
@@ -475,3 +475,51 @@ func TestRunRetention_NilServiceCheckStore(t *testing.T) {
 		t.Fatalf("expected 0 with nil svc store, got %d", result.ServiceChecksPruned)
 	}
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 18: RunRetention prunes disk_usage_history rows older than cutoff
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRunRetention_DiskUsageHistoryPruning(t *testing.T) {
+	store := storage.NewFakeStore()
+
+	// Seed 3 rows: 2 older than 365d, 1 recent
+	store.AddDiskUsageHistoryEntry("/mnt/disk1", time.Now().Add(-400*24*time.Hour))
+	store.AddDiskUsageHistoryEntry("/mnt/disk1", time.Now().Add(-366*24*time.Hour))
+	store.AddDiskUsageHistoryEntry("/mnt/disk1", time.Now().Add(-30*24*time.Hour))
+
+	rm := NewRetentionManager(store, store, discardLogger())
+	// DiskUsageMaxAge unset → falls back to 365d default
+	result := rm.RunRetention(defaultCfg())
+
+	if result.DiskUsageHistoryPruned != 2 {
+		t.Fatalf("expected 2 disk_usage_history rows pruned (default 365d), got %d", result.DiskUsageHistoryPruned)
+	}
+	if store.DiskUsageHistoryCount() != 1 {
+		t.Fatalf("expected 1 row remaining, got %d", store.DiskUsageHistoryCount())
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 19: RunRetention honors explicit DiskUsageMaxAge override
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRunRetention_DiskUsageHistoryPruning_ExplicitOverride(t *testing.T) {
+	store := storage.NewFakeStore()
+
+	store.AddDiskUsageHistoryEntry("/mnt/disk1", time.Now().Add(-10*24*time.Hour))
+	store.AddDiskUsageHistoryEntry("/mnt/disk1", time.Now().Add(-1*time.Hour))
+
+	rm := NewRetentionManager(store, store, discardLogger())
+	cfg := defaultCfg()
+	cfg.DiskUsageMaxAge = 7 * 24 * time.Hour
+
+	result := rm.RunRetention(cfg)
+
+	if result.DiskUsageHistoryPruned != 1 {
+		t.Fatalf("expected 1 pruned with 7d override, got %d", result.DiskUsageHistoryPruned)
+	}
+	if store.DiskUsageHistoryCount() != 1 {
+		t.Fatalf("expected 1 row remaining, got %d", store.DiskUsageHistoryCount())
+	}
+}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -1775,7 +1775,13 @@ func (d *DB) PruneSnapshots(olderThan time.Duration, keepMin int) (int, error) {
 
 	// Explicitly delete from history tables for the snapshots being pruned,
 	// in case foreign_keys or CASCADE is not fully honoured at runtime.
-	for _, table := range []string{"smart_history", "system_history", "disk_usage_history", "gpu_history", "container_stats_history", "speedtest_history", "process_history"} {
+	//
+	// NOTE: disk_usage_history is intentionally NOT in this list — it has no
+	// snapshot_id column (capacity-forecast rows outlive snapshot pruning).
+	// It is pruned independently via PruneDiskUsageHistory. Including it here
+	// previously caused the whole transaction to roll back on every run
+	// ("no such column: snapshot_id"), making snapshot+history pruning a no-op.
+	for _, table := range []string{"smart_history", "system_history", "gpu_history", "container_stats_history", "speedtest_history", "process_history"} {
 		_, err := tx.Exec(fmt.Sprintf(
 			`DELETE FROM %s WHERE snapshot_id IN (%s)`, table, pruneQuery,
 		), keepMin, cutoff)
@@ -2130,6 +2136,22 @@ func (d *DB) GetDBStats() (*DBStats, error) {
 	return stats, nil
 }
 
+// PruneDiskUsageHistory removes disk_usage_history rows whose timestamp is
+// strictly before cutoff. Returns the number of rows deleted.
+//
+// disk_usage_history is snapshot-independent (no snapshot_id column): it's
+// keyed by mount_point + timestamp so capacity-forecast data survives
+// snapshot pruning. It has its own retention policy, managed independently
+// of PruneSnapshots.
+func (d *DB) PruneDiskUsageHistory(cutoff time.Time) (int64, error) {
+	res, err := d.db.Exec(`DELETE FROM disk_usage_history WHERE timestamp < ?`, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("prune disk_usage_history: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
 // PruneToSizeMB aggressively deletes the oldest snapshots until the DB is under the target size.
 // Returns the number of snapshots deleted.
 func (d *DB) PruneToSizeMB(targetMB float64) (int, error) {
@@ -2155,7 +2177,8 @@ func (d *DB) PruneToSizeMB(targetMB float64) (int, error) {
 		if err != nil {
 			return totalPruned, err
 		}
-		for _, table := range []string{"smart_history", "system_history", "disk_usage_history", "gpu_history", "container_stats_history", "speedtest_history", "process_history"} {
+		// NOTE: disk_usage_history excluded — no snapshot_id column; see PruneSnapshots.
+		for _, table := range []string{"smart_history", "system_history", "gpu_history", "container_stats_history", "speedtest_history", "process_history"} {
 			d.db.Exec(fmt.Sprintf(`DELETE FROM %s WHERE snapshot_id IN (
 				SELECT id FROM snapshots ORDER BY timestamp ASC LIMIT ?
 			)`, table), batchSize)

--- a/internal/storage/db_prune_test.go
+++ b/internal/storage/db_prune_test.go
@@ -1,0 +1,216 @@
+package storage
+
+import (
+	"testing"
+	"time"
+)
+
+// seedSnapshotWithHistory inserts one snapshot plus one row into every
+// snapshot-bound history table (smart_history, system_history, gpu_history,
+// container_stats_history, speedtest_history, process_history) AND one row
+// into disk_usage_history (which is snapshot-independent).
+//
+// Inserts are done with raw SQL (bypassing SaveSnapshot) so each history
+// table ends up with exactly one row per snapshot seeded — SaveSnapshot
+// would add an extra system_history row automatically.
+func seedSnapshotWithHistory(t *testing.T, db *DB, snapID string, ts time.Time) {
+	t.Helper()
+
+	// 1. snapshot (raw insert — SaveSnapshot would auto-insert system_history)
+	if _, err := db.db.Exec(
+		`INSERT INTO snapshots (id, timestamp, duration_seconds, data) VALUES (?, ?, ?, ?)`,
+		snapID, ts, 0.1, "{}",
+	); err != nil {
+		t.Fatalf("insert snapshot: %v", err)
+	}
+
+	// 2. snapshot-bound history rows
+	inserts := []struct {
+		name string
+		sql  string
+		args []any
+	}{
+		{
+			"smart_history",
+			`INSERT INTO smart_history (snapshot_id, device, serial, model, temperature, timestamp) VALUES (?,?,?,?,?,?)`,
+			[]any{snapID, "/dev/sda", "SN1", "MODEL", 35, ts},
+		},
+		{
+			"system_history",
+			`INSERT INTO system_history (snapshot_id, cpu_usage, mem_percent, timestamp) VALUES (?,?,?,?)`,
+			[]any{snapID, 10.0, 50.0, ts},
+		},
+		{
+			"gpu_history",
+			`INSERT INTO gpu_history (snapshot_id, gpu_index, name, timestamp) VALUES (?,?,?,?)`,
+			[]any{snapID, 0, "gpu0", ts},
+		},
+		{
+			"container_stats_history",
+			`INSERT INTO container_stats_history (snapshot_id, container_id, name, timestamp) VALUES (?,?,?,?)`,
+			[]any{snapID, "cid1", "container1", ts},
+		},
+		{
+			"speedtest_history",
+			`INSERT INTO speedtest_history (snapshot_id, download_mbps, timestamp) VALUES (?,?,?)`,
+			[]any{snapID, 100.0, ts},
+		},
+		{
+			"process_history",
+			`INSERT INTO process_history (snapshot_id, pid, name, timestamp) VALUES (?,?,?,?)`,
+			[]any{snapID, 1, "init", ts},
+		},
+	}
+	for _, ins := range inserts {
+		if _, err := db.db.Exec(ins.sql, ins.args...); err != nil {
+			t.Fatalf("insert %s: %v", ins.name, err)
+		}
+	}
+
+	// 3. snapshot-independent disk_usage_history row (no snapshot_id column)
+	if _, err := db.db.Exec(
+		`INSERT INTO disk_usage_history (mount_point, label, device, total_gb, used_gb, free_gb, used_pct, timestamp) VALUES (?,?,?,?,?,?,?,?)`,
+		"/mnt/disk1", "disk1", "/dev/sda1", 1000.0, 500.0, 500.0, 50.0, ts,
+	); err != nil {
+		t.Fatalf("insert disk_usage_history: %v", err)
+	}
+}
+
+func countRows(t *testing.T, db *DB, table string) int {
+	t.Helper()
+	var n int
+	if err := db.db.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&n); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return n
+}
+
+// TestPruneSnapshots_WithDiskUsageHistory demonstrates the bug:
+// PruneSnapshots tries to `DELETE FROM disk_usage_history WHERE snapshot_id IN (...)`
+// but that column doesn't exist, so the whole transaction rolls back and NO
+// snapshot/history pruning happens.
+func TestPruneSnapshots_WithDiskUsageHistory(t *testing.T) {
+	db := newTestDB(t)
+
+	// Seed one old snapshot + rows in every history table.
+	seedSnapshotWithHistory(t, db, "snap-old", time.Now().Add(-48*time.Hour))
+
+	// Prune everything older than 1h, keep 0 minimum.
+	pruned, err := db.PruneSnapshots(1*time.Hour, 0)
+	if err != nil {
+		t.Fatalf("PruneSnapshots: %v", err)
+	}
+	if pruned != 1 {
+		t.Errorf("expected 1 snapshot pruned, got %d", pruned)
+	}
+
+	// snapshot gone
+	if n := countRows(t, db, "snapshots"); n != 0 {
+		t.Errorf("expected 0 snapshots after prune, got %d", n)
+	}
+	// All 6 snapshot-bound history tables empty
+	for _, table := range []string{
+		"smart_history", "system_history", "gpu_history",
+		"container_stats_history", "speedtest_history", "process_history",
+	} {
+		if n := countRows(t, db, table); n != 0 {
+			t.Errorf("expected 0 rows in %s, got %d", table, n)
+		}
+	}
+
+	// disk_usage_history untouched by PruneSnapshots (managed independently)
+	if n := countRows(t, db, "disk_usage_history"); n != 1 {
+		t.Errorf("expected disk_usage_history untouched (1 row), got %d", n)
+	}
+}
+
+// TestPruneSnapshots_RollbackIsolation proves that when disk_usage_history is
+// wrongly included in the prune loop, the transaction rollback cascades and
+// deletes from smart_history/system_history are reverted too. After the fix,
+// those deletes actually commit.
+func TestPruneSnapshots_RollbackIsolation(t *testing.T) {
+	db := newTestDB(t)
+
+	// Two snapshots: one old (should prune), one recent (should stay).
+	seedSnapshotWithHistory(t, db, "snap-old", time.Now().Add(-48*time.Hour))
+	seedSnapshotWithHistory(t, db, "snap-new", time.Now().Add(-5*time.Minute))
+
+	// 2 rows in each history table now
+	if n := countRows(t, db, "smart_history"); n != 2 {
+		t.Fatalf("seeding: expected 2 smart_history rows, got %d", n)
+	}
+	if n := countRows(t, db, "system_history"); n != 2 {
+		t.Fatalf("seeding: expected 2 system_history rows, got %d", n)
+	}
+
+	// Prune snapshots older than 1h, keep minimum 0.
+	pruned, err := db.PruneSnapshots(1*time.Hour, 0)
+	if err != nil {
+		t.Fatalf("PruneSnapshots: %v", err)
+	}
+	if pruned != 1 {
+		t.Errorf("expected 1 snapshot pruned, got %d", pruned)
+	}
+
+	// Only the snap-old row should have been removed from each history table.
+	// Pre-fix: transaction rolled back → still 2 rows each.
+	// Post-fix: 1 row each remains.
+	for _, table := range []string{"smart_history", "system_history"} {
+		if n := countRows(t, db, table); n != 1 {
+			t.Errorf("%s: expected 1 row to remain (rollback bug), got %d", table, n)
+		}
+	}
+	// Snapshots table
+	if n := countRows(t, db, "snapshots"); n != 1 {
+		t.Errorf("expected 1 remaining snapshot, got %d", n)
+	}
+}
+
+// TestPruneDiskUsageHistory_DeletesOldRowsOnly — the new dedicated prune path.
+func TestPruneDiskUsageHistory_DeletesOldRowsOnly(t *testing.T) {
+	db := newTestDB(t)
+
+	now := time.Now()
+	// 3 rows: 2 old, 1 recent
+	rows := []struct {
+		mount string
+		ts    time.Time
+	}{
+		{"/mnt/disk1", now.Add(-400 * 24 * time.Hour)}, // very old
+		{"/mnt/disk1", now.Add(-366 * 24 * time.Hour)}, // old (just past 365d)
+		{"/mnt/disk1", now.Add(-30 * 24 * time.Hour)},  // recent
+	}
+	for _, r := range rows {
+		if _, err := db.db.Exec(
+			`INSERT INTO disk_usage_history (mount_point, label, device, total_gb, used_gb, free_gb, used_pct, timestamp) VALUES (?,?,?,?,?,?,?,?)`,
+			r.mount, "label", "dev", 100.0, 50.0, 50.0, 50.0, r.ts,
+		); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	cutoff := now.Add(-365 * 24 * time.Hour)
+	deleted, err := db.PruneDiskUsageHistory(cutoff)
+	if err != nil {
+		t.Fatalf("PruneDiskUsageHistory: %v", err)
+	}
+	if deleted != 2 {
+		t.Errorf("expected 2 deleted, got %d", deleted)
+	}
+	if n := countRows(t, db, "disk_usage_history"); n != 1 {
+		t.Errorf("expected 1 row remaining, got %d", n)
+	}
+}
+
+// TestPruneDiskUsageHistory_EmptyTable_NoError — defensive: should work on empty table.
+func TestPruneDiskUsageHistory_EmptyTable_NoError(t *testing.T) {
+	db := newTestDB(t)
+
+	deleted, err := db.PruneDiskUsageHistory(time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("expected 0 deleted, got %d", deleted)
+	}
+}

--- a/internal/storage/fake.go
+++ b/internal/storage/fake.go
@@ -54,6 +54,16 @@ type FakeStore struct {
 	// Orphaned findings: findings whose snapshot ID doesn't match any snapshot.
 	// Seeded by tests via AddOrphanedFindings().
 	orphanedFindingCount int
+
+	// Disk usage history rows (snapshot-independent; keyed by timestamp).
+	// Seeded via AddDiskUsageHistoryEntry() and pruned by PruneDiskUsageHistory().
+	diskUsageHistory []diskUsageRow
+}
+
+// diskUsageRow is the minimal fake representation of a disk_usage_history row.
+type diskUsageRow struct {
+	MountPoint string
+	Timestamp  time.Time
 }
 
 // NewFakeStore creates a ready-to-use in-memory store.
@@ -685,6 +695,23 @@ func (f *FakeStore) PruneAlerts(olderThan time.Duration) (int, error) {
 	return pruned, nil
 }
 
+// PruneDiskUsageHistory removes disk_usage_history rows with timestamp < cutoff.
+func (f *FakeStore) PruneDiskUsageHistory(cutoff time.Time) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var kept []diskUsageRow
+	var pruned int64
+	for _, r := range f.diskUsageHistory {
+		if r.Timestamp.Before(cutoff) {
+			pruned++
+		} else {
+			kept = append(kept, r)
+		}
+	}
+	f.diskUsageHistory = kept
+	return pruned, nil
+}
+
 // PruneOrphanedFindings removes orphaned findings and returns the count.
 func (f *FakeStore) PruneOrphanedFindings() (int, error) {
 	f.mu.Lock()
@@ -777,6 +804,23 @@ func (f *FakeStore) AddNotificationLogEntry(entry NotificationLogEntry) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.notificationLog = append(f.notificationLog, entry)
+}
+
+// AddDiskUsageHistoryEntry seeds a disk_usage_history row for testing.
+func (f *FakeStore) AddDiskUsageHistoryEntry(mountPoint string, ts time.Time) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.diskUsageHistory = append(f.diskUsageHistory, diskUsageRow{
+		MountPoint: mountPoint,
+		Timestamp:  ts,
+	})
+}
+
+// DiskUsageHistoryCount returns the number of disk_usage_history rows in the fake store.
+func (f *FakeStore) DiskUsageHistoryCount() int {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return len(f.diskUsageHistory)
 }
 
 // SnapshotCount returns the current number of snapshots.

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -96,6 +96,7 @@ type LifecycleStore interface {
 	PruneNotificationLog(olderThan time.Duration) (int, error)
 	PruneAlerts(olderThan time.Duration) (int, error)
 	PruneOrphanedFindings() (int, error)
+	PruneDiskUsageHistory(cutoff time.Time) (int64, error)
 	PruneToSizeMB(targetMB float64) (int, error)
 	Vacuum() error
 	GetDBStats() (*DBStats, error)


### PR DESCRIPTION
Closes #141

## Summary

- **Bug**: since commit `82177d2`, `disk_usage_history` was included in the
  per-table `DELETE … WHERE snapshot_id IN (…)` loop inside `PruneSnapshots`
  and `PruneToSizeMB`. That table has no `snapshot_id` column (it's
  intentionally snapshot-independent — capacity-forecast rows outlive
  snapshot pruning), so every call failed with
  `no such column: snapshot_id`.
- `PruneSnapshots` runs inside a transaction with `defer tx.Rollback()`, so
  the failure *rolled back* the `smart_history` / `system_history` deletes
  that had already succeeded. Net effect on every deployment since that
  commit: **snapshot + history retention is a complete no-op**, and
  `smart_history`, `system_history`, `gpu_history`,
  `container_stats_history`, `speedtest_history`, `process_history`, and
  `snapshots` have been accumulating forever.

## Fix

- Remove `"disk_usage_history"` from the table-list slice in both
  `PruneSnapshots` (`db.go`) and `PruneToSizeMB` (`db.go`).
- Add `PruneDiskUsageHistory(cutoff time.Time) (int64, error)` on `*DB`
  and `FakeStore`, and to the `LifecycleStore` interface.
- Wire it into `RetentionManager.RunRetention` as a new step with a
  hardcoded 365-day default (`defaultDiskUsageMaxAge`). Callers can
  override via `RetentionManagerConfig.DiskUsageMaxAge`.

## Tests

### RED → GREEN (new)

`internal/storage/db_prune_test.go`:

- `TestPruneSnapshots_WithDiskUsageHistory` — reproduces the broken prune.
- `TestPruneSnapshots_RollbackIsolation` — proves smart_history /
  system_history deletes actually commit now.
- `TestPruneDiskUsageHistory_DeletesOldRowsOnly` — cutoff semantics.
- `TestPruneDiskUsageHistory_EmptyTable_NoError` — defensive.

`internal/scheduler/retention_test.go`:

- `TestRunRetention_DiskUsageHistoryPruning` — default 365d.
- `TestRunRetention_DiskUsageHistoryPruning_ExplicitOverride` — custom age.

### RED output (pre-fix)

```
=== RUN   TestPruneSnapshots_WithDiskUsageHistory
    db_prune_test.go:101: PruneSnapshots: prune disk_usage_history:
    SQL logic error: no such column: snapshot_id (1)
--- FAIL: TestPruneSnapshots_WithDiskUsageHistory (0.01s)
=== RUN   TestPruneSnapshots_RollbackIsolation
    db_prune_test.go:149: PruneSnapshots: prune disk_usage_history:
    SQL logic error: no such column: snapshot_id (1)
--- FAIL: TestPruneSnapshots_RollbackIsolation (0.01s)
=== RUN   TestPruneDiskUsageHistory_DeletesOldRowsOnly
--- PASS: TestPruneDiskUsageHistory_DeletesOldRowsOnly (0.00s)
=== RUN   TestPruneDiskUsageHistory_EmptyTable_NoError
--- PASS: TestPruneDiskUsageHistory_EmptyTable_NoError (0.00s)
FAIL
```

### GREEN output (post-fix)

```
=== RUN   TestPruneSnapshots_WithDiskUsageHistory
--- PASS: TestPruneSnapshots_WithDiskUsageHistory (0.01s)
=== RUN   TestPruneSnapshots_RollbackIsolation
--- PASS: TestPruneSnapshots_RollbackIsolation (0.01s)
=== RUN   TestPruneDiskUsageHistory_DeletesOldRowsOnly
--- PASS: TestPruneDiskUsageHistory_DeletesOldRowsOnly (0.00s)
=== RUN   TestPruneDiskUsageHistory_EmptyTable_NoError
--- PASS: TestPruneDiskUsageHistory_EmptyTable_NoError (0.01s)
PASS
```

Full suite: `go build ./...` + `go test ./...` green.

## Scope boundary — advanced settings UI is **out of scope**

This PR is the bug-fix only. The 365-day value is hardcoded via
`defaultDiskUsageMaxAge` and not surfaced in the UI.

A user-configurable per-subsystem retention widget in Advanced Settings
(i.e., `internal/api/api_extended.go` + `internal/api/templates/settings.html`)
belongs in a follow-up PR, likely bundled with #127 (Advanced scan settings).

## Follow-ups

- Surface `DiskUsageMaxAge` + other per-subsystem retention durations as
  configurable settings (with #127).
- Consider an SQLite startup migration/VACUUM pass to reclaim space from
  deployments that have been accumulating history tables since `82177d2`.