### PR TITLE
fix(charts): measure label width to stop x-axis overlap on /disk/<serial> (#165)

### DIFF
--- a/internal/api/charts.go
+++ b/internal/api/charts.go
@@ -154,9 +154,22 @@ function drawAxes(ctx,m,w,h,yInfo,labels,opts){
   /* x labels */
   if(labels&&labels.length){
     ctx.textAlign="center"; ctx.textBaseline="top";
-    var step=Math.max(1,Math.floor(labels.length/(cw/50)));
+    /* Derive stride from the widest rendered label so adjacent labels never
+       overlap. The old hardcoded ~50px label budget silently broke once
+       labels exceeded that width — datetime strings like "4/17 23:11"
+       measure ~70px in 11px sans-serif. See issue #165. */
+    var maxLabelWidth=0;
+    for(var mi=0;mi<labels.length;mi++){
+      var lw=ctx.measureText(labels[mi]==null?"":String(labels[mi])).width;
+      if(lw>maxLabelWidth) maxLabelWidth=lw;
+    }
+    var LABEL_PAD=12; /* horizontal gutter between adjacent labels */
+    var minLabelDist=maxLabelWidth+LABEL_PAD;
+    var intervals=labels.length-1||1;
+    /* Smallest stride s such that s*(cw/intervals) >= minLabelDist. */
+    var step=Math.max(1,Math.ceil(minLabelDist*intervals/cw));
     for(var j=0;j<labels.length;j+=step){
-      var px=m.l+j/(labels.length-1||1)*cw;
+      var px=m.l+j/intervals*cw;
       ctx.fillStyle=th.text;
       ctx.fillText(labels[j],px,h-m.b+8);
     }

--- a/internal/api/charts_test.go
+++ b/internal/api/charts_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestChartJS_DrawAxes_UsesMeasureText guards against regression of the fix
+// for issue #165 (x-axis label overlap on /disk/<serial>). drawAxes() must
+// size its label stride based on the actual rendered text width rather than
+// a hardcoded pixel budget, otherwise datetime labels like "4/17 23:11"
+// (65-75px wide in the default 11px sans-serif) collide into an unreadable
+// wall once history density grows.
+//
+// If this test fails, it means someone reverted drawAxes() back to the old
+// `Math.floor(labels.length / (cw / 50))` logic or removed measureText()
+// entirely — the charts on /disk/<serial>, /stats, /parity and /service_checks
+// will start overlapping again.
+func TestChartJS_DrawAxes_UsesMeasureText(t *testing.T) {
+	js := ChartJS
+
+	// Locate the x-labels block inside drawAxes. We assert against a slice
+	// of the source rather than the whole blob so that the test pinpoints
+	// the regression instead of matching a measureText call elsewhere.
+	const marker = "/* x labels */"
+	idx := strings.Index(js, marker)
+	if idx < 0 {
+		t.Fatalf("ChartJS: could not locate %q marker — drawAxes() structure changed unexpectedly", marker)
+	}
+	// Slice a generous window (next 1200 chars should comfortably cover
+	// the x-labels block even after refactors).
+	end := idx + 1200
+	if end > len(js) {
+		end = len(js)
+	}
+	xBlock := js[idx:end]
+
+	checks := []struct {
+		name   string
+		substr string
+		why    string
+	}{
+		{
+			"measureText call for actual label width",
+			"measureText",
+			"drawAxes() must measure real label widths via ctx.measureText() — hardcoded pixel budgets cause overlap once labels exceed ~50px",
+		},
+		{
+			"tracks the widest label",
+			"maxLabelWidth",
+			"drawAxes() must derive stride from the widest measured label so the worst-case label never overlaps its neighbour",
+		},
+		{
+			"hardcoded-50 stride formula is gone",
+			"cw/50",
+			"the old `labels.length/(cw/50)` stride formula must not come back — it was the root cause of issue #165",
+		},
+	}
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.name == "hardcoded-50 stride formula is gone" {
+				if strings.Contains(xBlock, tc.substr) {
+					t.Errorf("ChartJS x-labels block still contains the old hardcoded stride formula %q — %s", tc.substr, tc.why)
+				}
+				return
+			}
+			if !strings.Contains(xBlock, tc.substr) {
+				t.Errorf("ChartJS x-labels block missing %q — %s", tc.substr, tc.why)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #165

## Summary

On `/disk/<serial>`, the Temperature History chart and the four SMART Trends charts (Reallocated Sectors, Pending Sectors, UDMA CRC Errors, Command Timeout) showed overlapping x-axis datetime labels once history grew (~2 weeks at the default 30-minute scan interval).

`drawAxes()` in `internal/api/charts.go` picked its stride from a hardcoded ~50px label budget (`labels.length / (cw / 50)`), but datetime labels like `"4/17 23:11"` measure ~70px in the default 11px sans-serif. Adjacent kept-labels therefore collided.

## Approach

Replaced the hardcoded stride with a `ctx.measureText()`-driven one:

1. Walk every label, measure its rendered width, track the max.
2. `minLabelDist = maxLabelWidth + 12` (12px gutter between neighbours).
3. `step = ceil(minLabelDist * intervals / cw)` — smallest integer stride such that every pair of drawn labels is at least `minLabelDist` apart.

Scope-wise: shipped **only the measureText-driven stride**, which is the mandatory piece called out in the issue. The time-boundary-aware tick placement (ticks at hour/day/week boundaries instead of arbitrary indices) is still a nice-to-have but was left for a follow-up — it would require threading timestamps + a `timeScale` hint from every caller (`disk_detail.html`, `stats.html`, `parity.html`, `service_checks.html`, `alerts.html`), which materially expands scope and isn't needed to make labels readable. The new stride degrades gracefully across all of those callers without any changes on the caller side.

The fix lives in the shared `drawAxes()` helper, so the same no-overlap guarantee applies to stats, parity, and service-check history charts — not just `/disk/<serial>`.

## Testing

- Added `internal/api/charts_test.go` with `TestChartJS_DrawAxes_UsesMeasureText` that greps the `ChartJS` constant for `measureText`, `maxLabelWidth`, and asserts the old `cw/50` stride formula is gone. This is the regression guard the issue's TDD notes called for (canvas can't be Go-unit-tested directly since `charts.go` ships JS as a string constant).
- TDD RED confirmed (test fails before the fix lands), then GREEN after.
- Full suite: `go build ./...`, `go test ./...`, `go vet ./...` — all green.

Manual visual verification on real hardware (nas-doctor-uat has the accumulated history density) is still recommended as part of the user's RC test flow.

## Notes

- **Do not auto-merge.** User tests RC releases manually before stable.
- No version bumps, no tags, no workflow changes — just `internal/api/charts.go` and the new test file.