### PR TITLE
fix(settings): unstick saves for upgraders with legacy DNS-IP checks (#169)

### DIFF
--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -584,17 +584,33 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		settings.ServiceChecks.Checks = []internal.ServiceCheckConfig{}
 	}
 	serviceNames := make(map[string]struct{}, len(settings.ServiceChecks.Checks))
+	// Accumulate per-check validation errors so users with multiple
+	// invalid checks see all of them at once, and each error names
+	// the offending check. Issue #169: a flat error that didn't
+	// identify WHICH check failed led upgraders to assume the check
+	// they were currently editing was broken, even when the real
+	// problem was a pre-existing check left over from v0.9.2.
+	var checkErrs []string
 	for i := range settings.ServiceChecks.Checks {
 		check := &settings.ServiceChecks.Checks[i]
+		label := strings.TrimSpace(check.Name)
+		if label == "" {
+			label = fmt.Sprintf("#%d", i+1)
+		}
 		if err := normalizeServiceCheckConfig(check); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-			return
+			checkErrs = append(checkErrs, fmt.Sprintf("%q: %s", label, err.Error()))
 		}
 		if _, exists := serviceNames[strings.ToLower(check.Name)]; exists {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "duplicate service check name: " + check.Name})
-			return
+			checkErrs = append(checkErrs, fmt.Sprintf("%q: duplicate service check name", label))
+			continue
 		}
 		serviceNames[strings.ToLower(check.Name)] = struct{}{}
+	}
+	if len(checkErrs) > 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "service_checks: " + strings.Join(checkErrs, "; "),
+		})
+		return
 	}
 	if settings.LogPush.Destinations == nil {
 		settings.LogPush.Destinations = []LogForwardDestination{}

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -335,6 +335,10 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 	if settings.ServiceChecks.Checks == nil {
 		settings.ServiceChecks.Checks = []internal.ServiceCheckConfig{}
 	}
+	// Issue #169 — soft-disable service checks that were valid under
+	// older schemas but fail current validation, so upgraders aren't
+	// soft-bricked on Save. Does not rewrite the stored config.
+	settings.ServiceChecks.Checks = applyLegacyCheckMigration(settings.ServiceChecks.Checks)
 	if settings.LogPush.Destinations == nil {
 		settings.LogPush.Destinations = []LogForwardDestination{}
 	}
@@ -445,6 +449,91 @@ func normalizeServiceCheckConfig(check *internal.ServiceCheckConfig) error {
 	}
 	return nil
 }
+
+// normalizeLegacyDisabledServiceCheckConfig applies the subset of
+// normalization that is safe for a check that has been flagged by the
+// load-time migration (Warning set, Enabled=false). It skips the
+// strict target validation that the current schema enforces so the
+// check can round-trip through save without blocking unrelated edits.
+//
+// Issue #169: pre-v0.9.3 DNS checks with IP targets are the only
+// currently-known legacy shape that needs grandfathering; the branch
+// is intentionally narrow so a latent bug here cannot whitewash
+// freshly-authored bad config.
+func normalizeLegacyDisabledServiceCheckConfig(check *internal.ServiceCheckConfig) error {
+	check.Name = strings.TrimSpace(check.Name)
+	check.Type = strings.ToLower(strings.TrimSpace(check.Type))
+	check.Target = strings.TrimSpace(check.Target)
+	check.DNSServer = strings.TrimSpace(check.DNSServer)
+	if check.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	// A disabled check must stay disabled — if a user wants to re-enable
+	// it, they also need to fix the Target (which strips the Warning).
+	check.Enabled = false
+	// Apply lenient defaults so the struct is internally consistent.
+	if check.IntervalSec <= 0 {
+		check.IntervalSec = 300
+	}
+	if check.IntervalSec < 30 {
+		check.IntervalSec = 30
+	}
+	if check.TimeoutSec <= 0 {
+		check.TimeoutSec = 5
+	}
+	if check.TimeoutSec > 30 {
+		check.TimeoutSec = 30
+	}
+	if check.FailureThreshold <= 0 {
+		check.FailureThreshold = 1
+	}
+	if check.FailureSeverity == "" {
+		check.FailureSeverity = internal.SeverityWarning
+	}
+	return nil
+}
+
+// applyLegacyCheckMigration scans loaded service checks for configs
+// that are valid under older schemas but fail the current validator,
+// and flips them to Enabled=false with a user-visible Warning. This is
+// a read-time transform only; the stored config is NOT rewritten —
+// the user must acknowledge and resave.
+//
+// Issue #169: the known case is DNS-type checks whose target is a
+// literal IP — a silent no-op under v0.9.0-v0.9.2, now rejected at
+// save time by #159. Without this migration an upgrader's entire
+// settings payload bounces with a misleading error.
+func applyLegacyCheckMigration(checks []internal.ServiceCheckConfig) []internal.ServiceCheckConfig {
+	out := make([]internal.ServiceCheckConfig, len(checks))
+	copy(out, checks)
+	for i := range out {
+		c := &out[i]
+		if !isLegacyDisableTarget(c) {
+			continue
+		}
+		c.Enabled = false
+		if strings.TrimSpace(c.Warning) == "" {
+			c.Warning = legacyDNSIPWarning
+		}
+	}
+	return out
+}
+
+// isLegacyDisableTarget reports whether a stored check is a shape that
+// the load-time migration should flag. Keep narrow: only patterns we
+// have explicitly triaged.
+func isLegacyDisableTarget(c *internal.ServiceCheckConfig) bool {
+	if strings.ToLower(strings.TrimSpace(c.Type)) == internal.ServiceCheckDNS {
+		if net.ParseIP(strings.TrimSpace(c.Target)) != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// legacyDNSIPWarning is the user-facing message surfaced for auto-
+// disabled DNS-IP checks (issue #169).
+const legacyDNSIPWarning = "This DNS check has an IP target (invalid since v0.9.3) and has been auto-disabled. Change the target to a hostname like google.com, or delete it. To test IP reachability use a Ping or TCP check."
 
 // validateDNSServer checks that a user-supplied DNS resolver address is a
 // valid host (or host:port). Port, when present, must be 1-65535.
@@ -585,11 +674,10 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 	}
 	serviceNames := make(map[string]struct{}, len(settings.ServiceChecks.Checks))
 	// Accumulate per-check validation errors so users with multiple
-	// invalid checks see all of them at once, and each error names
-	// the offending check. Issue #169: a flat error that didn't
-	// identify WHICH check failed led upgraders to assume the check
-	// they were currently editing was broken, even when the real
-	// problem was a pre-existing check left over from v0.9.2.
+	// legacy-invalid checks see all of them at once, and each error
+	// names the offending check. Issue #169: pre-v0.9.3 DNS-IP checks
+	// would fail save silently with a flat error that looked like it
+	// referred to whatever check the user happened to be editing.
 	var checkErrs []string
 	for i := range settings.ServiceChecks.Checks {
 		check := &settings.ServiceChecks.Checks[i]
@@ -597,7 +685,15 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		if label == "" {
 			label = fmt.Sprintf("#%d", i+1)
 		}
-		if err := normalizeServiceCheckConfig(check); err != nil {
+		// Legacy grandfather: a check that was flagged invalid on load
+		// (Warning set) AND is disabled cannot run, so its invalid
+		// target is harmless. Exempt it from strict target validation
+		// so upgraders can still save unrelated settings.
+		if !check.Enabled && strings.TrimSpace(check.Warning) != "" {
+			if err := normalizeLegacyDisabledServiceCheckConfig(check); err != nil {
+				checkErrs = append(checkErrs, fmt.Sprintf("%q: %s", label, err.Error()))
+			}
+		} else if err := normalizeServiceCheckConfig(check); err != nil {
 			checkErrs = append(checkErrs, fmt.Sprintf("%q: %s", label, err.Error()))
 		}
 		if _, exists := serviceNames[strings.ToLower(check.Name)]; exists {

--- a/internal/api/settings_legacy_migration_test.go
+++ b/internal/api/settings_legacy_migration_test.go
@@ -1,0 +1,318 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// putSettings issues a PUT /api/v1/settings against the given test server and
+// returns the recorder for inspection.
+func putSettings(t *testing.T, srv *Server, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	buf, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(buf))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.handleUpdateSettings(rec, req)
+	return rec
+}
+
+// getSettings issues a GET /api/v1/settings and parses the response.
+func getSettings(t *testing.T, srv *Server) Settings {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	rec := httptest.NewRecorder()
+	srv.handleGetSettings(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/settings: %d %s", rec.Code, rec.Body.String())
+	}
+	var s Settings
+	body, _ := io.ReadAll(rec.Body)
+	if err := json.Unmarshal(body, &s); err != nil {
+		t.Fatalf("decode settings: %v", err)
+	}
+	return s
+}
+
+// seedRawSettings writes a JSON blob straight into the store under the
+// settings key, bypassing the update handler — this simulates settings.json
+// written by an older version that would now fail validation.
+func seedRawSettings(t *testing.T, srv *Server, raw string) {
+	t.Helper()
+	if err := srv.store.SetConfig(settingsConfigKey, raw); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+}
+
+// TestHandleUpdateSettings_InvalidCheck_ErrorNamesTheCheck — Phase 1:
+// when a check fails validation the error must identify which check
+// by name so users can self-diagnose. Regression for #169 where users
+// upgrading from v0.9.2 with a DNS-IP check received a flat error
+// that seemed to reference the check they were currently editing.
+func TestHandleUpdateSettings_InvalidCheck_ErrorNamesTheCheck(t *testing.T) {
+	srv := newSettingsTestServer()
+	rec := putSettings(t, srv, map[string]any{
+		"scan_interval": "30m",
+		"theme":         "midnight",
+		"service_checks": map[string]any{
+			"checks": []map[string]any{
+				{
+					"name":    "my-legacy-dns",
+					"type":    "dns",
+					"target":  "1.1.1.1",
+					"enabled": true,
+				},
+			},
+		},
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "my-legacy-dns") {
+		t.Fatalf("error must identify failing check by name 'my-legacy-dns', got: %s", rec.Body.String())
+	}
+}
+
+// TestHandleUpdateSettings_MultipleInvalidChecks_AllReported — Phase 1:
+// the validator must accumulate errors across all checks and surface
+// all failures, not short-circuit on the first. Users editing an
+// unrelated check shouldn't have to fix each broken check one by one.
+func TestHandleUpdateSettings_MultipleInvalidChecks_AllReported(t *testing.T) {
+	srv := newSettingsTestServer()
+	rec := putSettings(t, srv, map[string]any{
+		"scan_interval": "30m",
+		"theme":         "midnight",
+		"service_checks": map[string]any{
+			"checks": []map[string]any{
+				{"name": "bad-one", "type": "dns", "target": "1.1.1.1", "enabled": true},
+				{"name": "bad-two", "type": "dns", "target": "8.8.8.8", "enabled": true},
+			},
+		},
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "bad-one") {
+		t.Errorf("expected 'bad-one' in error body, got: %s", body)
+	}
+	if !strings.Contains(body, "bad-two") {
+		t.Errorf("expected 'bad-two' in error body, got: %s", body)
+	}
+}
+
+// TestSettingsLoad_DNSIPCheck_SoftDisabled — Phase 2: when the stored
+// settings contain a legacy DNS check with an IP target (valid under
+// v0.9.2 but invalid under v0.9.3+), the load path must mark it
+// disabled and surface a user-visible warning, NOT silently drop it.
+func TestSettingsLoad_DNSIPCheck_SoftDisabled(t *testing.T) {
+	srv := newSettingsTestServer()
+	seedRawSettings(t, srv, `{
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"service_checks": {
+			"checks": [
+				{"name": "legacy-dns", "type": "dns", "target": "1.1.1.1", "enabled": true}
+			]
+		}
+	}`)
+
+	loaded := getSettings(t, srv)
+	if len(loaded.ServiceChecks.Checks) != 1 {
+		t.Fatalf("expected 1 check, got %d", len(loaded.ServiceChecks.Checks))
+	}
+	check := loaded.ServiceChecks.Checks[0]
+	if check.Enabled {
+		t.Errorf("expected legacy DNS-IP check to be auto-disabled on load, Enabled=true")
+	}
+	if strings.TrimSpace(check.Warning) == "" {
+		t.Errorf("expected non-empty Warning on auto-disabled legacy check, got %q", check.Warning)
+	}
+	// Stored config must remain untouched — we do NOT rewrite disk.
+	raw, err := srv.store.GetConfig(settingsConfigKey)
+	if err != nil {
+		t.Fatalf("load raw stored settings: %v", err)
+	}
+	if !strings.Contains(raw, `"enabled": true`) && !strings.Contains(raw, `"enabled":true`) {
+		t.Errorf("stored settings should not be silently mutated; got: %s", raw)
+	}
+}
+
+// TestSettingsLoad_Then_UpdateSucceeds_WithLegacyCheck — Phase 2 + save path:
+// after load-time soft-disable marks a legacy DNS-IP check with
+// Enabled=false, round-tripping that check back through PUT must NOT
+// re-trigger the validator (disabled checks can't run, so their
+// invalid target is harmless). This is the whole point of #169 —
+// unsticking the save path for upgraders.
+func TestSettingsLoad_Then_UpdateSucceeds_WithLegacyCheck(t *testing.T) {
+	srv := newSettingsTestServer()
+	seedRawSettings(t, srv, `{
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"service_checks": {
+			"checks": [
+				{"name": "legacy-dns", "type": "dns", "target": "1.1.1.1", "enabled": true}
+			]
+		}
+	}`)
+
+	loaded := getSettings(t, srv)
+
+	// Simulate the UI editing an unrelated setting while keeping the
+	// (auto-disabled) legacy check in the payload. Also add a fresh
+	// valid HTTP check — this is the scenario from the issue.
+	loaded.ServiceChecks.Checks = append(loaded.ServiceChecks.Checks, internal.ServiceCheckConfig{
+		Name:    "new-http",
+		Type:    "http",
+		Target:  "https://example.com",
+		Enabled: true,
+	})
+
+	rec := putSettings(t, srv, loaded)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 — save must succeed with legacy disabled check + fresh valid check; got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Reload and assert both checks persist.
+	after := getSettings(t, srv)
+	if len(after.ServiceChecks.Checks) != 2 {
+		t.Fatalf("expected 2 checks after save, got %d", len(after.ServiceChecks.Checks))
+	}
+	names := map[string]bool{}
+	var legacy *internal.ServiceCheckConfig
+	for i := range after.ServiceChecks.Checks {
+		c := &after.ServiceChecks.Checks[i]
+		names[c.Name] = true
+		if c.Name == "legacy-dns" {
+			legacy = c
+		}
+	}
+	if !names["legacy-dns"] || !names["new-http"] {
+		t.Fatalf("expected both checks persisted, got %v", names)
+	}
+	if legacy == nil {
+		t.Fatal("legacy check not found")
+	}
+	if legacy.Enabled {
+		t.Errorf("legacy check should remain disabled after save, got Enabled=true")
+	}
+}
+
+// TestSettingsLoad_ValidDNSCheck_NotTouched — a DNS check with a
+// hostname target is valid under the current schema and must pass
+// through load+save untouched (no warning, enabled preserved). This
+// guards against the Phase 2 migration over-reaching.
+func TestSettingsLoad_ValidDNSCheck_NotTouched(t *testing.T) {
+	srv := newSettingsTestServer()
+	seedRawSettings(t, srv, `{
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"service_checks": {
+			"checks": [
+				{"name": "good-dns", "type": "dns", "target": "google.com", "enabled": true}
+			]
+		}
+	}`)
+
+	loaded := getSettings(t, srv)
+	if len(loaded.ServiceChecks.Checks) != 1 {
+		t.Fatalf("expected 1 check, got %d", len(loaded.ServiceChecks.Checks))
+	}
+	c := loaded.ServiceChecks.Checks[0]
+	if !c.Enabled {
+		t.Errorf("valid DNS hostname check must stay enabled on load, got Enabled=false")
+	}
+	if strings.TrimSpace(c.Warning) != "" {
+		t.Errorf("valid DNS hostname check must have empty Warning, got %q", c.Warning)
+	}
+
+	// Resave — also must round-trip cleanly.
+	rec := putSettings(t, srv, loaded)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("resave failed: %d %s", rec.Code, rec.Body.String())
+	}
+	after := getSettings(t, srv)
+	if !after.ServiceChecks.Checks[0].Enabled {
+		t.Errorf("valid DNS check flipped disabled on resave")
+	}
+	if strings.TrimSpace(after.ServiceChecks.Checks[0].Warning) != "" {
+		t.Errorf("valid DNS check acquired Warning on resave: %q", after.ServiceChecks.Checks[0].Warning)
+	}
+}
+
+// TestSettingsLoad_LegacyCheck_FixingTargetRestoresCheck — when the
+// user edits the auto-disabled legacy check to use a hostname target
+// and clears the Warning field (as a UI would when the user applies
+// the "fix"), the check validates normally on save. Enabled stays
+// false until the user explicitly re-enables — we never silently flip
+// a user-disabled check back on.
+func TestSettingsLoad_LegacyCheck_FixingTargetRestoresCheck(t *testing.T) {
+	srv := newSettingsTestServer()
+	seedRawSettings(t, srv, `{
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"service_checks": {
+			"checks": [
+				{"name": "legacy-dns", "type": "dns", "target": "1.1.1.1", "enabled": true}
+			]
+		}
+	}`)
+
+	loaded := getSettings(t, srv)
+	// UI-equivalent edit: target fixed, warning cleared, enabled left
+	// at false (user must opt back in explicitly).
+	loaded.ServiceChecks.Checks[0].Target = "google.com"
+	loaded.ServiceChecks.Checks[0].Warning = ""
+
+	rec := putSettings(t, srv, loaded)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 after target fix, got %d: %s", rec.Code, rec.Body.String())
+	}
+	after := getSettings(t, srv)
+	if len(after.ServiceChecks.Checks) != 1 {
+		t.Fatalf("expected 1 check, got %d", len(after.ServiceChecks.Checks))
+	}
+	c := after.ServiceChecks.Checks[0]
+	if c.Enabled {
+		t.Errorf("fixed check must stay disabled until user re-enables, got Enabled=true")
+	}
+	if strings.TrimSpace(c.Warning) != "" {
+		t.Errorf("fixed check must not re-acquire warning, got %q", c.Warning)
+	}
+	if c.Target != "google.com" {
+		t.Errorf("target not persisted: got %q", c.Target)
+	}
+}
+
+// TestHandleUpdateSettings_FreshDNSIPCheck_StillRejected — do NOT regress #159:
+// a freshly submitted DNS check with an IP target (enabled=true) must
+// still be rejected with 400. Only pre-existing checks that arrived
+// via the load-time migration path (enabled=false) are grandfathered.
+func TestHandleUpdateSettings_FreshDNSIPCheck_StillRejected(t *testing.T) {
+	srv := newSettingsTestServer()
+	rec := putSettings(t, srv, map[string]any{
+		"scan_interval": "30m",
+		"theme":         "midnight",
+		"service_checks": map[string]any{
+			"checks": []map[string]any{
+				{"name": "brand-new", "type": "dns", "target": "1.1.1.1", "enabled": true},
+			},
+		},
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("fresh DNS-IP check must still be rejected (issue #159); got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(strings.ToLower(rec.Body.String()), "hostname") {
+		t.Errorf("expected hostname guidance in error, got: %s", rec.Body.String())
+	}
+}

--- a/internal/models.go
+++ b/internal/models.go
@@ -226,6 +226,15 @@ type ServiceCheckConfig struct {
 	// "1.1.1.1", "8.8.8.8:53", "192.168.1.1:1053"). Empty means use the
 	// system resolver. Port defaults to 53 when unspecified.
 	DNSServer string `json:"dns_server,omitempty"`
+
+	// Warning is a transient, load-time-populated message shown when the
+	// stored check configuration is invalid under the current schema but
+	// was valid under a previous version (e.g. issue #169 — a DNS check
+	// with an IP target saved under v0.9.2 is invalid under v0.9.3+).
+	// The load path sets Enabled=false and populates this so the UI can
+	// surface the issue; it is NOT persisted back to the store
+	// automatically — user must acknowledge and resave.
+	Warning string `json:"warning,omitempty"`
 }
 
 type ServiceCheckResult struct {


### PR DESCRIPTION
Closes #169.

## Summary

v0.9.3 shipped #159 with strict validation for DNS service checks (IP targets are a silent no-op, now rejected at save time) but no migration. Upgraders with a pre-existing DNS-IP check saved under v0.9.0–v0.9.2 now cannot save **any** settings change — the validator fails on the grandfathered-invalid check on every PUT, regardless of what the user actually edited. The error message was also flat, so users had no way to know **which** check was broken.

This PR ships the MVP backend fix (phases 1 + 2 of the TDD plan). UI Phase 3 is left as a follow-up.

## Phase 1 — per-check error messaging (commit 1)

`handleUpdateSettings` now wraps each per-check validation error with the check's name and accumulates errors across all checks, so users see all failing checks at once:

> `service_checks: "bad-one": DNS checks need a hostname…; "bad-two": DNS checks need a hostname…`

## Phase 2 — load-time soft-disable migration (commit 2)

- `handleGetSettings` runs `applyLegacyCheckMigration` after unmarshalling. For each stored check that matches a known legacy-invalid shape (currently only: DNS type + IP target), `Enabled` is flipped to `false` and a new transient `Warning` field is populated with user-facing guidance.
- The stored config is **NOT** rewritten — user acknowledges and resaves.
- On save, checks that arrive with `Warning` set AND `Enabled=false` are routed through a lenient normalizer (`normalizeLegacyDisabledServiceCheckConfig`) that skips strict target validation. A disabled check cannot run, so its invalid target is harmless.
- Freshly-authored DNS-IP checks (`Enabled=true`, no warning) continue to fail strictly — **#159 behavior is preserved** for new input.

New field: `internal.ServiceCheckConfig.Warning string \`json:"warning,omitempty"\`` — omitempty, so existing API consumers see no change when unpopulated. Existing settings.html JS ignores unknown fields; the Phase 3 follow-up will render a per-check banner that reads this field.

## Tests (commit 3)

6 new tests in `internal/api/settings_legacy_migration_test.go`:

- `TestHandleUpdateSettings_InvalidCheck_ErrorNamesTheCheck`
- `TestHandleUpdateSettings_MultipleInvalidChecks_AllReported`
- `TestSettingsLoad_DNSIPCheck_SoftDisabled`
- `TestSettingsLoad_Then_UpdateSucceeds_WithLegacyCheck` — the core unsticking scenario
- `TestSettingsLoad_ValidDNSCheck_NotTouched` — guards against over-reach
- `TestSettingsLoad_LegacyCheck_FixingTargetRestoresCheck` — user-fix flow
- `TestHandleUpdateSettings_FreshDNSIPCheck_StillRejected` — #159 regression guard

Existing `TestNormalizeServiceCheckConfig_*` continue to pass unmodified.

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅
- Fresh DNS-IP check still fails strict validation — **yes** (preserves #159)
- Saving with legacy auto-disabled DNS-IP check succeeds — **yes** (the fix)

## Out of scope (follow-up)

- Phase 3 UI banner in `settings.html` — the backend now exposes `check.warning` per check; a follow-up PR should render a badge and a "Convert to Ping" quick-action.
- Broader validator refactor (`checkConfigIssue` type suggested in the issue) — kept narrow for this fix.