### PR TITLE
fix(storage): drop snapshots FK so lightweight save loops succeed (#155)

### DIFF
--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -157,9 +157,14 @@ func (d *DB) migrate() error {
 		`CREATE INDEX IF NOT EXISTS idx_gpu_history_gpu ON gpu_history(gpu_index, timestamp DESC)`,
 
 		// --- Container stats history ---
+		// snapshot_id is intentionally NOT a REFERENCES FK: SaveContainerStats
+		// is called from the lightweight 5-minute collection loop with a
+		// synthetic "cstats-<ms>" ID that has no matching snapshots row.
+		// PruneSnapshots uses explicit DELETE (see PR #151 precedent) to
+		// clean up scan-captured entries, so the FK is not needed.
 		`CREATE TABLE IF NOT EXISTS container_stats_history (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			snapshot_id TEXT NOT NULL REFERENCES snapshots(id) ON DELETE CASCADE,
+			snapshot_id TEXT NOT NULL,
 			container_id TEXT NOT NULL,
 			name TEXT NOT NULL,
 			image TEXT,
@@ -177,9 +182,12 @@ func (d *DB) migrate() error {
 		`CREATE INDEX IF NOT EXISTS idx_container_stats_name ON container_stats_history(name, timestamp DESC)`,
 
 		// --- Speed test history ---
+		// See note on container_stats_history: snapshot_id is NOT a FK for
+		// the same reason. SaveSpeedTest gets "speedtest-<ts>" synthetic IDs
+		// from the scheduler when the test runs outside a scan.
 		`CREATE TABLE IF NOT EXISTS speedtest_history (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			snapshot_id TEXT NOT NULL REFERENCES snapshots(id) ON DELETE CASCADE,
+			snapshot_id TEXT NOT NULL,
 			download_mbps REAL,
 			upload_mbps REAL,
 			latency_ms REAL,
@@ -304,7 +312,136 @@ func (d *DB) migrate() error {
 		return fmt.Errorf("create alerts snooze index: %w", err)
 	}
 
+	// Issue #155: drop the snapshots(id) FK from container_stats_history and
+	// speedtest_history for existing databases. The CREATE TABLE statements
+	// above no longer define the FK for fresh installs, but existing DBs
+	// keep the old constraint until we rebuild the tables. SQLite has no
+	// ALTER TABLE ... DROP CONSTRAINT, so we rename → create-fresh → copy
+	// → drop guarded by a PRAGMA foreign_key_list probe (idempotent).
+	if err := d.dropSnapshotFKIfPresent("container_stats_history"); err != nil {
+		return fmt.Errorf("drop FK on container_stats_history: %w", err)
+	}
+	if err := d.dropSnapshotFKIfPresent("speedtest_history"); err != nil {
+		return fmt.Errorf("drop FK on speedtest_history: %w", err)
+	}
+
 	return nil
+}
+
+// dropSnapshotFKIfPresent rebuilds the given table without its
+// `snapshot_id REFERENCES snapshots(id)` foreign key if one is currently
+// defined. No-op on fresh installs (where the CREATE TABLE above already
+// omits the FK) and on second calls. Data is preserved by copying rows
+// from the renamed old table before dropping it.
+func (d *DB) dropSnapshotFKIfPresent(table string) error {
+	// Probe for an FK that targets the snapshots table.
+	rows, err := d.db.Query(fmt.Sprintf(`PRAGMA foreign_key_list(%s)`, table))
+	if err != nil {
+		return fmt.Errorf("pragma foreign_key_list(%s): %w", table, err)
+	}
+	hasSnapshotFK := false
+	for rows.Next() {
+		var (
+			id, seq         int
+			tableRef        string
+			from, to        string
+			onUpdate, onDel string
+			match           string
+		)
+		if err := rows.Scan(&id, &seq, &tableRef, &from, &to, &onUpdate, &onDel, &match); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan foreign_key_list(%s): %w", table, err)
+		}
+		if tableRef == "snapshots" && from == "snapshot_id" {
+			hasSnapshotFK = true
+		}
+	}
+	rows.Close()
+	if !hasSnapshotFK {
+		return nil
+	}
+
+	// Per-table rebuild. We do NOT parameterise the CREATE with a helper —
+	// explicit SQL per table keeps the migration greppable and removes any
+	// doubt about column lists drifting from the migration section above.
+	switch table {
+	case "container_stats_history":
+		return d.rebuildTable(
+			table,
+			`CREATE TABLE container_stats_history (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				snapshot_id TEXT NOT NULL,
+				container_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				image TEXT,
+				cpu_pct REAL,
+				mem_mb REAL,
+				mem_pct REAL,
+				net_in_bytes REAL,
+				net_out_bytes REAL,
+				block_read_bytes REAL,
+				block_write_bytes REAL,
+				timestamp DATETIME NOT NULL,
+				created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+			)`,
+			[]string{
+				`CREATE INDEX IF NOT EXISTS idx_container_stats_ts ON container_stats_history(timestamp DESC)`,
+				`CREATE INDEX IF NOT EXISTS idx_container_stats_name ON container_stats_history(name, timestamp DESC)`,
+			},
+			`id, snapshot_id, container_id, name, image, cpu_pct, mem_mb, mem_pct, net_in_bytes, net_out_bytes, block_read_bytes, block_write_bytes, timestamp, created_at`,
+		)
+	case "speedtest_history":
+		return d.rebuildTable(
+			table,
+			`CREATE TABLE speedtest_history (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				snapshot_id TEXT NOT NULL,
+				download_mbps REAL,
+				upload_mbps REAL,
+				latency_ms REAL,
+				jitter_ms REAL,
+				server_name TEXT,
+				isp TEXT,
+				timestamp DATETIME NOT NULL,
+				created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+			)`,
+			[]string{
+				`CREATE INDEX IF NOT EXISTS idx_speedtest_ts ON speedtest_history(timestamp DESC)`,
+			},
+			`id, snapshot_id, download_mbps, upload_mbps, latency_ms, jitter_ms, server_name, isp, timestamp, created_at`,
+		)
+	}
+	return fmt.Errorf("dropSnapshotFKIfPresent: no rebuild recipe for table %q", table)
+}
+
+// rebuildTable implements the SQLite FK-dropping recipe for a single table:
+// rename old → create new → copy rows → drop old → recreate indexes. All
+// steps run in a single transaction so a failure rolls back cleanly.
+func (d *DB) rebuildTable(table, createSQL string, indexSQLs []string, copyCols string) error {
+	tx, err := d.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(fmt.Sprintf(`ALTER TABLE %s RENAME TO %s_old_fk`, table, table)); err != nil {
+		return fmt.Errorf("rename: %w", err)
+	}
+	if _, err := tx.Exec(createSQL); err != nil {
+		return fmt.Errorf("create new: %w", err)
+	}
+	if _, err := tx.Exec(fmt.Sprintf(`INSERT INTO %s (%s) SELECT %s FROM %s_old_fk`, table, copyCols, copyCols, table)); err != nil {
+		return fmt.Errorf("copy rows: %w", err)
+	}
+	if _, err := tx.Exec(fmt.Sprintf(`DROP TABLE %s_old_fk`, table)); err != nil {
+		return fmt.Errorf("drop old: %w", err)
+	}
+	for _, ix := range indexSQLs {
+		if _, err := tx.Exec(ix); err != nil {
+			return fmt.Errorf("recreate index: %w", err)
+		}
+	}
+	return tx.Commit()
 }
 
 func (d *DB) ensureColumn(table, column, definition string) error {

--- a/internal/storage/db_standalone_saves_test.go
+++ b/internal/storage/db_standalone_saves_test.go
@@ -1,0 +1,205 @@
+package storage
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// ── Standalone collection loop saves ──
+
+// TestSaveContainerStats_NoMatchingSnapshot_Succeeds reproduces #155: the
+// 5-minute container stats loop uses synthetic "cstats-<ms>" snapshot IDs
+// that don't match any row in `snapshots`. Before the fix, the FK constraint
+// rejected every INSERT with "FOREIGN KEY constraint failed (787)"; after,
+// the save succeeds because the FK was dropped.
+func TestSaveContainerStats_NoMatchingSnapshot_Succeeds(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	docker := &internal.DockerInfo{
+		Available: true,
+		Containers: []internal.ContainerInfo{
+			{
+				ID: "c1", Name: "web", Image: "nginx:latest", State: "running",
+				CPU: 12.5, MemMB: 128, MemPct: 4.2,
+				NetIn: 1024, NetOut: 2048,
+			},
+		},
+	}
+
+	// No snapshot rows exist — this is the exact hardware scenario.
+	if err := db.SaveContainerStats(docker); err != nil {
+		t.Fatalf("SaveContainerStats: %v (regression of #155 — FK must stay dropped)", err)
+	}
+
+	history, err := db.GetContainerHistory(1)
+	if err != nil {
+		t.Fatalf("GetContainerHistory: %v", err)
+	}
+	found := false
+	for _, p := range history {
+		if p.Name == "web" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("history missing container 'web'; got %d points total", len(history))
+	}
+}
+
+// TestSaveSpeedTest_NoMatchingSnapshot_Succeeds is the speedtest twin of the
+// above: the scheduler's independent speedtest loop uses "speedtest-<ts>"
+// IDs that aren't in `snapshots`. FK removal lets the save succeed.
+func TestSaveSpeedTest_NoMatchingSnapshot_Succeeds(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	result := &internal.SpeedTestResult{
+		DownloadMbps: 94.0,
+		UploadMbps:   93.0,
+		LatencyMs:    3.5,
+		ServerName:   "example-pop",
+		ISP:          "Example ISP",
+		Timestamp:    time.Now().UTC(),
+	}
+
+	if err := db.SaveSpeedTest("speedtest-20260420-180000", result); err != nil {
+		t.Fatalf("SaveSpeedTest: %v (regression of #155)", err)
+	}
+
+	// Count directly rather than going through GetSpeedTestHistory, which
+	// filters on a time window. The row existing at all is what proves the
+	// FK removal works — window filtering is unrelated to #155.
+	var n int
+	if err := db.db.QueryRow(`SELECT COUNT(*) FROM speedtest_history WHERE snapshot_id = ?`, "speedtest-20260420-180000").Scan(&n); err != nil {
+		t.Fatalf("count speedtest_history: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("speedtest_history row count: got %d, want 1 (regression of #155)", n)
+	}
+}
+
+// TestMigration_DropSnapshotFK_PreservesData proves the FK-dropping migration
+// is safe for existing users: we simulate the pre-fix schema by rebuilding
+// the two tables WITH the old FK, seeding a couple of rows against a valid
+// parent snapshot, then running the migration helper and verifying every
+// row survived.
+func TestMigration_DropSnapshotFK_PreservesData(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	// Force the pre-fix schema shape by rebuilding both tables WITH the FK.
+	for _, table := range []string{"container_stats_history", "speedtest_history"} {
+		if _, err := db.db.Exec(fmt.Sprintf(`DROP TABLE %s`, table)); err != nil {
+			t.Fatalf("drop %s: %v", table, err)
+		}
+	}
+	if _, err := db.db.Exec(`CREATE TABLE container_stats_history (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		snapshot_id TEXT NOT NULL REFERENCES snapshots(id) ON DELETE CASCADE,
+		container_id TEXT NOT NULL,
+		name TEXT NOT NULL,
+		image TEXT,
+		cpu_pct REAL, mem_mb REAL, mem_pct REAL,
+		net_in_bytes REAL, net_out_bytes REAL,
+		block_read_bytes REAL, block_write_bytes REAL,
+		timestamp DATETIME NOT NULL,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	)`); err != nil {
+		t.Fatalf("recreate container_stats_history with FK: %v", err)
+	}
+	if _, err := db.db.Exec(`CREATE TABLE speedtest_history (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		snapshot_id TEXT NOT NULL REFERENCES snapshots(id) ON DELETE CASCADE,
+		download_mbps REAL, upload_mbps REAL,
+		latency_ms REAL, jitter_ms REAL,
+		server_name TEXT, isp TEXT,
+		timestamp DATETIME NOT NULL,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	)`); err != nil {
+		t.Fatalf("recreate speedtest_history with FK: %v", err)
+	}
+
+	// Seed a valid parent snapshot + one row in each child table so the FK is happy.
+	snapID := "scan-seed"
+	ts := time.Now().UTC()
+	if _, err := db.db.Exec(`INSERT INTO snapshots (id, timestamp, duration_seconds, data) VALUES (?, ?, 0, ?)`, snapID, ts, `{}`); err != nil {
+		t.Fatalf("seed snapshot: %v", err)
+	}
+	if _, err := db.db.Exec(`INSERT INTO container_stats_history (snapshot_id, container_id, name, image, cpu_pct, mem_mb, timestamp) VALUES (?, 'c1', 'web', 'nginx', 10.0, 100.0, ?)`, snapID, ts); err != nil {
+		t.Fatalf("seed container_stats_history: %v", err)
+	}
+	if _, err := db.db.Exec(`INSERT INTO speedtest_history (snapshot_id, download_mbps, upload_mbps, timestamp) VALUES (?, 50.0, 25.0, ?)`, snapID, ts); err != nil {
+		t.Fatalf("seed speedtest_history: %v", err)
+	}
+
+	// Run the migration helper for each table. Idempotent: second call must no-op.
+	for i := 0; i < 2; i++ {
+		if err := db.dropSnapshotFKIfPresent("container_stats_history"); err != nil {
+			t.Fatalf("pass %d: drop FK container_stats_history: %v", i, err)
+		}
+		if err := db.dropSnapshotFKIfPresent("speedtest_history"); err != nil {
+			t.Fatalf("pass %d: drop FK speedtest_history: %v", i, err)
+		}
+	}
+
+	// Rows must still exist.
+	var cnt int
+	if err := db.db.QueryRow(`SELECT COUNT(*) FROM container_stats_history`).Scan(&cnt); err != nil || cnt != 1 {
+		t.Errorf("container_stats_history rows after migration: got %d, want 1 (err=%v)", cnt, err)
+	}
+	if err := db.db.QueryRow(`SELECT COUNT(*) FROM speedtest_history`).Scan(&cnt); err != nil || cnt != 1 {
+		t.Errorf("speedtest_history rows after migration: got %d, want 1 (err=%v)", cnt, err)
+	}
+
+	// FK must be gone.
+	for _, table := range []string{"container_stats_history", "speedtest_history"} {
+		rows, err := db.db.Query(fmt.Sprintf(`PRAGMA foreign_key_list(%s)`, table))
+		if err != nil {
+			t.Fatalf("pragma foreign_key_list(%s): %v", table, err)
+		}
+		if rows.Next() {
+			t.Errorf("%s still has a foreign_key after migration", table)
+		}
+		rows.Close()
+	}
+
+	// Indexes must still exist (migration recreates them).
+	for _, idx := range []string{"idx_container_stats_ts", "idx_container_stats_name", "idx_speedtest_ts"} {
+		var name string
+		if err := db.db.QueryRow(`SELECT name FROM sqlite_master WHERE type='index' AND name=?`, idx).Scan(&name); err != nil {
+			t.Errorf("missing index %s after migration: %v", idx, err)
+		}
+	}
+
+	// After the FK is dropped, synthetic-ID saves must now work.
+	if err := db.SaveContainerStats(&internal.DockerInfo{
+		Available: true,
+		Containers: []internal.ContainerInfo{
+			{ID: "c2", Name: "web2", State: "running", CPU: 1, MemMB: 1},
+		},
+	}); err != nil {
+		t.Errorf("SaveContainerStats after migration: %v", err)
+	}
+}
+
+// openTestDB creates a fresh SQLite database file under t.TempDir() so each
+// test has an isolated schema. The caller owns Close().
+func openTestDB(t *testing.T) *DB {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	db, err := Open(dbPath, logger)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return db
+}


### PR DESCRIPTION
Closes #155.

## Summary
The container_stats every-5min loop and the scheduled speed test both call `SaveContainerStats` / `SaveSpeedTest` with synthetic `snapshot_id` values (`cstats-<ms>`, `speedtest-<ts>`) that never match a row in the `snapshots` table. Both tables carried a `REFERENCES snapshots(id) ON DELETE CASCADE` FK, so every such INSERT failed silently with 'FOREIGN KEY constraint failed (787)'. Effect: Container Metrics and Speed Test charts had almost no history data, plus one WARN log per container every five minutes.

## Change
- CREATE TABLE for both tables no longer declares the FK (new installs).
- Idempotent migration `dropSnapshotFKIfPresent` probes `PRAGMA foreign_key_list` and rebuilds each table (rename → create new → copy → drop → recreate indexes) in a single transaction. No-op on fresh installs and on second run.
- Schema comments document *why* the FK is intentionally absent.

## Pruning
`PruneSnapshots` already uses explicit `DELETE … WHERE snapshot_id IN (…)` (see PR #151), so snapshot-tied cleanup still works. Standalone (synthetic-ID) rows will accumulate; age-based retention for them lands with #127 Advanced Scan Settings.

## Tests
- `TestSaveContainerStats_NoMatchingSnapshot_Succeeds` — the exact hardware-UAT scenario
- `TestSaveSpeedTest_NoMatchingSnapshot_Succeeds` — same for speed tests
- `TestMigration_DropSnapshotFK_PreservesData` — forces pre-fix schema with FK, seeds rows against a valid parent, runs the migration twice, asserts: data survives, FK is gone, indexes recreated, synthetic-ID saves now work