### PR TITLE
ci: run docker build on PRs that touch Dockerfile (#153)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,16 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/docker.yml'
   workflow_dispatch:
 
 env:
@@ -47,6 +57,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -70,7 +81,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
Closes #153

## Summary

Adds a `pull_request` trigger to `.github/workflows/docker.yml` so Dockerfile-touching PRs get a visible multi-arch image-build check before merge, without pushing to GHCR.

Prevents the class of bug that caused v0.9.2-rc1 to fail post-tag (Alpine `nut-client` vs `nut` package name). The Go test suite can't catch Dockerfile-only failures — only an actual image build can.

## Changes (+12 / -1, YAML-only)

- **`pull_request` trigger** targeting `main` with a `paths:` filter (`Dockerfile`, `.dockerignore`, `cmd/**`, `internal/**`, `go.mod`, `go.sum`, the workflow itself). Docs-only PRs skip the ~2-minute build.
- **GHCR login gated** with `if: github.event_name != 'pull_request'` — no write credentials exposed to PR builds.
- **`push:` gated** with `${{ github.event_name != 'pull_request' }}` — PR runs build both `linux/amd64` and `linux/arm64` but never publish.

Existing `push: [main]` / `tags: [v*]` triggers and the multi-arch build config are unchanged — purely additive.

## Acceptance criteria (from issue)

- [x] Dockerfile-touching PRs will show a "Build and Push Docker Image / build-and-push" check — the `pull_request` trigger fires for this file set
- [x] PR builds do NOT push to GHCR — `push:` evaluates to `false` on PRs; login step skipped
- [x] Non-Dockerfile PRs skip the check — `paths:` filter limits to the listed globs
- [x] Existing `main`-push and tag-push behavior unchanged — those triggers are byte-identical to before

Per the issue, validation is manual (no automated test). This PR itself touches the workflow file, so it *should* trigger the new check on its own run — useful self-test.

## Pre-push checks

- YAML parses cleanly (verified with `ruby -ryaml`)
- Diff confined to `.github/workflows/docker.yml`
- No Go code touched; no secrets introduced