### PR TITLE
fix(scheduler): guarantee orphan service-check history is purged on startup (#181)

### DIFF
--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -331,6 +331,17 @@ func main() {
 
 		sched = scheduler.New(coll, store, notif, metrics, logger, interval)
 		applySchedulerSettingsFromStore(sched, persistedSettings)
+		// Defense-in-depth: guarantee the scheduler's in-memory service check
+		// set matches whatever history the DB carries, even when the settings
+		// payload failed to load or was nil (empty DB, corrupt JSON). Without
+		// this, a prior-boot orphan row in service_checks_history would
+		// continue to surface on /api/v1/service-checks as a phantom check
+		// the user cannot remove via the settings UI. Issue #181.
+		if pruned, err := sched.PurgeOrphanServiceCheckHistory(); err != nil {
+			logger.Warn("startup: purge orphan service check history", "error", err)
+		} else if pruned > 0 {
+			logger.Info("startup: pruned orphan service check history", "rows", pruned)
+		}
 		// Apply Proxmox config to collector on startup
 		if persistedSettings != nil && persistedSettings.Proxmox.Enabled {
 			coll.SetProxmoxConfig(collector.ProxmoxConfig{

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -556,19 +556,50 @@ func (s *Scheduler) UpdateServiceChecks(checks []internal.ServiceCheckConfig) {
 	s.mu.Unlock()
 
 	// Purge orphaned history for any check that was removed from the config.
-	if s.store != nil {
-		keepKeys := make([]string, 0, len(normalized))
-		for _, c := range normalized {
-			keepKeys = append(keepKeys, CheckKey(c))
-		}
-		if pruned, err := s.store.DeleteServiceChecksNotIn(keepKeys); err != nil {
-			s.logger.Warn("prune orphaned service check history", "error", err)
-		} else if pruned > 0 {
-			s.logger.Info("pruned orphaned service check history", "rows", pruned)
-		}
-	}
+	s.pruneOrphanServiceCheckHistory(normalized)
 
 	s.logger.Info("service check config updated", "checks", len(normalized))
+}
+
+// PurgeOrphanServiceCheckHistory removes history rows for any check_key NOT
+// present in the currently configured service checks. Safe to call at any
+// time — idempotent, and a no-op when the store has no orphans.
+//
+// This is a defense-in-depth API: normally UpdateServiceChecks handles the
+// purge automatically as part of config updates. Callers that cannot
+// guarantee UpdateServiceChecks has run (e.g. startup paths where the
+// persisted settings failed to load) can invoke this directly to collapse
+// any drift between in-memory config and the history table. Issue #181.
+//
+// Returns the number of rows deleted.
+func (s *Scheduler) PurgeOrphanServiceCheckHistory() (int, error) {
+	s.mu.RLock()
+	checks := make([]internal.ServiceCheckConfig, len(s.serviceChecks))
+	copy(checks, s.serviceChecks)
+	s.mu.RUnlock()
+	return s.pruneOrphanServiceCheckHistory(checks), nil
+}
+
+// pruneOrphanServiceCheckHistory is the shared implementation for the orphan
+// purge. It derives keep-keys from the supplied (already-normalized) checks
+// and delegates to the store. Returns the count of rows pruned.
+func (s *Scheduler) pruneOrphanServiceCheckHistory(checks []internal.ServiceCheckConfig) int {
+	if s.store == nil {
+		return 0
+	}
+	keepKeys := make([]string, 0, len(checks))
+	for _, c := range checks {
+		keepKeys = append(keepKeys, CheckKey(c))
+	}
+	pruned, err := s.store.DeleteServiceChecksNotIn(keepKeys)
+	if err != nil {
+		s.logger.Warn("prune orphaned service check history", "error", err)
+		return 0
+	}
+	if pruned > 0 {
+		s.logger.Info("pruned orphaned service check history", "rows", pruned)
+	}
+	return pruned
 }
 
 // RunServiceChecksNow executes configured service checks immediately and persists results.

--- a/internal/scheduler/service_checks_purge_test.go
+++ b/internal/scheduler/service_checks_purge_test.go
@@ -132,3 +132,104 @@ func TestUpdateServiceChecks_KeysDerivedFromNormalizedConfig(t *testing.T) {
 		t.Error("orphan history must be purged")
 	}
 }
+
+// Issue #181 — reproduce the UAT scenario: settings.json on disk has only
+// {A, B} but service_checks_history still contains rows for {A, B, C}
+// from a prior-boot drift. Simulate startup (call UpdateServiceChecks with
+// the loaded config) and assert C is purged — proving the existing
+// UpdateServiceChecks purge IS a correct startup defense when it runs.
+func TestScheduler_Startup_PurgesOrphanHistory(t *testing.T) {
+	store := storage.NewFakeStore()
+
+	checkA := internal.ServiceCheckConfig{Name: "A", Type: "http", Target: "http://a.example"}
+	checkB := internal.ServiceCheckConfig{Name: "B", Type: "http", Target: "http://b.example"}
+	checkC := internal.ServiceCheckConfig{Name: "Cloudflare 1.1.1.1", Type: "dns", Target: "1.1.1.1"}
+	// Seed history as if C was legitimately running in a previous
+	// container boot — the point of the bug is that its rows persist
+	// into the next boot where C no longer exists in settings.json.
+	seedHistory(t, store, CheckKey(checkA), CheckKey(checkB), CheckKey(checkC))
+
+	// Simulate main.go startup: construct scheduler, apply only the
+	// checks that remain on disk. UpdateServiceChecks MUST purge C.
+	sched := newSchedulerForTest(store)
+	sched.UpdateServiceChecks([]internal.ServiceCheckConfig{checkA, checkB})
+
+	after := historyKeys(t, store)
+	if len(after) != 2 {
+		t.Errorf("expected 2 keys in history after startup purge, got %d: %v", len(after), after)
+	}
+	if after[CheckKey(checkC)] {
+		t.Error("orphan Cloudflare 1.1.1.1 history must be purged at startup")
+	}
+	if !after[CheckKey(checkA)] || !after[CheckKey(checkB)] {
+		t.Error("configured checks A and B must be retained")
+	}
+}
+
+// Issue #181 defense-in-depth — PurgeOrphanServiceCheckHistory MUST be
+// callable directly without first invoking UpdateServiceChecks, for the
+// startup path where persisted settings failed to load (nil settings).
+// When scheduler.serviceChecks is empty, the entire history table is
+// drained: a legitimate outcome because the scheduler has no config to
+// run checks against, so any existing history is necessarily stale.
+func TestPurgeOrphanServiceCheckHistory_EmptyConfigDrainsHistory(t *testing.T) {
+	store := storage.NewFakeStore()
+	seedHistory(t, store, "orphan-1", "orphan-2", "orphan-3")
+
+	sched := newSchedulerForTest(store)
+	// No UpdateServiceChecks call — serviceChecks is the empty slice
+	// assigned in newSchedulerForTest, matching main.go's behavior when
+	// persistedSettings is nil and applySchedulerSettingsFromStore
+	// returns early.
+	pruned, err := sched.PurgeOrphanServiceCheckHistory()
+	if err != nil {
+		t.Fatalf("PurgeOrphanServiceCheckHistory: %v", err)
+	}
+	if pruned != 3 {
+		t.Errorf("expected 3 rows pruned, got %d", pruned)
+	}
+	after := historyKeys(t, store)
+	if len(after) != 0 {
+		t.Errorf("expected empty history after purge with no config, got %d keys: %v", len(after), after)
+	}
+}
+
+// Issue #181 — when the scheduler's in-memory config matches the history
+// table, PurgeOrphanServiceCheckHistory is a safe no-op. This is the
+// expected path for 99% of boots; it must not churn the DB.
+func TestPurgeOrphanServiceCheckHistory_NoopWhenConfigMatches(t *testing.T) {
+	store := storage.NewFakeStore()
+	checkA := internal.ServiceCheckConfig{Name: "A", Type: "http", Target: "http://a.example"}
+	seedHistory(t, store, CheckKey(checkA))
+
+	sched := newSchedulerForTest(store)
+	sched.UpdateServiceChecks([]internal.ServiceCheckConfig{checkA})
+
+	// Second purge invocation (simulating the startup defense-in-depth
+	// call in main.go immediately after applySchedulerSettingsFromStore)
+	// MUST be a no-op: the config is already in sync.
+	pruned, err := sched.PurgeOrphanServiceCheckHistory()
+	if err != nil {
+		t.Fatalf("PurgeOrphanServiceCheckHistory: %v", err)
+	}
+	if pruned != 0 {
+		t.Errorf("expected 0 rows pruned on second call, got %d", pruned)
+	}
+	after := historyKeys(t, store)
+	if !after[CheckKey(checkA)] {
+		t.Error("configured check A must still be in history")
+	}
+}
+
+// Issue #181 — PurgeOrphanServiceCheckHistory must tolerate a nil store
+// (defensive: a misbuilt scheduler must never panic on shutdown/startup).
+func TestPurgeOrphanServiceCheckHistory_NilStoreSafe(t *testing.T) {
+	sched := newSchedulerForTest(nil)
+	pruned, err := sched.PurgeOrphanServiceCheckHistory()
+	if err != nil {
+		t.Fatalf("PurgeOrphanServiceCheckHistory with nil store: %v", err)
+	}
+	if pruned != 0 {
+		t.Errorf("expected 0 pruned with nil store, got %d", pruned)
+	}
+}


### PR DESCRIPTION
Closes #181

## Summary

Phantom service checks (rows in `/api/v1/service-checks` that don't exist in settings) now cannot survive a container restart. Adds a defense-in-depth startup purge so that even when persisted settings fail to load, the scheduler's history table is reconciled against its in-memory config.

## The bug

On UAT v0.9.4-rc4 a "Cloudflare 1.1.1.1" DNS check removed from `settings.json` kept being executed by the scheduler — `/api/v1/service-checks` showed 6 entries while `/api/v1/settings` showed only 5. A round-trip PUT of settings purged the orphan, proving the save path is correct. The drift lives in the boot path.

## The fix

`UpdateServiceChecks` already calls `DeleteServiceChecksNotIn` internally. But that method only fires when called from `applySchedulerSettingsFromStore`, which early-returns on `nil` settings. If persisted settings fail to parse, are missing (fresh install), or the drift source is some path that writes settings without triggering the scheduler update, history rows outlive their config.

- Extracted the purge into a new exported method `Scheduler.PurgeOrphanServiceCheckHistory()` — shares implementation with `UpdateServiceChecks` via a package-private helper, no duplication.
- `main.go` now calls `sched.PurgeOrphanServiceCheckHistory()` unconditionally after `applySchedulerSettingsFromStore` — runs even when settings are nil, when no checks are configured, or when the persisted payload is corrupt. Idempotent: no-op when history already matches config.

## Phase 2 investigation (root cause)

I traced every caller of `UpdateServiceChecks`, `s.serviceChecks` mutation, and related Fleet code. Findings:

- **Fleet does NOT inject local service checks** — it only reads remote `snap.ServiceChecks` as a summary stat (`internal/fleet/fleet.go:286-293`).
- **No other mutation path** for `s.serviceChecks` exists — only `UpdateServiceChecks` assigns to it.
- **Settings-writing paths that do NOT call UpdateServiceChecks**: `handleDismissFinding`, `handleRestoreFinding`, `handleFleetUpdateServers`, `handleSetChartRange`, `handleSetSectionHeights`, `handleSetSectionOrder`, `handleDashboardTheme`. Some of these (`getSettings` for example) go through a settings-version migration that re-writes the config row. None of these correlate obviously with the UAT repro, but they do mean the scheduler's `s.serviceChecks` can become stale relative to `settings.json` without a matching scheduler update. Any subsequent event that writes service check history (notably: a still-active in-memory check running after the deletion race) would re-populate history for a key no longer in settings.

I could not definitively pin a single root cause from static analysis — the UAT state had already been cleaned when my session started. Phase 1 alone closes the user-visible bug for good: whatever path creates drift, the next container restart wipes it. If we observe new occurrences post-v0.9.4 we now have the primitive (`PurgeOrphanServiceCheckHistory`) to wire into a periodic reconciliation tick (Phase 3 territory).

## Tests

- `TestScheduler_Startup_PurgesOrphanHistory` — seeds history with {A, B, C}, calls `UpdateServiceChecks({A, B})`, asserts C is gone and A/B retained. Exact UAT shape.
- `TestPurgeOrphanServiceCheckHistory_EmptyConfigDrainsHistory` — the nil-settings scenario: no `UpdateServiceChecks` call, scheduler has no checks in memory, purge drains all 3 orphan rows.
- `TestPurgeOrphanServiceCheckHistory_NoopWhenConfigMatches` — happy path: idempotent, 0 rows pruned on the second (defense-in-depth) call.
- `TestPurgeOrphanServiceCheckHistory_NilStoreSafe` — guards against a misconstructed scheduler panicking at startup.

All 4 new tests + the 3 existing `TestUpdateServiceChecks_*` still pass. `go vet ./...` clean. Full `go test ./...` green.

## Manual integration test

Seeded a SQLite DB with an orphan row + empty `settings.json`. Booted the binary; logs emitted:

```
{"level":"INFO","msg":"pruned orphaned service check history","rows":1}
{"level":"INFO","msg":"startup: pruned orphan service check history","rows":1}
```

Post-boot `SELECT COUNT(*) FROM service_checks_history` = 0. Confirmed with three variants (settings present but checks empty, settings entirely missing, settings with 1 valid check + 1 orphan in history).

## Line-count breakdown

| File | Lines added | Purpose |
|---|---|---|
| `internal/scheduler/scheduler.go` | +42, -10 | Extract shared helper, add `PurgeOrphanServiceCheckHistory` public method |
| `cmd/nas-doctor/main.go` | +11 | Unconditional startup purge call with log output |
| `internal/scheduler/service_checks_purge_test.go` | +101 | 4 new tests |

## Follow-up / orchestrator gotchas

- **No Phase 2 commit** — my investigation did not isolate a smoking-gun drift source. If the UAT re-accumulates orphans post-v0.9.4, Phase 3 (periodic reconciliation tick on a 5-minute timer calling `PurgeOrphanServiceCheckHistory`) is a straightforward follow-up that reuses the primitive this PR introduces.
- **Release target**: PR is against `release/v0.9.4-stage`, not `main`. Merge into stage; it'll ride along with the other v0.9.4 bundled PRs. Don't cherry-pick to `main` alone — let the stage branch land.
- **UAT verification plan**: On next `v0.9.4-rc5` build, check UAT logs for `"startup: pruned orphan service check history"` — if it fires on boot, we now have proof the drift source still exists and can file a follow-up with the actual pruned rows as a clue.