### PR TITLE
docs(readme): mention agentic coding harness and workflow (#168)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ NAS Doctor runs periodic health checks on your server — analyzing SMART data, 
 
 Born from an [OpenCode diagnostic skill](https://github.com/mcdays94/opencode-server-diagnostic-skill) that generates professional PDF server reports, NAS Doctor packages the same intelligence into a self-hosted app anyone can install.
 
-It's also an experiment in how far agentic coding can carry a production-shaped project. The whole thing is written through [opencode](https://opencode.ai), mostly by a mix of Claude Opus 4.7 / 4.6 and GPT Codex 5.3, directed by hand. In the same spirit, the issue tracker itself is partly automated — an opencode agent triages open issues, posts replies, and drafts PRs. The orchestration uses dedicated agents and sub-agents inspired by [Matt Pocock's](https://www.mattpocock.com/) workflow: a top-level orchestrator that breaks features into independently-shippable pieces and dispatches worker agents to execute them on isolated branches.
-
 ---
 
 ## Table of Contents
@@ -49,6 +47,7 @@ It's also an experiment in how far agentic coding can carry a production-shaped 
 - [Project Structure](#project-structure)
 - [Platform Support](#platform-support)
 - [Diagnostic Report](#diagnostic-report)
+- [Agentic Setup](#agentic-setup)
 - [Contributing](#contributing)
 
 ---
@@ -733,6 +732,14 @@ Click **Export Report** on the dashboard to generate a print-ready diagnostic re
   <img src="screenshots/report-drives.jpg" alt="Report — Drives" width="240">
   <img src="screenshots/report-actions.jpg" alt="Report — Actions" width="240">
 </p>
+
+---
+
+## Agentic Setup
+
+NAS Doctor is also an experiment in how far agentic coding can carry a production-shaped project. The whole thing is written through [opencode](https://opencode.ai), mostly by a mix of Claude Opus 4.7 / 4.6 and GPT Codex 5.3, directed by hand.
+
+In the same spirit, the issue tracker itself is partly automated — an opencode agent triages open issues, posts replies, and drafts PRs. The orchestration uses dedicated agents and sub-agents inspired by [Matt Pocock's](https://www.mattpocock.com/) workflow: a top-level orchestrator that breaks features into independently-shippable pieces and dispatches worker agents to execute them on isolated branches.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ NAS Doctor runs periodic health checks on your server — analyzing SMART data, 
 
 Born from an [OpenCode diagnostic skill](https://github.com/mcdays94/opencode-server-diagnostic-skill) that generates professional PDF server reports, NAS Doctor packages the same intelligence into a self-hosted app anyone can install.
 
+It's also an experiment in how far agentic coding can carry a production-shaped project. The whole thing is written through [opencode](https://opencode.ai), mostly by a mix of Claude Opus 4.7 / 4.6 and GPT Codex 5.3, directed by hand. In the same spirit, the issue tracker itself is partly automated — an opencode agent triages open issues, posts replies, and drafts PRs. The orchestration uses dedicated agents and sub-agents inspired by [Matt Pocock's](https://www.mattpocock.com/) workflow: a top-level orchestrator that breaks features into independently-shippable pieces and dispatches worker agents to execute them on isolated branches.
+
 ---
 
 ## Table of Contents


### PR DESCRIPTION
Closes #168

Adds a short paragraph to the README describing the agentic coding harness (opencode + Claude/Codex models) and the Pocock-inspired orchestrator/worker workflow used to develop this project. Docs-only change — no code, workflows, or metadata touched.

Do not auto-merge. User tests RC releases manually before stable.