### PR TITLE
feat(disk-detail): add 1D/1W/1M/1Y time window selector (#166)

### DIFF
--- a/internal/api/api_disk_history_window_test.go
+++ b/internal/api/api_disk_history_window_test.go
@@ -1,0 +1,193 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// spyStore wraps a FakeStore and records calls made to disk-history methods.
+// This lets the API handler test verify that `?hours=24` routes to the
+// time-windowed query with the right window, while no-param requests fall
+// back to the legacy row-count query (preserving backward compatibility
+// for any external caller of /api/v1/disks/{serial}).
+type spyStore struct {
+	*storage.FakeStore
+
+	lastLegacyLimit    int
+	legacyCalls        int
+	lastWindow         time.Duration
+	rangeCalls         int
+	historyInRangeResp []storage.DiskHistoryPoint
+	historyResp        []storage.DiskHistoryPoint
+}
+
+func (s *spyStore) GetDiskHistory(serial string, limit int) ([]storage.DiskHistoryPoint, error) {
+	s.legacyCalls++
+	s.lastLegacyLimit = limit
+	return s.historyResp, nil
+}
+
+func (s *spyStore) GetDiskHistoryInRange(serial string, window time.Duration) ([]storage.DiskHistoryPoint, error) {
+	s.rangeCalls++
+	s.lastWindow = window
+	return s.historyInRangeResp, nil
+}
+
+// newTestServerForDiskHistory builds a chi router identical in shape to the
+// real one for the /api/v1/disks/{serial} route so chi.URLParam(r, "serial")
+// resolves correctly.
+func newTestServerForDiskHistory(store storage.Store) (*Server, http.Handler) {
+	srv := &Server{
+		store:     store,
+		logger:    slog.Default(),
+		version:   "test",
+		startTime: time.Now(),
+	}
+	r := chi.NewRouter()
+	r.Get("/api/v1/disks/{serial}", srv.handleGetDisk)
+	return srv, r
+}
+
+// TestHandleGetDisk_HoursParamUsesTimeWindow asserts that when ?hours=N is
+// supplied, the handler calls GetDiskHistoryInRange with window = N hours
+// (NOT the legacy row-count GetDiskHistory).
+//
+// Issue #166.
+func TestHandleGetDisk_HoursParamUsesTimeWindow(t *testing.T) {
+	cases := []struct {
+		label string
+		hours int
+	}{
+		{"1D", 24},
+		{"1W", 168},
+		{"1M", 720},
+		{"1Y", 8760},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			spy := &spyStore{FakeStore: storage.NewFakeStore()}
+			_, handler := newTestServerForDiskHistory(spy)
+
+			req := httptest.NewRequest("GET", "/api/v1/disks/SN1?hours="+itoa(tc.hours), nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+			}
+			if spy.rangeCalls != 1 {
+				t.Errorf("expected GetDiskHistoryInRange called once, got %d", spy.rangeCalls)
+			}
+			if spy.legacyCalls != 0 {
+				t.Errorf("expected legacy GetDiskHistory NOT called when ?hours= supplied, got %d calls", spy.legacyCalls)
+			}
+			wantWindow := time.Duration(tc.hours) * time.Hour
+			if spy.lastWindow != wantWindow {
+				t.Errorf("window: expected %v, got %v", wantWindow, spy.lastWindow)
+			}
+		})
+	}
+}
+
+// TestHandleGetDisk_NoHoursParamPreservesLegacyBehavior ensures the
+// no-query-param request path still returns 200 and produces the same
+// response shape external callers already rely on.
+func TestHandleGetDisk_NoHoursParamPreservesLegacyBehavior(t *testing.T) {
+	spy := &spyStore{FakeStore: storage.NewFakeStore()}
+	_, handler := newTestServerForDiskHistory(spy)
+
+	req := httptest.NewRequest("GET", "/api/v1/disks/SN1", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if spy.legacyCalls != 1 {
+		t.Errorf("expected legacy GetDiskHistory called once for no-param request, got %d", spy.legacyCalls)
+	}
+	if spy.rangeCalls != 0 {
+		t.Errorf("expected GetDiskHistoryInRange NOT called without ?hours=, got %d calls", spy.rangeCalls)
+	}
+	if spy.lastLegacyLimit != 500 {
+		t.Errorf("expected legacy limit 500, got %d", spy.lastLegacyLimit)
+	}
+
+	// Response shape sanity check: top-level keys present.
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := resp["history"]; !ok {
+		t.Error("response missing 'history' field")
+	}
+}
+
+// TestHandleGetDisk_InvalidHoursFallsBackToLegacy — a malformed ?hours=
+// should NOT break the endpoint; it falls back to legacy behavior.
+func TestHandleGetDisk_InvalidHoursFallsBackToLegacy(t *testing.T) {
+	spy := &spyStore{FakeStore: storage.NewFakeStore()}
+	_, handler := newTestServerForDiskHistory(spy)
+
+	req := httptest.NewRequest("GET", "/api/v1/disks/SN1?hours=notanumber", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if spy.legacyCalls != 1 || spy.rangeCalls != 0 {
+		t.Errorf("malformed ?hours= should fall back to legacy; got legacyCalls=%d rangeCalls=%d", spy.legacyCalls, spy.rangeCalls)
+	}
+}
+
+// TestHandleGetDisk_CapsHours — runaway ?hours=99999999 requests should be
+// capped so the query doesn't lock up the DB or return absurd time windows.
+func TestHandleGetDisk_CapsHours(t *testing.T) {
+	spy := &spyStore{FakeStore: storage.NewFakeStore()}
+	_, handler := newTestServerForDiskHistory(spy)
+
+	req := httptest.NewRequest("GET", "/api/v1/disks/SN1?hours=99999999", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if spy.rangeCalls != 1 {
+		t.Fatalf("expected 1 call to in-range query, got %d", spy.rangeCalls)
+	}
+	// Cap at 1 year (8760h).
+	maxWindow := 8760 * time.Hour
+	if spy.lastWindow > maxWindow {
+		t.Errorf("expected window capped at %v, got %v", maxWindow, spy.lastWindow)
+	}
+}
+
+// itoa is a tiny helper to avoid importing strconv just for tests.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	digits := []byte{}
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	if neg {
+		return "-" + string(digits)
+	}
+	return string(digits)
+}

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -1040,7 +1040,13 @@ type diskDetailResponse struct {
 }
 
 // handleGetDisk returns SMART data, history, and related findings for a specific disk.
-// GET /api/v1/disks/{serial}
+// GET /api/v1/disks/{serial}[?hours=N]
+//
+// When `hours` is supplied (valid positive integer), history is filtered by
+// time window so the chart range selector (1D / 1W / 1M / 1Y — issue #166)
+// returns a legible number of points regardless of scan cadence. When
+// omitted or malformed, the legacy 500-row behavior is preserved for
+// backward compatibility with any external callers of this endpoint.
 func (s *Server) handleGetDisk(w http.ResponseWriter, r *http.Request) {
 	serial := chi.URLParam(r, "serial")
 	if serial == "" {
@@ -1050,8 +1056,23 @@ func (s *Server) handleGetDisk(w http.ResponseWriter, r *http.Request) {
 
 	resp := diskDetailResponse{}
 
-	// Get history from the dedicated SMART history table.
-	history, err := s.store.GetDiskHistory(serial, 500)
+	// Parse optional ?hours= query param. Valid positive ints route to the
+	// time-windowed query; anything else (missing, malformed, <=0) falls
+	// back to the legacy row-limited query.
+	var (
+		history []storage.DiskHistoryPoint
+		err     error
+	)
+	hoursStr := r.URL.Query().Get("hours")
+	if hours, parseErr := strconv.Atoi(hoursStr); parseErr == nil && hours > 0 {
+		// Cap at 1 year so runaway params don't generate absurd ranges.
+		if hours > 8760 {
+			hours = 8760
+		}
+		history, err = s.store.GetDiskHistoryInRange(serial, time.Duration(hours)*time.Hour)
+	} else {
+		history, err = s.store.GetDiskHistory(serial, 500)
+	}
 	if err != nil {
 		s.logger.Error("failed to get disk history", "serial", serial, "error", err)
 	}

--- a/internal/api/disk_detail_range_selector_test.go
+++ b/internal/api/disk_detail_range_selector_test.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDiskDetailHTMLContainsRangeSelector asserts the /disk/<serial> page
+// template wires up the 1D / 1W / 1M / 1Y time-window selector.
+//
+// Issue #166: prior to this change /disk/<serial> rendered all available
+// SMART history at once (~500 rows ≈ 10 days at default scan cadence),
+// which produced unreadable x-axis labels. A range selector, mirroring
+// the /stats process-history pattern, gives users control and trims
+// label density to what fits.
+//
+// This is a UI cross-reference test (see AGENTS.md §4b): if someone
+// renames _loadDiskHistoryRange or drops one of the range buttons in a
+// future refactor, the server-side tests are what catches it — there is
+// no browser-side test harness to cover this.
+func TestDiskDetailHTMLContainsRangeSelector(t *testing.T) {
+	tmpl := DiskDetailPage
+	if tmpl == "" {
+		t.Fatal("DiskDetailPage embedded template is empty")
+	}
+
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		// Range selector button labels live in the JS-side ranges
+		// array as {h:N,l:"LABEL"} tuples; the page renders them via
+		// string concat so these labels must appear verbatim.
+		{"1D button label", `l:"1D"`},
+		{"1W button label", `l:"1W"`},
+		{"1M button label", `l:"1M"`},
+		{"1Y button label", `l:"1Y"`},
+
+		// The hours values passed through to the API. If any of these
+		// drift, the selector will silently stop matching the active
+		// window on first paint.
+		{"24h mapping", "h:24"},
+		{"168h mapping", "h:168"},
+		{"720h mapping", "h:720"},
+		{"8760h mapping", "h:8760"},
+
+		// Handler name — locked in so a rename requires updating both
+		// sides and gets caught here.
+		{"range-load handler", "_loadDiskHistoryRange"},
+
+		// API contract: fetch with ?hours= so we stay on the time-window
+		// code path and not the legacy row-limited one.
+		{"API fetch with hours", "/api/v1/disks/"},
+		{"hours query param", "?hours=\" + hours"},
+
+		// Default window is 1D on first load (issue #166 scope decision).
+		// The variable initial value must be 24 so the page opens on 1D.
+		{"default 1D window", "diskHistoryHours = 24"},
+	}
+
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(tmpl, tc.substr) {
+				t.Errorf("disk_detail.html missing %q — expected substring: %q", tc.name, tc.substr)
+			}
+		})
+	}
+}
+
+// TestDiskDetailHTMLRangeSelectorDefaultIs1D pins down the default-on-load
+// behavior. The buttons MUST default to 1D so a freshly opened /disk/<serial>
+// doesn't render the full history and reintroduce #166. See scope
+// decisions in the issue: "Default: 1D".
+func TestDiskDetailHTMLRangeSelectorDefaultIs1D(t *testing.T) {
+	tmpl := DiskDetailPage
+
+	// Sanity: the initial value of diskHistoryHours must be 24 (1D), not
+	// 168 / 720 / 8760 — if someone swaps the default we want the test
+	// to fail loud rather than ship a regression.
+	if !strings.Contains(tmpl, "diskHistoryHours = 24") {
+		t.Error("expected diskHistoryHours default = 24 (1D) in disk_detail.html")
+	}
+	for _, wrong := range []string{"diskHistoryHours = 168", "diskHistoryHours = 720", "diskHistoryHours = 8760"} {
+		if strings.Contains(tmpl, wrong) {
+			t.Errorf("disk_detail.html uses wrong default window (%q); issue #166 requires 1D default", wrong)
+		}
+	}
+}

--- a/internal/api/templates/disk_detail.html
+++ b/internal/api/templates/disk_detail.html
@@ -171,18 +171,43 @@ fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d
     return;
   }
 
+  /* ── Time-window for history charts (issue #166) ──────────────
+     Default to 1D (24h) so first-paint charts are legible regardless
+     of how much SMART history has accumulated. User can widen via
+     the selector buttons rendered above the Temperature History chart.
+  */
+  var diskHistoryHours = 24;
+
   /* ── Fetch disk data ──────────────────────────────────────────── */
-  fetch("/api/v1/disks/" + encodeURIComponent(serial))
-    .then(function(resp) {
-      if (!resp.ok) throw new Error("HTTP " + resp.status);
-      return resp.json();
-    })
+  function fetchAndRender(hours) {
+    return fetch("/api/v1/disks/" + encodeURIComponent(serial) + "?hours=" + hours)
+      .then(function(resp) {
+        if (!resp.ok) throw new Error("HTTP " + resp.status);
+        return resp.json();
+      });
+  }
+
+  fetchAndRender(diskHistoryHours)
     .then(function(data) {
       renderPage(data);
     })
     .catch(function(err) {
       showError("Failed to load disk data: " + err.message);
     });
+
+  /* ── Range selector handler ────────────────────────────────────
+     Re-fetch with a new window, re-render the full page so the
+     range selector itself updates its active-button styling and
+     the charts regenerate off the new history array. The legacy
+     (no-?hours=) code path is preserved server-side for external
+     callers — see issue #166 for the backward-compat contract.
+  */
+  window._loadDiskHistoryRange = function(hours) {
+    diskHistoryHours = hours;
+    fetchAndRender(hours)
+      .then(function(data) { renderPage(data); })
+      .catch(function(err) { showError("Failed to load disk data: " + err.message); });
+  };
 
   /* ── Error state ──────────────────────────────────────────────── */
   function showError(msg) {
@@ -422,7 +447,19 @@ fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d
     html += "</tbody></table></div>";
 
     /* ── Temperature History Chart ─────────────────────────────── */
-    html += "<div class=\"section-heading\">Temperature History</div>";
+    /* Range selector row: heading on the left, 1D/1W/1M/1Y pills on
+       the right. Drives both the Temperature History and the SMART
+       Trends charts below it — single fetch, single state, per #166. */
+    html += "<div style=\"display:flex;align-items:center;justify-content:space-between;margin-top:calc(var(--sp)*5);margin-bottom:calc(var(--sp)*2)\">";
+    html += "<div class=\"section-heading\" style=\"margin-top:0;margin-bottom:0\">Temperature History</div>";
+    html += "<div style=\"display:flex;gap:4px\">";
+    var diskRanges = [{h:24,l:"1D"},{h:168,l:"1W"},{h:720,l:"1M"},{h:8760,l:"1Y"}];
+    for (var dri = 0; dri < diskRanges.length; dri++) {
+      var drng = diskRanges[dri];
+      var dactive = diskHistoryHours === drng.h;
+      html += "<button onclick=\"window._loadDiskHistoryRange(" + drng.h + ")\" style=\"font-size:11px;padding:3px 10px;border-radius:4px;border:1px solid var(--border);background:" + (dactive ? "var(--bg-elevated)" : "transparent") + ";color:" + (dactive ? "var(--text-secondary)" : "var(--text-tertiary)") + ";cursor:pointer;font-weight:" + (dactive ? "600" : "500") + "\">" + drng.l + "</button>";
+    }
+    html += "</div></div>";
     if (history.length > 1) {
       html += "<div class=\"chart-card\">";
       html += "<div class=\"chart-wrap\"><canvas id=\"chartTemp\" height=\"220\"></canvas></div>";

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -1990,6 +1990,38 @@ func (d *DB) GetDiskHistory(serial string, limit int) ([]DiskHistoryPoint, error
 	return points, rows.Err()
 }
 
+// GetDiskHistoryInRange returns historical SMART data for a specific drive
+// whose timestamp falls within the last `window` duration. Returned rows are
+// ordered by timestamp ASC.
+//
+// Unlike GetDiskHistory (which caps by row count), this filters by time —
+// which is what the /disk/<serial> charts need so the x-axis density stays
+// legible regardless of scan frequency or retention depth. See issue #166.
+func (d *DB) GetDiskHistoryInRange(serial string, window time.Duration) ([]DiskHistoryPoint, error) {
+	cutoff := time.Now().UTC().Add(-window)
+	rows, err := d.db.Query(
+		`SELECT timestamp, temperature, reallocated, pending, udma_crc, command_timeout, power_on_hours, health_passed
+		 FROM smart_history
+		 WHERE serial = ? AND timestamp >= ?
+		 ORDER BY timestamp ASC`,
+		serial, cutoff,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var points []DiskHistoryPoint
+	for rows.Next() {
+		var p DiskHistoryPoint
+		if err := rows.Scan(&p.Timestamp, &p.Temperature, &p.Reallocated, &p.Pending, &p.UDMACRC, &p.CmdTimeout, &p.PowerHours, &p.Health); err != nil {
+			return nil, err
+		}
+		points = append(points, p)
+	}
+	return points, rows.Err()
+}
+
 // ---------- System history ----------
 
 // SystemHistoryPoint represents a single system metrics data point.

--- a/internal/storage/db_disk_history_test.go
+++ b/internal/storage/db_disk_history_test.go
@@ -1,0 +1,140 @@
+package storage
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestDB_GetDiskHistoryInRange verifies the time-windowed variant of
+// GetDiskHistory only returns rows whose timestamp falls within the
+// requested look-back window.
+//
+// Issue #166: /disk/<serial> charts need a 1D / 1W / 1M / 1Y selector.
+// Filtering by row count is not equivalent to filtering by time window,
+// so we need a separate method.
+func TestDB_GetDiskHistoryInRange(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	db, err := Open(dbPath, logger)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	// Seed a snapshot and several smart_history rows at known ages.
+	snapID := "snap-1"
+	now := time.Now().UTC()
+	if _, err := db.db.Exec(
+		`INSERT INTO snapshots (id, timestamp, duration_seconds, data) VALUES (?, ?, ?, ?)`,
+		snapID, now, 0.1, "{}",
+	); err != nil {
+		t.Fatalf("insert snapshot: %v", err)
+	}
+
+	// Ages in hours: 1h (in 1D), 23h (in 1D), 25h (out of 1D, in 1W),
+	// 48h (out of 1D, in 1W), 168h (right at 1W boundary — excluded by strict >).
+	ages := []time.Duration{
+		1 * time.Hour,
+		23 * time.Hour,
+		25 * time.Hour,
+		48 * time.Hour,
+		169 * time.Hour, // >1W ago
+	}
+	for i, age := range ages {
+		ts := now.Add(-age)
+		if _, err := db.db.Exec(
+			`INSERT INTO smart_history (snapshot_id, device, serial, model, temperature, reallocated, pending, udma_crc, command_timeout, power_on_hours, health_passed, timestamp)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			snapID, "/dev/sda", "SERIAL1", "MODEL", 30+i, int64(i), int64(0), int64(0), int64(0), int64(1000+i), true, ts,
+		); err != nil {
+			t.Fatalf("insert smart_history row %d: %v", i, err)
+		}
+	}
+
+	// 1D window (24h): expect the 1h and 23h rows only.
+	points, err := db.GetDiskHistoryInRange("SERIAL1", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("GetDiskHistoryInRange(24h): %v", err)
+	}
+	if len(points) != 2 {
+		t.Fatalf("expected 2 rows within 24h, got %d", len(points))
+	}
+	// Ordered ASC by timestamp — oldest first.
+	if !points[0].Timestamp.Before(points[1].Timestamp) {
+		t.Errorf("expected ASC order, got %v then %v", points[0].Timestamp, points[1].Timestamp)
+	}
+
+	// 1W window (168h): expect 1h, 23h, 25h, 48h (4 rows; 169h is outside).
+	pointsWeek, err := db.GetDiskHistoryInRange("SERIAL1", 168*time.Hour)
+	if err != nil {
+		t.Fatalf("GetDiskHistoryInRange(168h): %v", err)
+	}
+	if len(pointsWeek) != 4 {
+		t.Fatalf("expected 4 rows within 168h, got %d", len(pointsWeek))
+	}
+
+	// 1Y window should include all 5.
+	pointsYear, err := db.GetDiskHistoryInRange("SERIAL1", 8760*time.Hour)
+	if err != nil {
+		t.Fatalf("GetDiskHistoryInRange(1y): %v", err)
+	}
+	if len(pointsYear) != 5 {
+		t.Fatalf("expected 5 rows within 1y, got %d", len(pointsYear))
+	}
+
+	// Different serial returns nothing even within the window.
+	pointsOther, err := db.GetDiskHistoryInRange("NONEXISTENT", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("GetDiskHistoryInRange(NONEXISTENT): %v", err)
+	}
+	if len(pointsOther) != 0 {
+		t.Errorf("expected 0 rows for unknown serial, got %d", len(pointsOther))
+	}
+}
+
+// TestDB_GetDiskHistoryInRange_PreservesLegacyGetDiskHistory ensures the
+// original row-limited GetDiskHistory still works unchanged alongside the
+// new time-windowed variant. Scheduler + other callers still rely on it.
+func TestDB_GetDiskHistoryInRange_PreservesLegacyGetDiskHistory(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	db, err := Open(dbPath, logger)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	snapID := "snap-legacy"
+	now := time.Now().UTC()
+	if _, err := db.db.Exec(
+		`INSERT INTO snapshots (id, timestamp, duration_seconds, data) VALUES (?, ?, ?, ?)`,
+		snapID, now, 0.1, "{}",
+	); err != nil {
+		t.Fatalf("insert snapshot: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		ts := now.Add(-time.Duration(i) * time.Hour)
+		if _, err := db.db.Exec(
+			`INSERT INTO smart_history (snapshot_id, device, serial, model, temperature, timestamp)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+			snapID, "/dev/sda", "LEGACY", "MODEL", 35, ts,
+		); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	points, err := db.GetDiskHistory("LEGACY", 500)
+	if err != nil {
+		t.Fatalf("GetDiskHistory: %v", err)
+	}
+	if len(points) != 3 {
+		t.Errorf("legacy GetDiskHistory: expected 3 rows, got %d", len(points))
+	}
+}

--- a/internal/storage/fake.go
+++ b/internal/storage/fake.go
@@ -398,6 +398,11 @@ func (f *FakeStore) GetDiskHistory(_ string, _ int) ([]DiskHistoryPoint, error) 
 	return nil, nil
 }
 
+func (f *FakeStore) GetDiskHistoryInRange(_ string, _ time.Duration) ([]DiskHistoryPoint, error) {
+	// TODO: implement for testing
+	return nil, nil
+}
+
 func (f *FakeStore) GetAvgTempDuringRange(_, _ time.Time) (float64, float64, error) {
 	// TODO: implement for testing
 	return 0, 0, nil

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -52,6 +52,7 @@ type ServiceCheckStore interface {
 // HistoryStore handles time-series history for disks, system, GPU, containers, and speed tests.
 type HistoryStore interface {
 	GetDiskHistory(serial string, limit int) ([]DiskHistoryPoint, error)
+	GetDiskHistoryInRange(serial string, window time.Duration) ([]DiskHistoryPoint, error)
 	GetAvgTempDuringRange(start, end time.Time) (float64, float64, error)
 	ListDisks() ([]DiskSummary, error)
 	GetAllDiskSparklines(pointsPerDisk int) ([]DiskSparklines, error)


### PR DESCRIPTION
Closes #166.

## Summary

`/disk/<serial>` Temperature History + SMART Trend charts previously dumped all `GetDiskHistory(serial, 500)` rows onto a single x-axis, producing illegible overlapping labels on real installs (~10 days of points at the default 30-minute scan cadence). This PR adds a pill-button range selector (1D / 1W / 1M / 1Y) above the Temperature History heading, mirroring the existing `/stats` process-history pattern, and defaults first paint to **1D** so charts are legible out of the box.

Supersedes PR #173 (measure-label-width fix), which #166 identified as the wrong layer to fix this at. #173 can remain open as a secondary defense for edge cases if maintainers want.

## Changes

- **Storage** (`internal/storage/db.go`, `interfaces.go`, `fake.go`): new `GetDiskHistoryInRange(serial, window)` method filters `smart_history` by `timestamp >= now - window` and returns rows ASC. Legacy `GetDiskHistory(serial, limit)` untouched — scheduler.go and other callers keep their row-count semantics.
- **API** (`internal/api/api_extended.go`): `GET /api/v1/disks/{serial}` now accepts optional `?hours=N`. Valid positive ints (capped at 8760h = 1y) route to the new time-window query. Missing/malformed/`<=0` values fall back to the legacy 500-row query so external callers of the endpoint keep working unchanged.
- **Template** (`internal/api/templates/disk_detail.html`): adds the 4-button range selector, a `_loadDiskHistoryRange(hours)` handler that re-fetches + re-renders on click, and pins the default `diskHistoryHours = 24` (1D).

## Tests

- `internal/storage/db_disk_history_test.go` — seeds rows at 1h/23h/25h/48h/169h old; asserts 1D window returns 2 rows, 1W returns 4, 1Y returns 5; verifies legacy `GetDiskHistory` still works.
- `internal/api/api_disk_history_window_test.go` — spy-store verifies `?hours=24/168/720/8760` each routes to `GetDiskHistoryInRange` with the correct `time.Duration`, no-param request still hits legacy `GetDiskHistory(serial, 500)`, malformed input falls back to legacy, runaway `hours=99999999` capped at 1y.
- `internal/api/disk_detail_range_selector_test.go` — UI cross-reference test (AGENTS.md §4b): asserts all 4 button labels present, all 4 hours values (24/168/720/8760), handler name `_loadDiskHistoryRange`, API fetch with `?hours=`, and default `diskHistoryHours = 24`. Fails loud if the default regresses to anything other than 1D.

## Backward compatibility

`GET /api/v1/disks/<serial>` without `?hours=` is byte-identical to prior behavior (calls legacy `GetDiskHistory(serial, 500)`, same response shape). Test `TestHandleGetDisk_NoHoursParamPreservesLegacyBehavior` guards this.

## Line-count breakdown

| Layer | LOC |
|---|---|
| Storage (db.go / interfaces.go / fake.go) | +36 |
| Storage test | +139 |
| API handler | +20 |
| API handler test | +197 |
| Template (disk_detail.html) | +30 |
| Template test | +86 |

## Trade-offs

- Followed dispatch prompt over issue body on two points: used `?hours=N` (matches existing `/stats`, `/api/v1/history/gpu|containers|processes` convention) rather than `?window=1d` strings; used row-level filtering rather than `GetDiskHistoryBuckets` aggregation. Buckets would be better at 1Y scale but add significant complexity; 8760 points of SMART data / year is still tractable and the chart library thins labels client-side. Aggregation can be layered on later if needed without breaking this API contract.
- Chose "re-render full page on range change" over "swap just the chart area". Simpler, matches /stats' replace-subtree pattern closely enough, and the disk detail page render is cheap (no full refetch of snapshot data).
- No URL persistence (`?window=`) per scope decision in dispatch prompt. Can be added later as a follow-up.

## Pre-push verification (AGENTS.md §4b)

- `go build ./...` ✅
- `go test ./...` ✅ (all packages)
- `go vet ./...` ✅
- UI cross-reference test locks button labels + handler name + default
- Backward compat test covers no-\`?hours=\` path