### PR TITLE
fix(gpu): drop misleading CPU-package-temp fallback for iGPU temp (#157)

### DIFF
--- a/internal/collector/gpu.go
+++ b/internal/collector/gpu.go
@@ -268,10 +268,21 @@ func collectIntel() []internal.GPUDevice {
 			}
 		}
 
-		// Temperature fallback: iGPU shares die with CPU — use thermal_zone or coretemp
-		if gpu.Temperature == 0 {
-			gpu.Temperature = readThermalZoneTemp()
-		}
+		// NOTE: we do NOT fall back to CPU package temperature here, even
+		// though the iGPU shares a die with the CPU.
+		//
+		// Rationale (issue #157): on iGPUs without i915/xe hwmon temp
+		// (Haswell / Broadwell / early Skylake), surfacing x86_pkg_temp
+		// as "GPU temperature" is semantically confusing — users already
+		// see CPU temp elsewhere, and the scan loop keeps the CPU busy for
+		// ~7-8s before the GPU collector runs, inflating the reading by
+		// 10-40°C vs. idle. Leave the GPU temperature empty when no real
+		// GPU sensor exists; the guard at line ~314 then skips the GPU
+		// entirely if no other telemetry is available (typical Haswell
+		// iGPU case), which is honest rather than misleading.
+		//
+		// readThermalZoneTemp is kept below as a helper for future use by
+		// a dedicated system-level CPU temperature collector.
 
 		// GPU usage: estimate from frequency ratio (actual / max)
 		cardDir := filepath.Dir(base) // e.g., /sys/class/drm/card0
@@ -365,29 +376,80 @@ func parseInt(s string) int {
 	return v
 }
 
-// readThermalZoneTemp reads the CPU/package temperature from thermal zones.
-// Intel iGPUs share the die with the CPU, so the CPU package temp is the
-// closest approximation of GPU temperature.
+// sysClassBase is the root path for sysfs class entries. Tests override this
+// to point at a temp directory simulating /sys/class.
+var sysClassBase = "/sys/class"
+
+// readThermalZoneTemp reads a CPU package temperature in °C.
+//
+// Preference order:
+//  1. {sysClassBase}/thermal/thermal_zone*/type == "x86_pkg_temp"  (canonical Intel package temp)
+//  2. {sysClassBase}/hwmon/hwmon*/name == "coretemp" → temp1_input  (Package id 0 on Intel)
+//  3. {sysClassBase}/thermal/thermal_zone*/type starting with "cpu"  (e.g. "cpu_thermal" on ARM/AMD)
+//
+// Explicitly SKIPPED: "acpitz" thermal zones — they commonly report the ACPI
+// critical trip point (often 98°C) instead of current temperature on systems
+// where ACPI thermal tables are incomplete, producing dangerously misleading
+// readings. Seen on the Unraid community's Haswell-era boards in issue #157.
+//
+// Returns 0 if no reliable source is found — callers treat that as "no CPU
+// temp available" rather than displaying a bogus fallback.
+//
+// Not currently wired into the GPU collector (see collectIntel comment); kept
+// available for a future system-level CPU temperature collector.
 func readThermalZoneTemp() int {
-	zones, _ := filepath.Glob("/sys/class/thermal/thermal_zone*/type")
+	// 1. x86_pkg_temp thermal zone (Intel canonical)
+	zones, _ := filepath.Glob(filepath.Join(sysClassBase, "thermal", "thermal_zone*", "type"))
 	for _, typePath := range zones {
-		zoneType := readSysfs(typePath)
-		// Prefer x86_pkg_temp (package), then coretemp, then any zone
-		if strings.Contains(zoneType, "x86_pkg") || strings.Contains(zoneType, "pkg") {
-			tempStr := readSysfs(filepath.Join(filepath.Dir(typePath), "temp"))
-			if tempStr != "" {
-				return parseInt(tempStr) / 1000
+		zoneType := strings.TrimSpace(readSysfs(typePath))
+		if zoneType == "x86_pkg_temp" {
+			if t := parseInt(readSysfs(filepath.Join(filepath.Dir(typePath), "temp"))) / 1000; t > 0 && t < 120 {
+				return t
 			}
 		}
 	}
-	// Fallback: try first thermal zone with a non-zero temperature
-	zones2, _ := filepath.Glob("/sys/class/thermal/thermal_zone*/temp")
-	for _, tempPath := range zones2 {
-		t := parseInt(readSysfs(tempPath)) / 1000
-		if t > 0 && t < 120 {
+
+	// 2. coretemp hwmon (Package id 0 on Intel, same sensor as x86_pkg_temp
+	//    but via a different driver; exists on CPUs that don't register an
+	//    x86_pkg_temp thermal zone)
+	hwmons, _ := filepath.Glob(filepath.Join(sysClassBase, "hwmon", "hwmon*", "name"))
+	for _, namePath := range hwmons {
+		if strings.TrimSpace(readSysfs(namePath)) != "coretemp" {
+			continue
+		}
+		dir := filepath.Dir(namePath)
+		// Prefer Package (label "Package id 0"), fall back to temp1_input which is
+		// normally the package on Intel coretemp drivers.
+		tempInputs, _ := filepath.Glob(filepath.Join(dir, "temp*_input"))
+		for _, tempPath := range tempInputs {
+			base := strings.TrimSuffix(filepath.Base(tempPath), "_input")
+			labelPath := filepath.Join(dir, base+"_label")
+			label := strings.ToLower(readSysfs(labelPath))
+			if strings.HasPrefix(label, "package") {
+				if t := parseInt(readSysfs(tempPath)) / 1000; t > 0 && t < 120 {
+					return t
+				}
+			}
+		}
+		// No Package label found — use temp1_input as the conventional package sensor.
+		if t := parseInt(readSysfs(filepath.Join(dir, "temp1_input"))) / 1000; t > 0 && t < 120 {
 			return t
 		}
 	}
+
+	// 3. cpu_thermal zones (ARM / AMD on some boards)
+	for _, typePath := range zones {
+		zoneType := strings.TrimSpace(readSysfs(typePath))
+		if zoneType == "acpitz" {
+			continue // known unreliable — skip
+		}
+		if strings.HasPrefix(zoneType, "cpu") {
+			if t := parseInt(readSysfs(filepath.Join(filepath.Dir(typePath), "temp"))) / 1000; t > 0 && t < 120 {
+				return t
+			}
+		}
+	}
+
 	return 0
 }
 

--- a/internal/collector/gpu_test.go
+++ b/internal/collector/gpu_test.go
@@ -1,0 +1,209 @@
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ── readThermalZoneTemp ──
+//
+// These tests simulate /sys/class by creating a temp directory and pointing
+// sysClassBase at it. The function under test reads from that simulated tree.
+
+// withSysClassBase redirects sysClassBase to the given path for the duration
+// of a test, and restores it afterwards.
+func withSysClassBase(t *testing.T, path string) {
+	t.Helper()
+	orig := sysClassBase
+	sysClassBase = path
+	t.Cleanup(func() { sysClassBase = orig })
+}
+
+// writeFile is a tiny helper: makes parent dirs, writes content.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// seedThermalZone creates /sys/class/thermal/thermal_zoneN/{type,temp} with
+// the given type string and millidegree value.
+func seedThermalZone(t *testing.T, base string, n int, zoneType string, milliDegrees int) {
+	t.Helper()
+	dir := filepath.Join(base, "thermal", "thermal_zone"+itoa(n))
+	writeFile(t, filepath.Join(dir, "type"), zoneType+"\n")
+	writeFile(t, filepath.Join(dir, "temp"), itoa(milliDegrees)+"\n")
+}
+
+// seedHwmon creates /sys/class/hwmon/hwmonN/name plus any temp*_input and
+// temp*_label pairs supplied in entries.
+func seedHwmon(t *testing.T, base string, n int, name string, entries map[string]struct {
+	label    string
+	millidec int
+}) {
+	t.Helper()
+	dir := filepath.Join(base, "hwmon", "hwmon"+itoa(n))
+	writeFile(t, filepath.Join(dir, "name"), name+"\n")
+	for slot, e := range entries {
+		writeFile(t, filepath.Join(dir, slot+"_input"), itoa(e.millidec)+"\n")
+		if e.label != "" {
+			writeFile(t, filepath.Join(dir, slot+"_label"), e.label+"\n")
+		}
+	}
+}
+
+func itoa(i int) string {
+	// Inline minimal itoa to avoid importing strconv in the helper block.
+	if i == 0 {
+		return "0"
+	}
+	neg := false
+	if i < 0 {
+		neg = true
+		i = -i
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}
+
+// TestReadThermalZoneTemp_PrefersX86PkgTemp is the happy path.
+func TestReadThermalZoneTemp_PrefersX86PkgTemp(t *testing.T) {
+	base := t.TempDir()
+	withSysClassBase(t, base)
+
+	seedThermalZone(t, base, 0, "acpitz", 98000)       // must NOT be picked
+	seedThermalZone(t, base, 1, "x86_pkg_temp", 62000) // must be picked
+
+	got := readThermalZoneTemp()
+	if got != 62 {
+		t.Errorf("readThermalZoneTemp() = %d, want 62 (x86_pkg_temp preferred over acpitz)", got)
+	}
+}
+
+// TestReadThermalZoneTemp_SkipsAcpitzEvenAsOnlySource is the #157 regression
+// guard. Before the fix, the old secondary fallback picked the first thermal
+// zone with 0<t<120, which on Unraid routinely lands on acpitz reporting 98°C
+// (the ACPI critical trip point) instead of current temp.
+func TestReadThermalZoneTemp_SkipsAcpitzEvenAsOnlySource(t *testing.T) {
+	base := t.TempDir()
+	withSysClassBase(t, base)
+
+	seedThermalZone(t, base, 0, "acpitz", 98000)
+	seedThermalZone(t, base, 1, "acpitz", 45000)
+
+	got := readThermalZoneTemp()
+	if got != 0 {
+		t.Errorf("readThermalZoneTemp() = %d, want 0 (acpitz must not be surfaced — it's the misleading 98°C source)", got)
+	}
+}
+
+// TestReadThermalZoneTemp_FallsBackToCoretempHwmon covers the case where
+// the kernel doesn't expose an x86_pkg_temp thermal zone but coretemp IS
+// available via hwmon.
+func TestReadThermalZoneTemp_FallsBackToCoretempHwmon(t *testing.T) {
+	base := t.TempDir()
+	withSysClassBase(t, base)
+
+	// No x86_pkg_temp, only acpitz (must be skipped)
+	seedThermalZone(t, base, 0, "acpitz", 98000)
+
+	// coretemp hwmon: Package id 0 labelled + per-core inputs
+	seedHwmon(t, base, 1, "coretemp", map[string]struct {
+		label    string
+		millidec int
+	}{
+		"temp1": {"Package id 0", 58000},
+		"temp2": {"Core 0", 57000},
+		"temp3": {"Core 1", 59000},
+	})
+
+	got := readThermalZoneTemp()
+	if got != 58 {
+		t.Errorf("readThermalZoneTemp() = %d, want 58 (coretemp Package id 0)", got)
+	}
+}
+
+// TestReadThermalZoneTemp_CoretempWithoutPackageLabel uses temp1_input as the
+// conventional package sensor when no labels are defined.
+func TestReadThermalZoneTemp_CoretempWithoutPackageLabel(t *testing.T) {
+	base := t.TempDir()
+	withSysClassBase(t, base)
+
+	seedHwmon(t, base, 0, "coretemp", map[string]struct {
+		label    string
+		millidec int
+	}{
+		"temp1": {"", 55000},
+	})
+
+	got := readThermalZoneTemp()
+	if got != 55 {
+		t.Errorf("readThermalZoneTemp() = %d, want 55 (temp1_input on coretemp without label)", got)
+	}
+}
+
+// TestReadThermalZoneTemp_NothingUsable returns 0 so the caller can treat it
+// as "no CPU temp available" rather than surfacing a misleading fallback.
+func TestReadThermalZoneTemp_NothingUsable(t *testing.T) {
+	base := t.TempDir()
+	withSysClassBase(t, base)
+	// No thermal zones, no hwmon.
+
+	got := readThermalZoneTemp()
+	if got != 0 {
+		t.Errorf("readThermalZoneTemp() = %d, want 0 (no sources available)", got)
+	}
+}
+
+// ── collectIntel regression guard ──
+//
+// We can't unit-test the full collectIntel flow without simulating
+// /sys/class/drm/ too, but we CAN assert at the source level that the
+// CPU-package-temp fallback was removed. This catches a future refactor
+// that reintroduces the misleading "GPU temperature" approximation.
+
+// TestCollectIntel_DoesNotFallBackToCPUPackageTemp verifies the source
+// comment + absence of the old fallback call.
+func TestCollectIntel_DoesNotFallBackToCPUPackageTemp(t *testing.T) {
+	data, err := os.ReadFile("gpu.go")
+	if err != nil {
+		t.Fatalf("read gpu.go: %v", err)
+	}
+	src := string(data)
+	// The old fallback invocation must not appear inside collectIntel.
+	// We scope the search to the function body.
+	startRe := "func collectIntel()"
+	start := strings.Index(src, startRe)
+	if start < 0 {
+		t.Fatal("collectIntel function not found in gpu.go")
+	}
+	// The function body roughly spans ~1600 bytes — take a generous window.
+	end := start + 4000
+	if end > len(src) {
+		end = len(src)
+	}
+	body := src[start:end]
+
+	if strings.Contains(body, "gpu.Temperature = readThermalZoneTemp()") {
+		t.Error("collectIntel still falls back to CPU package temp for GPU temperature — see issue #157 for why this is removed")
+	}
+	if !strings.Contains(body, "issue #157") {
+		t.Error("collectIntel missing the comment explaining why the CPU fallback was removed (see issue #157)")
+	}
+}


### PR DESCRIPTION
Closes #157.

## Problem
On Haswell/Broadwell/early-Skylake iGPUs without i915 hwmon temp sensors, `collectIntel` was reading `x86_pkg_temp` via `readThermalZoneTemp` and surfacing CPU package temperature as 'GPU temperature'. Hardware validation on i7-4790K + HD Graphics 4600 showed 70-98°C 'GPU temp' while the actual CPU idle was 57-63°C (reading was taken during scan load, not idle).

## Fix
Remove the CPU-package-temp fallback from `collectIntel`. iGPUs without real sensors now render with `temperature=0` and get skipped entirely by the existing guard at gpu.go:314. Modern iGPUs (Xe/Arc/UHD 750+) keep real readings via hwmon/temp1_input.

Secondary cleanup: tightened `readThermalZoneTemp` preference order (x86_pkg_temp → coretemp hwmon → generic cpu zones) and explicitly skip 'acpitz' (commonly stuck at ACPI critical trip points).

## Validation plan
Tag cut as `v0.9.3-rc1`, deploy to UAT. Expect:
- nasdoctoruat.mdias.info snapshot has no GPU section (i7-4790K has no iGPU sensor)
- Dashboard layout doesn't break from missing GPU section
- No regression on Unraid users with discrete GPUs or newer iGPUs