### PR TITLE
settings: add "Test" button to validate service check config before saving

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -61,12 +61,11 @@ func New(store storage.Store, sched *scheduler.Scheduler, coll *collector.Collec
 func (s *Server) Router() http.Handler {
 	r := chi.NewRouter()
 
-	// Middleware
+	// Baseline middleware — cheap, applied to every route.
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Compress(5))
-	r.Use(middleware.Timeout(30 * time.Second))
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   []string{"*"},
 		AllowedMethods:   []string{"GET", "POST", "PUT", "OPTIONS"},
@@ -76,27 +75,39 @@ func (s *Server) Router() http.Handler {
 		MaxAge:           300,
 	}))
 
-	// Health endpoint — always public (Docker HEALTHCHECK, K8s probes, load balancers)
-	r.Get("/api/v1/health", s.handleHealth)
+	// Long-running test endpoints — registered BEFORE the Timeout group.
+	// Speed-type service-check tests invoke the Ookla CLI, which can take
+	// 10-60s, so we can't subject them to the 30s router-wide timeout.
+	// RunCheck uses its own per-check context from cfg.TimeoutSec.
+	r.Post("/api/v1/service-checks/test", s.handleTestServiceCheck)
 
-	// API routes — protected by API key when set
-	r.Route("/api/v1", func(r chi.Router) {
-		r.Use(s.apiKeyMiddleware)
-		r.Get("/status", s.handleStatus)
-		r.Get("/snapshot/latest", s.handleLatestSnapshot)
-		r.Get("/snapshot/{id}", s.handleGetSnapshot)
-		r.Get("/snapshots", s.handleListSnapshots)
-		r.Post("/scan", s.handleTriggerScan)
-		r.Get("/report", s.handleReport)
+	// Standard-latency routes — 30s soft timeout via a Group so we don't
+	// apply it to the long-running route above.
+	r.Group(func(r chi.Router) {
+		r.Use(middleware.Timeout(30 * time.Second))
+
+		// Health endpoint — always public (Docker HEALTHCHECK, K8s probes, load balancers)
+		r.Get("/api/v1/health", s.handleHealth)
+
+		// API routes — protected by API key when set
+		r.Route("/api/v1", func(r chi.Router) {
+			r.Use(s.apiKeyMiddleware)
+			r.Get("/status", s.handleStatus)
+			r.Get("/snapshot/latest", s.handleLatestSnapshot)
+			r.Get("/snapshot/{id}", s.handleGetSnapshot)
+			r.Get("/snapshots", s.handleListSnapshots)
+			r.Post("/scan", s.handleTriggerScan)
+			r.Get("/report", s.handleReport)
+		})
+
+		// Prometheus metrics
+		if s.metrics != nil {
+			r.Handle("/metrics", promhttp.HandlerFor(s.metrics.Registry(), promhttp.HandlerOpts{}))
+		}
+
+		// Extended API routes (settings, disks, history, notifications)
+		s.RegisterExtendedRoutes(r)
 	})
-
-	// Prometheus metrics
-	if s.metrics != nil {
-		r.Handle("/metrics", promhttp.HandlerFor(s.metrics.Registry(), promhttp.HandlerOpts{}))
-	}
-
-	// Extended API routes (settings, disks, history, notifications)
-	s.RegisterExtendedRoutes(r)
 
 	// Chart library JS
 	r.Get("/js/charts.js", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -1311,8 +1311,17 @@ func (s *Server) handleServiceCheckHistory(w http.ResponseWriter, r *http.Reques
 // Intended for the settings page "Test" button so users can validate a check
 // before saving. Supports all 7 check types. Speed-type tests run the Ookla
 // CLI and may take 10-60s — this route is registered outside the router-wide
-// 30s Timeout group (see api.go).
+// 30s Timeout group (see api.go) AND disables the http.Server WriteTimeout
+// per-request (set to 30s in cmd/nas-doctor/main.go for baseline safety).
 func (s *Server) handleTestServiceCheck(w http.ResponseWriter, r *http.Request) {
+	// Disable the per-connection write deadline for this handler. The baseline
+	// http.Server.WriteTimeout=30s would otherwise kill long-running Ookla
+	// speed tests and return a 502 upstream. RunCheck still enforces the
+	// check's own TimeoutSec, so the request cannot hang indefinitely.
+	if rc := http.NewResponseController(w); rc != nil {
+		_ = rc.SetWriteDeadline(time.Time{})
+	}
+
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	if err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to read request body"})

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -354,6 +354,70 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, settings)
 }
 
+// normalizeServiceCheckConfig validates and applies default values to a
+// single ServiceCheckConfig in place. It returns a non-nil error when the
+// config is invalid; otherwise it is behaviour-preserving with respect to
+// the historical validation loop in handleUpdateSettings.
+//
+// Callers that handle multiple checks must still enforce slice-level
+// invariants (e.g. duplicate-name detection) themselves.
+func normalizeServiceCheckConfig(check *internal.ServiceCheckConfig) error {
+	check.Name = strings.TrimSpace(check.Name)
+	check.Type = strings.ToLower(strings.TrimSpace(check.Type))
+	check.Target = strings.TrimSpace(check.Target)
+	if check.Name == "" {
+		return fmt.Errorf("service_checks.checks name is required")
+	}
+	if check.Target == "" {
+		return fmt.Errorf("service_checks.checks target is required")
+	}
+	switch check.Type {
+	case internal.ServiceCheckHTTP, internal.ServiceCheckTCP, internal.ServiceCheckDNS, internal.ServiceCheckSMB, internal.ServiceCheckNFS, internal.ServiceCheckPing, internal.ServiceCheckSpeed:
+		// valid
+	default:
+		return fmt.Errorf("invalid service check type: %s", check.Type)
+	}
+	if check.IntervalSec <= 0 {
+		check.IntervalSec = 300 // default 5 minutes
+	}
+	if check.IntervalSec < 30 {
+		check.IntervalSec = 30 // minimum 30 seconds
+	}
+	if check.TimeoutSec <= 0 {
+		check.TimeoutSec = 5
+	}
+	if check.TimeoutSec > 30 {
+		check.TimeoutSec = 30
+	}
+	if check.Port < 0 || check.Port > 65535 {
+		return fmt.Errorf("service check port must be between 0 and 65535")
+	}
+	if check.FailureThreshold <= 0 {
+		check.FailureThreshold = 1
+	}
+	if check.FailureSeverity == "" {
+		check.FailureSeverity = internal.SeverityWarning
+	}
+	switch check.FailureSeverity {
+	case internal.SeverityInfo, internal.SeverityWarning, internal.SeverityCritical:
+		// valid
+	default:
+		return fmt.Errorf("invalid service check failure_severity")
+	}
+	if check.Type == internal.ServiceCheckHTTP {
+		if check.ExpectedMin <= 0 {
+			check.ExpectedMin = 200
+		}
+		if check.ExpectedMax <= 0 {
+			check.ExpectedMax = 399
+		}
+		if check.ExpectedMax < check.ExpectedMin {
+			check.ExpectedMax = check.ExpectedMin
+		}
+	}
+	return nil
+}
+
 // handleUpdateSettings validates and persists the settings JSON.
 // PUT /api/v1/settings
 func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
@@ -464,15 +528,8 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 	serviceNames := make(map[string]struct{}, len(settings.ServiceChecks.Checks))
 	for i := range settings.ServiceChecks.Checks {
 		check := &settings.ServiceChecks.Checks[i]
-		check.Name = strings.TrimSpace(check.Name)
-		check.Type = strings.ToLower(strings.TrimSpace(check.Type))
-		check.Target = strings.TrimSpace(check.Target)
-		if check.Name == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "service_checks.checks name is required"})
-			return
-		}
-		if check.Target == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "service_checks.checks target is required"})
+		if err := normalizeServiceCheckConfig(check); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
 		if _, exists := serviceNames[strings.ToLower(check.Name)]; exists {
@@ -480,53 +537,6 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		serviceNames[strings.ToLower(check.Name)] = struct{}{}
-		switch check.Type {
-		case internal.ServiceCheckHTTP, internal.ServiceCheckTCP, internal.ServiceCheckDNS, internal.ServiceCheckSMB, internal.ServiceCheckNFS, internal.ServiceCheckPing, internal.ServiceCheckSpeed:
-			// valid
-		default:
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid service check type: " + check.Type})
-			return
-		}
-		if check.IntervalSec <= 0 {
-			check.IntervalSec = 300 // default 5 minutes
-		}
-		if check.IntervalSec < 30 {
-			check.IntervalSec = 30 // minimum 30 seconds
-		}
-		if check.TimeoutSec <= 0 {
-			check.TimeoutSec = 5
-		}
-		if check.TimeoutSec > 30 {
-			check.TimeoutSec = 30
-		}
-		if check.Port < 0 || check.Port > 65535 {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "service check port must be between 0 and 65535"})
-			return
-		}
-		if check.FailureThreshold <= 0 {
-			check.FailureThreshold = 1
-		}
-		if check.FailureSeverity == "" {
-			check.FailureSeverity = internal.SeverityWarning
-		}
-		switch check.FailureSeverity {
-		case internal.SeverityInfo, internal.SeverityWarning, internal.SeverityCritical:
-			// valid
-		default:
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid service check failure_severity"})
-			return
-		}
-		if check.Type == internal.ServiceCheckHTTP {
-			if check.ExpectedMin <= 0 {
-				check.ExpectedMin = 200
-			}
-			if check.ExpectedMax <= 0 {
-				check.ExpectedMax = 399
-			}
-			if check.ExpectedMax < check.ExpectedMin {
-				check.ExpectedMax = check.ExpectedMin
-			}
-		}
 	}
 	if settings.LogPush.Destinations == nil {
 		settings.LogPush.Destinations = []LogForwardDestination{}

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -1304,6 +1304,46 @@ func (s *Server) handleServiceCheckHistory(w http.ResponseWriter, r *http.Reques
 	writeJSON(w, http.StatusOK, history)
 }
 
+// handleTestServiceCheck runs a single service check synchronously using the
+// supplied config, without persisting the result or mutating any saved state.
+// POST /api/v1/service-checks/test
+//
+// Intended for the settings page "Test" button so users can validate a check
+// before saving. Supports all 7 check types. Speed-type tests run the Ookla
+// CLI and may take 10-60s — this route is registered outside the router-wide
+// 30s Timeout group (see api.go).
+func (s *Server) handleTestServiceCheck(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to read request body"})
+		return
+	}
+	defer r.Body.Close()
+
+	var cfg internal.ServiceCheckConfig
+	if err := json.Unmarshal(body, &cfg); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		return
+	}
+
+	if err := normalizeServiceCheckConfig(&cfg); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	// Build a fresh checker per request. It uses the store purely for read-only
+	// state lookups it does NOT actually perform in RunCheck (it's only touched
+	// by RunDueChecks, which we don't call). We deliberately avoid using
+	// s.scheduler here so the endpoint works in demo mode and tests.
+	checker := scheduler.NewServiceChecker(s.store, s.logger)
+	if cfg.Type == internal.ServiceCheckSpeed {
+		checker.SetSpeedTestRunner(collector.RunSpeedTest)
+	}
+
+	result := checker.RunCheck(cfg, time.Now().UTC())
+	writeJSON(w, http.StatusOK, result)
+}
+
 // handleRunServiceChecks triggers immediate service check execution.
 // POST /api/v1/service-checks/run
 func (s *Server) handleRunServiceChecks(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/service_check_test_endpoint_test.go
+++ b/internal/api/service_check_test_endpoint_test.go
@@ -1,0 +1,340 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/scheduler"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// postServiceCheckTest issues a POST request against handleTestServiceCheck
+// and returns the recorder for inspection.
+func postServiceCheckTest(t *testing.T, srv *Server, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf []byte
+	var err error
+	switch v := body.(type) {
+	case string:
+		buf = []byte(v)
+	case []byte:
+		buf = v
+	default:
+		buf, err = json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/service-checks/test", bytes.NewReader(buf))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.handleTestServiceCheck(rec, req)
+	return rec
+}
+
+func decodeResult(t *testing.T, rec *httptest.ResponseRecorder) internal.ServiceCheckResult {
+	t.Helper()
+	var r internal.ServiceCheckResult
+	body, _ := io.ReadAll(rec.Body)
+	if err := json.Unmarshal(body, &r); err != nil {
+		t.Fatalf("decode result: %v (body=%s)", err, string(body))
+	}
+	return r
+}
+
+// TestHandleTestServiceCheck_HTTP_Up — a reachable HTTP target reports up with
+// a positive response time.
+func TestHandleTestServiceCheck_HTTP_Up(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	srv := newSettingsTestServer()
+	rec := postServiceCheckTest(t, srv, map[string]any{
+		"name":   "web",
+		"type":   "http",
+		"target": ts.URL,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	r := decodeResult(t, rec)
+	if r.Status != "up" {
+		t.Fatalf("expected status up, got %q (error=%q)", r.Status, r.Error)
+	}
+	if r.ResponseMS < 0 {
+		t.Fatalf("expected non-negative response time, got %d", r.ResponseMS)
+	}
+}
+
+// TestHandleTestServiceCheck_HTTP_Down — an unreachable target reports down
+// with a non-empty error.
+func TestHandleTestServiceCheck_HTTP_Down(t *testing.T) {
+	srv := newSettingsTestServer()
+	rec := postServiceCheckTest(t, srv, map[string]any{
+		"name":        "bad",
+		"type":        "http",
+		"target":      "http://192.0.2.1:1", // RFC 5737 TEST-NET, unreachable
+		"timeout_sec": 1,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 (check ran, down), got %d: %s", rec.Code, rec.Body.String())
+	}
+	r := decodeResult(t, rec)
+	if r.Status != "down" {
+		t.Fatalf("expected status down, got %q", r.Status)
+	}
+	if r.Error == "" {
+		t.Fatal("expected non-empty error on unreachable target")
+	}
+}
+
+// TestHandleTestServiceCheck_TCP_Up — an open TCP port reports up.
+func TestHandleTestServiceCheck_TCP_Up(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	_, port, _ := net.SplitHostPort(ln.Addr().String())
+
+	srv := newSettingsTestServer()
+	rec := postServiceCheckTest(t, srv, map[string]any{
+		"name":   "tcp-svc",
+		"type":   "tcp",
+		"target": "127.0.0.1:" + port,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	r := decodeResult(t, rec)
+	if r.Status != "up" {
+		t.Fatalf("expected status up, got %q (error=%q)", r.Status, r.Error)
+	}
+}
+
+// TestHandleTestServiceCheck_TCP_Down — a closed TCP port reports down.
+func TestHandleTestServiceCheck_TCP_Down(t *testing.T) {
+	srv := newSettingsTestServer()
+	rec := postServiceCheckTest(t, srv, map[string]any{
+		"name":        "tcp-closed",
+		"type":        "tcp",
+		"target":      "127.0.0.1:1",
+		"timeout_sec": 1,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	r := decodeResult(t, rec)
+	if r.Status != "down" {
+		t.Fatalf("expected status down, got %q", r.Status)
+	}
+}
+
+// TestHandleTestServiceCheck_InvalidType — unknown types are rejected 400.
+func TestHandleTestServiceCheck_InvalidType(t *testing.T) {
+	srv := newSettingsTestServer()
+	rec := postServiceCheckTest(t, srv, map[string]any{
+		"name":   "weird",
+		"type":   "gibberish",
+		"target": "example.com",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "invalid service check type") {
+		t.Fatalf("expected invalid-type error, got: %s", rec.Body.String())
+	}
+}
+
+// TestHandleTestServiceCheck_MissingTarget — empty target rejected 400.
+func TestHandleTestServiceCheck_MissingTarget(t *testing.T) {
+	srv := newSettingsTestServer()
+	rec := postServiceCheckTest(t, srv, map[string]any{
+		"name":   "no-target",
+		"type":   "http",
+		"target": "",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "target") {
+		t.Fatalf("expected target error, got: %s", rec.Body.String())
+	}
+}
+
+// TestHandleTestServiceCheck_MissingName — empty name rejected 400.
+func TestHandleTestServiceCheck_MissingName(t *testing.T) {
+	srv := newSettingsTestServer()
+	rec := postServiceCheckTest(t, srv, map[string]any{
+		"name":   "",
+		"type":   "http",
+		"target": "http://example.com",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "name") {
+		t.Fatalf("expected name error, got: %s", rec.Body.String())
+	}
+}
+
+// TestHandleTestServiceCheck_DoesNotPersist — calling /test must not write a
+// row into the service-check history store.
+func TestHandleTestServiceCheck_DoesNotPersist(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	srv := newSettingsTestServer()
+	store := srv.store.(*storage.FakeStore)
+
+	// Seed a known baseline so we can count precisely.
+	baseline, _ := store.ListLatestServiceChecks(1000)
+	beforeCount := len(baseline)
+
+	rec := postServiceCheckTest(t, srv, map[string]any{
+		"name":   "ephemeral",
+		"type":   "http",
+		"target": ts.URL,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("test call failed: %d %s", rec.Code, rec.Body.String())
+	}
+
+	after, _ := store.ListLatestServiceChecks(1000)
+	if len(after) != beforeCount {
+		t.Fatalf("service-check store changed: before=%d after=%d — /test must not persist", beforeCount, len(after))
+	}
+}
+
+// TestHandleTestServiceCheck_DoesNotMutateSettings — a /test call must not
+// mutate the saved settings (service_checks slice).
+func TestHandleTestServiceCheck_DoesNotMutateSettings(t *testing.T) {
+	srv := newSettingsTestServer()
+	// Seed a saved service check named "web" pointing at a known target.
+	saved := Settings{
+		ScanInterval: "30m",
+		Theme:        "midnight",
+	}
+	saved.ServiceChecks.Checks = []internal.ServiceCheckConfig{{
+		Name:    "web",
+		Type:    "http",
+		Target:  "http://saved-target.example.com",
+		Enabled: true,
+	}}
+	data, _ := json.Marshal(saved)
+	if err := srv.store.SetConfig(settingsConfigKey, string(data)); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+
+	// POST a /test with the SAME name but a different target.
+	rec := postServiceCheckTest(t, srv, map[string]any{
+		"name":        "web",
+		"type":        "http",
+		"target":      "http://different-target.example.com",
+		"timeout_sec": 1,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("test call failed: %d %s", rec.Code, rec.Body.String())
+	}
+
+	// Reload settings from store — target for "web" must be unchanged.
+	raw, err := srv.store.GetConfig(settingsConfigKey)
+	if err != nil {
+		t.Fatalf("reload settings: %v", err)
+	}
+	var reloaded Settings
+	if err := json.Unmarshal([]byte(raw), &reloaded); err != nil {
+		t.Fatalf("parse reloaded settings: %v", err)
+	}
+	if len(reloaded.ServiceChecks.Checks) != 1 {
+		t.Fatalf("expected 1 saved check, got %d", len(reloaded.ServiceChecks.Checks))
+	}
+	if reloaded.ServiceChecks.Checks[0].Target != "http://saved-target.example.com" {
+		t.Fatalf("saved service check target was mutated: got %q", reloaded.ServiceChecks.Checks[0].Target)
+	}
+}
+
+// TestHandleTestServiceCheck_DoesNotTouchConsecutiveFailures — the ConsecutiveFailures
+// tracked in store state must not be bumped by a failing /test call.
+func TestHandleTestServiceCheck_DoesNotTouchConsecutiveFailures(t *testing.T) {
+	srv := newSettingsTestServer()
+	store := srv.store.(*storage.FakeStore)
+
+	// Seed a failing history entry with ConsecutiveFailures=3.
+	cfg := internal.ServiceCheckConfig{
+		Name: "web", Type: "http", Target: "http://saved.example.com",
+	}
+	key := scheduler.CheckKey(cfg)
+	_ = store.SaveServiceCheckResults([]internal.ServiceCheckResult{{
+		Key:                 key,
+		Name:                "web",
+		Type:                "http",
+		Target:              "http://saved.example.com",
+		Status:              "down",
+		ConsecutiveFailures: 3,
+		CheckedAt:           "2026-01-01T00:00:00Z",
+	}})
+
+	stateBefore, ok, err := store.GetLatestServiceCheckState(key)
+	if err != nil || !ok || stateBefore.ConsecutiveFailures != 3 {
+		t.Fatalf("seed failed: ok=%v err=%v state=%+v", ok, err, stateBefore)
+	}
+
+	// POST a failing /test for the same-keyed config.
+	rec := postServiceCheckTest(t, srv, map[string]any{
+		"name":        "web",
+		"type":        "http",
+		"target":      "http://saved.example.com",
+		"timeout_sec": 1,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("test call failed: %d %s", rec.Code, rec.Body.String())
+	}
+
+	stateAfter, ok, err := store.GetLatestServiceCheckState(key)
+	if err != nil || !ok {
+		t.Fatalf("read state after: ok=%v err=%v", ok, err)
+	}
+	if stateAfter.ConsecutiveFailures != 3 {
+		t.Fatalf("ConsecutiveFailures changed: before=3 after=%d — /test must not bump it",
+			stateAfter.ConsecutiveFailures)
+	}
+}
+
+// TestRegisterExtendedRoutes_ExposesServiceCheckTest — the new route is registered
+// and responds on POST through the router.
+func TestRegisterExtendedRoutes_ExposesServiceCheckTest(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	srv := newSettingsTestServer()
+	handler := srv.Router()
+
+	body, _ := json.Marshal(map[string]any{
+		"name": "routed", "type": "http", "target": ts.URL,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/service-checks/test", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusNotFound || rec.Code == http.StatusMethodNotAllowed {
+		t.Fatalf("expected route to be registered, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 from router, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/api/settings_service_check_test_button_test.go
+++ b/internal/api/settings_service_check_test_button_test.go
@@ -140,6 +140,52 @@ func TestSettingsHTML_SpeedCheckInterval_DefaultsToDaily(t *testing.T) {
 	}
 }
 
+// TestSettingsHTML_IntervalSelect_OptionsMatchAnyAutoDefault guards against the
+// regression where onServiceTypeChange sets the interval to a value not in the
+// <select id="sc-interval"> options list. Observed in rc4: the JS set value
+// to 86400 but the select had no matching <option>, so the dropdown rendered
+// blank. Every value the JS can auto-assign MUST have a corresponding option.
+func TestSettingsHTML_IntervalSelect_OptionsMatchAnyAutoDefault(t *testing.T) {
+	html := loadSettingsHTML(t)
+
+	// Extract the <select id="sc-interval">...</select> block.
+	selectRe := regexp.MustCompile(`(?s)<select id="sc-interval">(.*?)</select>`)
+	m := selectRe.FindStringSubmatch(html)
+	if m == nil {
+		t.Fatal("<select id=\"sc-interval\"> not found")
+	}
+	optsBlock := m[1]
+
+	// Collect every value="…" occurrence.
+	optRe := regexp.MustCompile(`value="(\d+)"`)
+	present := map[string]bool{}
+	for _, match := range optRe.FindAllStringSubmatch(optsBlock, -1) {
+		present[match[1]] = true
+	}
+
+	// Every value that onServiceTypeChange or similar code can set as a
+	// default MUST be in the options.
+	required := []struct{ value, label string }{
+		{"300", "5 minutes (new-check baseline)"},
+		{"86400", "daily (auto-assigned for speed checks)"},
+	}
+	for _, r := range required {
+		if !present[r.value] {
+			t.Errorf("<select id=\"sc-interval\"> missing option value=%q (%s) — onServiceTypeChange sets this value and it must match an existing <option>", r.value, r.label)
+		}
+	}
+
+	// Nice-to-have options (don't fail loudly, but flag as missing for
+	// future richness — users who opt into daily speed tests probably want
+	// weekly as an alternative too).
+	niceTo := []string{"604800"}
+	for _, v := range niceTo {
+		if !present[v] {
+			t.Logf("NOTE: <select id=\"sc-interval\"> missing option value=%q (consider adding)", v)
+		}
+	}
+}
+
 // TestHandleTestServiceCheck_DisablesWriteDeadline verifies that the handler
 // code invokes http.NewResponseController(w).SetWriteDeadline(time.Time{}) so
 // that speed tests can run longer than the 30s baseline http.Server.WriteTimeout

--- a/internal/api/settings_service_check_test_button_test.go
+++ b/internal/api/settings_service_check_test_button_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// loadSettingsHTML returns the settings.html template content for assertions.
+func loadSettingsHTML(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.html: %v", err)
+	}
+	return string(data)
+}
+
+// TestSettingsHTML_HasServiceCheckTestButton verifies the Test button is
+// rendered inside the service-check form, alongside Save and Cancel.
+func TestSettingsHTML_HasServiceCheckTestButton(t *testing.T) {
+	html := loadSettingsHTML(t)
+	if !strings.Contains(html, `onclick="testServiceCheck()"`) {
+		t.Fatal("settings.html missing Test button (expected onclick=\"testServiceCheck()\")")
+	}
+	// Button must live in the same action row as Save/Cancel.
+	idx := strings.Index(html, `onclick="testServiceCheck()"`)
+	windowStart := idx - 400
+	if windowStart < 0 {
+		windowStart = 0
+	}
+	window := html[windowStart : idx+400]
+	if !strings.Contains(window, `saveServiceCheck()`) || !strings.Contains(window, `cancelServiceCheckForm()`) {
+		t.Fatalf("Test button should sit alongside Save/Cancel in the same action row; local window:\n%s", window)
+	}
+}
+
+// TestSettingsHTML_TestServiceCheckFunctionExists verifies a testServiceCheck
+// JS function is defined in the page.
+func TestSettingsHTML_TestServiceCheckFunctionExists(t *testing.T) {
+	html := loadSettingsHTML(t)
+	re := regexp.MustCompile(`function\s+testServiceCheck\s*\(`)
+	if !re.MatchString(html) {
+		t.Fatal("settings.html missing `function testServiceCheck(` definition")
+	}
+}
+
+// TestSettingsHTML_ReadServiceCheckFormExtracted verifies the DOM-reading
+// logic has been factored out into a readServiceCheckForm() helper.
+func TestSettingsHTML_ReadServiceCheckFormExtracted(t *testing.T) {
+	html := loadSettingsHTML(t)
+	re := regexp.MustCompile(`function\s+readServiceCheckForm\s*\(`)
+	if !re.MatchString(html) {
+		t.Fatal("settings.html missing `function readServiceCheckForm(` helper — extract DOM reading so saveServiceCheck and testServiceCheck share it")
+	}
+}
+
+// TestSettingsHTML_SaveServiceCheckUsesReader verifies saveServiceCheck
+// invokes readServiceCheckForm instead of duplicating the DOM reads.
+func TestSettingsHTML_SaveServiceCheckUsesReader(t *testing.T) {
+	html := loadSettingsHTML(t)
+	// locate the saveServiceCheck body
+	startRe := regexp.MustCompile(`function\s+saveServiceCheck\s*\(\s*\)\s*\{`)
+	loc := startRe.FindStringIndex(html)
+	if loc == nil {
+		t.Fatal("saveServiceCheck() function not found")
+	}
+	// Take a reasonable window of the body.
+	end := loc[1] + 2000
+	if end > len(html) {
+		end = len(html)
+	}
+	body := html[loc[0]:end]
+	if !strings.Contains(body, "readServiceCheckForm(") {
+		t.Fatalf("saveServiceCheck should call readServiceCheckForm(); body window:\n%s", body)
+	}
+}
+
+// TestSettingsHTML_TestServiceCheckPostsToCorrectEndpoint verifies the JS
+// targets the new /api/v1/service-checks/test endpoint.
+func TestSettingsHTML_TestServiceCheckPostsToCorrectEndpoint(t *testing.T) {
+	html := loadSettingsHTML(t)
+	if !strings.Contains(html, "/api/v1/service-checks/test") {
+		t.Fatal("settings.html missing fetch to /api/v1/service-checks/test")
+	}
+}
+
+// TestSettingsHTML_TestServiceCheckShowsSpeedWarning verifies that when the
+// check type is speed the user is warned about the long runtime.
+func TestSettingsHTML_TestServiceCheckShowsSpeedWarning(t *testing.T) {
+	html := loadSettingsHTML(t)
+	// Locate testServiceCheck body.
+	startRe := regexp.MustCompile(`function\s+testServiceCheck\s*\(\s*\)\s*\{`)
+	loc := startRe.FindStringIndex(html)
+	if loc == nil {
+		t.Fatal("testServiceCheck() function not found")
+	}
+	end := loc[1] + 3000
+	if end > len(html) {
+		end = len(html)
+	}
+	body := html[loc[0]:end]
+	if !strings.Contains(strings.ToLower(body), "60s") && !strings.Contains(strings.ToLower(body), "60 s") {
+		t.Fatalf("testServiceCheck should warn users that speed tests can take up to 60s; body window:\n%s", body)
+	}
+}

--- a/internal/api/settings_service_check_test_button_test.go
+++ b/internal/api/settings_service_check_test_button_test.go
@@ -107,3 +107,70 @@ func TestSettingsHTML_TestServiceCheckShowsSpeedWarning(t *testing.T) {
 		t.Fatalf("testServiceCheck should warn users that speed tests can take up to 60s; body window:\n%s", body)
 	}
 }
+
+// TestSettingsHTML_SpeedCheckInterval_DefaultsToDaily verifies that when the
+// user selects "speed" in the service-check type dropdown, onServiceTypeChange
+// bumps the interval from the new-check default of 300s (5min) to 86400s
+// (daily). Running Ookla speedtest every 5 minutes would waste bandwidth and
+// likely trigger ISP throttling.
+func TestSettingsHTML_SpeedCheckInterval_DefaultsToDaily(t *testing.T) {
+	html := loadSettingsHTML(t)
+	startRe := regexp.MustCompile(`function\s+onServiceTypeChange\s*\(\s*\)\s*\{`)
+	loc := startRe.FindStringIndex(html)
+	if loc == nil {
+		t.Fatal("onServiceTypeChange() function not found")
+	}
+	end := loc[1] + 2000
+	if end > len(html) {
+		end = len(html)
+	}
+	body := html[loc[0]:end]
+	// Must guard on type === "speed" to avoid overwriting the interval for
+	// other types.
+	if !regexp.MustCompile(`type\s*===\s*["']speed["']`).MatchString(body) {
+		t.Error("onServiceTypeChange should check for speed type before changing interval")
+	}
+	// Must set interval to 86400 (seconds in a day).
+	if !strings.Contains(body, "86400") {
+		t.Errorf("onServiceTypeChange should default speed-type interval to 86400s (daily); got body:\n%s", body)
+	}
+	// Must guard on still-at-default-300 so user-customised values aren't overwritten.
+	if !regexp.MustCompile(`===?\s*300`).MatchString(body) {
+		t.Error("onServiceTypeChange should only change interval if user hasn't customised from the 300s default")
+	}
+}
+
+// TestHandleTestServiceCheck_DisablesWriteDeadline verifies that the handler
+// code invokes http.NewResponseController(w).SetWriteDeadline(time.Time{}) so
+// that speed tests can run longer than the 30s baseline http.Server.WriteTimeout
+// set in cmd/nas-doctor/main.go. Without this, long Ookla runs trigger a
+// transport-layer 502 Bad Gateway upstream (observed during v0.9.2-rc3 UAT).
+//
+// This is a source-level assertion rather than a behavioural test — exercising
+// the real 30s timeout would make the suite slow and flaky. The fix itself is
+// one line of well-known Go 1.20+ API, so a grep-style guard is proportionate.
+func TestHandleTestServiceCheck_DisablesWriteDeadline(t *testing.T) {
+	path := filepath.Join(".", "api_extended.go")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read api_extended.go: %v", err)
+	}
+	src := string(data)
+	handlerRe := regexp.MustCompile(`func\s+\(s\s+\*Server\)\s+handleTestServiceCheck\s*\(`)
+	loc := handlerRe.FindStringIndex(src)
+	if loc == nil {
+		t.Fatal("handleTestServiceCheck function not found")
+	}
+	// Look within the first ~1500 bytes of the handler body.
+	end := loc[0] + 1500
+	if end > len(src) {
+		end = len(src)
+	}
+	body := src[loc[0]:end]
+	if !strings.Contains(body, "NewResponseController") {
+		t.Error("handleTestServiceCheck should use http.NewResponseController to override WriteTimeout for long-running speed tests")
+	}
+	if !strings.Contains(body, "SetWriteDeadline(time.Time{})") {
+		t.Error("handleTestServiceCheck should call SetWriteDeadline(time.Time{}) to disable the per-connection write deadline")
+	}
+}

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -525,6 +525,7 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
       </div>
       <div class="webhook-form-actions">
         <button class="btn btn-primary" onclick="saveServiceCheck()">Save Check</button>
+        <button class="btn btn-secondary" id="sc-test-btn" onclick="testServiceCheck()">Test</button>
         <button class="btn btn-secondary" onclick="cancelServiceCheckForm()">Cancel</button>
       </div>
     </div>
@@ -1719,7 +1720,11 @@ function cancelServiceCheckForm() {
   document.getElementById("service-check-form").classList.remove("visible");
 }
 
-function saveServiceCheck() {
+// readServiceCheckForm reads the service-check editor form into a plain
+// JS object matching the ServiceCheckConfig JSON schema. Returns null if
+// required fields are missing (and shows a toast in that case). Shared by
+// saveServiceCheck() and testServiceCheck() so validation cannot drift.
+function readServiceCheckForm() {
   var name = document.getElementById("sc-name").value.trim();
   var type = document.getElementById("sc-type").value;
   var target = document.getElementById("sc-target").value.trim();
@@ -1727,7 +1732,7 @@ function saveServiceCheck() {
   if (type === "speed") { target = "speedtest"; }
   if (!name || (!target && type !== "speed")) {
     showToast("Name and target are required", "error");
-    return;
+    return null;
   }
   var sc = {
     name: name,
@@ -1758,6 +1763,13 @@ function saveServiceCheck() {
     sc.margin_pct = parseFloat(document.getElementById("sc-margin").value) || 10;
     sc.target = "speedtest";
   }
+  return sc;
+}
+
+function saveServiceCheck() {
+  var sc = readServiceCheckForm();
+  if (!sc) return;
+  var name = sc.name;
 
   for (var i = 0; i < serviceChecks.length; i++) {
     if (i === parseInt(document.getElementById("sc-edit-index").value, 10)) continue;
@@ -1776,6 +1788,70 @@ function saveServiceCheck() {
   renderServiceChecks();
   cancelServiceCheckForm();
   saveSettings();
+}
+
+// testServiceCheck runs the current form's configuration through the
+// /api/v1/service-checks/test endpoint without persisting the result. It
+// surfaces status, response time, and error messages via toast. Speed-type
+// checks can take up to 60s on real hardware (Ookla CLI), so we warn the
+// user up-front and disable the button for the duration of the request.
+function testServiceCheck() {
+  var sc = readServiceCheckForm();
+  if (!sc) return;
+
+  var btn = document.getElementById("sc-test-btn");
+  var originalLabel = btn ? btn.textContent : "Test";
+  if (btn) { btn.disabled = true; btn.textContent = "Testing…"; }
+
+  if (sc.type === "speed") {
+    showToast("Running speed test (can take up to 60s)…", "info");
+  } else {
+    showToast("Testing " + sc.type + " check…", "info");
+  }
+
+  fetch("/api/v1/service-checks/test", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(sc)
+  })
+    .then(function(r) {
+      return r.json().then(function(data) { return { ok: r.ok, data: data }; });
+    })
+    .then(function(res) {
+      if (!res.ok) {
+        showToast("Test failed: " + (res.data && res.data.error ? res.data.error : "server error"), "error");
+        return;
+      }
+      var result = res.data || {};
+      var status = result.status || "unknown";
+      var ms = result.response_ms;
+      var msg;
+      var toastKind = "info";
+      if (status === "up") {
+        msg = "✓ Check is UP" + (typeof ms === "number" ? " (" + ms + " ms)" : "");
+        toastKind = "success";
+      } else if (status === "degraded") {
+        msg = "△ Degraded";
+        toastKind = "warning";
+      } else {
+        msg = "✗ Check is DOWN";
+        toastKind = "error";
+      }
+      if (sc.type === "speed" && (typeof result.download_mbps === "number" || typeof result.upload_mbps === "number")) {
+        msg += " — " + (result.download_mbps || 0).toFixed(0) + " ↓ / " +
+               (result.upload_mbps || 0).toFixed(0) + " ↑ Mbps";
+      }
+      if (result.error) {
+        msg += " — " + result.error;
+      }
+      showToast(msg, toastKind);
+    })
+    .catch(function(e) {
+      showToast("Test failed: " + (e && e.message ? e.message : "network error"), "error");
+    })
+    .finally(function() {
+      if (btn) { btn.disabled = false; btn.textContent = originalLabel; }
+    });
 }
 
 function removeServiceCheck(idx) {

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -461,6 +461,10 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
             <option value="900">15 minutes</option>
             <option value="1800">30 minutes</option>
             <option value="3600">1 hour</option>
+            <option value="21600">6 hours</option>
+            <option value="43200">12 hours</option>
+            <option value="86400">Daily</option>
+            <option value="604800">Weekly</option>
           </select>
         </div>
         <div>

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -1678,6 +1678,15 @@ function onServiceTypeChange() {
     else if (type === "dns") targetInput.placeholder = "e.g. google.com";
     else targetInput.placeholder = "https://nas.local/health, 192.168.1.10, or host:port";
   }
+  // Speed tests are expensive (Ookla CLI runs ~30-60s and saturates the
+  // connection), so bump the interval to daily when the user picks the speed
+  // type, but only if they haven't customised it yet — i.e. it's still at the
+  // new-check default of 300s. An interval of 5 minutes for a speed test
+  // would waste bandwidth and trigger ISP throttling.
+  var intervalInput = document.getElementById("sc-interval");
+  if (intervalInput && type === "speed" && parseInt(intervalInput.value, 10) === 300) {
+    intervalInput.value = "86400";
+  }
 }
 function parseScHeaders() {
   var raw = (document.getElementById("sc-headers") || {}).value || "";


### PR DESCRIPTION
Closes #142

## Summary

Adds a **Test** button to each service-check editor in Settings. Clicking it runs the check synchronously against the live target using the **same** `scheduler.ServiceChecker.RunCheck` that the cron loop uses, but without persisting the result or mutating any saved state. Users can validate `http` / `tcp` / `dns` / `ping` / `smb` / `nfs` / `speed` configurations before saving.

## Changes

**Backend** (`internal/api/api_extended.go`, `internal/api/api.go`)
- Extracted `normalizeServiceCheckConfig(*ServiceCheckConfig) error` so the new endpoint and `handleUpdateSettings` share a single validator (no rule drift).
- New handler `handleTestServiceCheck` — decodes JSON, normalises + validates (400 on bad input), builds a fresh `NewServiceChecker(s.store, s.logger)` per request, injects `collector.RunSpeedTest` only when `type == speed`, calls `RunCheck`, returns JSON. No writes to the store.
- New route `POST /api/v1/service-checks/test`.

**Frontend** (`internal/api/templates/settings.html`)
- New Test button in the service-check form action row (id `sc-test-btn`).
- Extracted `readServiceCheckForm()` helper; `saveServiceCheck` now calls it instead of duplicating DOM reads.
- New `testServiceCheck()` — warns up-front for speed-type (`"can take up to 60s…"`), disables the button during the request, and surfaces up/degraded/down with response time, download/upload Mbps (for speed), and any server-side error message via toast.

## Chi timeout handling

`internal/api/api.go` previously applied `middleware.Timeout(30 * time.Second)` via `r.Use(...)` across every route. That is incompatible with speed-type tests, which invoke the Ookla CLI and can legitimately take 10-60s (30s would return 504 mid-test).

I moved `middleware.Timeout(30s)` into a nested `r.Group` that now wraps every other route. The new `/api/v1/service-checks/test` route is registered on the **root** router **before** that group, so it is exempt. `RunCheck` still enforces its own per-check `context.WithTimeout(timeoutSec)` — the endpoint stays bounded by user-configured timeouts, never runs forever.

Speed tests should now work through the Test button on real hardware, though I haven't executed a speed test end-to-end in CI (no Ookla CLI available in the unit-test environment — the test covers schema wiring and the non-speed check types). Verify on UAT with a `speed`-type service check before cutting a stable tag.

## Behaviour guarantees (verified by tests)

- `FakeStore.SaveServiceCheckResults` is never called (`DoesNotPersist`).
- Saved `service_checks` slice is untouched when POSTing a `/test` with the same name + different target (`DoesNotMutateSettings`).
- `ConsecutiveFailures` is not bumped on a failing `/test` (`DoesNotTouchConsecutiveFailures`).

## Tests

**17 new tests, all passing:**

**Backend (11)** — `internal/api/service_check_test_endpoint_test.go`
- `TestHandleTestServiceCheck_HTTP_Up`
- `TestHandleTestServiceCheck_HTTP_Down`
- `TestHandleTestServiceCheck_TCP_Up`
- `TestHandleTestServiceCheck_TCP_Down`
- `TestHandleTestServiceCheck_InvalidType`
- `TestHandleTestServiceCheck_MissingTarget`
- `TestHandleTestServiceCheck_MissingName`
- `TestHandleTestServiceCheck_DoesNotPersist`
- `TestHandleTestServiceCheck_DoesNotMutateSettings`
- `TestHandleTestServiceCheck_DoesNotTouchConsecutiveFailures`
- `TestRegisterExtendedRoutes_ExposesServiceCheckTest`

**Template (6)** — `internal/api/settings_service_check_test_button_test.go`
- `TestSettingsHTML_HasServiceCheckTestButton`
- `TestSettingsHTML_TestServiceCheckFunctionExists`
- `TestSettingsHTML_ReadServiceCheckFormExtracted`
- `TestSettingsHTML_SaveServiceCheckUsesReader`
- `TestSettingsHTML_TestServiceCheckPostsToCorrectEndpoint`
- `TestSettingsHTML_TestServiceCheckShowsSpeedWarning`

```
$ go test ./... -count=1
ok  	github.com/mcdays94/nas-doctor/cmd/nas-doctor        0.477s
ok  	github.com/mcdays94/nas-doctor/internal/api          2.332s
ok  	github.com/mcdays94/nas-doctor/internal/collector    0.942s
ok  	github.com/mcdays94/nas-doctor/internal/scheduler    2.984s
ok  	github.com/mcdays94/nas-doctor/internal/storage      1.882s
```

`go build ./...` and `go vet ./...` both clean.

## Commits

Five TDD steps — none squashed:

1. `refactor(api): extract normalizeServiceCheckConfig helper` — behaviour-preserving.
2. `test(api): failing tests for /api/v1/service-checks/test endpoint` — RED.
3. `feat(api): implement POST /api/v1/service-checks/test handler` — GREEN + chi-timeout restructure.
4. `test(api): failing template tests for service-check Test button` — RED.
5. `feat(settings-ui): add Test button and testServiceCheck() wiring` — GREEN.

## Follow-ups

- Verify speed-type Test end-to-end on UAT (Ookla CLI runs in the Docker image but not in unit tests).
- Consider surfacing a more structured result panel (icon + colour + metrics) instead of a single toast — current toast is functional but terse, especially for degraded speed results.