### PR TITLE
feat(service-checks): persist + display per-type Details in log entries (#182)

### DIFF
--- a/internal/api/service_checks_log_details_test.go
+++ b/internal/api/service_checks_log_details_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestServiceChecksHTML_LogDetail_RendersPerTypeDetails guards the UI
+// changes for issue #182. When a user expands a log entry on the
+// /service-checks page, the detail panel must render the per-type
+// Details map (HTTP status_code, DNS records, TCP resolved_address,
+// Ping rtt_ms + packet_loss_pct, failure_stage for any type) so the
+// same rich context the Test button already shows is visible on
+// persisted log rows.
+//
+// We verify by cross-reference — the template must mention the exact
+// Details keys the scheduler persists. Keeps the test hermetic (no
+// headless browser), catches regressions where a refactor deletes the
+// rendering branch for one type.
+func TestServiceChecksHTML_LogDetail_RendersPerTypeDetails(t *testing.T) {
+	html := loadServiceChecksHTML(t)
+
+	// The renderer helper must exist and be invoked from the log expand
+	// path. Naming follows #154's settings.html helper so a future refactor
+	// can promote it without renaming callers.
+	mustContain(t, html, "renderServiceCheckDetails",
+		"log expand path must reference the renderServiceCheckDetails helper")
+
+	// The entry's details payload must be consumed. ServiceCheckEntry's
+	// JSON tag is "details,omitempty"; the template reads e.details.
+	mustContain(t, html, "e.details",
+		"log expand path must read e.details from the persisted entry")
+
+	// Per-type keys — match the set the scheduler runners populate.
+	// One failure here pinpoints exactly which branch regressed.
+	perTypeKeys := map[string]string{
+		"HTTP status_code":     "status_code",
+		"HTTP content_type":    "content_type",
+		"HTTP body_bytes":      "body_bytes",
+		"HTTP final_url":       "final_url",
+		"DNS records":          "records",
+		"DNS query_host":       "query_host",
+		"DNS dns_server":       "dns_server",
+		"TCP resolved_address": "resolved_address",
+		"Ping rtt_ms":          "rtt_ms",
+		"Ping packet_loss_pct": "packet_loss_pct",
+		"Shared failure_stage": "failure_stage",
+	}
+	for label, key := range perTypeKeys {
+		if !strings.Contains(html, key) {
+			t.Errorf("service_checks.html missing %s key %q — log detail panel won't render it", label, key)
+		}
+	}
+}
+
+// TestServiceChecksHTML_LogDetail_ExistingFieldsStillRendered — sanity
+// guard against accidentally losing the original fields in the detail
+// panel while wiring up the new helper. These were shipped by the
+// expand-row UI prior to #182 (Check Name, Type, Target, Status, Response
+// Time, Checked At, etc.); they must still appear.
+func TestServiceChecksHTML_LogDetail_ExistingFieldsStillRendered(t *testing.T) {
+	html := loadServiceChecksHTML(t)
+	required := []string{
+		"Check Name",
+		"Target",
+		"Response Time",
+		"Checked At",
+		"Consecutive Failures",
+		"Check Key",
+	}
+	for _, label := range required {
+		if !strings.Contains(html, label) {
+			t.Errorf("service_checks.html lost legacy detail-panel label %q during #182 wiring", label)
+		}
+	}
+}
+
+func mustContain(t *testing.T, haystack, needle, why string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("%s\n  expected substring: %q", why, needle)
+	}
+}

--- a/internal/api/templates/service_checks.html
+++ b/internal/api/templates/service_checks.html
@@ -169,6 +169,71 @@
 
   function esc(s){var d=document.createElement("div");d.textContent=s||"";return d.innerHTML;}
   function fetchJSON(url){return fetch(url).then(function(r){if(!r.ok)throw new Error(r.status);return r.json()});}
+
+  // renderServiceCheckDetails turns the per-type Details map (persisted
+  // in service_checks_history.details_json, surfaced by the API as
+  // entry.details) into a set of <div class="log-detail-item"> cells
+  // that drop into the existing log-detail-grid. Same contract as the
+  // settings.html Test-button helper from #154, so a future refactor
+  // can promote this to a shared file. See issue #182.
+  //
+  // Only the keys actually set by the scheduler runners are rendered —
+  // unknown keys are silently ignored so a forward-compat server (adds
+  // a new detail key in a future release) doesn't cause blank cells
+  // here. Numeric keys tolerate int OR float (JSON round-tripping the
+  // map through SQLite turns Go ints into JS numbers but keeps the
+  // exact value).
+  function renderServiceCheckDetails(type, details, entry) {
+    if (!details || typeof details !== "object") return "";
+    var t = (type || "").toLowerCase();
+    var out = "";
+    function cell(label, val, extraStyle) {
+      var s = extraStyle ? ' style="'+extraStyle+'"' : "";
+      return '<div class="log-detail-item"'+s+'><div class="ld-label">'+esc(label)+'</div><div class="ld-val">'+val+'</div></div>';
+    }
+    if (t === "http") {
+      if (typeof details.status_code === "number") {
+        // Colour the code so 2xx pops green, 4xx/5xx red — mirrors the
+        // Test button toast.
+        var codeColor = details.status_code >= 200 && details.status_code < 400 ? "var(--green)"
+                      : details.status_code >= 400 ? "var(--red)" : "var(--text)";
+        out += cell("HTTP Status", '<span style="color:'+codeColor+'">'+details.status_code+'</span>');
+      }
+      if (details.content_type) out += cell("Content-Type", esc(details.content_type));
+      if (typeof details.body_bytes === "number") out += cell("Body Size", details.body_bytes + " bytes");
+      // final_url is only interesting when it differs from the request
+      // (i.e. a redirect happened). Otherwise it's redundant with Target.
+      if (details.final_url && details.final_url !== details.request_url && details.final_url !== (entry && entry.target)) {
+        out += cell("Final URL", '<span style="font-size:11px;font-family:var(--font-mono);word-break:break-all">'+esc(details.final_url)+'</span>', "grid-column:1/-1");
+      }
+    } else if (t === "tcp" || t === "smb" || t === "nfs") {
+      if (details.resolved_address) out += cell("Resolved Address", '<span style="font-family:var(--font-mono)">'+esc(details.resolved_address)+'</span>');
+    } else if (t === "dns") {
+      if (details.query_host) out += cell("Query Host", '<span style="font-family:var(--font-mono)">'+esc(details.query_host)+'</span>');
+      if (details.dns_server) out += cell("DNS Server", '<span style="font-family:var(--font-mono)">'+esc(details.dns_server)+'</span>');
+      if (Array.isArray(details.records) && details.records.length) {
+        // Records listed comma-separated; the grid cell wraps on commas
+        // naturally. Span the row on many records so readability wins
+        // over grid symmetry.
+        var recVal = details.records.map(function(r){return esc(String(r));}).join(", ");
+        var span = details.records.length > 2 ? ' style="grid-column:1/-1"' : "";
+        out += '<div class="log-detail-item"'+span+'><div class="ld-label">Resolved Records</div><div class="ld-val" style="font-family:var(--font-mono);font-size:11px">'+recVal+'</div></div>';
+      }
+    } else if (t === "ping") {
+      if (details.query_host) out += cell("Host", '<span style="font-family:var(--font-mono)">'+esc(details.query_host)+'</span>');
+      if (typeof details.rtt_ms === "number") out += cell("RTT", details.rtt_ms.toFixed(2) + " ms");
+      if (typeof details.packet_loss_pct === "number") {
+        var lossColor = details.packet_loss_pct > 0 ? "var(--red)" : "var(--text)";
+        out += cell("Packet Loss", '<span style="color:'+lossColor+'">'+details.packet_loss_pct+'%</span>');
+      }
+    }
+    // failure_stage is shared across types; only meaningful on non-up
+    // results so we skip on "up" to keep the happy-path grid tight.
+    if (details.failure_stage && entry && entry.status !== "up") {
+      out += cell("Failure Stage", '<span style="color:var(--red)">'+esc(details.failure_stage)+'</span>');
+    }
+    return out;
+  }
   function pillClass(t){t=(t||"").toLowerCase();if(t==="http")return"pill-http";if(t==="tcp")return"pill-tcp";if(t==="dns")return"pill-dns";if(t==="ping")return"pill-ping";if(t==="smb"||t==="nfs")return"pill-smb";if(t==="speed")return"pill-speed";return"pill-http";}
   function fmtInterval(sec){if(sec<60)return sec+"s";if(sec<3600)return Math.floor(sec/60)+"m";return Math.floor(sec/3600)+"h";}
   function faviconHTML(type,target){
@@ -301,16 +366,13 @@
       h+='<div class="log-detail-item"><div class="ld-label">Consecutive Failures</div><div class="ld-val">'+(e.consecutive_failures||0)+' / '+(e.failure_threshold||1)+'</div></div>';
       h+='<div class="log-detail-item"><div class="ld-label">Check Key</div><div class="ld-val" style="font-size:10px;font-family:var(--font-mono);word-break:break-all;color:var(--text3)">'+esc(e.key||"—")+'</div></div>';
       if(e.error)h+='<div class="log-detail-item" style="grid-column:1/-1"><div class="ld-label">Error</div><div class="ld-val" style="font-size:12px;color:var(--red);font-weight:400;word-break:break-all">'+esc(e.error)+'</div></div>';
-      // Type-specific details
-      if((e.type||"").toLowerCase()==="http"){
-        h+='<div class="log-detail-item"><div class="ld-label">Expected Status</div><div class="ld-val">'+(e.expected_status_min||200)+' – '+(e.expected_status_max||399)+'</div></div>';
-      }
-      if((e.type||"").toLowerCase()==="dns"){
-        h+='<div class="log-detail-item"><div class="ld-label">DNS Lookup</div><div class="ld-val">'+esc(e.target||"")+'</div></div>';
-      }
-      if((e.type||"").toLowerCase()==="ping"){
-        h+='<div class="log-detail-item"><div class="ld-label">RTT</div><div class="ld-val">'+(e.response_ms||0)+' ms</div></div>';
-      }
+      // Per-type diagnostic details (HTTP status code, DNS records,
+      // Ping RTT/loss, TCP resolved address, failure_stage) from the
+      // Details map the scheduler now persists — same rich context
+      // the Test button already shows. Issue #182.
+      h+=renderServiceCheckDetails(e.type, e.details, e);
+      // Speed-type fields are top-level on the result (not in Details),
+      // so keep the dedicated block here.
       if((e.type||"").toLowerCase()==="speed"){
         h+='<div class="log-detail-item"><div class="ld-label">Download</div><div class="ld-val">'+(e.download_mbps?e.download_mbps.toFixed(1)+' Mbps':'—')+'</div></div>';
         h+='<div class="log-detail-item"><div class="ld-label">Upload</div><div class="ld-val">'+(e.upload_mbps?e.upload_mbps.toFixed(1)+' Mbps':'—')+'</div></div>';

--- a/internal/models.go
+++ b/internal/models.go
@@ -257,11 +257,13 @@ type ServiceCheckResult struct {
 	DownloadOK   *bool   `json:"download_ok,omitempty"` // nil for non-speed checks
 	UploadOK     *bool   `json:"upload_ok,omitempty"`
 
-	// Details carries per-check-type diagnostic context surfaced by the
-	// ad-hoc Test-button flow (HTTP status code, resolved IPs, DNS records,
-	// ping RTT, failure stage, etc.). It is intentionally NOT populated on
-	// the scheduled-check path — see ServiceChecker.SetCollectDetails —
-	// so every 30s run stays lean and history rows don't bloat. See #154.
+	// Details carries per-check-type diagnostic context (HTTP status code,
+	// resolved IPs, DNS records, ping RTT, failure stage, etc.). Populated
+	// when the parent ServiceChecker has SetCollectDetails(true) — both
+	// the ad-hoc Test-button flow (#154) and the scheduled path (#182,
+	// since v0.9.4) opt in. The scheduled path persists this map in the
+	// service_checks_history.details_json column so the log UI can render
+	// the same rich context the Test button already shows.
 	Details map[string]any `json:"details,omitempty"`
 }
 

--- a/internal/scheduler/checks.go
+++ b/internal/scheduler/checks.go
@@ -44,9 +44,10 @@ type ServiceChecker struct {
 	speedTestRunFn SpeedTestRunner // nil → speed checks return "no tool"
 	// collectDetails, when true, enriches RunCheck results with the
 	// per-check-type Details map (HTTP status code, resolved IPs, DNS
-	// records, etc.). The scheduled-check path (RunDueChecks) explicitly
-	// strips Details regardless of this flag — only the ad-hoc Test-button
-	// endpoint opts into this richer output. See issue #154.
+	// records, etc.). Both the ad-hoc Test-button endpoint (#154) and
+	// the scheduled path (#182, since v0.9.4) set this to true. The
+	// /service-checks log UI reads the persisted blob via
+	// service_checks_history.details_json.
 	collectDetails bool
 }
 
@@ -66,11 +67,14 @@ func (sc *ServiceChecker) SetSpeedTestRunner(fn SpeedTestRunner) {
 	sc.speedTestRunFn = fn
 }
 
-// SetCollectDetails toggles the opt-in rich-details output. Call with true
-// from the ad-hoc /service-checks/test endpoint to get diagnostic context
-// (HTTP status code, resolved IPs, DNS records, etc.) alongside the usual
-// status/response_ms/error triple. The scheduled-check path never emits
-// details — see RunDueChecks. Issue #154.
+// SetCollectDetails toggles rich-details output. When true, RunCheck
+// populates the per-type Details map (HTTP status code, resolved IPs,
+// DNS records, failure stage, etc.) alongside the usual
+// status/response_ms/error triple. Both the scheduler (issue #182) and
+// the ad-hoc /service-checks/test endpoint (issue #154) call this with
+// true; the scheduled path additionally persists the map into
+// service_checks_history.details_json so the /service-checks log UI
+// can render the rich context on expanded log rows.
 func (sc *ServiceChecker) SetCollectDetails(enabled bool) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
@@ -108,11 +112,13 @@ func (sc *ServiceChecker) RunDueChecks(checks []internal.ServiceCheckConfig, now
 	results := make([]internal.ServiceCheckResult, 0, len(due))
 	for _, check := range due {
 		result := sc.RunCheck(check, now)
-		// Scheduled path never emits Details — those are only for the
-		// ad-hoc Test-button flow. Strip them defensively in case the
-		// checker was flipped into collect-details mode elsewhere. See
-		// #154 (keeps history rows lean and JSON payloads small).
-		result.Details = nil
+		// Relaxation of the #154 invariant: the scheduled path now
+		// carries the per-type Details map through to the store so
+		// the /service-checks log UI can show HTTP status codes, DNS
+		// records, resolved addresses, etc. in expanded log rows.
+		// See issue #182. The map is only populated when the parent
+		// ServiceChecker has SetCollectDetails(true) — otherwise
+		// RunCheck returns Details == nil and this loop is a no-op.
 
 		// Track consecutive failures from store history.
 		state, ok, err := sc.store.GetLatestServiceCheckState(result.Key)

--- a/internal/scheduler/checks_details_persist_test.go
+++ b/internal/scheduler/checks_details_persist_test.go
@@ -1,0 +1,79 @@
+package scheduler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// TestRunDueChecks_HTTP_PersistsStatusCode — issue #182. Once the scheduled
+// path stops stripping Details, a 404 from the target server must round-
+// trip into the persisted history row so the /service-checks log UI can
+// render HTTP 404 alongside the status=down line.
+//
+// This is the sibling of TestRunCheck_Details_HTTP_404_StillRecordsCode,
+// but asserted at the RunDueChecks level — i.e. end-to-end through the
+// store, which is what the log UI actually reads.
+func TestRunDueChecks_HTTP_PersistsStatusCode(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	sc, store := newTestChecker()
+	sc.SetCollectDetails(true) // mirrors the scheduler-owned checker setup in #182
+
+	checks := []internal.ServiceCheckConfig{{
+		Name:    "scheduled-404",
+		Type:    internal.ServiceCheckHTTP,
+		Target:  ts.URL,
+		Enabled: true,
+	}}
+	results := sc.RunDueChecks(checks, time.Now().UTC())
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != "down" {
+		t.Fatalf("expected down, got %q", results[0].Status)
+	}
+
+	entries, err := store.ListLatestServiceChecks(10)
+	if err != nil {
+		t.Fatalf("ListLatestServiceChecks: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 persisted entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.Details == nil {
+		t.Fatalf("expected Details persisted, got nil (scheduled path still stripping)")
+	}
+	// FakeStore preserves original int; the DB path would come back as
+	// float64 via JSON. Accept either.
+	got, ok := detailsInt(e.Details["status_code"])
+	if !ok || got != 404 {
+		t.Fatalf("expected status_code=404 in persisted Details, got %v (%T)", e.Details["status_code"], e.Details["status_code"])
+	}
+	if stage, _ := e.Details["failure_stage"].(string); stage != "http_status" {
+		t.Fatalf("expected failure_stage=http_status, got %v", e.Details["failure_stage"])
+	}
+	if ct, _ := e.Details["content_type"].(string); ct == "" {
+		t.Fatalf("expected content_type populated, got %v", e.Details["content_type"])
+	}
+}
+
+func detailsInt(v any) (int, bool) {
+	switch x := v.(type) {
+	case int:
+		return x, true
+	case int64:
+		return int(x), true
+	case float64:
+		return int(x), true
+	}
+	return 0, false
+}

--- a/internal/scheduler/checks_details_test.go
+++ b/internal/scheduler/checks_details_test.go
@@ -69,19 +69,26 @@ func TestRunCheck_Details_PopulatedWhenEnabled(t *testing.T) {
 	}
 }
 
-// TestRunDueChecks_NeverPopulatesDetails — even if SetCollectDetails(true)
-// was called (ad-hoc test button flow), the scheduled-check path must NOT
-// attach Details. The scheduled path uses a fresh checker in production; we
-// still guarantee it here as defensive invariant so accidentally sharing a
-// checker wouldn't blow up history rows or JSON payloads.
-func TestRunDueChecks_NeverPopulatesDetails(t *testing.T) {
+// TestRunDueChecks_OmitsDetailsWhenCollectorOff — with SetCollectDetails
+// left at its default (false), scheduled check rows must NOT carry
+// Details. This preserves the pre-#182 on-the-wire shape for integrations
+// that haven't opted in (e.g. unit tests constructing a bare checker via
+// NewServiceChecker). Production wires details on — see scheduler.go —
+// but the default still round-trips cleanly with no payload bloat.
+//
+// Replaces the old TestRunDueChecks_NeverPopulatesDetails which asserted
+// the stricter invariant that RunDueChecks unconditionally stripped the
+// map. Issue #182 relaxed that: the scheduler now persists details so
+// the /service-checks log UI can render them on expanded log rows.
+func TestRunDueChecks_OmitsDetailsWhenCollectorOff(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()
 
 	sc, _ := newTestChecker()
-	sc.SetCollectDetails(true) // simulate an ad-hoc flag being flipped
+	// NB: SetCollectDetails deliberately not called — the default is
+	// false so a bare NewServiceChecker stays details-free.
 
 	checks := []internal.ServiceCheckConfig{{
 		Name:    "scheduled",
@@ -94,7 +101,38 @@ func TestRunDueChecks_NeverPopulatesDetails(t *testing.T) {
 		t.Fatalf("expected 1 scheduled result, got %d", len(results))
 	}
 	if len(results[0].Details) != 0 {
-		t.Fatalf("RunDueChecks must not carry Details, got: %+v", results[0].Details)
+		t.Fatalf("RunDueChecks with collectDetails=false must not carry Details, got: %+v", results[0].Details)
+	}
+}
+
+// TestRunDueChecks_CarriesDetailsWhenCollectorOn — #182: when the parent
+// checker has collectDetails enabled (as the production scheduler does
+// via scheduler.go), RunDueChecks must now propagate the Details map
+// out of RunCheck instead of stripping it as it did under #154.
+func TestRunDueChecks_CarriesDetailsWhenCollectorOn(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true) // mirrors scheduler.go's production wiring
+
+	checks := []internal.ServiceCheckConfig{{
+		Name:    "scheduled-with-details",
+		Type:    internal.ServiceCheckHTTP,
+		Target:  ts.URL,
+		Enabled: true,
+	}}
+	results := sc.RunDueChecks(checks, time.Now().UTC())
+	if len(results) != 1 {
+		t.Fatalf("expected 1 scheduled result, got %d", len(results))
+	}
+	if len(results[0].Details) == 0 {
+		t.Fatalf("RunDueChecks with collectDetails=true must propagate Details, got empty map")
+	}
+	if code, _ := results[0].Details["status_code"].(int); code != 200 {
+		t.Fatalf("expected status_code=200 in scheduled Details, got %v", results[0].Details["status_code"])
 	}
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -130,6 +130,14 @@ func New(
 		restart:       make(chan time.Duration, 1),
 	}
 	s.checker = NewServiceChecker(store, logger)
+	// Opt into the per-type Details map on the scheduled path too —
+	// HTTP status codes, resolved IPs, DNS records, Ping RTT, failure
+	// stages are persisted into service_checks_history.details_json so
+	// the /service-checks log UI can render the same rich context the
+	// Test button already shows. Overhead is well under 1ms per check
+	// (the runners already compute these values; we just stop
+	// discarding them). See issue #182.
+	s.checker.SetCollectDetails(true)
 	s.retentionMgr = NewRetentionManager(store, store, logger)
 	return s
 }

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -246,6 +246,7 @@ func (d *DB) migrate() error {
 			failure_threshold INTEGER NOT NULL DEFAULT 1,
 			failure_severity TEXT NOT NULL DEFAULT 'warning',
 			checked_at DATETIME NOT NULL,
+			details_json TEXT,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_service_checks_key_ts ON service_checks_history(check_key, checked_at DESC)`,
@@ -301,6 +302,16 @@ func (d *DB) migrate() error {
 	}
 	if err := d.ensureColumn("alerts", "snoozed_until", "DATETIME"); err != nil {
 		return fmt.Errorf("ensure alerts.snoozed_until: %w", err)
+	}
+	// details_json holds a per-type diagnostic JSON blob (HTTP status_code,
+	// DNS records, Ping rtt_ms, TCP resolved_address, failure_stage, …)
+	// persisted by the scheduler so the /service-checks log UI can render
+	// the same rich context the Test button already shows. Legacy rows
+	// pre-dating this column read back as NULL → Details == nil. A single
+	// TEXT column (vs per-key columns) keeps schema churn zero when new
+	// detail keys get added. See issue #182.
+	if err := d.ensureColumn("service_checks_history", "details_json", "TEXT"); err != nil {
+		return fmt.Errorf("ensure service_checks_history.details_json: %w", err)
 	}
 	if _, err := d.db.Exec(`CREATE INDEX IF NOT EXISTS idx_alerts_fingerprint_open ON alerts(fingerprint, resolved_at)`); err != nil {
 		return fmt.Errorf("create alerts fingerprint index: %w", err)
@@ -1623,6 +1634,13 @@ type ServiceCheckEntry struct {
 	FailureThreshold    int    `json:"failure_threshold"`
 	FailureSeverity     string `json:"failure_severity"`
 	CheckedAt           string `json:"checked_at"`
+
+	// Details carries the per-check-type diagnostic map (HTTP status_code,
+	// DNS records, Ping rtt_ms, TCP resolved_address, failure_stage, …)
+	// deserialised from the details_json column. nil on legacy rows
+	// written before the column existed, or for check types that produce
+	// no extra context. See issue #182.
+	Details map[string]any `json:"details,omitempty"`
 }
 
 // SaveServiceCheckResults appends service check run results to history.
@@ -1644,11 +1662,26 @@ func (d *DB) SaveServiceCheckResults(results []internal.ServiceCheckResult) erro
 		if parsed, err := time.Parse(time.RFC3339, result.CheckedAt); err == nil {
 			checkedAt = parsed.UTC()
 		}
+		// Serialise the per-type Details map. A nil or empty map writes
+		// SQL NULL so legacy readers and the pre-migration world stay
+		// unaffected. We do NOT fail the whole transaction on encoding
+		// errors — the core row still contains status/ms/error so losing
+		// details gracefully is preferable to losing the whole check
+		// history for a run. See issue #182.
+		var detailsPayload any // sql.NullString wrapped via any; nil = SQL NULL
+		if len(result.Details) > 0 {
+			if buf, err := json.Marshal(result.Details); err == nil {
+				detailsPayload = string(buf)
+			} else {
+				d.logger.Warn("service check details_json marshal failed; row saved without details",
+					"check", result.Name, "error", err)
+			}
+		}
 		_, err := tx.Exec(
 			`INSERT INTO service_checks_history (
 				check_key, name, check_type, target, status, response_ms, error_message,
-				consecutive_failures, failure_threshold, failure_severity, checked_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				consecutive_failures, failure_threshold, failure_severity, checked_at, details_json
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			result.Key,
 			result.Name,
 			result.Type,
@@ -1660,6 +1693,7 @@ func (d *DB) SaveServiceCheckResults(results []internal.ServiceCheckResult) erro
 			result.FailureThreshold,
 			result.FailureSeverity,
 			checkedAt,
+			detailsPayload,
 		)
 		if err != nil {
 			return err
@@ -1701,7 +1735,7 @@ func (d *DB) ListLatestServiceChecks(limit int) ([]ServiceCheckEntry, error) {
 		`SELECT check_key, name, check_type, target, status,
 				COALESCE(response_ms, 0), COALESCE(error_message, ''),
 				COALESCE(consecutive_failures, 0), COALESCE(failure_threshold, 1), COALESCE(failure_severity, 'warning'),
-				checked_at
+				checked_at, details_json
 		 FROM service_checks_history
 		 WHERE id IN (
 			SELECT MAX(id) FROM service_checks_history GROUP BY check_key
@@ -1719,6 +1753,7 @@ func (d *DB) ListLatestServiceChecks(limit int) ([]ServiceCheckEntry, error) {
 	for rows.Next() {
 		var e ServiceCheckEntry
 		var checkedAt time.Time
+		var detailsJSON sql.NullString
 		if err := rows.Scan(
 			&e.Key,
 			&e.Name,
@@ -1731,10 +1766,12 @@ func (d *DB) ListLatestServiceChecks(limit int) ([]ServiceCheckEntry, error) {
 			&e.FailureThreshold,
 			&e.FailureSeverity,
 			&checkedAt,
+			&detailsJSON,
 		); err != nil {
 			return nil, err
 		}
 		e.CheckedAt = checkedAt.UTC().Format(time.RFC3339)
+		e.Details = decodeDetailsJSON(d.logger, detailsJSON, e.Key)
 		entries = append(entries, e)
 	}
 	return entries, rows.Err()
@@ -1752,7 +1789,7 @@ func (d *DB) GetServiceCheckHistory(checkKey string, limit int) ([]ServiceCheckE
 		`SELECT check_key, name, check_type, target, status,
 				COALESCE(response_ms, 0), COALESCE(error_message, ''),
 				COALESCE(consecutive_failures, 0), COALESCE(failure_threshold, 1), COALESCE(failure_severity, 'warning'),
-				checked_at
+				checked_at, details_json
 		 FROM service_checks_history
 		 WHERE check_key = ?
 		 ORDER BY checked_at DESC
@@ -1769,6 +1806,7 @@ func (d *DB) GetServiceCheckHistory(checkKey string, limit int) ([]ServiceCheckE
 	for rows.Next() {
 		var e ServiceCheckEntry
 		var checkedAt time.Time
+		var detailsJSON sql.NullString
 		if err := rows.Scan(
 			&e.Key,
 			&e.Name,
@@ -1781,13 +1819,42 @@ func (d *DB) GetServiceCheckHistory(checkKey string, limit int) ([]ServiceCheckE
 			&e.FailureThreshold,
 			&e.FailureSeverity,
 			&checkedAt,
+			&detailsJSON,
 		); err != nil {
 			return nil, err
 		}
 		e.CheckedAt = checkedAt.UTC().Format(time.RFC3339)
+		e.Details = decodeDetailsJSON(d.logger, detailsJSON, e.Key)
 		entries = append(entries, e)
 	}
 	return entries, rows.Err()
+}
+
+// decodeDetailsJSON deserialises the details_json column from a history
+// row. Returns nil on SQL NULL, empty strings, or malformed JSON — the
+// log UI treats nil as "no extra context to render" rather than an error.
+// Corrupted rows are logged at warn level but never break list/history
+// queries, since the core row is still valuable. See issue #182.
+func decodeDetailsJSON(logger *slog.Logger, raw sql.NullString, checkKey string) map[string]any {
+	if !raw.Valid {
+		return nil
+	}
+	s := strings.TrimSpace(raw.String)
+	if s == "" || s == "null" {
+		return nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		if logger != nil {
+			logger.Warn("service check details_json unmarshal failed; row returned without details",
+				"check_key", checkKey, "error", err)
+		}
+		return nil
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
 }
 
 // PruneServiceCheckHistory deletes service check history rows older than the given duration.

--- a/internal/storage/db_service_checks_details_test.go
+++ b/internal/storage/db_service_checks_details_test.go
@@ -1,0 +1,248 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// TestSaveServiceCheckResult_PersistsDetailsJSON — a scheduled check run
+// that attaches a per-type Details map (HTTP status_code, DNS records, …)
+// must round-trip through SQLite so the /service-checks log UI can render
+// the same diagnostic context that the Test button already shows. See
+// issue #182.
+func TestSaveServiceCheckResult_PersistsDetailsJSON(t *testing.T) {
+	db := newTestDB(t)
+
+	now := time.Now().UTC()
+	recs := []string{"1.2.3.4", "5.6.7.8"}
+	results := []internal.ServiceCheckResult{{
+		Key:              "svc-http",
+		Name:             "HTTP With Details",
+		Type:             "http",
+		Target:           "https://example.com/health",
+		Status:           "down",
+		ResponseMS:       42,
+		FailureThreshold: 1,
+		FailureSeverity:  internal.SeverityWarning,
+		CheckedAt:        now.Format(time.RFC3339),
+		Details: map[string]any{
+			"status_code":   404,
+			"content_type":  "text/html; charset=utf-8",
+			"body_bytes":    int64(1234),
+			"final_url":     "https://example.com/health",
+			"failure_stage": "http_status",
+		},
+	}, {
+		Key:              "svc-dns",
+		Name:             "DNS With Records",
+		Type:             "dns",
+		Target:           "example.com",
+		Status:           "up",
+		ResponseMS:       7,
+		FailureThreshold: 1,
+		FailureSeverity:  internal.SeverityWarning,
+		CheckedAt:        now.Add(time.Second).Format(time.RFC3339),
+		Details: map[string]any{
+			"query_host": "example.com",
+			"dns_server": "1.1.1.1:53",
+			"records":    recs,
+		},
+	}}
+
+	if err := db.SaveServiceCheckResults(results); err != nil {
+		t.Fatalf("SaveServiceCheckResults: %v", err)
+	}
+
+	// ListLatestServiceChecks must echo back the Details map for both rows.
+	entries, err := db.ListLatestServiceChecks(100)
+	if err != nil {
+		t.Fatalf("ListLatestServiceChecks: %v", err)
+	}
+	byKey := make(map[string]ServiceCheckEntry, len(entries))
+	for _, e := range entries {
+		byKey[e.Key] = e
+	}
+
+	httpEntry, ok := byKey["svc-http"]
+	if !ok {
+		t.Fatalf("svc-http not in ListLatestServiceChecks result; got keys %v", mapKeys(byKey))
+	}
+	if httpEntry.Details == nil {
+		t.Fatalf("svc-http: expected Details populated, got nil (the persistence path still strips the map)")
+	}
+	// JSON round-trip turns numbers into float64 by default — assert on
+	// the concrete JSON representation rather than int.
+	if code, _ := asFloat(httpEntry.Details["status_code"]); code != 404 {
+		t.Errorf("svc-http: expected status_code=404, got %v (%T)", httpEntry.Details["status_code"], httpEntry.Details["status_code"])
+	}
+	if stage, _ := httpEntry.Details["failure_stage"].(string); stage != "http_status" {
+		t.Errorf("svc-http: expected failure_stage=http_status, got %v", httpEntry.Details["failure_stage"])
+	}
+
+	dnsEntry, ok := byKey["svc-dns"]
+	if !ok {
+		t.Fatalf("svc-dns missing from list; got keys %v", mapKeys(byKey))
+	}
+	if dnsEntry.Details == nil {
+		t.Fatalf("svc-dns: expected Details populated, got nil")
+	}
+	// DNS records round-trip as []interface{} through encoding/json.
+	records, ok := dnsEntry.Details["records"].([]interface{})
+	if !ok {
+		t.Fatalf("svc-dns: records should be []interface{}, got %T: %v", dnsEntry.Details["records"], dnsEntry.Details["records"])
+	}
+	if len(records) != 2 || records[0].(string) != "1.2.3.4" {
+		t.Fatalf("svc-dns: expected [1.2.3.4 5.6.7.8], got %v", records)
+	}
+
+	// GetServiceCheckHistory must also return Details for a per-key query.
+	hist, err := db.GetServiceCheckHistory("svc-http", 10)
+	if err != nil {
+		t.Fatalf("GetServiceCheckHistory: %v", err)
+	}
+	if len(hist) != 1 {
+		t.Fatalf("expected 1 history row for svc-http, got %d", len(hist))
+	}
+	if hist[0].Details == nil {
+		t.Fatalf("GetServiceCheckHistory: expected Details populated, got nil")
+	}
+	if code, _ := asFloat(hist[0].Details["status_code"]); code != 404 {
+		t.Errorf("GetServiceCheckHistory: expected status_code=404, got %v", hist[0].Details["status_code"])
+	}
+}
+
+// TestSaveServiceCheckResult_NilDetailsIsOK — legacy code paths (and the
+// pre-migration world) produce results with no Details map at all. Those
+// must still persist cleanly and round-trip as nil / empty so the log UI
+// doesn't choke.
+func TestSaveServiceCheckResult_NilDetailsIsOK(t *testing.T) {
+	db := newTestDB(t)
+
+	now := time.Now().UTC()
+	results := []internal.ServiceCheckResult{{
+		Key:              "svc-plain",
+		Name:             "No Details",
+		Type:             "tcp",
+		Target:           "127.0.0.1:22",
+		Status:           "up",
+		ResponseMS:       1,
+		FailureThreshold: 1,
+		FailureSeverity:  internal.SeverityWarning,
+		CheckedAt:        now.Format(time.RFC3339),
+		Details:          nil,
+	}}
+	if err := db.SaveServiceCheckResults(results); err != nil {
+		t.Fatalf("SaveServiceCheckResults: %v", err)
+	}
+	entries, err := db.ListLatestServiceChecks(100)
+	if err != nil {
+		t.Fatalf("ListLatestServiceChecks: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Details != nil {
+		t.Errorf("expected Details nil for row saved without details, got %v", entries[0].Details)
+	}
+}
+
+// TestMigration_AddsDetailsJsonColumn — Open on an existing database
+// without the details_json column must transparently add it and leave
+// historical rows with a NULL value (rendered as nil Details on read).
+func TestMigration_AddsDetailsJsonColumn(t *testing.T) {
+	db := newTestDB(t)
+
+	// Simulate a pre-migration state: the fresh newTestDB has the column.
+	// Drop it (SQLite 3.35+) to recreate a pre-migration shape, then
+	// re-run migrations to prove the ensureColumn path is idempotent and
+	// actually re-adds the column on a DB missing it.
+	if _, err := db.db.Exec(`ALTER TABLE service_checks_history DROP COLUMN details_json`); err != nil {
+		// Older SQLite builds without DROP COLUMN support — the test
+		// still serves its purpose on fresh runs (ensureColumn no-ops),
+		// but we can't assert the re-add path. Skip rather than fail.
+		t.Skipf("SQLite does not support DROP COLUMN on this build: %v", err)
+	}
+	if columnExists(t, db, "service_checks_history", "details_json") {
+		t.Fatalf("precondition: details_json should have been dropped")
+	}
+
+	// Seed a legacy row while the column is absent.
+	if _, err := db.db.Exec(
+		`INSERT INTO service_checks_history (check_key, name, check_type, target, status, response_ms, error_message, consecutive_failures, failure_threshold, failure_severity, checked_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"legacy", "Legacy Row", "http", "http://x", "up", 1, "", 0, 1, "warning", time.Now().UTC(),
+	); err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+
+	// Re-run migrations. migrate() is the internal helper the constructor
+	// calls; re-running it on an already-open DB must be a no-op for
+	// everything except the ensureColumn lines, which should add the
+	// dropped details_json column back.
+	if err := db.migrate(); err != nil {
+		t.Fatalf("migrate (re-run): %v", err)
+	}
+	if !columnExists(t, db, "service_checks_history", "details_json") {
+		t.Fatalf("runMigrations did not re-add details_json column")
+	}
+	// Legacy row must still be readable and have nil Details.
+	entries, err := db.ListLatestServiceChecks(100)
+	if err != nil {
+		t.Fatalf("ListLatestServiceChecks: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 legacy entry, got %d", len(entries))
+	}
+	if entries[0].Details != nil {
+		t.Errorf("expected legacy row Details nil after migration, got %v", entries[0].Details)
+	}
+}
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+func mapKeys(m map[string]ServiceCheckEntry) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// asFloat normalises JSON-decoded numerics: encoding/json produces float64
+// for generic map[string]any, so the assertion can't assume int.
+func asFloat(v any) (float64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return x, true
+	case int:
+		return float64(x), true
+	case int64:
+		return float64(x), true
+	}
+	return 0, false
+}
+
+func columnExists(t *testing.T, db *DB, table, column string) bool {
+	t.Helper()
+	rows, err := db.db.Query("PRAGMA table_info(" + table + ")")
+	if err != nil {
+		t.Fatalf("PRAGMA table_info: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid         int
+			name, ctype string
+			notnull, pk int
+			dflt        any
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan table_info: %v", err)
+		}
+		if name == column {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/storage/fake.go
+++ b/internal/storage/fake.go
@@ -280,6 +280,7 @@ func (f *FakeStore) ListLatestServiceChecks(limit int) ([]ServiceCheckEntry, err
 			FailureThreshold:    r.FailureThreshold,
 			FailureSeverity:     string(r.FailureSeverity),
 			CheckedAt:           r.CheckedAt,
+			Details:             cloneDetails(r.Details),
 		})
 	}
 	// Sort by CheckedAt descending.
@@ -313,6 +314,7 @@ func (f *FakeStore) GetServiceCheckHistory(checkKey string, limit int) ([]Servic
 			FailureThreshold:    r.FailureThreshold,
 			FailureSeverity:     string(r.FailureSeverity),
 			CheckedAt:           r.CheckedAt,
+			Details:             cloneDetails(r.Details),
 		})
 		if limit > 0 && len(entries) >= limit {
 			break
@@ -861,4 +863,20 @@ func (f *FakeStore) ResetVacuum() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.VacuumCalled = false
+}
+
+// cloneDetails returns a shallow copy of the per-type Details map so
+// successive Reads don't hand out the same underlying map that a later
+// Save mutates (issue #182: persisted log rows round-trip Details).
+// Returns nil for nil/empty input so reads match the DB path where NULL
+// JSON is surfaced as nil.
+func cloneDetails(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }


### PR DESCRIPTION
Closes #182

## Summary

Extends PR #167's rich per-type `Details` map (HTTP status_code, DNS records, TCP resolved_address, Ping rtt_ms/packet_loss_pct, failure_stage) from the ad-hoc Test button path to the **persisted** scheduled-check history, and renders it on the expanded log rows of `/service-checks`. Same diagnostic context the Test button already shows — now available on every row of the log table, not just the last ad-hoc test.

Bundled for v0.9.4-rc5 alongside #181.

## Changes (3 commits, each its own phase)

### Phase 1 — schema + persistence (`2ffe02e`)

- `service_checks_history` gains a `details_json TEXT` column. Single TEXT column rather than per-key columns means new detail keys don't require schema churn.
- `ensureColumn()` migration + idempotent via existing pattern. Legacy rows read back as `Details == nil` — UI treats that as "no extra context".
- `SaveServiceCheckResults` JSON-encodes `result.Details`, `ListLatestServiceChecks` + `GetServiceCheckHistory` decode on read.
- Corruption/marshal errors log at warn, never break the list query (core row still useful).
- `FakeStore` mirrors the round-trip with a `cloneDetails()` helper so tests hit the same shape.
- `ServiceCheckEntry` gains `Details map[string]any` with `json:"details,omitempty"` so the API serialises identically to the Test button's `ServiceCheckResult`.

### Phase 2 — runner wiring (`d97e0d0`)

- The defensive `result.Details = nil` strip in `RunDueChecks` (added by #154 to keep the scheduled path lean) is **removed**. Replaced with a comment explaining the deliberate relaxation.
- `Scheduler`'s constructor calls `checker.SetCollectDetails(true)` once at startup. Zero per-check allocation cost beyond the 4-slot map `RunCheck` already made; the runner code already computed these values for error messages.
- Comments on `ServiceCheckResult.Details`, `SetCollectDetails`, and the `collectDetails` field brought up to date — the old text said "scheduled path never sets this" which is now wrong.
- `TestRunDueChecks_NeverPopulatesDetails` → **renamed + rewritten** as `TestRunDueChecks_OmitsDetailsWhenCollectorOff` (default-off still omits) + new sibling `TestRunDueChecks_CarriesDetailsWhenCollectorOn` (opt-in now propagates). The old invariant is explicitly gone with a comment explaining why.

### Phase 3 — UI (`136813a`)

- New JS helper `renderServiceCheckDetails(type, details, entry)` in `service_checks.html`. Mirrors the `settings.html` helper's contract (same name, same per-type switch) so a future refactor can promote to a shared file without renaming callers.
- Per-type output on expanded log rows:
  - **HTTP**: status code (green 2xx/3xx, red 4xx/5xx), Content-Type, body bytes, final URL (only when it differs from request — i.e. a redirect happened)
  - **TCP/SMB/NFS**: resolved_address (monospace)
  - **DNS**: query_host, dns_server, resolved records (comma-joined, row-spanning when >2)
  - **Ping**: query_host, rtt_ms (2 decimals), packet_loss_pct (red when >0)
  - **All types on non-up**: failure_stage (red)
- Removed 3 legacy type-specific blocks that tried to approximate this data from top-level fields (`DNS Lookup` = just Target; `RTT` = millisecond-truncated response_ms; `Expected Status` was config-sourced, not runtime — belongs on settings). Speed block stays because download/upload/latency are top-level, not in `Details`.

## Performance

- `go test ./internal/scheduler/... -run TestRunDueChecks_MultipleChecks -count=5`: 0.00s per iteration. Well under the <5ms budget from the issue.
- Added cost per check: one `SetCollectDetails`-flag read under a `sync.Mutex`, `make(map[string]any, 4)`, a handful of map writes, and one `json.Marshal` at save time. Runner-side computation unchanged (these values were already being computed for error messages and discarded).

## Migration behaviour

- **Forward-only.** Fresh DBs get the column via the base `CREATE TABLE`. Existing DBs get it via `ensureColumn()` on next boot. Existing rows read back as `Details == nil`.
- **Safe to re-run.** `TestMigration_AddsDetailsJsonColumn` drops the column (SQLite 3.35+ required; skipped otherwise) and re-runs `migrate()` to prove idempotency.
- Not reversible — there's no `DROP COLUMN` migration. Rollback = redeploy the previous binary; the column lingers in SQLite but is ignored by old readers. No UPDATE/DELETE goes out; historical rows are untouched.

## Persisted details, by check type

| Type | Keys persisted in `details_json` |
|---|---|
| HTTP | `status_code`, `content_type`, `body_bytes`, `final_url`, `request_url`, `failure_stage` |
| TCP / SMB / NFS | `resolved_address`, `failure_stage` |
| DNS | `query_host`, `dns_server`, `records[]`, `failure_stage` |
| Ping | `query_host`, `rtt_ms`, `packet_loss_pct`, `failure_stage` |
| Speed | (none — top-level `download_mbps` / `upload_mbps` / `latency_ms` already persist) |

## Test coverage added

| Phase | File | Tests |
|---|---|---|
| 1 | `internal/storage/db_service_checks_details_test.go` | `TestSaveServiceCheckResult_PersistsDetailsJSON`, `TestSaveServiceCheckResult_NilDetailsIsOK`, `TestMigration_AddsDetailsJsonColumn` |
| 2 | `internal/scheduler/checks_details_persist_test.go` | `TestRunDueChecks_HTTP_PersistsStatusCode` |
| 2 | `internal/scheduler/checks_details_test.go` (edited) | `TestRunDueChecks_OmitsDetailsWhenCollectorOff` (rewritten from `NeverPopulates`), `TestRunDueChecks_CarriesDetailsWhenCollectorOn` (new sibling) |
| 3 | `internal/api/service_checks_log_details_test.go` | `TestServiceChecksHTML_LogDetail_RendersPerTypeDetails` (cross-ref 11 per-type keys), `TestServiceChecksHTML_LogDetail_ExistingFieldsStillRendered` (legacy field guard) |

## Out of scope (per issue)

- Filtering / sorting / color-coding logs — noted as "future plan"
- Speed streaming log detail — tracked by #171
- New detail keys beyond what #167 already populates

## Line-count breakdown

| Area | LOC added |
|---|---|
| Schema / DB persistence | ~75 |
| FakeStore | ~18 |
| Runner wiring (scheduler) | ~40 (mostly comments) |
| UI helper + wiring | ~75 |
| Tests | ~410 |
| **Total** | ~620 (~210 prod + ~410 test) |

## Verification

- `go build ./...` ✓
- `go vet ./...` ✓
- `go test ./... -count=1` ✓ (all packages, no cached results)
- Migration round-trip via `TestMigration_AddsDetailsJsonColumn` (DROP → re-migrate → re-ADD)
- `TestRunDueChecks_NeverPopulatesDetails` **intentionally updated** (not broken) with a comment explaining why the old invariant was relaxed

## Base branch note

Pushed against `release/v0.9.4-stage` to match the issue's bundling note ("Bundled for v0.9.4-rc5 alongside #181"). The worktree came up on `origin/main` which pre-dates PR #167 / #178 — files and symbols the issue references (`SetCollectDetails`, the log-wrap CSS) only exist on stage, so I fast-forwarded the branch onto stage before starting work. Flagging this in the PR body as well as the return summary so the orchestrator can fix the worktree-base selection for the next bundled PR.