### PR TITLE
feat(service-checks): enrich Test button with per-type diagnostic details (#154)

### DIFF
--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -1403,6 +1403,12 @@ func (s *Server) handleTestServiceCheck(w http.ResponseWriter, r *http.Request) 
 	// by RunDueChecks, which we don't call). We deliberately avoid using
 	// s.scheduler here so the endpoint works in demo mode and tests.
 	checker := scheduler.NewServiceChecker(s.store, s.logger)
+	// Opt into the per-type rich details map — status codes, resolved IPs,
+	// DNS records, failure stages — so the settings UI can render an
+	// actionable diagnosis, not just "down". See issue #154. The
+	// scheduled-check path does NOT set this flag, so 30s loops remain
+	// lean.
+	checker.SetCollectDetails(true)
 	if cfg.Type == internal.ServiceCheckSpeed {
 		checker.SetSpeedTestRunner(collector.RunSpeedTest)
 	}

--- a/internal/api/service_check_test_endpoint_test.go
+++ b/internal/api/service_check_test_endpoint_test.go
@@ -312,6 +312,39 @@ func TestHandleTestServiceCheck_DoesNotTouchConsecutiveFailures(t *testing.T) {
 	}
 }
 
+// TestHandleTestServiceCheck_HTTP_ReturnsDetails — the /test endpoint must
+// opt-in to rich details so the UI can display status_code, content_type,
+// body_bytes, final_url, etc. (issue #154).
+func TestHandleTestServiceCheck_HTTP_ReturnsDetails(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer ts.Close()
+
+	srv := newSettingsTestServer()
+	rec := postServiceCheckTest(t, srv, map[string]any{
+		"name": "details-http", "type": "http", "target": ts.URL,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// Decode through a generic map so we can assert details keys without
+	// losing the numeric type fidelity that Go's json encoder produces.
+	var generic map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &generic); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	details, ok := generic["details"].(map[string]any)
+	if !ok || len(details) == 0 {
+		t.Fatalf("expected details in response, got %+v", generic["details"])
+	}
+	if _, hasCode := details["status_code"]; !hasCode {
+		t.Fatalf("expected status_code in details, got keys: %+v", details)
+	}
+}
+
 // TestRegisterExtendedRoutes_ExposesServiceCheckTest — the new route is registered
 // and responds on POST through the router.
 func TestRegisterExtendedRoutes_ExposesServiceCheckTest(t *testing.T) {

--- a/internal/api/settings_service_check_test_button_test.go
+++ b/internal/api/settings_service_check_test_button_test.go
@@ -186,6 +186,50 @@ func TestSettingsHTML_IntervalSelect_OptionsMatchAnyAutoDefault(t *testing.T) {
 	}
 }
 
+// TestSettingsHTML_TestServiceCheckRendersDetails verifies that
+// testServiceCheck (or a helper it invokes) renders the rich per-type
+// Details map returned by the /service-checks/test endpoint (issue #154)
+// — at a minimum, HTTP status_code, DNS records, TCP resolved_address,
+// and ping rtt_ms must appear in the human-readable output. A regression
+// here silently drops the new diagnostic fields even though the backend
+// returns them.
+func TestSettingsHTML_TestServiceCheckRendersDetails(t *testing.T) {
+	html := loadSettingsHTML(t)
+
+	// testServiceCheck itself must read the details payload. We scan a
+	// generous window from the function declaration so the test tolerates
+	// details rendering being factored into a helper above or below.
+	testRe := regexp.MustCompile(`function\s+testServiceCheck\s*\(\s*\)\s*\{`)
+	testLoc := testRe.FindStringIndex(html)
+	if testLoc == nil {
+		t.Fatal("testServiceCheck() function not found")
+	}
+	testEnd := testLoc[1] + 4000
+	if testEnd > len(html) {
+		testEnd = len(html)
+	}
+	testBody := html[testLoc[0]:testEnd]
+	if !regexp.MustCompile(`result\s*\.\s*details|\bdetails\b`).MatchString(testBody) {
+		t.Fatalf("testServiceCheck should read result.details to render per-type diagnostics; body window:\n%s", testBody)
+	}
+
+	// Per-type renderer keys MUST be present somewhere in the template —
+	// the whole value of issue #154 is that users can distinguish 404
+	// from connection-refused, DNS failures from connect failures, etc.
+	mustSurface := []string{"status_code", "records", "resolved_address", "rtt_ms"}
+	for _, key := range mustSurface {
+		if !strings.Contains(html, key) {
+			t.Errorf("settings.html missing detail renderer key %q — test button won't display this field", key)
+		}
+	}
+
+	// A dedicated per-type renderer is clearer than a flat dump. Expect
+	// explicit branching on check type somewhere in the page.
+	if !regexp.MustCompile(`type\s*===?\s*["']http["']|type\s*===?\s*["']dns["']`).MatchString(html) {
+		t.Error("settings.html should branch on check type for per-type rendering (expected type===\"http\" or type===\"dns\")")
+	}
+}
+
 // TestHandleTestServiceCheck_DisablesWriteDeadline verifies that the handler
 // code invokes http.NewResponseController(w).SetWriteDeadline(time.Time{}) so
 // that speed tests can run longer than the 30s baseline http.Server.WriteTimeout

--- a/internal/api/styles.go
+++ b/internal/api/styles.go
@@ -301,10 +301,12 @@ body.theme-clean .badge-generic { background:rgba(0,0,0,0.06) }
   padding:10px 18px; border-radius:var(--radius);
   font-size:13px; font-weight:500; color:#fff;
   animation:toast-in 0.25s ease; pointer-events:none;
+  max-width:420px; white-space:pre-wrap;
 }
 .toast-success { background:var(--green) }
 .toast-error   { background:var(--red) }
 .toast-info    { background:var(--accent) }
+.toast-warning { background:var(--orange, #f59e0b) }
 @keyframes toast-in { from{opacity:0;transform:translateY(-8px)} to{opacity:1;transform:translateY(0)} }
 @keyframes toast-out { from{opacity:1} to{opacity:0;transform:translateY(-8px)} }
 

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -907,10 +907,14 @@ function showToast(msg, type) {
   t.className = "toast toast-" + (type || "info");
   t.textContent = msg;
   c.appendChild(t);
+  // Multi-line toasts (Test-button diagnostics) need more read time.
+  // Rough heuristic: 3s + ~1.2s per extra line, capped at 10s.
+  var lines = String(msg).split("\n").length;
+  var hold = Math.min(3000 + Math.max(0, lines - 1) * 1200, 10000);
   setTimeout(function() {
     t.style.animation = "toast-out 0.25s ease forwards";
     setTimeout(function() { t.remove(); }, 260);
-  }, 3000);
+  }, hold);
 }
 
 /* ---------- Theme selection ---------- */
@@ -1818,11 +1822,52 @@ function saveServiceCheck() {
   saveSettings();
 }
 
+// renderServiceCheckDetails turns the per-type Details map returned by
+// POST /api/v1/service-checks/test into a human-readable multi-line
+// summary. Each check type has its own renderer so we highlight the
+// fields that matter most for diagnosing THAT type's failures (HTTP
+// status code vs DNS records vs ping loss). See issue #154.
+function renderServiceCheckDetails(type, details, result) {
+  if (!details || typeof details !== "object") return "";
+  var lines = [];
+  if (type === "http") {
+    if (typeof details.status_code === "number") lines.push("HTTP " + details.status_code);
+    if (details.content_type) lines.push("Content-Type: " + details.content_type);
+    if (typeof details.body_bytes === "number") lines.push("Body: " + details.body_bytes + " bytes");
+    if (details.final_url && details.final_url !== details.request_url) {
+      lines.push("Final URL: " + details.final_url);
+    }
+    if (details.failure_stage) lines.push("Failed at: " + details.failure_stage);
+  } else if (type === "tcp" || type === "smb" || type === "nfs") {
+    if (details.resolved_address) lines.push("Connected to: " + details.resolved_address);
+    if (details.failure_stage) lines.push("Failed at: " + details.failure_stage);
+  } else if (type === "dns") {
+    if (details.query_host) lines.push("Queried: " + details.query_host);
+    if (details.dns_server) lines.push("Server: " + details.dns_server);
+    if (details.records && details.records.length) {
+      lines.push("Records: " + details.records.join(", "));
+    }
+    if (details.failure_stage) lines.push("Failed at: " + details.failure_stage);
+  } else if (type === "ping") {
+    if (details.query_host) lines.push("Host: " + details.query_host);
+    if (typeof details.rtt_ms === "number") lines.push("RTT: " + details.rtt_ms.toFixed(2) + " ms");
+    if (typeof details.packet_loss_pct === "number") lines.push("Loss: " + details.packet_loss_pct + "%");
+    if (details.failure_stage) lines.push("Failed at: " + details.failure_stage);
+  } else if (type === "speed") {
+    if (typeof result.download_mbps === "number") lines.push("Download: " + result.download_mbps.toFixed(0) + " Mbps");
+    if (typeof result.upload_mbps === "number") lines.push("Upload: " + result.upload_mbps.toFixed(0) + " Mbps");
+    if (typeof result.latency_ms === "number") lines.push("Latency: " + result.latency_ms.toFixed(1) + " ms");
+  }
+  return lines.join("\n");
+}
+
 // testServiceCheck runs the current form's configuration through the
 // /api/v1/service-checks/test endpoint without persisting the result. It
-// surfaces status, response time, and error messages via toast. Speed-type
-// checks can take up to 60s on real hardware (Ookla CLI), so we warn the
-// user up-front and disable the button for the duration of the request.
+// surfaces status, response time, error messages, and the per-type
+// Details map (HTTP status code, resolved IPs, DNS records, ping RTT,
+// etc.) via toast. Speed-type checks can take up to 60s on real hardware
+// (Ookla CLI), so we warn the user up-front and disable the button for
+// the duration of the request. See issue #154.
 function testServiceCheck() {
   var sc = readServiceCheckForm();
   if (!sc) return;
@@ -1853,24 +1898,29 @@ function testServiceCheck() {
       var result = res.data || {};
       var status = result.status || "unknown";
       var ms = result.response_ms;
-      var msg;
+      var headline;
       var toastKind = "info";
       if (status === "up") {
-        msg = "✓ Check is UP" + (typeof ms === "number" ? " (" + ms + " ms)" : "");
+        headline = "✓ Check is UP" + (typeof ms === "number" ? " (" + ms + " ms)" : "");
         toastKind = "success";
       } else if (status === "degraded") {
-        msg = "△ Degraded";
+        headline = "△ Degraded";
         toastKind = "warning";
       } else {
-        msg = "✗ Check is DOWN";
+        headline = "✗ Check is DOWN";
         toastKind = "error";
       }
-      if (sc.type === "speed" && (typeof result.download_mbps === "number" || typeof result.upload_mbps === "number")) {
-        msg += " — " + (result.download_mbps || 0).toFixed(0) + " ↓ / " +
-               (result.upload_mbps || 0).toFixed(0) + " ↑ Mbps";
+
+      // Per-type details + optional error message. Build a multi-line
+      // toast so users can see WHY a check failed (404? connection
+      // refused? NXDOMAIN?) rather than just THAT it failed.
+      var msg = headline;
+      var detailsText = renderServiceCheckDetails(sc.type, result.details, result);
+      if (detailsText) {
+        msg += "\n" + detailsText;
       }
       if (result.error) {
-        msg += " — " + result.error;
+        msg += "\n" + result.error;
       }
       showToast(msg, toastKind);
     })

--- a/internal/models.go
+++ b/internal/models.go
@@ -247,6 +247,13 @@ type ServiceCheckResult struct {
 	LatencyMs    float64 `json:"latency_ms,omitempty"`
 	DownloadOK   *bool   `json:"download_ok,omitempty"` // nil for non-speed checks
 	UploadOK     *bool   `json:"upload_ok,omitempty"`
+
+	// Details carries per-check-type diagnostic context surfaced by the
+	// ad-hoc Test-button flow (HTTP status code, resolved IPs, DNS records,
+	// ping RTT, failure stage, etc.). It is intentionally NOT populated on
+	// the scheduled-check path — see ServiceChecker.SetCollectDetails —
+	// so every 30s run stays lean and history rows don't bloat. See #154.
+	Details map[string]any `json:"details,omitempty"`
 }
 
 // ---------- System ----------

--- a/internal/scheduler/checks.go
+++ b/internal/scheduler/checks.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -41,6 +42,12 @@ type ServiceChecker struct {
 	lastRun        map[string]time.Time
 	mu             sync.Mutex
 	speedTestRunFn SpeedTestRunner // nil → speed checks return "no tool"
+	// collectDetails, when true, enriches RunCheck results with the
+	// per-check-type Details map (HTTP status code, resolved IPs, DNS
+	// records, etc.). The scheduled-check path (RunDueChecks) explicitly
+	// strips Details regardless of this flag — only the ad-hoc Test-button
+	// endpoint opts into this richer output. See issue #154.
+	collectDetails bool
 }
 
 // NewServiceChecker creates a ready-to-use ServiceChecker.
@@ -57,6 +64,17 @@ func (sc *ServiceChecker) SetSpeedTestRunner(fn SpeedTestRunner) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 	sc.speedTestRunFn = fn
+}
+
+// SetCollectDetails toggles the opt-in rich-details output. Call with true
+// from the ad-hoc /service-checks/test endpoint to get diagnostic context
+// (HTTP status code, resolved IPs, DNS records, etc.) alongside the usual
+// status/response_ms/error triple. The scheduled-check path never emits
+// details — see RunDueChecks. Issue #154.
+func (sc *ServiceChecker) SetCollectDetails(enabled bool) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.collectDetails = enabled
 }
 
 // RunDueChecks evaluates which checks are due based on their intervals,
@@ -90,6 +108,11 @@ func (sc *ServiceChecker) RunDueChecks(checks []internal.ServiceCheckConfig, now
 	results := make([]internal.ServiceCheckResult, 0, len(due))
 	for _, check := range due {
 		result := sc.RunCheck(check, now)
+		// Scheduled path never emits Details — those are only for the
+		// ad-hoc Test-button flow. Strip them defensively in case the
+		// checker was flipped into collect-details mode elsewhere. See
+		// #154 (keeps history rows lean and JSON payloads small).
+		result.Details = nil
 
 		// Track consecutive failures from store history.
 		state, ok, err := sc.store.GetLatestServiceCheckState(result.Key)
@@ -148,6 +171,13 @@ func (sc *ServiceChecker) RunCheck(check internal.ServiceCheckConfig, now time.T
 		FailureSeverity:  severity,
 	}
 
+	sc.mu.Lock()
+	collect := sc.collectDetails
+	sc.mu.Unlock()
+	if collect {
+		result.Details = make(map[string]any, 4)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSec)*time.Second)
 	defer cancel()
 
@@ -165,6 +195,13 @@ func (sc *ServiceChecker) RunCheck(check internal.ServiceCheckConfig, now time.T
 		sc.runSpeedCheck(check, &result, start)
 	default:
 		result.Error = "unsupported service check type"
+	}
+
+	// If collection is off, ensure Details is nil (zero-length maps would
+	// still serialise as "details":{}). This guarantees backward-compat
+	// JSON output for the scheduled path.
+	if !collect {
+		result.Details = nil
 	}
 
 	if result.ResponseMS == 0 {
@@ -187,9 +224,15 @@ func (sc *ServiceChecker) RunCheck(check internal.ServiceCheckConfig, now time.T
 
 func (sc *ServiceChecker) runHTTPCheck(ctx context.Context, check internal.ServiceCheckConfig, result *internal.ServiceCheckResult, start time.Time, timeoutSec int) {
 	urlValue := NormalizeHTTPURL(check.Target)
+	if result.Details != nil {
+		result.Details["request_url"] = urlValue
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlValue, nil)
 	if err != nil {
 		result.Error = err.Error()
+		if result.Details != nil {
+			result.Details["failure_stage"] = "request_build"
+		}
 		return
 	}
 	req.Header.Set("User-Agent", "nas-doctor-service-check/1.0")
@@ -200,9 +243,29 @@ func (sc *ServiceChecker) runHTTPCheck(ctx context.Context, check internal.Servi
 	result.ResponseMS = time.Since(start).Milliseconds()
 	if err != nil {
 		result.Error = err.Error()
+		if result.Details != nil {
+			result.Details["failure_stage"] = classifyHTTPError(err)
+		}
 		return
 	}
-	_ = resp.Body.Close()
+	defer resp.Body.Close()
+
+	if result.Details != nil {
+		result.Details["status_code"] = resp.StatusCode
+		if ct := resp.Header.Get("Content-Type"); ct != "" {
+			result.Details["content_type"] = ct
+		}
+		if resp.Request != nil && resp.Request.URL != nil {
+			result.Details["final_url"] = resp.Request.URL.String()
+		} else {
+			result.Details["final_url"] = urlValue
+		}
+		// Read body (capped) so we can report size AND release the
+		// connection cleanly. Cap at 1 MiB to bound memory for users
+		// who accidentally test a file-server URL.
+		n, _ := io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+		result.Details["body_bytes"] = n
+	}
 
 	minStatus := check.ExpectedMin
 	maxStatus := check.ExpectedMax
@@ -217,13 +280,44 @@ func (sc *ServiceChecker) runHTTPCheck(ctx context.Context, check internal.Servi
 	}
 	if resp.StatusCode < minStatus || resp.StatusCode > maxStatus {
 		result.Error = fmt.Sprintf("unexpected HTTP status %d", resp.StatusCode)
+		if result.Details != nil {
+			result.Details["failure_stage"] = "http_status"
+		}
 		return
 	}
 	result.Status = "up"
 }
 
+// classifyHTTPError maps the common failure shapes to a short diagnostic
+// label the UI can render (e.g. "connection refused", "dns lookup failed",
+// "tls handshake failed", "timeout"). We look at both the error text and
+// the typed wrappers Go's net stack produces; best-effort, not exhaustive.
+func classifyHTTPError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "x509") || strings.Contains(msg, "tls"):
+		return "tls"
+	case strings.Contains(msg, "no such host") || strings.Contains(msg, "dns"):
+		return "dns"
+	case strings.Contains(msg, "connection refused"):
+		return "connection_refused"
+	case strings.Contains(msg, "timeout") || strings.Contains(msg, "deadline exceeded"):
+		return "timeout"
+	case strings.Contains(msg, "unreachable") || strings.Contains(msg, "no route"):
+		return "network_unreachable"
+	default:
+		return "connect"
+	}
+}
+
 func (sc *ServiceChecker) runDNSCheck(ctx context.Context, check internal.ServiceCheckConfig, result *internal.ServiceCheckResult, start time.Time) {
 	host := NormalizeDNSHost(check.Target)
+	if result.Details != nil {
+		result.Details["query_host"] = host
+	}
 	if host == "" {
 		result.Error = "empty DNS target"
 		return
@@ -236,15 +330,20 @@ func (sc *ServiceChecker) runDNSCheck(ctx context.Context, check internal.Servic
 	// See issue #159.
 	if net.ParseIP(host) != nil {
 		result.Error = "DNS checks need a hostname like google.com; to test IP reachability use a Ping or TCP check"
+		if result.Details != nil {
+			result.Details["failure_stage"] = "ip_target_rejected"
+		}
 		return
 	}
 
 	resolver := net.DefaultResolver
+	resolvedServer := "system"
 	if dnsServer := strings.TrimSpace(check.DNSServer); dnsServer != "" {
 		server := dnsServer
 		if _, _, err := net.SplitHostPort(server); err != nil {
 			server = net.JoinHostPort(server, "53")
 		}
+		resolvedServer = server
 		timeoutSec := check.TimeoutSec
 		if timeoutSec <= 0 {
 			timeoutSec = 5
@@ -257,30 +356,72 @@ func (sc *ServiceChecker) runDNSCheck(ctx context.Context, check internal.Servic
 			},
 		}
 	}
+	if result.Details != nil {
+		result.Details["dns_server"] = resolvedServer
+	}
 	addrs, err := resolver.LookupHost(ctx, host)
 	result.ResponseMS = time.Since(start).Milliseconds()
 	if err != nil {
 		result.Error = err.Error()
+		if result.Details != nil {
+			result.Details["failure_stage"] = classifyDNSError(err)
+		}
 		return
 	}
 	if len(addrs) == 0 {
 		result.Error = "no DNS records found"
+		if result.Details != nil {
+			result.Details["failure_stage"] = "empty_answer"
+		}
 		return
 	}
+	if result.Details != nil {
+		result.Details["records"] = addrs
+	}
 	result.Status = "up"
+}
+
+// classifyDNSError buckets the common lookup failures so the UI can
+// explain why a DNS check is down.
+func classifyDNSError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "no such host"):
+		return "nxdomain"
+	case strings.Contains(msg, "timeout") || strings.Contains(msg, "deadline exceeded"):
+		return "timeout"
+	case strings.Contains(msg, "refused"):
+		return "refused"
+	case strings.Contains(msg, "server misbehaving"):
+		return "servfail"
+	default:
+		return "resolver_error"
+	}
 }
 
 func (sc *ServiceChecker) runTCPCheck(ctx context.Context, check internal.ServiceCheckConfig, result *internal.ServiceCheckResult, start time.Time, timeoutSec int) {
 	addr, err := NormalizeTCPAddress(check)
 	if err != nil {
 		result.Error = err.Error()
+		if result.Details != nil {
+			result.Details["failure_stage"] = "address_parse"
+		}
 		return
+	}
+	if result.Details != nil {
+		result.Details["resolved_address"] = addr
 	}
 	dialer := net.Dialer{Timeout: time.Duration(timeoutSec) * time.Second}
 	conn, err := dialer.DialContext(ctx, "tcp", addr)
 	result.ResponseMS = time.Since(start).Milliseconds()
 	if err != nil {
 		result.Error = err.Error()
+		if result.Details != nil {
+			result.Details["failure_stage"] = classifyHTTPError(err) // reuse: same net.Error families
+		}
 		return
 	}
 	_ = conn.Close()
@@ -289,6 +430,9 @@ func (sc *ServiceChecker) runTCPCheck(ctx context.Context, check internal.Servic
 
 func (sc *ServiceChecker) runPingCheck(ctx context.Context, check internal.ServiceCheckConfig, result *internal.ServiceCheckResult, start time.Time, timeoutSec int) {
 	host := NormalizeDNSHost(check.Target)
+	if result.Details != nil {
+		result.Details["query_host"] = host
+	}
 	if host == "" {
 		result.Error = "empty ping target"
 		return
@@ -304,6 +448,9 @@ func (sc *ServiceChecker) runPingCheck(ctx context.Context, check internal.Servi
 	result.ResponseMS = time.Since(start).Milliseconds()
 	if err != nil {
 		result.Error = "host unreachable"
+		if result.Details != nil {
+			result.Details["failure_stage"] = "unreachable"
+		}
 		return
 	}
 	// Parse round-trip time from ping output if available.
@@ -313,10 +460,49 @@ func (sc *ServiceChecker) runPingCheck(ctx context.Context, check internal.Servi
 		if sp := strings.IndexAny(sub, " m\n"); sp > 0 {
 			if ms, parseErr := strconv.ParseFloat(sub[:sp], 64); parseErr == nil {
 				result.ResponseMS = int64(ms)
+				if result.Details != nil {
+					result.Details["rtt_ms"] = ms
+				}
 			}
 		}
 	}
+	// Best-effort loss parsing — ping prints e.g. "0% packet loss" on both
+	// Linux and Darwin. Not all ping implementations include a space before
+	// "packet loss"; we look for the "%" and walk backwards.
+	if result.Details != nil {
+		if pct := extractPacketLossPercent(outStr); pct >= 0 {
+			result.Details["packet_loss_pct"] = pct
+		}
+	}
 	result.Status = "up"
+}
+
+// extractPacketLossPercent parses "0% packet loss" / "0.0% packet loss" out
+// of ping stdout. Returns -1 when the token is absent so callers can skip
+// recording the key rather than lying about zero loss.
+func extractPacketLossPercent(out string) float64 {
+	idx := strings.Index(out, "% packet loss")
+	if idx <= 0 {
+		return -1
+	}
+	// Walk back until we hit a non-digit/non-dot character.
+	i := idx - 1
+	for i >= 0 {
+		c := out[i]
+		if (c >= '0' && c <= '9') || c == '.' {
+			i--
+			continue
+		}
+		break
+	}
+	num := out[i+1 : idx]
+	if num == "" {
+		return -1
+	}
+	if f, err := strconv.ParseFloat(num, 64); err == nil {
+		return f
+	}
+	return -1
 }
 
 func (sc *ServiceChecker) runSpeedCheck(check internal.ServiceCheckConfig, result *internal.ServiceCheckResult, start time.Time) {

--- a/internal/scheduler/checks_details_test.go
+++ b/internal/scheduler/checks_details_test.go
@@ -1,0 +1,335 @@
+package scheduler
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// These tests cover the opt-in "collect details" code path added for the
+// Test-button flow (issue #154). The scheduled-check path (RunDueChecks)
+// must remain unchanged — no extra detail overhead on every 30s run.
+
+// ── Phase 1: opt-in toggle ─────────────────────────────────────────────
+
+// TestRunCheck_Details_OmittedByDefault — the Details field must be empty
+// (nil or zero-length) when the collect-details toggle has not been enabled,
+// so scheduled checks carry zero detail overhead over the wire.
+func TestRunCheck_Details_OmittedByDefault(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	sc, _ := newTestChecker()
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:    "default-no-details",
+		Type:    internal.ServiceCheckHTTP,
+		Target:  ts.URL,
+		Enabled: true,
+	}, time.Now().UTC())
+
+	if result.Status != "up" {
+		t.Fatalf("expected status up, got %q (error=%q)", result.Status, result.Error)
+	}
+	if len(result.Details) != 0 {
+		t.Fatalf("expected no details on scheduled path, got %d keys: %+v", len(result.Details), result.Details)
+	}
+}
+
+// TestRunCheck_Details_PopulatedWhenEnabled — once SetCollectDetails(true)
+// has been called, subsequent RunCheck calls populate the Details map.
+func TestRunCheck_Details_PopulatedWhenEnabled(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer ts.Close()
+
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:    "with-details",
+		Type:    internal.ServiceCheckHTTP,
+		Target:  ts.URL,
+		Enabled: true,
+	}, time.Now().UTC())
+
+	if result.Status != "up" {
+		t.Fatalf("expected up, got %q (error=%q)", result.Status, result.Error)
+	}
+	if len(result.Details) == 0 {
+		t.Fatal("expected non-empty Details when SetCollectDetails(true)")
+	}
+}
+
+// TestRunDueChecks_NeverPopulatesDetails — even if SetCollectDetails(true)
+// was called (ad-hoc test button flow), the scheduled-check path must NOT
+// attach Details. The scheduled path uses a fresh checker in production; we
+// still guarantee it here as defensive invariant so accidentally sharing a
+// checker wouldn't blow up history rows or JSON payloads.
+func TestRunDueChecks_NeverPopulatesDetails(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true) // simulate an ad-hoc flag being flipped
+
+	checks := []internal.ServiceCheckConfig{{
+		Name:    "scheduled",
+		Type:    internal.ServiceCheckHTTP,
+		Target:  ts.URL,
+		Enabled: true,
+	}}
+	results := sc.RunDueChecks(checks, time.Now().UTC())
+	if len(results) != 1 {
+		t.Fatalf("expected 1 scheduled result, got %d", len(results))
+	}
+	if len(results[0].Details) != 0 {
+		t.Fatalf("RunDueChecks must not carry Details, got: %+v", results[0].Details)
+	}
+}
+
+// ── Phase 2: HTTP details ──────────────────────────────────────────────
+
+// TestRunCheck_Details_HTTP_Success_StatusCode — a successful HTTP test
+// records status_code, content_type, body_bytes, and final_url so users
+// can see what the server actually returned.
+func TestRunCheck_Details_HTTP_Success_StatusCode(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:    "http-details",
+		Type:    internal.ServiceCheckHTTP,
+		Target:  ts.URL,
+		Enabled: true,
+	}, time.Now().UTC())
+	if result.Status != "up" {
+		t.Fatalf("expected up, got %q (error=%q)", result.Status, result.Error)
+	}
+	code, ok := result.Details["status_code"].(int)
+	if !ok || code != 200 {
+		t.Fatalf("expected status_code=200 (int), got %v (%T)", result.Details["status_code"], result.Details["status_code"])
+	}
+	if ct, _ := result.Details["content_type"].(string); !strings.Contains(ct, "application/json") {
+		t.Fatalf("expected content_type containing application/json, got %v", result.Details["content_type"])
+	}
+	if size, ok := result.Details["body_bytes"].(int64); !ok || size < 1 {
+		t.Fatalf("expected body_bytes > 0 int64, got %v (%T)", result.Details["body_bytes"], result.Details["body_bytes"])
+	}
+	if final, _ := result.Details["final_url"].(string); final == "" {
+		t.Fatalf("expected final_url populated, got %v", result.Details["final_url"])
+	}
+}
+
+// TestRunCheck_Details_HTTP_404_StillRecordsCode — failure path: a 404
+// reports status_code=404 in Details (not just the generic "unexpected
+// HTTP status" error). This is the core diagnostic value the issue calls
+// out — distinguishing a 404 from a connection refused.
+func TestRunCheck_Details_HTTP_404_StillRecordsCode(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:    "http-404",
+		Type:    internal.ServiceCheckHTTP,
+		Target:  ts.URL,
+		Enabled: true,
+	}, time.Now().UTC())
+
+	if result.Status != "down" {
+		t.Fatalf("expected down, got %q", result.Status)
+	}
+	code, ok := result.Details["status_code"].(int)
+	if !ok || code != 404 {
+		t.Fatalf("expected status_code=404 on down, got %v", result.Details["status_code"])
+	}
+}
+
+// TestRunCheck_Details_HTTP_Unreachable_NoStatusCode — if we never got a
+// response (connection refused / TCP error), there is no status code to
+// record. The Details map may be empty or only contain failure_stage.
+// We assert status_code is NOT present so the UI doesn't lie about the
+// server's reply.
+func TestRunCheck_Details_HTTP_Unreachable_NoStatusCode(t *testing.T) {
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:       "http-unreach",
+		Type:       internal.ServiceCheckHTTP,
+		Target:     "http://192.0.2.1:1",
+		Enabled:    true,
+		TimeoutSec: 1,
+	}, time.Now().UTC())
+
+	if result.Status != "down" {
+		t.Fatalf("expected down, got %q", result.Status)
+	}
+	if _, present := result.Details["status_code"]; present {
+		t.Fatalf("unreachable should have no status_code, got %v", result.Details["status_code"])
+	}
+	// failure_stage lets the UI say "connection refused" vs "HTTP 4xx" vs "TLS failed".
+	stage, _ := result.Details["failure_stage"].(string)
+	if stage == "" {
+		t.Fatalf("expected failure_stage to be populated for unreachable target, got %+v", result.Details)
+	}
+}
+
+// ── Phase 2: TCP details ───────────────────────────────────────────────
+
+// TestRunCheck_Details_TCP_ResolvedAddress — on success, the TCP runner
+// records the resolved_address so users see which IP:port they actually
+// connected to (e.g. "1.2.3.4:445" when target was "nas.local").
+func TestRunCheck_Details_TCP_ResolvedAddress(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	_, port, _ := net.SplitHostPort(ln.Addr().String())
+
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:    "tcp-details",
+		Type:    internal.ServiceCheckTCP,
+		Target:  "127.0.0.1:" + port,
+		Enabled: true,
+	}, time.Now().UTC())
+	if result.Status != "up" {
+		t.Fatalf("expected up, got %q (error=%q)", result.Status, result.Error)
+	}
+	addr, _ := result.Details["resolved_address"].(string)
+	if !strings.HasPrefix(addr, "127.0.0.1:") {
+		t.Fatalf("expected resolved_address prefix 127.0.0.1:, got %v", addr)
+	}
+}
+
+// TestRunCheck_Details_TCP_Closed_RecordsAddress — on down, the address
+// we tried is still recorded (so the user can see which host:port the
+// failure references — useful when testing an SMB check with a hostname).
+func TestRunCheck_Details_TCP_Closed_RecordsAddress(t *testing.T) {
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:       "tcp-closed-details",
+		Type:       internal.ServiceCheckTCP,
+		Target:     "127.0.0.1:1",
+		Enabled:    true,
+		TimeoutSec: 1,
+	}, time.Now().UTC())
+
+	if result.Status != "down" {
+		t.Fatalf("expected down, got %q", result.Status)
+	}
+	if addr, _ := result.Details["resolved_address"].(string); addr != "127.0.0.1:1" {
+		t.Fatalf("expected resolved_address=127.0.0.1:1, got %v", result.Details["resolved_address"])
+	}
+}
+
+// ── Phase 2: DNS details ───────────────────────────────────────────────
+
+// TestRunCheck_Details_DNS_Records — a successful DNS lookup records the
+// resolved A/AAAA records so users see the actual addresses their
+// resolver returned (the #1 debugging need per the issue).
+func TestRunCheck_Details_DNS_Records(t *testing.T) {
+	addr, stop := startFakeDNS(t)
+	defer stop()
+
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:       "dns-details",
+		Type:       internal.ServiceCheckDNS,
+		Target:     "example.test.",
+		DNSServer:  addr,
+		TimeoutSec: 3,
+		Enabled:    true,
+	}, time.Now().UTC())
+	if result.Status != "up" {
+		t.Fatalf("expected up, got %q (error=%q)", result.Status, result.Error)
+	}
+	records, ok := result.Details["records"].([]string)
+	if !ok {
+		t.Fatalf("expected records []string, got %T: %v", result.Details["records"], result.Details["records"])
+	}
+	if len(records) == 0 {
+		t.Fatal("expected at least one record")
+	}
+	if records[0] != "127.0.0.1" {
+		t.Fatalf("expected first record 127.0.0.1, got %v", records[0])
+	}
+	if server, _ := result.Details["dns_server"].(string); server == "" {
+		t.Fatalf("expected dns_server recorded, got %v", result.Details["dns_server"])
+	}
+}
+
+// TestRunCheck_Details_DNS_NXDOMAIN_RecordsQueryHost — on failure, the
+// host we queried is still recorded so users see what was looked up.
+func TestRunCheck_Details_DNS_NXDOMAIN_RecordsQueryHost(t *testing.T) {
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:       "dns-fail",
+		Type:       internal.ServiceCheckDNS,
+		Target:     "this.domain.definitely.does.not.exist.invalid.",
+		Enabled:    true,
+		TimeoutSec: 3,
+	}, time.Now().UTC())
+
+	if result.Status != "down" {
+		t.Fatalf("expected down, got %q", result.Status)
+	}
+	host, _ := result.Details["query_host"].(string)
+	if host == "" {
+		t.Fatalf("expected query_host populated on failure, got %+v", result.Details)
+	}
+}
+
+// ── Phase 2: Ping details ──────────────────────────────────────────────
+
+// TestRunCheck_Details_Ping_RecordsRTT — a successful ping records the
+// parsed rtt_ms (float) and the resolved host so users see what was hit.
+// Uses the loopback so we don't flake on CI.
+func TestRunCheck_Details_Ping_RecordsRTT(t *testing.T) {
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:       "ping-details",
+		Type:       internal.ServiceCheckPing,
+		Target:     "127.0.0.1",
+		Enabled:    true,
+		TimeoutSec: 2,
+	}, time.Now().UTC())
+
+	// ping might not be available in all CI sandboxes — if it fails,
+	// we still want the query_host recorded so the UI can explain.
+	if result.Status == "down" {
+		t.Skipf("ping not available in this environment: %q", result.Error)
+	}
+	if _, ok := result.Details["rtt_ms"].(float64); !ok {
+		t.Fatalf("expected rtt_ms float64, got %v (%T)", result.Details["rtt_ms"], result.Details["rtt_ms"])
+	}
+	if host, _ := result.Details["query_host"].(string); host != "127.0.0.1" {
+		t.Fatalf("expected query_host=127.0.0.1, got %v", result.Details["query_host"])
+	}
+}


### PR DESCRIPTION
Closes #154.

Follow-up to #142 / #152 (v0.9.2). The Test button now explains *why* a check failed, not just *that* it failed.

## What changes

### Backend (`internal/scheduler/checks.go`, `internal/models.go`)

- `ServiceCheckResult.Details` — new optional `map[string]any` carrying per-check-type diagnostic context.
- `ServiceChecker.SetCollectDetails(true)` — opt-in toggle. **Scheduled checks (`RunDueChecks`) never emit details**, so 30s loops stay lean and history rows don't bloat. Only the ad-hoc `/api/v1/service-checks/test` endpoint opts in.
- Per-type enrichment:
  - **HTTP** → `status_code`, `content_type`, `body_bytes`, `final_url`, `request_url`, `failure_stage` (`tls` / `dns` / `connection_refused` / `timeout` / `network_unreachable` / `http_status` / …)
  - **TCP / SMB / NFS** → `resolved_address`, `failure_stage`
  - **DNS** → `query_host`, `dns_server`, `records []string`, `failure_stage` (`nxdomain` / `timeout` / `refused` / `servfail` / `empty_answer` / `ip_target_rejected`)
  - **Ping** → `query_host`, `rtt_ms` (float), `packet_loss_pct`, `failure_stage`

### Endpoint (`internal/api/api_extended.go`)

One-line wire-up: `checker.SetCollectDetails(true)` before `RunCheck` in `handleTestServiceCheck`.

### Frontend (`internal/api/templates/settings.html`, `internal/api/styles.go`)

- New `renderServiceCheckDetails(type, details, result)` helper builds a multi-line diagnostic summary.
- `testServiceCheck()` now composes `headline + details + error` into a multi-line toast.
- `.toast` CSS: `white-space: pre-wrap` + `max-width: 420px`; added missing `.toast-warning` variant; `showToast` hold timer scales 3–10s with line count.

## Acceptance criteria (from #154)

- [x] HTTP test shows actual status code (200/404/etc.), not just up/down
- [x] DNS test shows resolved records
- [x] Speed test shows some indication of progress during the ~20-60s run (existing "Running speed test (can take up to 60s)…" toast + disabled button; SSE streaming deliberately deferred — see below)
- [x] Failing tests distinguish DNS / connect / TLS / HTTP-level failures via `failure_stage`
- [x] Existing scheduled-check path unchanged — `RunDueChecks` strips `Details` defensively
- [x] `go test ./...` passes

## Explicitly deferred to follow-ups

- **Phase 3 — SMB/NFS richer reporting** (share listing, auth result, protocol version). These would need new CLI dependencies in the Docker image and the cost/benefit doesn't justify it in this iteration. Port-level connectivity via TCP path is already improved.
- **Phase 4 — Speed test SSE streaming** (live Ookla JSON lines via `text/event-stream`). Whole separate infrastructure; tracked as a candidate for a dedicated SSE spike. For this PR: the existing "up to 60s" informational toast plus the disabled button is the MVP.

## Tests added

- **`internal/scheduler/checks_details_test.go`** (new, ~335 LOC):
  - `TestRunCheck_Details_OmittedByDefault` — no details when flag is off
  - `TestRunCheck_Details_PopulatedWhenEnabled` — details present when flag is on
  - `TestRunDueChecks_NeverPopulatesDetails` — scheduled path strip invariant
  - `TestRunCheck_Details_HTTP_Success_StatusCode` — 200 + content_type + body_bytes + final_url
  - `TestRunCheck_Details_HTTP_404_StillRecordsCode` — 404 still populates status_code
  - `TestRunCheck_Details_HTTP_Unreachable_NoStatusCode` — no status_code but `failure_stage` present
  - `TestRunCheck_Details_TCP_ResolvedAddress` / `_Closed_RecordsAddress`
  - `TestRunCheck_Details_DNS_Records` — uses the existing `startFakeDNS` helper
  - `TestRunCheck_Details_DNS_NXDOMAIN_RecordsQueryHost`
  - `TestRunCheck_Details_Ping_RecordsRTT` — skips when ping unavailable

- **`internal/api/service_check_test_endpoint_test.go`**:
  - `TestHandleTestServiceCheck_HTTP_ReturnsDetails` — end-to-end through the handler, asserts the JSON payload contains a populated `details.status_code`

- **`internal/api/settings_service_check_test_button_test.go`**:
  - `TestSettingsHTML_TestServiceCheckRendersDetails` — UI cross-reference guard: template must mention each critical detail key (`status_code`, `records`, `resolved_address`, `rtt_ms`) and branch on check type

## Line-count breakdown (vs `origin/main`)

| Area | LOC |
|---|---|
| Backend production (`checks.go` + `models.go` + `api_extended.go`) | ~200 |
| Frontend (`settings.html` + `styles.go`) | ~76 |
| Tests (new + extensions) | ~400 |
| **Total** | ~676 |

Production-only diff (~275 LOC) sits comfortably under the 500 LOC guidance; the bulk is scheduler tests which were rightly treated as the place to prove behaviour.

## Surprises / gotchas

- **Toast rendering** — the existing toast used `textContent` + default `white-space: normal`, which collapses `\n` into a space. Multi-line diagnostics required the CSS `pre-wrap` fix alongside the JS changes. Added a `max-width` so a long `final_url` doesn't stretch the toast edge to edge.
- **`toast-warning`** — `testServiceCheck` already passed `"warning"` to `showToast` but the CSS only defined `toast-success` / `toast-error` / `toast-info`, so degraded toasts silently fell back to the default (unstyled). Added the missing class.
- **`failure_stage` classification** — HTTP and TCP share Go's `net` error shapes, so `classifyHTTPError` is reused for TCP; DNS gets its own classifier because the lookup error messages are distinct (`no such host` → `nxdomain`, `server misbehaving` → `servfail`).
- **Ping test** — skipped (not failed) when `ping` is missing from PATH so CI environments without the binary don't flake.