### PR TITLE
fix(service-checks): wrap long values in expanded log entries (#176)

### DIFF
--- a/internal/api/service_checks_log_wrap_test.go
+++ b/internal/api/service_checks_log_wrap_test.go
@@ -1,0 +1,132 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// loadServiceChecksHTML returns the service_checks.html template content
+// for assertions. Keeps the test hermetic (does not rely on the embedded
+// FS being initialized; reads the source file directly).
+func loadServiceChecksHTML(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join("templates", "service_checks.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read service_checks.html: %v", err)
+	}
+	return string(data)
+}
+
+// TestServiceChecksHTML_LogDetailWrapsLongValues guards the CSS fix for
+// issue #176. When a log entry is expanded on the Service Checks page,
+// long field values (URLs, error messages, check keys) must wrap within
+// their grid item; otherwise the unbroken string pushes the grid track
+// wider than its parent card and the card visibly overflows on desktop
+// and mobile alike.
+//
+// We assert three structural invariants in the CSS:
+//  1. .log-detail-item has min-width:0 — without this, the CSS grid
+//     track (grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)))
+//     refuses to shrink below the intrinsic width of its unbreakable
+//     content, so the grid expands horizontally beyond the card.
+//  2. .log-detail-item .ld-val has overflow-wrap:anywhere and
+//     word-break:break-word — together these force browsers to break
+//     at any character boundary for tokens without whitespace (URLs,
+//     base64 strings, etc.). Both are set because older engines honor
+//     word-break while modern engines prefer overflow-wrap; shipping
+//     both is the broadest-compat pattern.
+//  3. .log-table td must also wrap. The un-expanded log table lives
+//     inside the same .log-panel card; a long unbreakable value in a
+//     row cell (e.g. the Check Name column) stretches the <table>
+//     past the panel's width, which transitively pushes the
+//     colspan=6 expanded detail row past the card edge — even when
+//     the detail grid itself would have fit. We unset the inherited
+//     white-space:nowrap from the shared stylesheet (styles.go)
+//     and set word-break/overflow-wrap so no single cell can grow
+//     the table beyond 100% of the panel's inner width.
+//
+// This is a grep-based CSS test: it does not exercise a running page
+// (that's covered by §4c Playwright validation on the worker side),
+// but it does prevent accidental regression if someone later refactors
+// the log-detail styles and drops the wrap rules.
+func TestServiceChecksHTML_LogDetailWrapsLongValues(t *testing.T) {
+	html := loadServiceChecksHTML(t)
+
+	// Invariant 1: .log-detail-item must set min-width:0 so CSS grid
+	// tracks can shrink below the intrinsic width of long tokens.
+	itemRule := extractCSSRule(t, html, ".log-detail-item{")
+	if !strings.Contains(itemRule, "min-width:0") {
+		t.Errorf(".log-detail-item CSS must include min-width:0 so grid tracks shrink below intrinsic width of long unbreakable tokens; rule was:\n  %s", itemRule)
+	}
+
+	// Invariant 2: .log-detail-item .ld-val must wrap.
+	valRule := extractCSSRule(t, html, ".log-detail-item .ld-val{")
+	if !regexp.MustCompile(`overflow-wrap\s*:\s*anywhere`).MatchString(valRule) {
+		t.Errorf(".log-detail-item .ld-val CSS must include overflow-wrap:anywhere; rule was:\n  %s", valRule)
+	}
+	if !regexp.MustCompile(`word-break\s*:\s*break-word`).MatchString(valRule) {
+		t.Errorf(".log-detail-item .ld-val CSS must include word-break:break-word; rule was:\n  %s", valRule)
+	}
+
+	// Invariant 3: .log-table td must override the shared stylesheet's
+	// white-space:nowrap and permit character-boundary wrapping.
+	tdRule := extractCSSRule(t, html, ".log-table td{")
+	if !regexp.MustCompile(`white-space\s*:\s*normal`).MatchString(tdRule) {
+		t.Errorf(".log-table td CSS must include white-space:normal to unset the shared stylesheet's nowrap (otherwise long cell values stretch the table past the panel card); rule was:\n  %s", tdRule)
+	}
+	if !regexp.MustCompile(`overflow-wrap\s*:\s*anywhere`).MatchString(tdRule) {
+		t.Errorf(".log-table td CSS must include overflow-wrap:anywhere; rule was:\n  %s", tdRule)
+	}
+	if !regexp.MustCompile(`word-break\s*:\s*break-word`).MatchString(tdRule) {
+		t.Errorf(".log-table td CSS must include word-break:break-word; rule was:\n  %s", tdRule)
+	}
+}
+
+// TestServiceChecksHTML_LogDetailClassesCrossReference is the §4b
+// cross-reference guard: the CSS class names styled in the <style>
+// block must actually be emitted by the JS that renders expanded log
+// rows. If someone renames one side without the other, logic tests
+// and the CSS rule test both stay green while the fix silently stops
+// applying — classic drift trap.
+func TestServiceChecksHTML_LogDetailClassesCrossReference(t *testing.T) {
+	html := loadServiceChecksHTML(t)
+
+	// The JS in renderLogTable() emits both of these classes when it
+	// builds the expanded detail row. If either disappears from the
+	// template, the CSS wrap fix becomes a no-op.
+	for _, cls := range []string{"log-detail-item", "ld-val"} {
+		cssNeedle := "." + cls
+		if !strings.Contains(html, cssNeedle) {
+			t.Errorf("service_checks.html CSS no longer targets %q — wrap rule would no-op", cssNeedle)
+		}
+		jsNeedle := `class="` + cls
+		// The JS builds classes via string concatenation; the literal
+		// "class=\"<name>" fragment appears in the template source.
+		if !strings.Contains(html, jsNeedle) && !strings.Contains(html, `"`+cls+`"`) {
+			t.Errorf("service_checks.html JS no longer emits %q in rendered HTML — CSS rule would style nothing", cls)
+		}
+	}
+}
+
+// extractCSSRule returns the body (between { and }) of the first CSS
+// rule in html whose opening matches prefix (e.g. ".log-detail-item{").
+// Fails the test if the rule isn't present; returning a guaranteed
+// non-empty string lets the caller assert on contents without
+// dereferencing nil.
+func extractCSSRule(t *testing.T, html, prefix string) string {
+	t.Helper()
+	start := strings.Index(html, prefix)
+	if start < 0 {
+		t.Fatalf("CSS rule %q not found in service_checks.html — template was restructured or rule was removed", prefix)
+	}
+	bodyStart := start + len(prefix)
+	end := strings.Index(html[bodyStart:], "}")
+	if end < 0 {
+		t.Fatalf("CSS rule %q found but never closed with '}' — malformed CSS?", prefix)
+	}
+	return html[bodyStart : bodyStart+end]
+}

--- a/internal/api/templates/service_checks.html
+++ b/internal/api/templates/service_checks.html
@@ -42,7 +42,15 @@
 .log-panel{background:var(--surface);border:1px solid var(--border);border-radius:12px;overflow:hidden}
 .log-table{width:100%;font-size:12px;border-collapse:collapse}
 .log-table th{text-align:left;padding:8px 12px;color:var(--text3);font-size:10px;text-transform:uppercase;letter-spacing:0.5px;border-bottom:1px solid var(--border);background:var(--surface);position:sticky;top:0}
-.log-table td{padding:6px 12px;border-bottom:1px solid var(--border)}
+/* white-space:normal (unsets nowrap from shared styles.go), word-break,
+   and overflow-wrap together let long tokens in any cell break at
+   character boundaries instead of pushing the column — and transitively
+   the table — wider than the surrounding panel. Without this, a long
+   unbreakable Check Name stretches the table past the panel, and the
+   colspan=6 detail row inherits that width, pushing the expanded grid
+   past the card edge (#176). Cells with intentional ellipsis (e.g. the
+   error column) still opt out via inline `white-space:nowrap`. */
+.log-table td{padding:6px 12px;border-bottom:1px solid var(--border);white-space:normal;word-break:break-word;overflow-wrap:anywhere}
 .log-table .status-up{color:var(--green);font-weight:600}
 .log-table .status-down{color:var(--red);font-weight:600}
 .log-table .status-degraded{color:var(--amber);font-weight:600}
@@ -61,9 +69,17 @@
 .log-detail{padding:12px 16px;background:var(--bg-elevated);font-size:12px;display:none}
 .log-detail.open{display:block}
 .log-detail-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:8px}
-.log-detail-item{padding:6px 8px;background:var(--surface);border-radius:var(--radius);border:1px solid var(--border)}
+/* min-width:0 lets this grid track shrink below the intrinsic width
+   of long unbreakable content (URLs, check keys). Without it the track
+   refuses to collapse and the whole grid blows past the parent card's
+   right edge — see #176. */
+.log-detail-item{padding:6px 8px;background:var(--surface);border-radius:var(--radius);border:1px solid var(--border);min-width:0}
 .log-detail-item .ld-label{font-size:10px;color:var(--text3);text-transform:uppercase;letter-spacing:0.3px}
-.log-detail-item .ld-val{font-size:13px;font-weight:600;margin-top:2px}
+/* overflow-wrap:anywhere + word-break:break-word together force wrapping
+   at any character boundary for tokens without whitespace. Both are set
+   because older engines honor word-break and modern engines prefer
+   overflow-wrap; keeping both is the broadest-compat pattern. */
+.log-detail-item .ld-val{font-size:13px;font-weight:600;margin-top:2px;overflow-wrap:anywhere;word-break:break-word}
 /* Orphan badge */
 .orphan-badge{font-size:9px;padding:1px 6px;border-radius:999px;background:rgba(217,119,6,0.12);color:var(--amber);margin-left:6px}
 .btn-delete-check{font-size:10px;padding:2px 8px;border:1px solid var(--border);border-radius:var(--radius);background:var(--surface);color:var(--red);cursor:pointer;margin-left:auto}


### PR DESCRIPTION
Closes #176

## Summary

On the Service Checks page, expanding a log entry with a long field value (URL, error message, check key, Check Name) caused the value to render as a single unbroken string that overflowed the containing card. Observed on v0.9.4-rc3 during UAT; confirmed present across earlier versions too — this is a long-standing UX defect, not a regression.

## Root cause

Three cooperating CSS gaps, all on `internal/api/templates/service_checks.html`:

1. **`.log-detail-item` lacked `min-width:0`**. The grid is `grid-template-columns: repeat(auto-fill, minmax(160px, 1fr))`; without `min-width:0` a grid track refuses to shrink below the intrinsic width of its content, so an unbreakable 150-char URL stretches the track, and the whole grid past the card's right edge.
2. **`.log-detail-item .ld-val` had no wrap rules**. Some fields had inline `word-break:break-all` applied ad-hoc in the JS (Target, Check Key, Error), but Check Name and type-specific fields didn't — so any long name rendered as an unbroken string inside its mini-card.
3. **`.log-table td` inherited `white-space:nowrap` from the shared stylesheet** (`internal/api/styles.go:199`). That meant a long Check Name in an un-expanded row stretched the `<table>` past the panel's width, and the `colspan=6` detail row inherited the stretched width, forcing the expanded grid past the card edge even when the grid itself would have fit.

## Fix

Three small, scoped CSS additions:

```css
.log-table td{...;white-space:normal;word-break:break-word;overflow-wrap:anywhere}
.log-detail-item{...;min-width:0}
.log-detail-item .ld-val{...;overflow-wrap:anywhere;word-break:break-word}
```

`overflow-wrap:anywhere` + `word-break:break-word` are set together because older engines honor `word-break` while modern engines prefer `overflow-wrap` — shipping both is the broadest-compat pattern. Cells with intentional ellipsis (the error column) still opt out via inline `white-space:nowrap` on the `<td>`.

## Tests

New `internal/api/service_checks_log_wrap_test.go` (132 LOC) with two grep-based regression guards:

- **`TestServiceChecksHTML_LogDetailWrapsLongValues`** — asserts all three CSS rules contain the expected properties. Proven to fail cleanly when any of the three rules is reverted (verified by sed-revert + `go test` locally).
- **`TestServiceChecksHTML_LogDetailClassesCrossReference`** — asserts the CSS class names being styled (`log-detail-item`, `ld-val`) are actually emitted by the `renderLogTable()` JS. Guards against the §4b "CSS targets a class the template no longer outputs" footgun.

Full suite green: `go build ./...` + `go test ./...` all packages.

## §4c — Visual validation

Seeded a local SQLite DB with a service check entry containing:
- Check Name: `ServiceWithAnExtremelyLongNameThatContainsNoWhitespaceAndShouldForceBrowserToWrapAtCharacterBoundaries` (~100 chars, no whitespace)
- Target: a ~270-char URL with long query string + auth token
- Check Key: ~90-char unbroken identifier
- Error: ~150-char error message with no hyphens/spaces in the tail

Drove Playwright at **1400×900** (desktop) and **375×667** (mobile), clicked the row to expand, screenshotted, and programmatically asserted that every `.ld-val` fits within its parent `.log-detail-item` card's right edge (±1px tolerance).

### Result

| Viewport | `.ld-val` fits in `.log-detail-item` | `.log-detail` fits in `.log-panel` |
|---|---|---|
| Desktop 1400×900 | ✅ all 10 values, worst overflow 0.0px | ✅ fits (detail.right=1249, panel.right=1250) |
| Mobile 375×667  | ✅ all 10 values, worst overflow 0.0px | ⚠ pre-existing |

**Pre-fix reference** (validator run against stashed template):
- Desktop `.log-detail` overflowed `.log-panel` by **279px** on the same seed data → clearly reproduced the bug.
- Multiple `.ld-val` right-edges exceeded their items by up to **389px** depending on which field the long value landed in.

### Out of scope

On mobile, the overall 6-column `.log-table` still exceeds the 375px viewport regardless of this fix — a separate pre-existing layout issue (the table itself was always too wide for phones). Issue #176 is scoped to "long values in expanded log entries overflow the containing card"; that scope is fully satisfied. The mobile table-width issue should be tracked separately.

The user also mentioned "richer log entries" as future work — **not** included here; this PR is only the wrap bug.

## Screenshots

All taken post-fix on a locally-built binary at commit `0749f6e` against a seeded DB.

### Desktop — log table (before expand)
![desktop](https://raw.githubusercontent.com/mcdays94/nas-doctor/screenshots/issue-176-log-wrap/.screenshots/176/desktop.png)

### Desktop — expanded log entry (the card in the issue)
![desktop-expanded](https://raw.githubusercontent.com/mcdays94/nas-doctor/screenshots/issue-176-log-wrap/.screenshots/176/desktop-expanded.png)

Every value (Check Name, Target URL, Check Key, Error) wraps inside its mini-card. The whole `.log-detail` grid fits inside the outer `.log-panel` card.

### Mobile — log table (before expand)
![mobile](https://raw.githubusercontent.com/mcdays94/nas-doctor/screenshots/issue-176-log-wrap/.screenshots/176/mobile.png)

### Mobile — expanded log entry
![mobile-expanded](https://raw.githubusercontent.com/mcdays94/nas-doctor/screenshots/issue-176-log-wrap/.screenshots/176/mobile-expanded.png)

All mini-card values wrap at character boundaries inside their own borders. The outer 6-col table is still too wide for 375px (pre-existing, out of scope).

## Line counts

- `internal/api/templates/service_checks.html`: **+19 / −3**
- `internal/api/service_checks_log_wrap_test.go`: **+132 / 0** (new file)

## Pre-push checks

- ✅ `go build ./...`
- ✅ `go test ./...` — all packages green, including 2 new wrap tests
- ✅ §4c Playwright DOM-measurement assertion passes at 1400×900 and 375×667
- ✅ Tests proven to fail cleanly when the fix is reverted

Do not auto-merge — user validates all fixes on UAT before stable.