### PR TITLE
v0.9.4 bundle tail: log entry details (#182) + orphan purge on startup (#181)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ NAS Doctor runs periodic health checks on your server — analyzing SMART data, 
 
 Born from an [OpenCode diagnostic skill](https://github.com/mcdays94/opencode-server-diagnostic-skill) that generates professional PDF server reports, NAS Doctor packages the same intelligence into a self-hosted app anyone can install.
 
-It's also an experiment in how far agentic coding can carry a production-shaped project. The whole thing is written through [opencode](https://opencode.ai), mostly by a mix of Claude Opus 4.7 / 4.6 and GPT Codex 5.3, directed by hand. In the same spirit, the issue tracker itself is partly automated — an opencode agent triages open issues, posts replies, and drafts PRs. The orchestration uses dedicated agents and sub-agents inspired by [Matt Pocock's](https://www.mattpocock.com/) workflow: a top-level orchestrator that breaks features into independently-shippable pieces and dispatches worker agents to execute them on isolated branches.
-
 ---
 
 ## Table of Contents
@@ -49,6 +47,7 @@ It's also an experiment in how far agentic coding can carry a production-shaped 
 - [Project Structure](#project-structure)
 - [Platform Support](#platform-support)
 - [Diagnostic Report](#diagnostic-report)
+- [Agentic Setup](#agentic-setup)
 - [Contributing](#contributing)
 
 ---
@@ -733,6 +732,14 @@ Click **Export Report** on the dashboard to generate a print-ready diagnostic re
   <img src="screenshots/report-drives.jpg" alt="Report — Drives" width="240">
   <img src="screenshots/report-actions.jpg" alt="Report — Actions" width="240">
 </p>
+
+---
+
+## Agentic Setup
+
+NAS Doctor is also an experiment in how far agentic coding can carry a production-shaped project. The whole thing is written through [opencode](https://opencode.ai), mostly by a mix of Claude Opus 4.7 / 4.6 and GPT Codex 5.3, directed by hand.
+
+In the same spirit, the issue tracker itself is partly automated — an opencode agent triages open issues, posts replies, and drafts PRs. The orchestration uses dedicated agents and sub-agents inspired by [Matt Pocock's](https://www.mattpocock.com/) workflow: a top-level orchestrator that breaks features into independently-shippable pieces and dispatches worker agents to execute them on isolated branches.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ NAS Doctor runs periodic health checks on your server — analyzing SMART data, 
 
 Born from an [OpenCode diagnostic skill](https://github.com/mcdays94/opencode-server-diagnostic-skill) that generates professional PDF server reports, NAS Doctor packages the same intelligence into a self-hosted app anyone can install.
 
+It's also an experiment in how far agentic coding can carry a production-shaped project. The whole thing is written through [opencode](https://opencode.ai), mostly by a mix of Claude Opus 4.7 / 4.6 and GPT Codex 5.3, directed by hand. In the same spirit, the issue tracker itself is partly automated — an opencode agent triages open issues, posts replies, and drafts PRs. The orchestration uses dedicated agents and sub-agents inspired by [Matt Pocock's](https://www.mattpocock.com/) workflow: a top-level orchestrator that breaks features into independently-shippable pieces and dispatches worker agents to execute them on isolated branches.
+
 ---
 
 ## Table of Contents

--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -331,6 +331,17 @@ func main() {
 
 		sched = scheduler.New(coll, store, notif, metrics, logger, interval)
 		applySchedulerSettingsFromStore(sched, persistedSettings)
+		// Defense-in-depth: guarantee the scheduler's in-memory service check
+		// set matches whatever history the DB carries, even when the settings
+		// payload failed to load or was nil (empty DB, corrupt JSON). Without
+		// this, a prior-boot orphan row in service_checks_history would
+		// continue to surface on /api/v1/service-checks as a phantom check
+		// the user cannot remove via the settings UI. Issue #181.
+		if pruned, err := sched.PurgeOrphanServiceCheckHistory(); err != nil {
+			logger.Warn("startup: purge orphan service check history", "error", err)
+		} else if pruned > 0 {
+			logger.Info("startup: pruned orphan service check history", "rows", pruned)
+		}
 		// Apply Proxmox config to collector on startup
 		if persistedSettings != nil && persistedSettings.Proxmox.Enabled {
 			coll.SetProxmoxConfig(collector.ProxmoxConfig{

--- a/internal/api/api_disk_history_window_test.go
+++ b/internal/api/api_disk_history_window_test.go
@@ -1,0 +1,193 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// spyStore wraps a FakeStore and records calls made to disk-history methods.
+// This lets the API handler test verify that `?hours=24` routes to the
+// time-windowed query with the right window, while no-param requests fall
+// back to the legacy row-count query (preserving backward compatibility
+// for any external caller of /api/v1/disks/{serial}).
+type spyStore struct {
+	*storage.FakeStore
+
+	lastLegacyLimit    int
+	legacyCalls        int
+	lastWindow         time.Duration
+	rangeCalls         int
+	historyInRangeResp []storage.DiskHistoryPoint
+	historyResp        []storage.DiskHistoryPoint
+}
+
+func (s *spyStore) GetDiskHistory(serial string, limit int) ([]storage.DiskHistoryPoint, error) {
+	s.legacyCalls++
+	s.lastLegacyLimit = limit
+	return s.historyResp, nil
+}
+
+func (s *spyStore) GetDiskHistoryInRange(serial string, window time.Duration) ([]storage.DiskHistoryPoint, error) {
+	s.rangeCalls++
+	s.lastWindow = window
+	return s.historyInRangeResp, nil
+}
+
+// newTestServerForDiskHistory builds a chi router identical in shape to the
+// real one for the /api/v1/disks/{serial} route so chi.URLParam(r, "serial")
+// resolves correctly.
+func newTestServerForDiskHistory(store storage.Store) (*Server, http.Handler) {
+	srv := &Server{
+		store:     store,
+		logger:    slog.Default(),
+		version:   "test",
+		startTime: time.Now(),
+	}
+	r := chi.NewRouter()
+	r.Get("/api/v1/disks/{serial}", srv.handleGetDisk)
+	return srv, r
+}
+
+// TestHandleGetDisk_HoursParamUsesTimeWindow asserts that when ?hours=N is
+// supplied, the handler calls GetDiskHistoryInRange with window = N hours
+// (NOT the legacy row-count GetDiskHistory).
+//
+// Issue #166.
+func TestHandleGetDisk_HoursParamUsesTimeWindow(t *testing.T) {
+	cases := []struct {
+		label string
+		hours int
+	}{
+		{"1D", 24},
+		{"1W", 168},
+		{"1M", 720},
+		{"1Y", 8760},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			spy := &spyStore{FakeStore: storage.NewFakeStore()}
+			_, handler := newTestServerForDiskHistory(spy)
+
+			req := httptest.NewRequest("GET", "/api/v1/disks/SN1?hours="+itoa(tc.hours), nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+			}
+			if spy.rangeCalls != 1 {
+				t.Errorf("expected GetDiskHistoryInRange called once, got %d", spy.rangeCalls)
+			}
+			if spy.legacyCalls != 0 {
+				t.Errorf("expected legacy GetDiskHistory NOT called when ?hours= supplied, got %d calls", spy.legacyCalls)
+			}
+			wantWindow := time.Duration(tc.hours) * time.Hour
+			if spy.lastWindow != wantWindow {
+				t.Errorf("window: expected %v, got %v", wantWindow, spy.lastWindow)
+			}
+		})
+	}
+}
+
+// TestHandleGetDisk_NoHoursParamPreservesLegacyBehavior ensures the
+// no-query-param request path still returns 200 and produces the same
+// response shape external callers already rely on.
+func TestHandleGetDisk_NoHoursParamPreservesLegacyBehavior(t *testing.T) {
+	spy := &spyStore{FakeStore: storage.NewFakeStore()}
+	_, handler := newTestServerForDiskHistory(spy)
+
+	req := httptest.NewRequest("GET", "/api/v1/disks/SN1", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if spy.legacyCalls != 1 {
+		t.Errorf("expected legacy GetDiskHistory called once for no-param request, got %d", spy.legacyCalls)
+	}
+	if spy.rangeCalls != 0 {
+		t.Errorf("expected GetDiskHistoryInRange NOT called without ?hours=, got %d calls", spy.rangeCalls)
+	}
+	if spy.lastLegacyLimit != 500 {
+		t.Errorf("expected legacy limit 500, got %d", spy.lastLegacyLimit)
+	}
+
+	// Response shape sanity check: top-level keys present.
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := resp["history"]; !ok {
+		t.Error("response missing 'history' field")
+	}
+}
+
+// TestHandleGetDisk_InvalidHoursFallsBackToLegacy — a malformed ?hours=
+// should NOT break the endpoint; it falls back to legacy behavior.
+func TestHandleGetDisk_InvalidHoursFallsBackToLegacy(t *testing.T) {
+	spy := &spyStore{FakeStore: storage.NewFakeStore()}
+	_, handler := newTestServerForDiskHistory(spy)
+
+	req := httptest.NewRequest("GET", "/api/v1/disks/SN1?hours=notanumber", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if spy.legacyCalls != 1 || spy.rangeCalls != 0 {
+		t.Errorf("malformed ?hours= should fall back to legacy; got legacyCalls=%d rangeCalls=%d", spy.legacyCalls, spy.rangeCalls)
+	}
+}
+
+// TestHandleGetDisk_CapsHours — runaway ?hours=99999999 requests should be
+// capped so the query doesn't lock up the DB or return absurd time windows.
+func TestHandleGetDisk_CapsHours(t *testing.T) {
+	spy := &spyStore{FakeStore: storage.NewFakeStore()}
+	_, handler := newTestServerForDiskHistory(spy)
+
+	req := httptest.NewRequest("GET", "/api/v1/disks/SN1?hours=99999999", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if spy.rangeCalls != 1 {
+		t.Fatalf("expected 1 call to in-range query, got %d", spy.rangeCalls)
+	}
+	// Cap at 1 year (8760h).
+	maxWindow := 8760 * time.Hour
+	if spy.lastWindow > maxWindow {
+		t.Errorf("expected window capped at %v, got %v", maxWindow, spy.lastWindow)
+	}
+}
+
+// itoa is a tiny helper to avoid importing strconv just for tests.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	digits := []byte{}
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	if neg {
+		return "-" + string(digits)
+	}
+	return string(digits)
+}

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -1040,7 +1040,13 @@ type diskDetailResponse struct {
 }
 
 // handleGetDisk returns SMART data, history, and related findings for a specific disk.
-// GET /api/v1/disks/{serial}
+// GET /api/v1/disks/{serial}[?hours=N]
+//
+// When `hours` is supplied (valid positive integer), history is filtered by
+// time window so the chart range selector (1D / 1W / 1M / 1Y — issue #166)
+// returns a legible number of points regardless of scan cadence. When
+// omitted or malformed, the legacy 500-row behavior is preserved for
+// backward compatibility with any external callers of this endpoint.
 func (s *Server) handleGetDisk(w http.ResponseWriter, r *http.Request) {
 	serial := chi.URLParam(r, "serial")
 	if serial == "" {
@@ -1050,8 +1056,23 @@ func (s *Server) handleGetDisk(w http.ResponseWriter, r *http.Request) {
 
 	resp := diskDetailResponse{}
 
-	// Get history from the dedicated SMART history table.
-	history, err := s.store.GetDiskHistory(serial, 500)
+	// Parse optional ?hours= query param. Valid positive ints route to the
+	// time-windowed query; anything else (missing, malformed, <=0) falls
+	// back to the legacy row-limited query.
+	var (
+		history []storage.DiskHistoryPoint
+		err     error
+	)
+	hoursStr := r.URL.Query().Get("hours")
+	if hours, parseErr := strconv.Atoi(hoursStr); parseErr == nil && hours > 0 {
+		// Cap at 1 year so runaway params don't generate absurd ranges.
+		if hours > 8760 {
+			hours = 8760
+		}
+		history, err = s.store.GetDiskHistoryInRange(serial, time.Duration(hours)*time.Hour)
+	} else {
+		history, err = s.store.GetDiskHistory(serial, 500)
+	}
 	if err != nil {
 		s.logger.Error("failed to get disk history", "serial", serial, "error", err)
 	}

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -584,17 +584,33 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		settings.ServiceChecks.Checks = []internal.ServiceCheckConfig{}
 	}
 	serviceNames := make(map[string]struct{}, len(settings.ServiceChecks.Checks))
+	// Accumulate per-check validation errors so users with multiple
+	// invalid checks see all of them at once, and each error names
+	// the offending check. Issue #169: a flat error that didn't
+	// identify WHICH check failed led upgraders to assume the check
+	// they were currently editing was broken, even when the real
+	// problem was a pre-existing check left over from v0.9.2.
+	var checkErrs []string
 	for i := range settings.ServiceChecks.Checks {
 		check := &settings.ServiceChecks.Checks[i]
+		label := strings.TrimSpace(check.Name)
+		if label == "" {
+			label = fmt.Sprintf("#%d", i+1)
+		}
 		if err := normalizeServiceCheckConfig(check); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-			return
+			checkErrs = append(checkErrs, fmt.Sprintf("%q: %s", label, err.Error()))
 		}
 		if _, exists := serviceNames[strings.ToLower(check.Name)]; exists {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "duplicate service check name: " + check.Name})
-			return
+			checkErrs = append(checkErrs, fmt.Sprintf("%q: duplicate service check name", label))
+			continue
 		}
 		serviceNames[strings.ToLower(check.Name)] = struct{}{}
+	}
+	if len(checkErrs) > 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "service_checks: " + strings.Join(checkErrs, "; "),
+		})
+		return
 	}
 	if settings.LogPush.Destinations == nil {
 		settings.LogPush.Destinations = []LogForwardDestination{}

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -335,6 +335,10 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 	if settings.ServiceChecks.Checks == nil {
 		settings.ServiceChecks.Checks = []internal.ServiceCheckConfig{}
 	}
+	// Issue #169 — soft-disable service checks that were valid under
+	// older schemas but fail current validation, so upgraders aren't
+	// soft-bricked on Save. Does not rewrite the stored config.
+	settings.ServiceChecks.Checks = applyLegacyCheckMigration(settings.ServiceChecks.Checks)
 	if settings.LogPush.Destinations == nil {
 		settings.LogPush.Destinations = []LogForwardDestination{}
 	}
@@ -445,6 +449,91 @@ func normalizeServiceCheckConfig(check *internal.ServiceCheckConfig) error {
 	}
 	return nil
 }
+
+// normalizeLegacyDisabledServiceCheckConfig applies the subset of
+// normalization that is safe for a check that has been flagged by the
+// load-time migration (Warning set, Enabled=false). It skips the
+// strict target validation that the current schema enforces so the
+// check can round-trip through save without blocking unrelated edits.
+//
+// Issue #169: pre-v0.9.3 DNS checks with IP targets are the only
+// currently-known legacy shape that needs grandfathering; the branch
+// is intentionally narrow so a latent bug here cannot whitewash
+// freshly-authored bad config.
+func normalizeLegacyDisabledServiceCheckConfig(check *internal.ServiceCheckConfig) error {
+	check.Name = strings.TrimSpace(check.Name)
+	check.Type = strings.ToLower(strings.TrimSpace(check.Type))
+	check.Target = strings.TrimSpace(check.Target)
+	check.DNSServer = strings.TrimSpace(check.DNSServer)
+	if check.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	// A disabled check must stay disabled — if a user wants to re-enable
+	// it, they also need to fix the Target (which strips the Warning).
+	check.Enabled = false
+	// Apply lenient defaults so the struct is internally consistent.
+	if check.IntervalSec <= 0 {
+		check.IntervalSec = 300
+	}
+	if check.IntervalSec < 30 {
+		check.IntervalSec = 30
+	}
+	if check.TimeoutSec <= 0 {
+		check.TimeoutSec = 5
+	}
+	if check.TimeoutSec > 30 {
+		check.TimeoutSec = 30
+	}
+	if check.FailureThreshold <= 0 {
+		check.FailureThreshold = 1
+	}
+	if check.FailureSeverity == "" {
+		check.FailureSeverity = internal.SeverityWarning
+	}
+	return nil
+}
+
+// applyLegacyCheckMigration scans loaded service checks for configs
+// that are valid under older schemas but fail the current validator,
+// and flips them to Enabled=false with a user-visible Warning. This is
+// a read-time transform only; the stored config is NOT rewritten —
+// the user must acknowledge and resave.
+//
+// Issue #169: the known case is DNS-type checks whose target is a
+// literal IP — a silent no-op under v0.9.0-v0.9.2, now rejected at
+// save time by #159. Without this migration an upgrader's entire
+// settings payload bounces with a misleading error.
+func applyLegacyCheckMigration(checks []internal.ServiceCheckConfig) []internal.ServiceCheckConfig {
+	out := make([]internal.ServiceCheckConfig, len(checks))
+	copy(out, checks)
+	for i := range out {
+		c := &out[i]
+		if !isLegacyDisableTarget(c) {
+			continue
+		}
+		c.Enabled = false
+		if strings.TrimSpace(c.Warning) == "" {
+			c.Warning = legacyDNSIPWarning
+		}
+	}
+	return out
+}
+
+// isLegacyDisableTarget reports whether a stored check is a shape that
+// the load-time migration should flag. Keep narrow: only patterns we
+// have explicitly triaged.
+func isLegacyDisableTarget(c *internal.ServiceCheckConfig) bool {
+	if strings.ToLower(strings.TrimSpace(c.Type)) == internal.ServiceCheckDNS {
+		if net.ParseIP(strings.TrimSpace(c.Target)) != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// legacyDNSIPWarning is the user-facing message surfaced for auto-
+// disabled DNS-IP checks (issue #169).
+const legacyDNSIPWarning = "This DNS check has an IP target (invalid since v0.9.3) and has been auto-disabled. Change the target to a hostname like google.com, or delete it. To test IP reachability use a Ping or TCP check."
 
 // validateDNSServer checks that a user-supplied DNS resolver address is a
 // valid host (or host:port). Port, when present, must be 1-65535.
@@ -585,11 +674,10 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 	}
 	serviceNames := make(map[string]struct{}, len(settings.ServiceChecks.Checks))
 	// Accumulate per-check validation errors so users with multiple
-	// invalid checks see all of them at once, and each error names
-	// the offending check. Issue #169: a flat error that didn't
-	// identify WHICH check failed led upgraders to assume the check
-	// they were currently editing was broken, even when the real
-	// problem was a pre-existing check left over from v0.9.2.
+	// legacy-invalid checks see all of them at once, and each error
+	// names the offending check. Issue #169: pre-v0.9.3 DNS-IP checks
+	// would fail save silently with a flat error that looked like it
+	// referred to whatever check the user happened to be editing.
 	var checkErrs []string
 	for i := range settings.ServiceChecks.Checks {
 		check := &settings.ServiceChecks.Checks[i]
@@ -597,7 +685,15 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		if label == "" {
 			label = fmt.Sprintf("#%d", i+1)
 		}
-		if err := normalizeServiceCheckConfig(check); err != nil {
+		// Legacy grandfather: a check that was flagged invalid on load
+		// (Warning set) AND is disabled cannot run, so its invalid
+		// target is harmless. Exempt it from strict target validation
+		// so upgraders can still save unrelated settings.
+		if !check.Enabled && strings.TrimSpace(check.Warning) != "" {
+			if err := normalizeLegacyDisabledServiceCheckConfig(check); err != nil {
+				checkErrs = append(checkErrs, fmt.Sprintf("%q: %s", label, err.Error()))
+			}
+		} else if err := normalizeServiceCheckConfig(check); err != nil {
 			checkErrs = append(checkErrs, fmt.Sprintf("%q: %s", label, err.Error()))
 		}
 		if _, exists := serviceNames[strings.ToLower(check.Name)]; exists {

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -1403,6 +1403,12 @@ func (s *Server) handleTestServiceCheck(w http.ResponseWriter, r *http.Request) 
 	// by RunDueChecks, which we don't call). We deliberately avoid using
 	// s.scheduler here so the endpoint works in demo mode and tests.
 	checker := scheduler.NewServiceChecker(s.store, s.logger)
+	// Opt into the per-type rich details map — status codes, resolved IPs,
+	// DNS records, failure stages — so the settings UI can render an
+	// actionable diagnosis, not just "down". See issue #154. The
+	// scheduled-check path does NOT set this flag, so 30s loops remain
+	// lean.
+	checker.SetCollectDetails(true)
 	if cfg.Type == internal.ServiceCheckSpeed {
 		checker.SetSpeedTestRunner(collector.RunSpeedTest)
 	}

--- a/internal/api/charts.go
+++ b/internal/api/charts.go
@@ -133,6 +133,63 @@ function computeYTicks(dMin,dMax,yMax,count){
   return {min:mn,max:mx,ticks:ticks};
 }
 
+/* ── decimateLabels ──────────────────────────────────────────────
+   Given N label slots spread evenly across chart-pixel-width cw, the
+   widest rendered label width maxLabelWidth, and a minimum horizontal
+   gap minGap between adjacent labels, return the set of label indices
+   to render without any two labels overlapping.
+
+   Guarantees:
+     - Index 0 (first) is always present when N>=1.
+     - Index N-1 (last) is always present when N>=2.
+     - No two consecutive returned indices i<j produce rendered labels
+       whose pixel bounding boxes intersect. (Spacing between their
+       centers is stride*(cw/(N-1)) which is >= maxLabelWidth+minGap
+       by construction — except for the final "snap to last" entry,
+       which is guaranteed spacing >= maxLabelWidth+minGap because
+       we drop the previous anchor if it would collide with the last.)
+
+   Edge cases:
+     - N<=1         → [0] (or [] if N=0)
+     - cw<=0 or L=0 → just [0, N-1] (degenerate, no width info)
+     - L+G >= cw    → [0, N-1] (only first and last fit)
+
+   This is exported as a pure function on NasChart so it can be unit-
+   tested in isolation (see internal/api/charts_decimation_test.go and
+   scripts/charts_decimation.test.js). Issue #165. */
+function decimateLabels(n,cw,maxLabelWidth,minGap){
+  if(minGap==null) minGap=12;
+  if(!(n>0)) return [];
+  if(n===1) return [0];
+  if(!(cw>0)||!(maxLabelWidth>0)) return [0,n-1];
+  var per=maxLabelWidth+minGap;
+  var intervals=n-1;
+  /* How many labels fit? (cw + gap) / (label + gap) because the last
+     label doesn't need a trailing gap. */
+  var maxLabels=Math.floor((cw+minGap)/per);
+  if(maxLabels<2) return [0,n-1];
+  if(maxLabels>=n) {
+    /* every label fits */
+    var out=[];
+    for(var i=0;i<n;i++) out.push(i);
+    return out;
+  }
+  /* Smallest stride s such that s*(cw/intervals) >= per. */
+  var stride=Math.max(1,Math.ceil(per*intervals/cw));
+  var idx=[];
+  for(var j=0;j<n;j+=stride) idx.push(j);
+  /* Always include the last label. Drop the previous anchor if it
+     would collide with the last (pixel distance < per). */
+  var last=n-1;
+  if(idx[idx.length-1]!==last){
+    var lastAnchor=idx[idx.length-1];
+    var gapPx=(last-lastAnchor)*(cw/intervals);
+    if(gapPx<per) idx.pop();
+    idx.push(last);
+  }
+  return idx;
+}
+
 /* ── drawAxes ────────────────────────────────────────────────────── */
 function drawAxes(ctx,m,w,h,yInfo,labels,opts){
   var th=theme();
@@ -151,12 +208,25 @@ function drawAxes(ctx,m,w,h,yInfo,labels,opts){
     var lbl=vy%1===0?vy.toString():vy.toFixed(1);
     ctx.fillText(lbl,m.l-8,py);
   }
-  /* x labels */
+  /* x labels — decimate to prevent overlap. Measure real label widths
+     via ctx.measureText() and derive which indices to render from
+     decimateLabels(). Fixes issue #165: the old
+       step = floor(labels.length / (cw / 50))
+     hardcoded a ~50px label budget, so datetime labels like "4/17 23:11"
+     (~65-75px in 11px sans-serif) would collide into an unreadable wall
+     of overlapping text once enough history accumulated. */
   if(labels&&labels.length){
     ctx.textAlign="center"; ctx.textBaseline="top";
-    var step=Math.max(1,Math.floor(labels.length/(cw/50)));
-    for(var j=0;j<labels.length;j+=step){
-      var px=m.l+j/(labels.length-1||1)*cw;
+    var maxLabelWidth=0;
+    for(var mi=0;mi<labels.length;mi++){
+      var lw=ctx.measureText(labels[mi]==null?"":String(labels[mi])).width;
+      if(lw>maxLabelWidth) maxLabelWidth=lw;
+    }
+    var keep=decimateLabels(labels.length,cw,maxLabelWidth,12);
+    var intervals=labels.length-1||1;
+    for(var ki=0;ki<keep.length;ki++){
+      var j=keep[ki];
+      var px=m.l+j/intervals*cw;
       ctx.fillStyle=th.text;
       ctx.fillText(labels[j],px,h-m.b+8);
     }
@@ -509,7 +579,12 @@ var NasChart={
   area:      drawArea,
   bar:       drawBar,
   gauge:     drawGauge,
-  sparkline: drawSparkline
+  sparkline: drawSparkline,
+  /* _decimateLabels is exposed for unit tests only. It is not part of
+     the public API — name is prefixed with an underscore to signal
+     "internal / subject to change". See issue #165 and
+     internal/api/charts_decimation_test.go. */
+  _decimateLabels: decimateLabels
 };
 
 window.NasChart=NasChart;

--- a/internal/api/charts_decimation_test.go
+++ b/internal/api/charts_decimation_test.go
@@ -1,0 +1,198 @@
+package api
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestChartJS_DrawAxes_UsesDecimation guards against regression of the fix
+// for issue #165 (x-axis label overlap on /disk/<serial>). drawAxes() must:
+//  1. measure real label widths via ctx.measureText(), and
+//  2. call the exported decimateLabels() helper to pick which indices to
+//     render so that no two rendered labels overlap.
+//
+// If this test fails, someone reverted drawAxes() back to an index-only
+// stride formula (e.g. the historic Math.floor(labels.length / (cw / 50))
+// that caused #165 in the first place) or bypassed decimateLabels().
+func TestChartJS_DrawAxes_UsesDecimation(t *testing.T) {
+	js := ChartJS
+	const marker = "/* x labels"
+	idx := strings.Index(js, marker)
+	if idx < 0 {
+		t.Fatalf("ChartJS: could not locate %q marker — drawAxes() structure changed unexpectedly", marker)
+	}
+	end := idx + 1400
+	if end > len(js) {
+		end = len(js)
+	}
+	xBlock := js[idx:end]
+
+	mustContain := []struct {
+		substr string
+		why    string
+	}{
+		{"measureText", "drawAxes must measure real label widths — hardcoded pixel budgets cause overlap (issue #165)"},
+		{"maxLabelWidth", "drawAxes must track the widest measured label (issue #165)"},
+		{"decimateLabels(", "drawAxes must call decimateLabels() to pick non-overlapping label indices (issue #165)"},
+	}
+	for _, tc := range mustContain {
+		if !strings.Contains(xBlock, tc.substr) {
+			t.Errorf("ChartJS x-labels block missing %q — %s", tc.substr, tc.why)
+		}
+	}
+
+	mustNotContain := []struct {
+		substr string
+		why    string
+	}{
+		{"cw/50", "the old hardcoded-50 stride formula must not come back — root cause of #165"},
+		{"labels.length/(cw/50)", "the old hardcoded-50 stride formula must not come back — root cause of #165"},
+	}
+	for _, tc := range mustNotContain {
+		if strings.Contains(xBlock, tc.substr) {
+			t.Errorf("ChartJS x-labels block still contains %q — %s", tc.substr, tc.why)
+		}
+	}
+}
+
+// TestChartJS_DecimateLabels_Behavior runs the decimateLabels function in a
+// headless node runtime against a table of representative inputs. This is
+// the "real" TDD test — it verifies the algorithm produces correct output,
+// not just that certain substrings are present.
+//
+// The test is skipped if node is not on PATH (CI and local dev both have it).
+func TestChartJS_DecimateLabels_Behavior(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not available; skipping JS behavior test")
+	}
+
+	// Runner: injects a fake window/document, evaluates ChartJS, then calls
+	// NasChart._decimateLabels with a list of cases and prints JSON results.
+	runner := `
+const cases = [
+  // name, N, cw, L, gap, expectedFirst, expectedLast, expectedMaxGapPx (<=), mustIncludeAll (bool)
+  // --- degenerate ---
+  { name: "N=0",              n: 0,  cw: 1400, L: 60, expectEmpty: true },
+  { name: "N=1",              n: 1,  cw: 1400, L: 60, expect: [0] },
+  { name: "cw=0",             n: 10, cw: 0,    L: 60, expect: [0,9] },
+  { name: "L=0",              n: 10, cw: 1400, L: 0,  expect: [0,9] },
+  { name: "label wider than chart", n: 10, cw: 50, L: 100, expect: [0,9] },
+
+  // --- all fit (1D with small N or small L) ---
+  { name: "all-fit tiny",     n: 5,  cw: 1400, L: 60, expect: [0,1,2,3,4] },
+
+  // --- stress ranges from the issue ---
+  { name: "1D @ 48 points 1400px L=60", n: 48,   cw: 1400, L: 60,
+    mustIncludeFirstLast: true, maxOverlapAllowedPx: 0, minGapPx: 60 },
+  { name: "1W @ 336 points 1400px L=60", n: 336,  cw: 1400, L: 60,
+    mustIncludeFirstLast: true, maxOverlapAllowedPx: 0, minGapPx: 60 },
+  { name: "1M @ 1440 points 1400px L=60", n: 1440, cw: 1400, L: 60,
+    mustIncludeFirstLast: true, maxOverlapAllowedPx: 0, minGapPx: 60 },
+  { name: "1Y @ 17520 points 1400px L=60", n: 17520, cw: 1400, L: 60,
+    mustIncludeFirstLast: true, maxOverlapAllowedPx: 0, minGapPx: 60 },
+
+  // --- narrow container ---
+  { name: "narrow 768px 48 points", n: 48, cw: 768, L: 60,
+    mustIncludeFirstLast: true, minGapPx: 60 },
+];
+
+// Minimal stubs for the browser APIs ChartJS touches at module-load time.
+global.window = { matchMedia: () => ({ matches: false }), devicePixelRatio: 1 };
+global.document = {
+  body: {},
+  createElement: () => ({ style: {}, appendChild: () => {} }),
+};
+global.getComputedStyle = () => ({ backgroundColor: "rgb(255,255,255)", paddingLeft: "0", paddingRight: "0" });
+global.requestAnimationFrame = () => {};
+
+const fs = require("fs");
+const path = require("path");
+const src = fs.readFileSync(path.resolve("internal/api/charts.go"), "utf8");
+const m = src.match(/var ChartJS = ` + "`" + `([\s\S]*?)` + "`" + `/);
+if (!m) { console.error("could not extract ChartJS"); process.exit(2); }
+eval(m[1]);
+const decimate = window.NasChart._decimateLabels;
+
+const results = [];
+for (const c of cases) {
+  try {
+    const got = decimate(c.n, c.cw, c.L, 12);
+    const entry = { name: c.name, got };
+
+    if (c.expectEmpty) {
+      entry.ok = Array.isArray(got) && got.length === 0;
+      if (!entry.ok) entry.why = "expected empty array";
+    } else if (c.expect) {
+      entry.ok = JSON.stringify(got) === JSON.stringify(c.expect);
+      if (!entry.ok) entry.why = "expected " + JSON.stringify(c.expect);
+    } else {
+      // Assertions derived from N,cw,L
+      entry.ok = true;
+      entry.why = "";
+      if (c.mustIncludeFirstLast) {
+        if (got[0] !== 0) { entry.ok = false; entry.why = "missing first (0) — got " + got[0]; }
+        else if (got[got.length-1] !== c.n - 1) {
+          entry.ok = false;
+          entry.why = "missing last (" + (c.n-1) + ") — got " + got[got.length-1];
+        }
+      }
+      if (entry.ok && c.minGapPx != null) {
+        // pixel gap between adjacent kept labels must be >= L + 12
+        const intervals = c.n - 1 || 1;
+        const pxPerInterval = c.cw / intervals;
+        const needPx = c.L + 12;
+        for (let i = 1; i < got.length; i++) {
+          const gap = (got[i] - got[i-1]) * pxPerInterval;
+          if (gap + 0.0001 < needPx) {
+            entry.ok = false;
+            entry.why = "pixel gap " + gap.toFixed(2) + " < required " + needPx + " between " + got[i-1] + "→" + got[i];
+            break;
+          }
+        }
+      }
+      // strictly increasing, in-range
+      for (let i = 0; i < got.length; i++) {
+        if (got[i] < 0 || got[i] >= c.n) { entry.ok = false; entry.why = "out-of-range index " + got[i]; break; }
+        if (i > 0 && got[i] <= got[i-1]) { entry.ok = false; entry.why = "not strictly increasing at " + i; break; }
+      }
+    }
+    results.push(entry);
+  } catch (err) {
+    results.push({ name: c.name, ok: false, why: "threw: " + err.message });
+  }
+}
+console.log(JSON.stringify(results));
+`
+
+	cmd := exec.Command("node", "-e", runner)
+	// run from the repo root so the readFileSync path resolves
+	cmd.Dir = findRepoRoot(t)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("node runner failed: %v\noutput:\n%s", err, string(out))
+	}
+	// Last line is the JSON blob.
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	jsonLine := lines[len(lines)-1]
+
+	// Parse by substring search (avoids encoding/json dependency bump).
+	// Each result has name + ok. We fail if any "ok":false appears.
+	if !strings.Contains(jsonLine, "\"ok\":false") && !strings.Contains(jsonLine, "\"ok\": false") {
+		t.Logf("decimateLabels behavior: all cases passed")
+		return
+	}
+	t.Errorf("decimateLabels behavior failures:\n%s", jsonLine)
+}
+
+// findRepoRoot walks up from CWD looking for go.mod.
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	// From internal/api test binary, CWD is that package. Walk up.
+	// We know ChartJS is read from "internal/api/charts.go" relative to repo root.
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/api/disk_detail_range_selector_test.go
+++ b/internal/api/disk_detail_range_selector_test.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDiskDetailHTMLContainsRangeSelector asserts the /disk/<serial> page
+// template wires up the 1D / 1W / 1M / 1Y time-window selector.
+//
+// Issue #166: prior to this change /disk/<serial> rendered all available
+// SMART history at once (~500 rows ≈ 10 days at default scan cadence),
+// which produced unreadable x-axis labels. A range selector, mirroring
+// the /stats process-history pattern, gives users control and trims
+// label density to what fits.
+//
+// This is a UI cross-reference test (see AGENTS.md §4b): if someone
+// renames _loadDiskHistoryRange or drops one of the range buttons in a
+// future refactor, the server-side tests are what catches it — there is
+// no browser-side test harness to cover this.
+func TestDiskDetailHTMLContainsRangeSelector(t *testing.T) {
+	tmpl := DiskDetailPage
+	if tmpl == "" {
+		t.Fatal("DiskDetailPage embedded template is empty")
+	}
+
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		// Range selector button labels live in the JS-side ranges
+		// array as {h:N,l:"LABEL"} tuples; the page renders them via
+		// string concat so these labels must appear verbatim.
+		{"1D button label", `l:"1D"`},
+		{"1W button label", `l:"1W"`},
+		{"1M button label", `l:"1M"`},
+		{"1Y button label", `l:"1Y"`},
+
+		// The hours values passed through to the API. If any of these
+		// drift, the selector will silently stop matching the active
+		// window on first paint.
+		{"24h mapping", "h:24"},
+		{"168h mapping", "h:168"},
+		{"720h mapping", "h:720"},
+		{"8760h mapping", "h:8760"},
+
+		// Handler name — locked in so a rename requires updating both
+		// sides and gets caught here.
+		{"range-load handler", "_loadDiskHistoryRange"},
+
+		// API contract: fetch with ?hours= so we stay on the time-window
+		// code path and not the legacy row-limited one.
+		{"API fetch with hours", "/api/v1/disks/"},
+		{"hours query param", "?hours=\" + hours"},
+
+		// Default window is 1D on first load (issue #166 scope decision).
+		// The variable initial value must be 24 so the page opens on 1D.
+		{"default 1D window", "diskHistoryHours = 24"},
+	}
+
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(tmpl, tc.substr) {
+				t.Errorf("disk_detail.html missing %q — expected substring: %q", tc.name, tc.substr)
+			}
+		})
+	}
+}
+
+// TestDiskDetailHTMLRangeSelectorDefaultIs1D pins down the default-on-load
+// behavior. The buttons MUST default to 1D so a freshly opened /disk/<serial>
+// doesn't render the full history and reintroduce #166. See scope
+// decisions in the issue: "Default: 1D".
+func TestDiskDetailHTMLRangeSelectorDefaultIs1D(t *testing.T) {
+	tmpl := DiskDetailPage
+
+	// Sanity: the initial value of diskHistoryHours must be 24 (1D), not
+	// 168 / 720 / 8760 — if someone swaps the default we want the test
+	// to fail loud rather than ship a regression.
+	if !strings.Contains(tmpl, "diskHistoryHours = 24") {
+		t.Error("expected diskHistoryHours default = 24 (1D) in disk_detail.html")
+	}
+	for _, wrong := range []string{"diskHistoryHours = 168", "diskHistoryHours = 720", "diskHistoryHours = 8760"} {
+		if strings.Contains(tmpl, wrong) {
+			t.Errorf("disk_detail.html uses wrong default window (%q); issue #166 requires 1D default", wrong)
+		}
+	}
+}

--- a/internal/api/service_check_test_endpoint_test.go
+++ b/internal/api/service_check_test_endpoint_test.go
@@ -312,6 +312,39 @@ func TestHandleTestServiceCheck_DoesNotTouchConsecutiveFailures(t *testing.T) {
 	}
 }
 
+// TestHandleTestServiceCheck_HTTP_ReturnsDetails — the /test endpoint must
+// opt-in to rich details so the UI can display status_code, content_type,
+// body_bytes, final_url, etc. (issue #154).
+func TestHandleTestServiceCheck_HTTP_ReturnsDetails(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer ts.Close()
+
+	srv := newSettingsTestServer()
+	rec := postServiceCheckTest(t, srv, map[string]any{
+		"name": "details-http", "type": "http", "target": ts.URL,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// Decode through a generic map so we can assert details keys without
+	// losing the numeric type fidelity that Go's json encoder produces.
+	var generic map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &generic); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	details, ok := generic["details"].(map[string]any)
+	if !ok || len(details) == 0 {
+		t.Fatalf("expected details in response, got %+v", generic["details"])
+	}
+	if _, hasCode := details["status_code"]; !hasCode {
+		t.Fatalf("expected status_code in details, got keys: %+v", details)
+	}
+}
+
 // TestRegisterExtendedRoutes_ExposesServiceCheckTest — the new route is registered
 // and responds on POST through the router.
 func TestRegisterExtendedRoutes_ExposesServiceCheckTest(t *testing.T) {

--- a/internal/api/service_checks_log_details_test.go
+++ b/internal/api/service_checks_log_details_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestServiceChecksHTML_LogDetail_RendersPerTypeDetails guards the UI
+// changes for issue #182. When a user expands a log entry on the
+// /service-checks page, the detail panel must render the per-type
+// Details map (HTTP status_code, DNS records, TCP resolved_address,
+// Ping rtt_ms + packet_loss_pct, failure_stage for any type) so the
+// same rich context the Test button already shows is visible on
+// persisted log rows.
+//
+// We verify by cross-reference — the template must mention the exact
+// Details keys the scheduler persists. Keeps the test hermetic (no
+// headless browser), catches regressions where a refactor deletes the
+// rendering branch for one type.
+func TestServiceChecksHTML_LogDetail_RendersPerTypeDetails(t *testing.T) {
+	html := loadServiceChecksHTML(t)
+
+	// The renderer helper must exist and be invoked from the log expand
+	// path. Naming follows #154's settings.html helper so a future refactor
+	// can promote it without renaming callers.
+	mustContain(t, html, "renderServiceCheckDetails",
+		"log expand path must reference the renderServiceCheckDetails helper")
+
+	// The entry's details payload must be consumed. ServiceCheckEntry's
+	// JSON tag is "details,omitempty"; the template reads e.details.
+	mustContain(t, html, "e.details",
+		"log expand path must read e.details from the persisted entry")
+
+	// Per-type keys — match the set the scheduler runners populate.
+	// One failure here pinpoints exactly which branch regressed.
+	perTypeKeys := map[string]string{
+		"HTTP status_code":     "status_code",
+		"HTTP content_type":    "content_type",
+		"HTTP body_bytes":      "body_bytes",
+		"HTTP final_url":       "final_url",
+		"DNS records":          "records",
+		"DNS query_host":       "query_host",
+		"DNS dns_server":       "dns_server",
+		"TCP resolved_address": "resolved_address",
+		"Ping rtt_ms":          "rtt_ms",
+		"Ping packet_loss_pct": "packet_loss_pct",
+		"Shared failure_stage": "failure_stage",
+	}
+	for label, key := range perTypeKeys {
+		if !strings.Contains(html, key) {
+			t.Errorf("service_checks.html missing %s key %q — log detail panel won't render it", label, key)
+		}
+	}
+}
+
+// TestServiceChecksHTML_LogDetail_ExistingFieldsStillRendered — sanity
+// guard against accidentally losing the original fields in the detail
+// panel while wiring up the new helper. These were shipped by the
+// expand-row UI prior to #182 (Check Name, Type, Target, Status, Response
+// Time, Checked At, etc.); they must still appear.
+func TestServiceChecksHTML_LogDetail_ExistingFieldsStillRendered(t *testing.T) {
+	html := loadServiceChecksHTML(t)
+	required := []string{
+		"Check Name",
+		"Target",
+		"Response Time",
+		"Checked At",
+		"Consecutive Failures",
+		"Check Key",
+	}
+	for _, label := range required {
+		if !strings.Contains(html, label) {
+			t.Errorf("service_checks.html lost legacy detail-panel label %q during #182 wiring", label)
+		}
+	}
+}
+
+func mustContain(t *testing.T, haystack, needle, why string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("%s\n  expected substring: %q", why, needle)
+	}
+}

--- a/internal/api/service_checks_log_wrap_test.go
+++ b/internal/api/service_checks_log_wrap_test.go
@@ -1,0 +1,132 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// loadServiceChecksHTML returns the service_checks.html template content
+// for assertions. Keeps the test hermetic (does not rely on the embedded
+// FS being initialized; reads the source file directly).
+func loadServiceChecksHTML(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join("templates", "service_checks.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read service_checks.html: %v", err)
+	}
+	return string(data)
+}
+
+// TestServiceChecksHTML_LogDetailWrapsLongValues guards the CSS fix for
+// issue #176. When a log entry is expanded on the Service Checks page,
+// long field values (URLs, error messages, check keys) must wrap within
+// their grid item; otherwise the unbroken string pushes the grid track
+// wider than its parent card and the card visibly overflows on desktop
+// and mobile alike.
+//
+// We assert three structural invariants in the CSS:
+//  1. .log-detail-item has min-width:0 — without this, the CSS grid
+//     track (grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)))
+//     refuses to shrink below the intrinsic width of its unbreakable
+//     content, so the grid expands horizontally beyond the card.
+//  2. .log-detail-item .ld-val has overflow-wrap:anywhere and
+//     word-break:break-word — together these force browsers to break
+//     at any character boundary for tokens without whitespace (URLs,
+//     base64 strings, etc.). Both are set because older engines honor
+//     word-break while modern engines prefer overflow-wrap; shipping
+//     both is the broadest-compat pattern.
+//  3. .log-table td must also wrap. The un-expanded log table lives
+//     inside the same .log-panel card; a long unbreakable value in a
+//     row cell (e.g. the Check Name column) stretches the <table>
+//     past the panel's width, which transitively pushes the
+//     colspan=6 expanded detail row past the card edge — even when
+//     the detail grid itself would have fit. We unset the inherited
+//     white-space:nowrap from the shared stylesheet (styles.go)
+//     and set word-break/overflow-wrap so no single cell can grow
+//     the table beyond 100% of the panel's inner width.
+//
+// This is a grep-based CSS test: it does not exercise a running page
+// (that's covered by §4c Playwright validation on the worker side),
+// but it does prevent accidental regression if someone later refactors
+// the log-detail styles and drops the wrap rules.
+func TestServiceChecksHTML_LogDetailWrapsLongValues(t *testing.T) {
+	html := loadServiceChecksHTML(t)
+
+	// Invariant 1: .log-detail-item must set min-width:0 so CSS grid
+	// tracks can shrink below the intrinsic width of long tokens.
+	itemRule := extractCSSRule(t, html, ".log-detail-item{")
+	if !strings.Contains(itemRule, "min-width:0") {
+		t.Errorf(".log-detail-item CSS must include min-width:0 so grid tracks shrink below intrinsic width of long unbreakable tokens; rule was:\n  %s", itemRule)
+	}
+
+	// Invariant 2: .log-detail-item .ld-val must wrap.
+	valRule := extractCSSRule(t, html, ".log-detail-item .ld-val{")
+	if !regexp.MustCompile(`overflow-wrap\s*:\s*anywhere`).MatchString(valRule) {
+		t.Errorf(".log-detail-item .ld-val CSS must include overflow-wrap:anywhere; rule was:\n  %s", valRule)
+	}
+	if !regexp.MustCompile(`word-break\s*:\s*break-word`).MatchString(valRule) {
+		t.Errorf(".log-detail-item .ld-val CSS must include word-break:break-word; rule was:\n  %s", valRule)
+	}
+
+	// Invariant 3: .log-table td must override the shared stylesheet's
+	// white-space:nowrap and permit character-boundary wrapping.
+	tdRule := extractCSSRule(t, html, ".log-table td{")
+	if !regexp.MustCompile(`white-space\s*:\s*normal`).MatchString(tdRule) {
+		t.Errorf(".log-table td CSS must include white-space:normal to unset the shared stylesheet's nowrap (otherwise long cell values stretch the table past the panel card); rule was:\n  %s", tdRule)
+	}
+	if !regexp.MustCompile(`overflow-wrap\s*:\s*anywhere`).MatchString(tdRule) {
+		t.Errorf(".log-table td CSS must include overflow-wrap:anywhere; rule was:\n  %s", tdRule)
+	}
+	if !regexp.MustCompile(`word-break\s*:\s*break-word`).MatchString(tdRule) {
+		t.Errorf(".log-table td CSS must include word-break:break-word; rule was:\n  %s", tdRule)
+	}
+}
+
+// TestServiceChecksHTML_LogDetailClassesCrossReference is the §4b
+// cross-reference guard: the CSS class names styled in the <style>
+// block must actually be emitted by the JS that renders expanded log
+// rows. If someone renames one side without the other, logic tests
+// and the CSS rule test both stay green while the fix silently stops
+// applying — classic drift trap.
+func TestServiceChecksHTML_LogDetailClassesCrossReference(t *testing.T) {
+	html := loadServiceChecksHTML(t)
+
+	// The JS in renderLogTable() emits both of these classes when it
+	// builds the expanded detail row. If either disappears from the
+	// template, the CSS wrap fix becomes a no-op.
+	for _, cls := range []string{"log-detail-item", "ld-val"} {
+		cssNeedle := "." + cls
+		if !strings.Contains(html, cssNeedle) {
+			t.Errorf("service_checks.html CSS no longer targets %q — wrap rule would no-op", cssNeedle)
+		}
+		jsNeedle := `class="` + cls
+		// The JS builds classes via string concatenation; the literal
+		// "class=\"<name>" fragment appears in the template source.
+		if !strings.Contains(html, jsNeedle) && !strings.Contains(html, `"`+cls+`"`) {
+			t.Errorf("service_checks.html JS no longer emits %q in rendered HTML — CSS rule would style nothing", cls)
+		}
+	}
+}
+
+// extractCSSRule returns the body (between { and }) of the first CSS
+// rule in html whose opening matches prefix (e.g. ".log-detail-item{").
+// Fails the test if the rule isn't present; returning a guaranteed
+// non-empty string lets the caller assert on contents without
+// dereferencing nil.
+func extractCSSRule(t *testing.T, html, prefix string) string {
+	t.Helper()
+	start := strings.Index(html, prefix)
+	if start < 0 {
+		t.Fatalf("CSS rule %q not found in service_checks.html — template was restructured or rule was removed", prefix)
+	}
+	bodyStart := start + len(prefix)
+	end := strings.Index(html[bodyStart:], "}")
+	if end < 0 {
+		t.Fatalf("CSS rule %q found but never closed with '}' — malformed CSS?", prefix)
+	}
+	return html[bodyStart : bodyStart+end]
+}

--- a/internal/api/settings_legacy_migration_test.go
+++ b/internal/api/settings_legacy_migration_test.go
@@ -1,0 +1,318 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// putSettings issues a PUT /api/v1/settings against the given test server and
+// returns the recorder for inspection.
+func putSettings(t *testing.T, srv *Server, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	buf, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(buf))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.handleUpdateSettings(rec, req)
+	return rec
+}
+
+// getSettings issues a GET /api/v1/settings and parses the response.
+func getSettings(t *testing.T, srv *Server) Settings {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	rec := httptest.NewRecorder()
+	srv.handleGetSettings(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/settings: %d %s", rec.Code, rec.Body.String())
+	}
+	var s Settings
+	body, _ := io.ReadAll(rec.Body)
+	if err := json.Unmarshal(body, &s); err != nil {
+		t.Fatalf("decode settings: %v", err)
+	}
+	return s
+}
+
+// seedRawSettings writes a JSON blob straight into the store under the
+// settings key, bypassing the update handler — this simulates settings.json
+// written by an older version that would now fail validation.
+func seedRawSettings(t *testing.T, srv *Server, raw string) {
+	t.Helper()
+	if err := srv.store.SetConfig(settingsConfigKey, raw); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+}
+
+// TestHandleUpdateSettings_InvalidCheck_ErrorNamesTheCheck — Phase 1:
+// when a check fails validation the error must identify which check
+// by name so users can self-diagnose. Regression for #169 where users
+// upgrading from v0.9.2 with a DNS-IP check received a flat error
+// that seemed to reference the check they were currently editing.
+func TestHandleUpdateSettings_InvalidCheck_ErrorNamesTheCheck(t *testing.T) {
+	srv := newSettingsTestServer()
+	rec := putSettings(t, srv, map[string]any{
+		"scan_interval": "30m",
+		"theme":         "midnight",
+		"service_checks": map[string]any{
+			"checks": []map[string]any{
+				{
+					"name":    "my-legacy-dns",
+					"type":    "dns",
+					"target":  "1.1.1.1",
+					"enabled": true,
+				},
+			},
+		},
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "my-legacy-dns") {
+		t.Fatalf("error must identify failing check by name 'my-legacy-dns', got: %s", rec.Body.String())
+	}
+}
+
+// TestHandleUpdateSettings_MultipleInvalidChecks_AllReported — Phase 1:
+// the validator must accumulate errors across all checks and surface
+// all failures, not short-circuit on the first. Users editing an
+// unrelated check shouldn't have to fix each broken check one by one.
+func TestHandleUpdateSettings_MultipleInvalidChecks_AllReported(t *testing.T) {
+	srv := newSettingsTestServer()
+	rec := putSettings(t, srv, map[string]any{
+		"scan_interval": "30m",
+		"theme":         "midnight",
+		"service_checks": map[string]any{
+			"checks": []map[string]any{
+				{"name": "bad-one", "type": "dns", "target": "1.1.1.1", "enabled": true},
+				{"name": "bad-two", "type": "dns", "target": "8.8.8.8", "enabled": true},
+			},
+		},
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "bad-one") {
+		t.Errorf("expected 'bad-one' in error body, got: %s", body)
+	}
+	if !strings.Contains(body, "bad-two") {
+		t.Errorf("expected 'bad-two' in error body, got: %s", body)
+	}
+}
+
+// TestSettingsLoad_DNSIPCheck_SoftDisabled — Phase 2: when the stored
+// settings contain a legacy DNS check with an IP target (valid under
+// v0.9.2 but invalid under v0.9.3+), the load path must mark it
+// disabled and surface a user-visible warning, NOT silently drop it.
+func TestSettingsLoad_DNSIPCheck_SoftDisabled(t *testing.T) {
+	srv := newSettingsTestServer()
+	seedRawSettings(t, srv, `{
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"service_checks": {
+			"checks": [
+				{"name": "legacy-dns", "type": "dns", "target": "1.1.1.1", "enabled": true}
+			]
+		}
+	}`)
+
+	loaded := getSettings(t, srv)
+	if len(loaded.ServiceChecks.Checks) != 1 {
+		t.Fatalf("expected 1 check, got %d", len(loaded.ServiceChecks.Checks))
+	}
+	check := loaded.ServiceChecks.Checks[0]
+	if check.Enabled {
+		t.Errorf("expected legacy DNS-IP check to be auto-disabled on load, Enabled=true")
+	}
+	if strings.TrimSpace(check.Warning) == "" {
+		t.Errorf("expected non-empty Warning on auto-disabled legacy check, got %q", check.Warning)
+	}
+	// Stored config must remain untouched — we do NOT rewrite disk.
+	raw, err := srv.store.GetConfig(settingsConfigKey)
+	if err != nil {
+		t.Fatalf("load raw stored settings: %v", err)
+	}
+	if !strings.Contains(raw, `"enabled": true`) && !strings.Contains(raw, `"enabled":true`) {
+		t.Errorf("stored settings should not be silently mutated; got: %s", raw)
+	}
+}
+
+// TestSettingsLoad_Then_UpdateSucceeds_WithLegacyCheck — Phase 2 + save path:
+// after load-time soft-disable marks a legacy DNS-IP check with
+// Enabled=false, round-tripping that check back through PUT must NOT
+// re-trigger the validator (disabled checks can't run, so their
+// invalid target is harmless). This is the whole point of #169 —
+// unsticking the save path for upgraders.
+func TestSettingsLoad_Then_UpdateSucceeds_WithLegacyCheck(t *testing.T) {
+	srv := newSettingsTestServer()
+	seedRawSettings(t, srv, `{
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"service_checks": {
+			"checks": [
+				{"name": "legacy-dns", "type": "dns", "target": "1.1.1.1", "enabled": true}
+			]
+		}
+	}`)
+
+	loaded := getSettings(t, srv)
+
+	// Simulate the UI editing an unrelated setting while keeping the
+	// (auto-disabled) legacy check in the payload. Also add a fresh
+	// valid HTTP check — this is the scenario from the issue.
+	loaded.ServiceChecks.Checks = append(loaded.ServiceChecks.Checks, internal.ServiceCheckConfig{
+		Name:    "new-http",
+		Type:    "http",
+		Target:  "https://example.com",
+		Enabled: true,
+	})
+
+	rec := putSettings(t, srv, loaded)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 — save must succeed with legacy disabled check + fresh valid check; got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Reload and assert both checks persist.
+	after := getSettings(t, srv)
+	if len(after.ServiceChecks.Checks) != 2 {
+		t.Fatalf("expected 2 checks after save, got %d", len(after.ServiceChecks.Checks))
+	}
+	names := map[string]bool{}
+	var legacy *internal.ServiceCheckConfig
+	for i := range after.ServiceChecks.Checks {
+		c := &after.ServiceChecks.Checks[i]
+		names[c.Name] = true
+		if c.Name == "legacy-dns" {
+			legacy = c
+		}
+	}
+	if !names["legacy-dns"] || !names["new-http"] {
+		t.Fatalf("expected both checks persisted, got %v", names)
+	}
+	if legacy == nil {
+		t.Fatal("legacy check not found")
+	}
+	if legacy.Enabled {
+		t.Errorf("legacy check should remain disabled after save, got Enabled=true")
+	}
+}
+
+// TestSettingsLoad_ValidDNSCheck_NotTouched — a DNS check with a
+// hostname target is valid under the current schema and must pass
+// through load+save untouched (no warning, enabled preserved). This
+// guards against the Phase 2 migration over-reaching.
+func TestSettingsLoad_ValidDNSCheck_NotTouched(t *testing.T) {
+	srv := newSettingsTestServer()
+	seedRawSettings(t, srv, `{
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"service_checks": {
+			"checks": [
+				{"name": "good-dns", "type": "dns", "target": "google.com", "enabled": true}
+			]
+		}
+	}`)
+
+	loaded := getSettings(t, srv)
+	if len(loaded.ServiceChecks.Checks) != 1 {
+		t.Fatalf("expected 1 check, got %d", len(loaded.ServiceChecks.Checks))
+	}
+	c := loaded.ServiceChecks.Checks[0]
+	if !c.Enabled {
+		t.Errorf("valid DNS hostname check must stay enabled on load, got Enabled=false")
+	}
+	if strings.TrimSpace(c.Warning) != "" {
+		t.Errorf("valid DNS hostname check must have empty Warning, got %q", c.Warning)
+	}
+
+	// Resave — also must round-trip cleanly.
+	rec := putSettings(t, srv, loaded)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("resave failed: %d %s", rec.Code, rec.Body.String())
+	}
+	after := getSettings(t, srv)
+	if !after.ServiceChecks.Checks[0].Enabled {
+		t.Errorf("valid DNS check flipped disabled on resave")
+	}
+	if strings.TrimSpace(after.ServiceChecks.Checks[0].Warning) != "" {
+		t.Errorf("valid DNS check acquired Warning on resave: %q", after.ServiceChecks.Checks[0].Warning)
+	}
+}
+
+// TestSettingsLoad_LegacyCheck_FixingTargetRestoresCheck — when the
+// user edits the auto-disabled legacy check to use a hostname target
+// and clears the Warning field (as a UI would when the user applies
+// the "fix"), the check validates normally on save. Enabled stays
+// false until the user explicitly re-enables — we never silently flip
+// a user-disabled check back on.
+func TestSettingsLoad_LegacyCheck_FixingTargetRestoresCheck(t *testing.T) {
+	srv := newSettingsTestServer()
+	seedRawSettings(t, srv, `{
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"service_checks": {
+			"checks": [
+				{"name": "legacy-dns", "type": "dns", "target": "1.1.1.1", "enabled": true}
+			]
+		}
+	}`)
+
+	loaded := getSettings(t, srv)
+	// UI-equivalent edit: target fixed, warning cleared, enabled left
+	// at false (user must opt back in explicitly).
+	loaded.ServiceChecks.Checks[0].Target = "google.com"
+	loaded.ServiceChecks.Checks[0].Warning = ""
+
+	rec := putSettings(t, srv, loaded)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 after target fix, got %d: %s", rec.Code, rec.Body.String())
+	}
+	after := getSettings(t, srv)
+	if len(after.ServiceChecks.Checks) != 1 {
+		t.Fatalf("expected 1 check, got %d", len(after.ServiceChecks.Checks))
+	}
+	c := after.ServiceChecks.Checks[0]
+	if c.Enabled {
+		t.Errorf("fixed check must stay disabled until user re-enables, got Enabled=true")
+	}
+	if strings.TrimSpace(c.Warning) != "" {
+		t.Errorf("fixed check must not re-acquire warning, got %q", c.Warning)
+	}
+	if c.Target != "google.com" {
+		t.Errorf("target not persisted: got %q", c.Target)
+	}
+}
+
+// TestHandleUpdateSettings_FreshDNSIPCheck_StillRejected — do NOT regress #159:
+// a freshly submitted DNS check with an IP target (enabled=true) must
+// still be rejected with 400. Only pre-existing checks that arrived
+// via the load-time migration path (enabled=false) are grandfathered.
+func TestHandleUpdateSettings_FreshDNSIPCheck_StillRejected(t *testing.T) {
+	srv := newSettingsTestServer()
+	rec := putSettings(t, srv, map[string]any{
+		"scan_interval": "30m",
+		"theme":         "midnight",
+		"service_checks": map[string]any{
+			"checks": []map[string]any{
+				{"name": "brand-new", "type": "dns", "target": "1.1.1.1", "enabled": true},
+			},
+		},
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("fresh DNS-IP check must still be rejected (issue #159); got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(strings.ToLower(rec.Body.String()), "hostname") {
+		t.Errorf("expected hostname guidance in error, got: %s", rec.Body.String())
+	}
+}

--- a/internal/api/settings_service_check_test_button_test.go
+++ b/internal/api/settings_service_check_test_button_test.go
@@ -186,6 +186,50 @@ func TestSettingsHTML_IntervalSelect_OptionsMatchAnyAutoDefault(t *testing.T) {
 	}
 }
 
+// TestSettingsHTML_TestServiceCheckRendersDetails verifies that
+// testServiceCheck (or a helper it invokes) renders the rich per-type
+// Details map returned by the /service-checks/test endpoint (issue #154)
+// — at a minimum, HTTP status_code, DNS records, TCP resolved_address,
+// and ping rtt_ms must appear in the human-readable output. A regression
+// here silently drops the new diagnostic fields even though the backend
+// returns them.
+func TestSettingsHTML_TestServiceCheckRendersDetails(t *testing.T) {
+	html := loadSettingsHTML(t)
+
+	// testServiceCheck itself must read the details payload. We scan a
+	// generous window from the function declaration so the test tolerates
+	// details rendering being factored into a helper above or below.
+	testRe := regexp.MustCompile(`function\s+testServiceCheck\s*\(\s*\)\s*\{`)
+	testLoc := testRe.FindStringIndex(html)
+	if testLoc == nil {
+		t.Fatal("testServiceCheck() function not found")
+	}
+	testEnd := testLoc[1] + 4000
+	if testEnd > len(html) {
+		testEnd = len(html)
+	}
+	testBody := html[testLoc[0]:testEnd]
+	if !regexp.MustCompile(`result\s*\.\s*details|\bdetails\b`).MatchString(testBody) {
+		t.Fatalf("testServiceCheck should read result.details to render per-type diagnostics; body window:\n%s", testBody)
+	}
+
+	// Per-type renderer keys MUST be present somewhere in the template —
+	// the whole value of issue #154 is that users can distinguish 404
+	// from connection-refused, DNS failures from connect failures, etc.
+	mustSurface := []string{"status_code", "records", "resolved_address", "rtt_ms"}
+	for _, key := range mustSurface {
+		if !strings.Contains(html, key) {
+			t.Errorf("settings.html missing detail renderer key %q — test button won't display this field", key)
+		}
+	}
+
+	// A dedicated per-type renderer is clearer than a flat dump. Expect
+	// explicit branching on check type somewhere in the page.
+	if !regexp.MustCompile(`type\s*===?\s*["']http["']|type\s*===?\s*["']dns["']`).MatchString(html) {
+		t.Error("settings.html should branch on check type for per-type rendering (expected type===\"http\" or type===\"dns\")")
+	}
+}
+
 // TestHandleTestServiceCheck_DisablesWriteDeadline verifies that the handler
 // code invokes http.NewResponseController(w).SetWriteDeadline(time.Time{}) so
 // that speed tests can run longer than the 30s baseline http.Server.WriteTimeout

--- a/internal/api/styles.go
+++ b/internal/api/styles.go
@@ -301,10 +301,12 @@ body.theme-clean .badge-generic { background:rgba(0,0,0,0.06) }
   padding:10px 18px; border-radius:var(--radius);
   font-size:13px; font-weight:500; color:#fff;
   animation:toast-in 0.25s ease; pointer-events:none;
+  max-width:420px; white-space:pre-wrap;
 }
 .toast-success { background:var(--green) }
 .toast-error   { background:var(--red) }
 .toast-info    { background:var(--accent) }
+.toast-warning { background:var(--orange, #f59e0b) }
 @keyframes toast-in { from{opacity:0;transform:translateY(-8px)} to{opacity:1;transform:translateY(0)} }
 @keyframes toast-out { from{opacity:1} to{opacity:0;transform:translateY(-8px)} }
 

--- a/internal/api/templates/disk_detail.html
+++ b/internal/api/templates/disk_detail.html
@@ -171,18 +171,43 @@ fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d
     return;
   }
 
+  /* ── Time-window for history charts (issue #166) ──────────────
+     Default to 1D (24h) so first-paint charts are legible regardless
+     of how much SMART history has accumulated. User can widen via
+     the selector buttons rendered above the Temperature History chart.
+  */
+  var diskHistoryHours = 24;
+
   /* ── Fetch disk data ──────────────────────────────────────────── */
-  fetch("/api/v1/disks/" + encodeURIComponent(serial))
-    .then(function(resp) {
-      if (!resp.ok) throw new Error("HTTP " + resp.status);
-      return resp.json();
-    })
+  function fetchAndRender(hours) {
+    return fetch("/api/v1/disks/" + encodeURIComponent(serial) + "?hours=" + hours)
+      .then(function(resp) {
+        if (!resp.ok) throw new Error("HTTP " + resp.status);
+        return resp.json();
+      });
+  }
+
+  fetchAndRender(diskHistoryHours)
     .then(function(data) {
       renderPage(data);
     })
     .catch(function(err) {
       showError("Failed to load disk data: " + err.message);
     });
+
+  /* ── Range selector handler ────────────────────────────────────
+     Re-fetch with a new window, re-render the full page so the
+     range selector itself updates its active-button styling and
+     the charts regenerate off the new history array. The legacy
+     (no-?hours=) code path is preserved server-side for external
+     callers — see issue #166 for the backward-compat contract.
+  */
+  window._loadDiskHistoryRange = function(hours) {
+    diskHistoryHours = hours;
+    fetchAndRender(hours)
+      .then(function(data) { renderPage(data); })
+      .catch(function(err) { showError("Failed to load disk data: " + err.message); });
+  };
 
   /* ── Error state ──────────────────────────────────────────────── */
   function showError(msg) {
@@ -422,7 +447,19 @@ fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d
     html += "</tbody></table></div>";
 
     /* ── Temperature History Chart ─────────────────────────────── */
-    html += "<div class=\"section-heading\">Temperature History</div>";
+    /* Range selector row: heading on the left, 1D/1W/1M/1Y pills on
+       the right. Drives both the Temperature History and the SMART
+       Trends charts below it — single fetch, single state, per #166. */
+    html += "<div style=\"display:flex;align-items:center;justify-content:space-between;margin-top:calc(var(--sp)*5);margin-bottom:calc(var(--sp)*2)\">";
+    html += "<div class=\"section-heading\" style=\"margin-top:0;margin-bottom:0\">Temperature History</div>";
+    html += "<div style=\"display:flex;gap:4px\">";
+    var diskRanges = [{h:24,l:"1D"},{h:168,l:"1W"},{h:720,l:"1M"},{h:8760,l:"1Y"}];
+    for (var dri = 0; dri < diskRanges.length; dri++) {
+      var drng = diskRanges[dri];
+      var dactive = diskHistoryHours === drng.h;
+      html += "<button onclick=\"window._loadDiskHistoryRange(" + drng.h + ")\" style=\"font-size:11px;padding:3px 10px;border-radius:4px;border:1px solid var(--border);background:" + (dactive ? "var(--bg-elevated)" : "transparent") + ";color:" + (dactive ? "var(--text-secondary)" : "var(--text-tertiary)") + ";cursor:pointer;font-weight:" + (dactive ? "600" : "500") + "\">" + drng.l + "</button>";
+    }
+    html += "</div></div>";
     if (history.length > 1) {
       html += "<div class=\"chart-card\">";
       html += "<div class=\"chart-wrap\"><canvas id=\"chartTemp\" height=\"220\"></canvas></div>";

--- a/internal/api/templates/service_checks.html
+++ b/internal/api/templates/service_checks.html
@@ -169,6 +169,71 @@
 
   function esc(s){var d=document.createElement("div");d.textContent=s||"";return d.innerHTML;}
   function fetchJSON(url){return fetch(url).then(function(r){if(!r.ok)throw new Error(r.status);return r.json()});}
+
+  // renderServiceCheckDetails turns the per-type Details map (persisted
+  // in service_checks_history.details_json, surfaced by the API as
+  // entry.details) into a set of <div class="log-detail-item"> cells
+  // that drop into the existing log-detail-grid. Same contract as the
+  // settings.html Test-button helper from #154, so a future refactor
+  // can promote this to a shared file. See issue #182.
+  //
+  // Only the keys actually set by the scheduler runners are rendered —
+  // unknown keys are silently ignored so a forward-compat server (adds
+  // a new detail key in a future release) doesn't cause blank cells
+  // here. Numeric keys tolerate int OR float (JSON round-tripping the
+  // map through SQLite turns Go ints into JS numbers but keeps the
+  // exact value).
+  function renderServiceCheckDetails(type, details, entry) {
+    if (!details || typeof details !== "object") return "";
+    var t = (type || "").toLowerCase();
+    var out = "";
+    function cell(label, val, extraStyle) {
+      var s = extraStyle ? ' style="'+extraStyle+'"' : "";
+      return '<div class="log-detail-item"'+s+'><div class="ld-label">'+esc(label)+'</div><div class="ld-val">'+val+'</div></div>';
+    }
+    if (t === "http") {
+      if (typeof details.status_code === "number") {
+        // Colour the code so 2xx pops green, 4xx/5xx red — mirrors the
+        // Test button toast.
+        var codeColor = details.status_code >= 200 && details.status_code < 400 ? "var(--green)"
+                      : details.status_code >= 400 ? "var(--red)" : "var(--text)";
+        out += cell("HTTP Status", '<span style="color:'+codeColor+'">'+details.status_code+'</span>');
+      }
+      if (details.content_type) out += cell("Content-Type", esc(details.content_type));
+      if (typeof details.body_bytes === "number") out += cell("Body Size", details.body_bytes + " bytes");
+      // final_url is only interesting when it differs from the request
+      // (i.e. a redirect happened). Otherwise it's redundant with Target.
+      if (details.final_url && details.final_url !== details.request_url && details.final_url !== (entry && entry.target)) {
+        out += cell("Final URL", '<span style="font-size:11px;font-family:var(--font-mono);word-break:break-all">'+esc(details.final_url)+'</span>', "grid-column:1/-1");
+      }
+    } else if (t === "tcp" || t === "smb" || t === "nfs") {
+      if (details.resolved_address) out += cell("Resolved Address", '<span style="font-family:var(--font-mono)">'+esc(details.resolved_address)+'</span>');
+    } else if (t === "dns") {
+      if (details.query_host) out += cell("Query Host", '<span style="font-family:var(--font-mono)">'+esc(details.query_host)+'</span>');
+      if (details.dns_server) out += cell("DNS Server", '<span style="font-family:var(--font-mono)">'+esc(details.dns_server)+'</span>');
+      if (Array.isArray(details.records) && details.records.length) {
+        // Records listed comma-separated; the grid cell wraps on commas
+        // naturally. Span the row on many records so readability wins
+        // over grid symmetry.
+        var recVal = details.records.map(function(r){return esc(String(r));}).join(", ");
+        var span = details.records.length > 2 ? ' style="grid-column:1/-1"' : "";
+        out += '<div class="log-detail-item"'+span+'><div class="ld-label">Resolved Records</div><div class="ld-val" style="font-family:var(--font-mono);font-size:11px">'+recVal+'</div></div>';
+      }
+    } else if (t === "ping") {
+      if (details.query_host) out += cell("Host", '<span style="font-family:var(--font-mono)">'+esc(details.query_host)+'</span>');
+      if (typeof details.rtt_ms === "number") out += cell("RTT", details.rtt_ms.toFixed(2) + " ms");
+      if (typeof details.packet_loss_pct === "number") {
+        var lossColor = details.packet_loss_pct > 0 ? "var(--red)" : "var(--text)";
+        out += cell("Packet Loss", '<span style="color:'+lossColor+'">'+details.packet_loss_pct+'%</span>');
+      }
+    }
+    // failure_stage is shared across types; only meaningful on non-up
+    // results so we skip on "up" to keep the happy-path grid tight.
+    if (details.failure_stage && entry && entry.status !== "up") {
+      out += cell("Failure Stage", '<span style="color:var(--red)">'+esc(details.failure_stage)+'</span>');
+    }
+    return out;
+  }
   function pillClass(t){t=(t||"").toLowerCase();if(t==="http")return"pill-http";if(t==="tcp")return"pill-tcp";if(t==="dns")return"pill-dns";if(t==="ping")return"pill-ping";if(t==="smb"||t==="nfs")return"pill-smb";if(t==="speed")return"pill-speed";return"pill-http";}
   function fmtInterval(sec){if(sec<60)return sec+"s";if(sec<3600)return Math.floor(sec/60)+"m";return Math.floor(sec/3600)+"h";}
   function faviconHTML(type,target){
@@ -301,16 +366,13 @@
       h+='<div class="log-detail-item"><div class="ld-label">Consecutive Failures</div><div class="ld-val">'+(e.consecutive_failures||0)+' / '+(e.failure_threshold||1)+'</div></div>';
       h+='<div class="log-detail-item"><div class="ld-label">Check Key</div><div class="ld-val" style="font-size:10px;font-family:var(--font-mono);word-break:break-all;color:var(--text3)">'+esc(e.key||"—")+'</div></div>';
       if(e.error)h+='<div class="log-detail-item" style="grid-column:1/-1"><div class="ld-label">Error</div><div class="ld-val" style="font-size:12px;color:var(--red);font-weight:400;word-break:break-all">'+esc(e.error)+'</div></div>';
-      // Type-specific details
-      if((e.type||"").toLowerCase()==="http"){
-        h+='<div class="log-detail-item"><div class="ld-label">Expected Status</div><div class="ld-val">'+(e.expected_status_min||200)+' – '+(e.expected_status_max||399)+'</div></div>';
-      }
-      if((e.type||"").toLowerCase()==="dns"){
-        h+='<div class="log-detail-item"><div class="ld-label">DNS Lookup</div><div class="ld-val">'+esc(e.target||"")+'</div></div>';
-      }
-      if((e.type||"").toLowerCase()==="ping"){
-        h+='<div class="log-detail-item"><div class="ld-label">RTT</div><div class="ld-val">'+(e.response_ms||0)+' ms</div></div>';
-      }
+      // Per-type diagnostic details (HTTP status code, DNS records,
+      // Ping RTT/loss, TCP resolved address, failure_stage) from the
+      // Details map the scheduler now persists — same rich context
+      // the Test button already shows. Issue #182.
+      h+=renderServiceCheckDetails(e.type, e.details, e);
+      // Speed-type fields are top-level on the result (not in Details),
+      // so keep the dedicated block here.
       if((e.type||"").toLowerCase()==="speed"){
         h+='<div class="log-detail-item"><div class="ld-label">Download</div><div class="ld-val">'+(e.download_mbps?e.download_mbps.toFixed(1)+' Mbps':'—')+'</div></div>';
         h+='<div class="log-detail-item"><div class="ld-label">Upload</div><div class="ld-val">'+(e.upload_mbps?e.upload_mbps.toFixed(1)+' Mbps':'—')+'</div></div>';

--- a/internal/api/templates/service_checks.html
+++ b/internal/api/templates/service_checks.html
@@ -42,7 +42,15 @@
 .log-panel{background:var(--surface);border:1px solid var(--border);border-radius:12px;overflow:hidden}
 .log-table{width:100%;font-size:12px;border-collapse:collapse}
 .log-table th{text-align:left;padding:8px 12px;color:var(--text3);font-size:10px;text-transform:uppercase;letter-spacing:0.5px;border-bottom:1px solid var(--border);background:var(--surface);position:sticky;top:0}
-.log-table td{padding:6px 12px;border-bottom:1px solid var(--border)}
+/* white-space:normal (unsets nowrap from shared styles.go), word-break,
+   and overflow-wrap together let long tokens in any cell break at
+   character boundaries instead of pushing the column — and transitively
+   the table — wider than the surrounding panel. Without this, a long
+   unbreakable Check Name stretches the table past the panel, and the
+   colspan=6 detail row inherits that width, pushing the expanded grid
+   past the card edge (#176). Cells with intentional ellipsis (e.g. the
+   error column) still opt out via inline `white-space:nowrap`. */
+.log-table td{padding:6px 12px;border-bottom:1px solid var(--border);white-space:normal;word-break:break-word;overflow-wrap:anywhere}
 .log-table .status-up{color:var(--green);font-weight:600}
 .log-table .status-down{color:var(--red);font-weight:600}
 .log-table .status-degraded{color:var(--amber);font-weight:600}
@@ -61,9 +69,17 @@
 .log-detail{padding:12px 16px;background:var(--bg-elevated);font-size:12px;display:none}
 .log-detail.open{display:block}
 .log-detail-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:8px}
-.log-detail-item{padding:6px 8px;background:var(--surface);border-radius:var(--radius);border:1px solid var(--border)}
+/* min-width:0 lets this grid track shrink below the intrinsic width
+   of long unbreakable content (URLs, check keys). Without it the track
+   refuses to collapse and the whole grid blows past the parent card's
+   right edge — see #176. */
+.log-detail-item{padding:6px 8px;background:var(--surface);border-radius:var(--radius);border:1px solid var(--border);min-width:0}
 .log-detail-item .ld-label{font-size:10px;color:var(--text3);text-transform:uppercase;letter-spacing:0.3px}
-.log-detail-item .ld-val{font-size:13px;font-weight:600;margin-top:2px}
+/* overflow-wrap:anywhere + word-break:break-word together force wrapping
+   at any character boundary for tokens without whitespace. Both are set
+   because older engines honor word-break and modern engines prefer
+   overflow-wrap; keeping both is the broadest-compat pattern. */
+.log-detail-item .ld-val{font-size:13px;font-weight:600;margin-top:2px;overflow-wrap:anywhere;word-break:break-word}
 /* Orphan badge */
 .orphan-badge{font-size:9px;padding:1px 6px;border-radius:999px;background:rgba(217,119,6,0.12);color:var(--amber);margin-left:6px}
 .btn-delete-check{font-size:10px;padding:2px 8px;border:1px solid var(--border);border-radius:var(--radius);background:var(--surface);color:var(--red);cursor:pointer;margin-left:auto}

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -907,10 +907,14 @@ function showToast(msg, type) {
   t.className = "toast toast-" + (type || "info");
   t.textContent = msg;
   c.appendChild(t);
+  // Multi-line toasts (Test-button diagnostics) need more read time.
+  // Rough heuristic: 3s + ~1.2s per extra line, capped at 10s.
+  var lines = String(msg).split("\n").length;
+  var hold = Math.min(3000 + Math.max(0, lines - 1) * 1200, 10000);
   setTimeout(function() {
     t.style.animation = "toast-out 0.25s ease forwards";
     setTimeout(function() { t.remove(); }, 260);
-  }, 3000);
+  }, hold);
 }
 
 /* ---------- Theme selection ---------- */
@@ -1818,11 +1822,52 @@ function saveServiceCheck() {
   saveSettings();
 }
 
+// renderServiceCheckDetails turns the per-type Details map returned by
+// POST /api/v1/service-checks/test into a human-readable multi-line
+// summary. Each check type has its own renderer so we highlight the
+// fields that matter most for diagnosing THAT type's failures (HTTP
+// status code vs DNS records vs ping loss). See issue #154.
+function renderServiceCheckDetails(type, details, result) {
+  if (!details || typeof details !== "object") return "";
+  var lines = [];
+  if (type === "http") {
+    if (typeof details.status_code === "number") lines.push("HTTP " + details.status_code);
+    if (details.content_type) lines.push("Content-Type: " + details.content_type);
+    if (typeof details.body_bytes === "number") lines.push("Body: " + details.body_bytes + " bytes");
+    if (details.final_url && details.final_url !== details.request_url) {
+      lines.push("Final URL: " + details.final_url);
+    }
+    if (details.failure_stage) lines.push("Failed at: " + details.failure_stage);
+  } else if (type === "tcp" || type === "smb" || type === "nfs") {
+    if (details.resolved_address) lines.push("Connected to: " + details.resolved_address);
+    if (details.failure_stage) lines.push("Failed at: " + details.failure_stage);
+  } else if (type === "dns") {
+    if (details.query_host) lines.push("Queried: " + details.query_host);
+    if (details.dns_server) lines.push("Server: " + details.dns_server);
+    if (details.records && details.records.length) {
+      lines.push("Records: " + details.records.join(", "));
+    }
+    if (details.failure_stage) lines.push("Failed at: " + details.failure_stage);
+  } else if (type === "ping") {
+    if (details.query_host) lines.push("Host: " + details.query_host);
+    if (typeof details.rtt_ms === "number") lines.push("RTT: " + details.rtt_ms.toFixed(2) + " ms");
+    if (typeof details.packet_loss_pct === "number") lines.push("Loss: " + details.packet_loss_pct + "%");
+    if (details.failure_stage) lines.push("Failed at: " + details.failure_stage);
+  } else if (type === "speed") {
+    if (typeof result.download_mbps === "number") lines.push("Download: " + result.download_mbps.toFixed(0) + " Mbps");
+    if (typeof result.upload_mbps === "number") lines.push("Upload: " + result.upload_mbps.toFixed(0) + " Mbps");
+    if (typeof result.latency_ms === "number") lines.push("Latency: " + result.latency_ms.toFixed(1) + " ms");
+  }
+  return lines.join("\n");
+}
+
 // testServiceCheck runs the current form's configuration through the
 // /api/v1/service-checks/test endpoint without persisting the result. It
-// surfaces status, response time, and error messages via toast. Speed-type
-// checks can take up to 60s on real hardware (Ookla CLI), so we warn the
-// user up-front and disable the button for the duration of the request.
+// surfaces status, response time, error messages, and the per-type
+// Details map (HTTP status code, resolved IPs, DNS records, ping RTT,
+// etc.) via toast. Speed-type checks can take up to 60s on real hardware
+// (Ookla CLI), so we warn the user up-front and disable the button for
+// the duration of the request. See issue #154.
 function testServiceCheck() {
   var sc = readServiceCheckForm();
   if (!sc) return;
@@ -1853,24 +1898,29 @@ function testServiceCheck() {
       var result = res.data || {};
       var status = result.status || "unknown";
       var ms = result.response_ms;
-      var msg;
+      var headline;
       var toastKind = "info";
       if (status === "up") {
-        msg = "✓ Check is UP" + (typeof ms === "number" ? " (" + ms + " ms)" : "");
+        headline = "✓ Check is UP" + (typeof ms === "number" ? " (" + ms + " ms)" : "");
         toastKind = "success";
       } else if (status === "degraded") {
-        msg = "△ Degraded";
+        headline = "△ Degraded";
         toastKind = "warning";
       } else {
-        msg = "✗ Check is DOWN";
+        headline = "✗ Check is DOWN";
         toastKind = "error";
       }
-      if (sc.type === "speed" && (typeof result.download_mbps === "number" || typeof result.upload_mbps === "number")) {
-        msg += " — " + (result.download_mbps || 0).toFixed(0) + " ↓ / " +
-               (result.upload_mbps || 0).toFixed(0) + " ↑ Mbps";
+
+      // Per-type details + optional error message. Build a multi-line
+      // toast so users can see WHY a check failed (404? connection
+      // refused? NXDOMAIN?) rather than just THAT it failed.
+      var msg = headline;
+      var detailsText = renderServiceCheckDetails(sc.type, result.details, result);
+      if (detailsText) {
+        msg += "\n" + detailsText;
       }
       if (result.error) {
-        msg += " — " + result.error;
+        msg += "\n" + result.error;
       }
       showToast(msg, toastKind);
     })

--- a/internal/models.go
+++ b/internal/models.go
@@ -247,6 +247,13 @@ type ServiceCheckResult struct {
 	LatencyMs    float64 `json:"latency_ms,omitempty"`
 	DownloadOK   *bool   `json:"download_ok,omitempty"` // nil for non-speed checks
 	UploadOK     *bool   `json:"upload_ok,omitempty"`
+
+	// Details carries per-check-type diagnostic context surfaced by the
+	// ad-hoc Test-button flow (HTTP status code, resolved IPs, DNS records,
+	// ping RTT, failure stage, etc.). It is intentionally NOT populated on
+	// the scheduled-check path — see ServiceChecker.SetCollectDetails —
+	// so every 30s run stays lean and history rows don't bloat. See #154.
+	Details map[string]any `json:"details,omitempty"`
 }
 
 // ---------- System ----------

--- a/internal/models.go
+++ b/internal/models.go
@@ -226,6 +226,15 @@ type ServiceCheckConfig struct {
 	// "1.1.1.1", "8.8.8.8:53", "192.168.1.1:1053"). Empty means use the
 	// system resolver. Port defaults to 53 when unspecified.
 	DNSServer string `json:"dns_server,omitempty"`
+
+	// Warning is a transient, load-time-populated message shown when the
+	// stored check configuration is invalid under the current schema but
+	// was valid under a previous version (e.g. issue #169 — a DNS check
+	// with an IP target saved under v0.9.2 is invalid under v0.9.3+).
+	// The load path sets Enabled=false and populates this so the UI can
+	// surface the issue; it is NOT persisted back to the store
+	// automatically — user must acknowledge and resave.
+	Warning string `json:"warning,omitempty"`
 }
 
 type ServiceCheckResult struct {

--- a/internal/models.go
+++ b/internal/models.go
@@ -257,11 +257,13 @@ type ServiceCheckResult struct {
 	DownloadOK   *bool   `json:"download_ok,omitempty"` // nil for non-speed checks
 	UploadOK     *bool   `json:"upload_ok,omitempty"`
 
-	// Details carries per-check-type diagnostic context surfaced by the
-	// ad-hoc Test-button flow (HTTP status code, resolved IPs, DNS records,
-	// ping RTT, failure stage, etc.). It is intentionally NOT populated on
-	// the scheduled-check path — see ServiceChecker.SetCollectDetails —
-	// so every 30s run stays lean and history rows don't bloat. See #154.
+	// Details carries per-check-type diagnostic context (HTTP status code,
+	// resolved IPs, DNS records, ping RTT, failure stage, etc.). Populated
+	// when the parent ServiceChecker has SetCollectDetails(true) — both
+	// the ad-hoc Test-button flow (#154) and the scheduled path (#182,
+	// since v0.9.4) opt in. The scheduled path persists this map in the
+	// service_checks_history.details_json column so the log UI can render
+	// the same rich context the Test button already shows.
 	Details map[string]any `json:"details,omitempty"`
 }
 

--- a/internal/scheduler/checks.go
+++ b/internal/scheduler/checks.go
@@ -44,9 +44,10 @@ type ServiceChecker struct {
 	speedTestRunFn SpeedTestRunner // nil → speed checks return "no tool"
 	// collectDetails, when true, enriches RunCheck results with the
 	// per-check-type Details map (HTTP status code, resolved IPs, DNS
-	// records, etc.). The scheduled-check path (RunDueChecks) explicitly
-	// strips Details regardless of this flag — only the ad-hoc Test-button
-	// endpoint opts into this richer output. See issue #154.
+	// records, etc.). Both the ad-hoc Test-button endpoint (#154) and
+	// the scheduled path (#182, since v0.9.4) set this to true. The
+	// /service-checks log UI reads the persisted blob via
+	// service_checks_history.details_json.
 	collectDetails bool
 }
 
@@ -66,11 +67,14 @@ func (sc *ServiceChecker) SetSpeedTestRunner(fn SpeedTestRunner) {
 	sc.speedTestRunFn = fn
 }
 
-// SetCollectDetails toggles the opt-in rich-details output. Call with true
-// from the ad-hoc /service-checks/test endpoint to get diagnostic context
-// (HTTP status code, resolved IPs, DNS records, etc.) alongside the usual
-// status/response_ms/error triple. The scheduled-check path never emits
-// details — see RunDueChecks. Issue #154.
+// SetCollectDetails toggles rich-details output. When true, RunCheck
+// populates the per-type Details map (HTTP status code, resolved IPs,
+// DNS records, failure stage, etc.) alongside the usual
+// status/response_ms/error triple. Both the scheduler (issue #182) and
+// the ad-hoc /service-checks/test endpoint (issue #154) call this with
+// true; the scheduled path additionally persists the map into
+// service_checks_history.details_json so the /service-checks log UI
+// can render the rich context on expanded log rows.
 func (sc *ServiceChecker) SetCollectDetails(enabled bool) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
@@ -108,11 +112,13 @@ func (sc *ServiceChecker) RunDueChecks(checks []internal.ServiceCheckConfig, now
 	results := make([]internal.ServiceCheckResult, 0, len(due))
 	for _, check := range due {
 		result := sc.RunCheck(check, now)
-		// Scheduled path never emits Details — those are only for the
-		// ad-hoc Test-button flow. Strip them defensively in case the
-		// checker was flipped into collect-details mode elsewhere. See
-		// #154 (keeps history rows lean and JSON payloads small).
-		result.Details = nil
+		// Relaxation of the #154 invariant: the scheduled path now
+		// carries the per-type Details map through to the store so
+		// the /service-checks log UI can show HTTP status codes, DNS
+		// records, resolved addresses, etc. in expanded log rows.
+		// See issue #182. The map is only populated when the parent
+		// ServiceChecker has SetCollectDetails(true) — otherwise
+		// RunCheck returns Details == nil and this loop is a no-op.
 
 		// Track consecutive failures from store history.
 		state, ok, err := sc.store.GetLatestServiceCheckState(result.Key)

--- a/internal/scheduler/checks.go
+++ b/internal/scheduler/checks.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -41,6 +42,12 @@ type ServiceChecker struct {
 	lastRun        map[string]time.Time
 	mu             sync.Mutex
 	speedTestRunFn SpeedTestRunner // nil → speed checks return "no tool"
+	// collectDetails, when true, enriches RunCheck results with the
+	// per-check-type Details map (HTTP status code, resolved IPs, DNS
+	// records, etc.). The scheduled-check path (RunDueChecks) explicitly
+	// strips Details regardless of this flag — only the ad-hoc Test-button
+	// endpoint opts into this richer output. See issue #154.
+	collectDetails bool
 }
 
 // NewServiceChecker creates a ready-to-use ServiceChecker.
@@ -57,6 +64,17 @@ func (sc *ServiceChecker) SetSpeedTestRunner(fn SpeedTestRunner) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 	sc.speedTestRunFn = fn
+}
+
+// SetCollectDetails toggles the opt-in rich-details output. Call with true
+// from the ad-hoc /service-checks/test endpoint to get diagnostic context
+// (HTTP status code, resolved IPs, DNS records, etc.) alongside the usual
+// status/response_ms/error triple. The scheduled-check path never emits
+// details — see RunDueChecks. Issue #154.
+func (sc *ServiceChecker) SetCollectDetails(enabled bool) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.collectDetails = enabled
 }
 
 // RunDueChecks evaluates which checks are due based on their intervals,
@@ -90,6 +108,11 @@ func (sc *ServiceChecker) RunDueChecks(checks []internal.ServiceCheckConfig, now
 	results := make([]internal.ServiceCheckResult, 0, len(due))
 	for _, check := range due {
 		result := sc.RunCheck(check, now)
+		// Scheduled path never emits Details — those are only for the
+		// ad-hoc Test-button flow. Strip them defensively in case the
+		// checker was flipped into collect-details mode elsewhere. See
+		// #154 (keeps history rows lean and JSON payloads small).
+		result.Details = nil
 
 		// Track consecutive failures from store history.
 		state, ok, err := sc.store.GetLatestServiceCheckState(result.Key)
@@ -148,6 +171,13 @@ func (sc *ServiceChecker) RunCheck(check internal.ServiceCheckConfig, now time.T
 		FailureSeverity:  severity,
 	}
 
+	sc.mu.Lock()
+	collect := sc.collectDetails
+	sc.mu.Unlock()
+	if collect {
+		result.Details = make(map[string]any, 4)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSec)*time.Second)
 	defer cancel()
 
@@ -165,6 +195,13 @@ func (sc *ServiceChecker) RunCheck(check internal.ServiceCheckConfig, now time.T
 		sc.runSpeedCheck(check, &result, start)
 	default:
 		result.Error = "unsupported service check type"
+	}
+
+	// If collection is off, ensure Details is nil (zero-length maps would
+	// still serialise as "details":{}). This guarantees backward-compat
+	// JSON output for the scheduled path.
+	if !collect {
+		result.Details = nil
 	}
 
 	if result.ResponseMS == 0 {
@@ -187,9 +224,15 @@ func (sc *ServiceChecker) RunCheck(check internal.ServiceCheckConfig, now time.T
 
 func (sc *ServiceChecker) runHTTPCheck(ctx context.Context, check internal.ServiceCheckConfig, result *internal.ServiceCheckResult, start time.Time, timeoutSec int) {
 	urlValue := NormalizeHTTPURL(check.Target)
+	if result.Details != nil {
+		result.Details["request_url"] = urlValue
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlValue, nil)
 	if err != nil {
 		result.Error = err.Error()
+		if result.Details != nil {
+			result.Details["failure_stage"] = "request_build"
+		}
 		return
 	}
 	req.Header.Set("User-Agent", "nas-doctor-service-check/1.0")
@@ -200,9 +243,29 @@ func (sc *ServiceChecker) runHTTPCheck(ctx context.Context, check internal.Servi
 	result.ResponseMS = time.Since(start).Milliseconds()
 	if err != nil {
 		result.Error = err.Error()
+		if result.Details != nil {
+			result.Details["failure_stage"] = classifyHTTPError(err)
+		}
 		return
 	}
-	_ = resp.Body.Close()
+	defer resp.Body.Close()
+
+	if result.Details != nil {
+		result.Details["status_code"] = resp.StatusCode
+		if ct := resp.Header.Get("Content-Type"); ct != "" {
+			result.Details["content_type"] = ct
+		}
+		if resp.Request != nil && resp.Request.URL != nil {
+			result.Details["final_url"] = resp.Request.URL.String()
+		} else {
+			result.Details["final_url"] = urlValue
+		}
+		// Read body (capped) so we can report size AND release the
+		// connection cleanly. Cap at 1 MiB to bound memory for users
+		// who accidentally test a file-server URL.
+		n, _ := io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+		result.Details["body_bytes"] = n
+	}
 
 	minStatus := check.ExpectedMin
 	maxStatus := check.ExpectedMax
@@ -217,13 +280,44 @@ func (sc *ServiceChecker) runHTTPCheck(ctx context.Context, check internal.Servi
 	}
 	if resp.StatusCode < minStatus || resp.StatusCode > maxStatus {
 		result.Error = fmt.Sprintf("unexpected HTTP status %d", resp.StatusCode)
+		if result.Details != nil {
+			result.Details["failure_stage"] = "http_status"
+		}
 		return
 	}
 	result.Status = "up"
 }
 
+// classifyHTTPError maps the common failure shapes to a short diagnostic
+// label the UI can render (e.g. "connection refused", "dns lookup failed",
+// "tls handshake failed", "timeout"). We look at both the error text and
+// the typed wrappers Go's net stack produces; best-effort, not exhaustive.
+func classifyHTTPError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "x509") || strings.Contains(msg, "tls"):
+		return "tls"
+	case strings.Contains(msg, "no such host") || strings.Contains(msg, "dns"):
+		return "dns"
+	case strings.Contains(msg, "connection refused"):
+		return "connection_refused"
+	case strings.Contains(msg, "timeout") || strings.Contains(msg, "deadline exceeded"):
+		return "timeout"
+	case strings.Contains(msg, "unreachable") || strings.Contains(msg, "no route"):
+		return "network_unreachable"
+	default:
+		return "connect"
+	}
+}
+
 func (sc *ServiceChecker) runDNSCheck(ctx context.Context, check internal.ServiceCheckConfig, result *internal.ServiceCheckResult, start time.Time) {
 	host := NormalizeDNSHost(check.Target)
+	if result.Details != nil {
+		result.Details["query_host"] = host
+	}
 	if host == "" {
 		result.Error = "empty DNS target"
 		return
@@ -236,15 +330,20 @@ func (sc *ServiceChecker) runDNSCheck(ctx context.Context, check internal.Servic
 	// See issue #159.
 	if net.ParseIP(host) != nil {
 		result.Error = "DNS checks need a hostname like google.com; to test IP reachability use a Ping or TCP check"
+		if result.Details != nil {
+			result.Details["failure_stage"] = "ip_target_rejected"
+		}
 		return
 	}
 
 	resolver := net.DefaultResolver
+	resolvedServer := "system"
 	if dnsServer := strings.TrimSpace(check.DNSServer); dnsServer != "" {
 		server := dnsServer
 		if _, _, err := net.SplitHostPort(server); err != nil {
 			server = net.JoinHostPort(server, "53")
 		}
+		resolvedServer = server
 		timeoutSec := check.TimeoutSec
 		if timeoutSec <= 0 {
 			timeoutSec = 5
@@ -257,30 +356,72 @@ func (sc *ServiceChecker) runDNSCheck(ctx context.Context, check internal.Servic
 			},
 		}
 	}
+	if result.Details != nil {
+		result.Details["dns_server"] = resolvedServer
+	}
 	addrs, err := resolver.LookupHost(ctx, host)
 	result.ResponseMS = time.Since(start).Milliseconds()
 	if err != nil {
 		result.Error = err.Error()
+		if result.Details != nil {
+			result.Details["failure_stage"] = classifyDNSError(err)
+		}
 		return
 	}
 	if len(addrs) == 0 {
 		result.Error = "no DNS records found"
+		if result.Details != nil {
+			result.Details["failure_stage"] = "empty_answer"
+		}
 		return
 	}
+	if result.Details != nil {
+		result.Details["records"] = addrs
+	}
 	result.Status = "up"
+}
+
+// classifyDNSError buckets the common lookup failures so the UI can
+// explain why a DNS check is down.
+func classifyDNSError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "no such host"):
+		return "nxdomain"
+	case strings.Contains(msg, "timeout") || strings.Contains(msg, "deadline exceeded"):
+		return "timeout"
+	case strings.Contains(msg, "refused"):
+		return "refused"
+	case strings.Contains(msg, "server misbehaving"):
+		return "servfail"
+	default:
+		return "resolver_error"
+	}
 }
 
 func (sc *ServiceChecker) runTCPCheck(ctx context.Context, check internal.ServiceCheckConfig, result *internal.ServiceCheckResult, start time.Time, timeoutSec int) {
 	addr, err := NormalizeTCPAddress(check)
 	if err != nil {
 		result.Error = err.Error()
+		if result.Details != nil {
+			result.Details["failure_stage"] = "address_parse"
+		}
 		return
+	}
+	if result.Details != nil {
+		result.Details["resolved_address"] = addr
 	}
 	dialer := net.Dialer{Timeout: time.Duration(timeoutSec) * time.Second}
 	conn, err := dialer.DialContext(ctx, "tcp", addr)
 	result.ResponseMS = time.Since(start).Milliseconds()
 	if err != nil {
 		result.Error = err.Error()
+		if result.Details != nil {
+			result.Details["failure_stage"] = classifyHTTPError(err) // reuse: same net.Error families
+		}
 		return
 	}
 	_ = conn.Close()
@@ -289,6 +430,9 @@ func (sc *ServiceChecker) runTCPCheck(ctx context.Context, check internal.Servic
 
 func (sc *ServiceChecker) runPingCheck(ctx context.Context, check internal.ServiceCheckConfig, result *internal.ServiceCheckResult, start time.Time, timeoutSec int) {
 	host := NormalizeDNSHost(check.Target)
+	if result.Details != nil {
+		result.Details["query_host"] = host
+	}
 	if host == "" {
 		result.Error = "empty ping target"
 		return
@@ -304,6 +448,9 @@ func (sc *ServiceChecker) runPingCheck(ctx context.Context, check internal.Servi
 	result.ResponseMS = time.Since(start).Milliseconds()
 	if err != nil {
 		result.Error = "host unreachable"
+		if result.Details != nil {
+			result.Details["failure_stage"] = "unreachable"
+		}
 		return
 	}
 	// Parse round-trip time from ping output if available.
@@ -313,10 +460,49 @@ func (sc *ServiceChecker) runPingCheck(ctx context.Context, check internal.Servi
 		if sp := strings.IndexAny(sub, " m\n"); sp > 0 {
 			if ms, parseErr := strconv.ParseFloat(sub[:sp], 64); parseErr == nil {
 				result.ResponseMS = int64(ms)
+				if result.Details != nil {
+					result.Details["rtt_ms"] = ms
+				}
 			}
 		}
 	}
+	// Best-effort loss parsing — ping prints e.g. "0% packet loss" on both
+	// Linux and Darwin. Not all ping implementations include a space before
+	// "packet loss"; we look for the "%" and walk backwards.
+	if result.Details != nil {
+		if pct := extractPacketLossPercent(outStr); pct >= 0 {
+			result.Details["packet_loss_pct"] = pct
+		}
+	}
 	result.Status = "up"
+}
+
+// extractPacketLossPercent parses "0% packet loss" / "0.0% packet loss" out
+// of ping stdout. Returns -1 when the token is absent so callers can skip
+// recording the key rather than lying about zero loss.
+func extractPacketLossPercent(out string) float64 {
+	idx := strings.Index(out, "% packet loss")
+	if idx <= 0 {
+		return -1
+	}
+	// Walk back until we hit a non-digit/non-dot character.
+	i := idx - 1
+	for i >= 0 {
+		c := out[i]
+		if (c >= '0' && c <= '9') || c == '.' {
+			i--
+			continue
+		}
+		break
+	}
+	num := out[i+1 : idx]
+	if num == "" {
+		return -1
+	}
+	if f, err := strconv.ParseFloat(num, 64); err == nil {
+		return f
+	}
+	return -1
 }
 
 func (sc *ServiceChecker) runSpeedCheck(check internal.ServiceCheckConfig, result *internal.ServiceCheckResult, start time.Time) {

--- a/internal/scheduler/checks_details_persist_test.go
+++ b/internal/scheduler/checks_details_persist_test.go
@@ -1,0 +1,79 @@
+package scheduler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// TestRunDueChecks_HTTP_PersistsStatusCode — issue #182. Once the scheduled
+// path stops stripping Details, a 404 from the target server must round-
+// trip into the persisted history row so the /service-checks log UI can
+// render HTTP 404 alongside the status=down line.
+//
+// This is the sibling of TestRunCheck_Details_HTTP_404_StillRecordsCode,
+// but asserted at the RunDueChecks level — i.e. end-to-end through the
+// store, which is what the log UI actually reads.
+func TestRunDueChecks_HTTP_PersistsStatusCode(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	sc, store := newTestChecker()
+	sc.SetCollectDetails(true) // mirrors the scheduler-owned checker setup in #182
+
+	checks := []internal.ServiceCheckConfig{{
+		Name:    "scheduled-404",
+		Type:    internal.ServiceCheckHTTP,
+		Target:  ts.URL,
+		Enabled: true,
+	}}
+	results := sc.RunDueChecks(checks, time.Now().UTC())
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != "down" {
+		t.Fatalf("expected down, got %q", results[0].Status)
+	}
+
+	entries, err := store.ListLatestServiceChecks(10)
+	if err != nil {
+		t.Fatalf("ListLatestServiceChecks: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 persisted entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.Details == nil {
+		t.Fatalf("expected Details persisted, got nil (scheduled path still stripping)")
+	}
+	// FakeStore preserves original int; the DB path would come back as
+	// float64 via JSON. Accept either.
+	got, ok := detailsInt(e.Details["status_code"])
+	if !ok || got != 404 {
+		t.Fatalf("expected status_code=404 in persisted Details, got %v (%T)", e.Details["status_code"], e.Details["status_code"])
+	}
+	if stage, _ := e.Details["failure_stage"].(string); stage != "http_status" {
+		t.Fatalf("expected failure_stage=http_status, got %v", e.Details["failure_stage"])
+	}
+	if ct, _ := e.Details["content_type"].(string); ct == "" {
+		t.Fatalf("expected content_type populated, got %v", e.Details["content_type"])
+	}
+}
+
+func detailsInt(v any) (int, bool) {
+	switch x := v.(type) {
+	case int:
+		return x, true
+	case int64:
+		return int(x), true
+	case float64:
+		return int(x), true
+	}
+	return 0, false
+}

--- a/internal/scheduler/checks_details_test.go
+++ b/internal/scheduler/checks_details_test.go
@@ -69,19 +69,26 @@ func TestRunCheck_Details_PopulatedWhenEnabled(t *testing.T) {
 	}
 }
 
-// TestRunDueChecks_NeverPopulatesDetails — even if SetCollectDetails(true)
-// was called (ad-hoc test button flow), the scheduled-check path must NOT
-// attach Details. The scheduled path uses a fresh checker in production; we
-// still guarantee it here as defensive invariant so accidentally sharing a
-// checker wouldn't blow up history rows or JSON payloads.
-func TestRunDueChecks_NeverPopulatesDetails(t *testing.T) {
+// TestRunDueChecks_OmitsDetailsWhenCollectorOff — with SetCollectDetails
+// left at its default (false), scheduled check rows must NOT carry
+// Details. This preserves the pre-#182 on-the-wire shape for integrations
+// that haven't opted in (e.g. unit tests constructing a bare checker via
+// NewServiceChecker). Production wires details on — see scheduler.go —
+// but the default still round-trips cleanly with no payload bloat.
+//
+// Replaces the old TestRunDueChecks_NeverPopulatesDetails which asserted
+// the stricter invariant that RunDueChecks unconditionally stripped the
+// map. Issue #182 relaxed that: the scheduler now persists details so
+// the /service-checks log UI can render them on expanded log rows.
+func TestRunDueChecks_OmitsDetailsWhenCollectorOff(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()
 
 	sc, _ := newTestChecker()
-	sc.SetCollectDetails(true) // simulate an ad-hoc flag being flipped
+	// NB: SetCollectDetails deliberately not called — the default is
+	// false so a bare NewServiceChecker stays details-free.
 
 	checks := []internal.ServiceCheckConfig{{
 		Name:    "scheduled",
@@ -94,7 +101,38 @@ func TestRunDueChecks_NeverPopulatesDetails(t *testing.T) {
 		t.Fatalf("expected 1 scheduled result, got %d", len(results))
 	}
 	if len(results[0].Details) != 0 {
-		t.Fatalf("RunDueChecks must not carry Details, got: %+v", results[0].Details)
+		t.Fatalf("RunDueChecks with collectDetails=false must not carry Details, got: %+v", results[0].Details)
+	}
+}
+
+// TestRunDueChecks_CarriesDetailsWhenCollectorOn — #182: when the parent
+// checker has collectDetails enabled (as the production scheduler does
+// via scheduler.go), RunDueChecks must now propagate the Details map
+// out of RunCheck instead of stripping it as it did under #154.
+func TestRunDueChecks_CarriesDetailsWhenCollectorOn(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true) // mirrors scheduler.go's production wiring
+
+	checks := []internal.ServiceCheckConfig{{
+		Name:    "scheduled-with-details",
+		Type:    internal.ServiceCheckHTTP,
+		Target:  ts.URL,
+		Enabled: true,
+	}}
+	results := sc.RunDueChecks(checks, time.Now().UTC())
+	if len(results) != 1 {
+		t.Fatalf("expected 1 scheduled result, got %d", len(results))
+	}
+	if len(results[0].Details) == 0 {
+		t.Fatalf("RunDueChecks with collectDetails=true must propagate Details, got empty map")
+	}
+	if code, _ := results[0].Details["status_code"].(int); code != 200 {
+		t.Fatalf("expected status_code=200 in scheduled Details, got %v", results[0].Details["status_code"])
 	}
 }
 

--- a/internal/scheduler/checks_details_test.go
+++ b/internal/scheduler/checks_details_test.go
@@ -1,0 +1,335 @@
+package scheduler
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// These tests cover the opt-in "collect details" code path added for the
+// Test-button flow (issue #154). The scheduled-check path (RunDueChecks)
+// must remain unchanged — no extra detail overhead on every 30s run.
+
+// ── Phase 1: opt-in toggle ─────────────────────────────────────────────
+
+// TestRunCheck_Details_OmittedByDefault — the Details field must be empty
+// (nil or zero-length) when the collect-details toggle has not been enabled,
+// so scheduled checks carry zero detail overhead over the wire.
+func TestRunCheck_Details_OmittedByDefault(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	sc, _ := newTestChecker()
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:    "default-no-details",
+		Type:    internal.ServiceCheckHTTP,
+		Target:  ts.URL,
+		Enabled: true,
+	}, time.Now().UTC())
+
+	if result.Status != "up" {
+		t.Fatalf("expected status up, got %q (error=%q)", result.Status, result.Error)
+	}
+	if len(result.Details) != 0 {
+		t.Fatalf("expected no details on scheduled path, got %d keys: %+v", len(result.Details), result.Details)
+	}
+}
+
+// TestRunCheck_Details_PopulatedWhenEnabled — once SetCollectDetails(true)
+// has been called, subsequent RunCheck calls populate the Details map.
+func TestRunCheck_Details_PopulatedWhenEnabled(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer ts.Close()
+
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:    "with-details",
+		Type:    internal.ServiceCheckHTTP,
+		Target:  ts.URL,
+		Enabled: true,
+	}, time.Now().UTC())
+
+	if result.Status != "up" {
+		t.Fatalf("expected up, got %q (error=%q)", result.Status, result.Error)
+	}
+	if len(result.Details) == 0 {
+		t.Fatal("expected non-empty Details when SetCollectDetails(true)")
+	}
+}
+
+// TestRunDueChecks_NeverPopulatesDetails — even if SetCollectDetails(true)
+// was called (ad-hoc test button flow), the scheduled-check path must NOT
+// attach Details. The scheduled path uses a fresh checker in production; we
+// still guarantee it here as defensive invariant so accidentally sharing a
+// checker wouldn't blow up history rows or JSON payloads.
+func TestRunDueChecks_NeverPopulatesDetails(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true) // simulate an ad-hoc flag being flipped
+
+	checks := []internal.ServiceCheckConfig{{
+		Name:    "scheduled",
+		Type:    internal.ServiceCheckHTTP,
+		Target:  ts.URL,
+		Enabled: true,
+	}}
+	results := sc.RunDueChecks(checks, time.Now().UTC())
+	if len(results) != 1 {
+		t.Fatalf("expected 1 scheduled result, got %d", len(results))
+	}
+	if len(results[0].Details) != 0 {
+		t.Fatalf("RunDueChecks must not carry Details, got: %+v", results[0].Details)
+	}
+}
+
+// ── Phase 2: HTTP details ──────────────────────────────────────────────
+
+// TestRunCheck_Details_HTTP_Success_StatusCode — a successful HTTP test
+// records status_code, content_type, body_bytes, and final_url so users
+// can see what the server actually returned.
+func TestRunCheck_Details_HTTP_Success_StatusCode(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:    "http-details",
+		Type:    internal.ServiceCheckHTTP,
+		Target:  ts.URL,
+		Enabled: true,
+	}, time.Now().UTC())
+	if result.Status != "up" {
+		t.Fatalf("expected up, got %q (error=%q)", result.Status, result.Error)
+	}
+	code, ok := result.Details["status_code"].(int)
+	if !ok || code != 200 {
+		t.Fatalf("expected status_code=200 (int), got %v (%T)", result.Details["status_code"], result.Details["status_code"])
+	}
+	if ct, _ := result.Details["content_type"].(string); !strings.Contains(ct, "application/json") {
+		t.Fatalf("expected content_type containing application/json, got %v", result.Details["content_type"])
+	}
+	if size, ok := result.Details["body_bytes"].(int64); !ok || size < 1 {
+		t.Fatalf("expected body_bytes > 0 int64, got %v (%T)", result.Details["body_bytes"], result.Details["body_bytes"])
+	}
+	if final, _ := result.Details["final_url"].(string); final == "" {
+		t.Fatalf("expected final_url populated, got %v", result.Details["final_url"])
+	}
+}
+
+// TestRunCheck_Details_HTTP_404_StillRecordsCode — failure path: a 404
+// reports status_code=404 in Details (not just the generic "unexpected
+// HTTP status" error). This is the core diagnostic value the issue calls
+// out — distinguishing a 404 from a connection refused.
+func TestRunCheck_Details_HTTP_404_StillRecordsCode(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:    "http-404",
+		Type:    internal.ServiceCheckHTTP,
+		Target:  ts.URL,
+		Enabled: true,
+	}, time.Now().UTC())
+
+	if result.Status != "down" {
+		t.Fatalf("expected down, got %q", result.Status)
+	}
+	code, ok := result.Details["status_code"].(int)
+	if !ok || code != 404 {
+		t.Fatalf("expected status_code=404 on down, got %v", result.Details["status_code"])
+	}
+}
+
+// TestRunCheck_Details_HTTP_Unreachable_NoStatusCode — if we never got a
+// response (connection refused / TCP error), there is no status code to
+// record. The Details map may be empty or only contain failure_stage.
+// We assert status_code is NOT present so the UI doesn't lie about the
+// server's reply.
+func TestRunCheck_Details_HTTP_Unreachable_NoStatusCode(t *testing.T) {
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:       "http-unreach",
+		Type:       internal.ServiceCheckHTTP,
+		Target:     "http://192.0.2.1:1",
+		Enabled:    true,
+		TimeoutSec: 1,
+	}, time.Now().UTC())
+
+	if result.Status != "down" {
+		t.Fatalf("expected down, got %q", result.Status)
+	}
+	if _, present := result.Details["status_code"]; present {
+		t.Fatalf("unreachable should have no status_code, got %v", result.Details["status_code"])
+	}
+	// failure_stage lets the UI say "connection refused" vs "HTTP 4xx" vs "TLS failed".
+	stage, _ := result.Details["failure_stage"].(string)
+	if stage == "" {
+		t.Fatalf("expected failure_stage to be populated for unreachable target, got %+v", result.Details)
+	}
+}
+
+// ── Phase 2: TCP details ───────────────────────────────────────────────
+
+// TestRunCheck_Details_TCP_ResolvedAddress — on success, the TCP runner
+// records the resolved_address so users see which IP:port they actually
+// connected to (e.g. "1.2.3.4:445" when target was "nas.local").
+func TestRunCheck_Details_TCP_ResolvedAddress(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	_, port, _ := net.SplitHostPort(ln.Addr().String())
+
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:    "tcp-details",
+		Type:    internal.ServiceCheckTCP,
+		Target:  "127.0.0.1:" + port,
+		Enabled: true,
+	}, time.Now().UTC())
+	if result.Status != "up" {
+		t.Fatalf("expected up, got %q (error=%q)", result.Status, result.Error)
+	}
+	addr, _ := result.Details["resolved_address"].(string)
+	if !strings.HasPrefix(addr, "127.0.0.1:") {
+		t.Fatalf("expected resolved_address prefix 127.0.0.1:, got %v", addr)
+	}
+}
+
+// TestRunCheck_Details_TCP_Closed_RecordsAddress — on down, the address
+// we tried is still recorded (so the user can see which host:port the
+// failure references — useful when testing an SMB check with a hostname).
+func TestRunCheck_Details_TCP_Closed_RecordsAddress(t *testing.T) {
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:       "tcp-closed-details",
+		Type:       internal.ServiceCheckTCP,
+		Target:     "127.0.0.1:1",
+		Enabled:    true,
+		TimeoutSec: 1,
+	}, time.Now().UTC())
+
+	if result.Status != "down" {
+		t.Fatalf("expected down, got %q", result.Status)
+	}
+	if addr, _ := result.Details["resolved_address"].(string); addr != "127.0.0.1:1" {
+		t.Fatalf("expected resolved_address=127.0.0.1:1, got %v", result.Details["resolved_address"])
+	}
+}
+
+// ── Phase 2: DNS details ───────────────────────────────────────────────
+
+// TestRunCheck_Details_DNS_Records — a successful DNS lookup records the
+// resolved A/AAAA records so users see the actual addresses their
+// resolver returned (the #1 debugging need per the issue).
+func TestRunCheck_Details_DNS_Records(t *testing.T) {
+	addr, stop := startFakeDNS(t)
+	defer stop()
+
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:       "dns-details",
+		Type:       internal.ServiceCheckDNS,
+		Target:     "example.test.",
+		DNSServer:  addr,
+		TimeoutSec: 3,
+		Enabled:    true,
+	}, time.Now().UTC())
+	if result.Status != "up" {
+		t.Fatalf("expected up, got %q (error=%q)", result.Status, result.Error)
+	}
+	records, ok := result.Details["records"].([]string)
+	if !ok {
+		t.Fatalf("expected records []string, got %T: %v", result.Details["records"], result.Details["records"])
+	}
+	if len(records) == 0 {
+		t.Fatal("expected at least one record")
+	}
+	if records[0] != "127.0.0.1" {
+		t.Fatalf("expected first record 127.0.0.1, got %v", records[0])
+	}
+	if server, _ := result.Details["dns_server"].(string); server == "" {
+		t.Fatalf("expected dns_server recorded, got %v", result.Details["dns_server"])
+	}
+}
+
+// TestRunCheck_Details_DNS_NXDOMAIN_RecordsQueryHost — on failure, the
+// host we queried is still recorded so users see what was looked up.
+func TestRunCheck_Details_DNS_NXDOMAIN_RecordsQueryHost(t *testing.T) {
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:       "dns-fail",
+		Type:       internal.ServiceCheckDNS,
+		Target:     "this.domain.definitely.does.not.exist.invalid.",
+		Enabled:    true,
+		TimeoutSec: 3,
+	}, time.Now().UTC())
+
+	if result.Status != "down" {
+		t.Fatalf("expected down, got %q", result.Status)
+	}
+	host, _ := result.Details["query_host"].(string)
+	if host == "" {
+		t.Fatalf("expected query_host populated on failure, got %+v", result.Details)
+	}
+}
+
+// ── Phase 2: Ping details ──────────────────────────────────────────────
+
+// TestRunCheck_Details_Ping_RecordsRTT — a successful ping records the
+// parsed rtt_ms (float) and the resolved host so users see what was hit.
+// Uses the loopback so we don't flake on CI.
+func TestRunCheck_Details_Ping_RecordsRTT(t *testing.T) {
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:       "ping-details",
+		Type:       internal.ServiceCheckPing,
+		Target:     "127.0.0.1",
+		Enabled:    true,
+		TimeoutSec: 2,
+	}, time.Now().UTC())
+
+	// ping might not be available in all CI sandboxes — if it fails,
+	// we still want the query_host recorded so the UI can explain.
+	if result.Status == "down" {
+		t.Skipf("ping not available in this environment: %q", result.Error)
+	}
+	if _, ok := result.Details["rtt_ms"].(float64); !ok {
+		t.Fatalf("expected rtt_ms float64, got %v (%T)", result.Details["rtt_ms"], result.Details["rtt_ms"])
+	}
+	if host, _ := result.Details["query_host"].(string); host != "127.0.0.1" {
+		t.Fatalf("expected query_host=127.0.0.1, got %v", result.Details["query_host"])
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -556,19 +556,50 @@ func (s *Scheduler) UpdateServiceChecks(checks []internal.ServiceCheckConfig) {
 	s.mu.Unlock()
 
 	// Purge orphaned history for any check that was removed from the config.
-	if s.store != nil {
-		keepKeys := make([]string, 0, len(normalized))
-		for _, c := range normalized {
-			keepKeys = append(keepKeys, CheckKey(c))
-		}
-		if pruned, err := s.store.DeleteServiceChecksNotIn(keepKeys); err != nil {
-			s.logger.Warn("prune orphaned service check history", "error", err)
-		} else if pruned > 0 {
-			s.logger.Info("pruned orphaned service check history", "rows", pruned)
-		}
-	}
+	s.pruneOrphanServiceCheckHistory(normalized)
 
 	s.logger.Info("service check config updated", "checks", len(normalized))
+}
+
+// PurgeOrphanServiceCheckHistory removes history rows for any check_key NOT
+// present in the currently configured service checks. Safe to call at any
+// time — idempotent, and a no-op when the store has no orphans.
+//
+// This is a defense-in-depth API: normally UpdateServiceChecks handles the
+// purge automatically as part of config updates. Callers that cannot
+// guarantee UpdateServiceChecks has run (e.g. startup paths where the
+// persisted settings failed to load) can invoke this directly to collapse
+// any drift between in-memory config and the history table. Issue #181.
+//
+// Returns the number of rows deleted.
+func (s *Scheduler) PurgeOrphanServiceCheckHistory() (int, error) {
+	s.mu.RLock()
+	checks := make([]internal.ServiceCheckConfig, len(s.serviceChecks))
+	copy(checks, s.serviceChecks)
+	s.mu.RUnlock()
+	return s.pruneOrphanServiceCheckHistory(checks), nil
+}
+
+// pruneOrphanServiceCheckHistory is the shared implementation for the orphan
+// purge. It derives keep-keys from the supplied (already-normalized) checks
+// and delegates to the store. Returns the count of rows pruned.
+func (s *Scheduler) pruneOrphanServiceCheckHistory(checks []internal.ServiceCheckConfig) int {
+	if s.store == nil {
+		return 0
+	}
+	keepKeys := make([]string, 0, len(checks))
+	for _, c := range checks {
+		keepKeys = append(keepKeys, CheckKey(c))
+	}
+	pruned, err := s.store.DeleteServiceChecksNotIn(keepKeys)
+	if err != nil {
+		s.logger.Warn("prune orphaned service check history", "error", err)
+		return 0
+	}
+	if pruned > 0 {
+		s.logger.Info("pruned orphaned service check history", "rows", pruned)
+	}
+	return pruned
 }
 
 // RunServiceChecksNow executes configured service checks immediately and persists results.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -130,6 +130,14 @@ func New(
 		restart:       make(chan time.Duration, 1),
 	}
 	s.checker = NewServiceChecker(store, logger)
+	// Opt into the per-type Details map on the scheduled path too —
+	// HTTP status codes, resolved IPs, DNS records, Ping RTT, failure
+	// stages are persisted into service_checks_history.details_json so
+	// the /service-checks log UI can render the same rich context the
+	// Test button already shows. Overhead is well under 1ms per check
+	// (the runners already compute these values; we just stop
+	// discarding them). See issue #182.
+	s.checker.SetCollectDetails(true)
 	s.retentionMgr = NewRetentionManager(store, store, logger)
 	return s
 }

--- a/internal/scheduler/service_checks_purge_test.go
+++ b/internal/scheduler/service_checks_purge_test.go
@@ -132,3 +132,104 @@ func TestUpdateServiceChecks_KeysDerivedFromNormalizedConfig(t *testing.T) {
 		t.Error("orphan history must be purged")
 	}
 }
+
+// Issue #181 — reproduce the UAT scenario: settings.json on disk has only
+// {A, B} but service_checks_history still contains rows for {A, B, C}
+// from a prior-boot drift. Simulate startup (call UpdateServiceChecks with
+// the loaded config) and assert C is purged — proving the existing
+// UpdateServiceChecks purge IS a correct startup defense when it runs.
+func TestScheduler_Startup_PurgesOrphanHistory(t *testing.T) {
+	store := storage.NewFakeStore()
+
+	checkA := internal.ServiceCheckConfig{Name: "A", Type: "http", Target: "http://a.example"}
+	checkB := internal.ServiceCheckConfig{Name: "B", Type: "http", Target: "http://b.example"}
+	checkC := internal.ServiceCheckConfig{Name: "Cloudflare 1.1.1.1", Type: "dns", Target: "1.1.1.1"}
+	// Seed history as if C was legitimately running in a previous
+	// container boot — the point of the bug is that its rows persist
+	// into the next boot where C no longer exists in settings.json.
+	seedHistory(t, store, CheckKey(checkA), CheckKey(checkB), CheckKey(checkC))
+
+	// Simulate main.go startup: construct scheduler, apply only the
+	// checks that remain on disk. UpdateServiceChecks MUST purge C.
+	sched := newSchedulerForTest(store)
+	sched.UpdateServiceChecks([]internal.ServiceCheckConfig{checkA, checkB})
+
+	after := historyKeys(t, store)
+	if len(after) != 2 {
+		t.Errorf("expected 2 keys in history after startup purge, got %d: %v", len(after), after)
+	}
+	if after[CheckKey(checkC)] {
+		t.Error("orphan Cloudflare 1.1.1.1 history must be purged at startup")
+	}
+	if !after[CheckKey(checkA)] || !after[CheckKey(checkB)] {
+		t.Error("configured checks A and B must be retained")
+	}
+}
+
+// Issue #181 defense-in-depth — PurgeOrphanServiceCheckHistory MUST be
+// callable directly without first invoking UpdateServiceChecks, for the
+// startup path where persisted settings failed to load (nil settings).
+// When scheduler.serviceChecks is empty, the entire history table is
+// drained: a legitimate outcome because the scheduler has no config to
+// run checks against, so any existing history is necessarily stale.
+func TestPurgeOrphanServiceCheckHistory_EmptyConfigDrainsHistory(t *testing.T) {
+	store := storage.NewFakeStore()
+	seedHistory(t, store, "orphan-1", "orphan-2", "orphan-3")
+
+	sched := newSchedulerForTest(store)
+	// No UpdateServiceChecks call — serviceChecks is the empty slice
+	// assigned in newSchedulerForTest, matching main.go's behavior when
+	// persistedSettings is nil and applySchedulerSettingsFromStore
+	// returns early.
+	pruned, err := sched.PurgeOrphanServiceCheckHistory()
+	if err != nil {
+		t.Fatalf("PurgeOrphanServiceCheckHistory: %v", err)
+	}
+	if pruned != 3 {
+		t.Errorf("expected 3 rows pruned, got %d", pruned)
+	}
+	after := historyKeys(t, store)
+	if len(after) != 0 {
+		t.Errorf("expected empty history after purge with no config, got %d keys: %v", len(after), after)
+	}
+}
+
+// Issue #181 — when the scheduler's in-memory config matches the history
+// table, PurgeOrphanServiceCheckHistory is a safe no-op. This is the
+// expected path for 99% of boots; it must not churn the DB.
+func TestPurgeOrphanServiceCheckHistory_NoopWhenConfigMatches(t *testing.T) {
+	store := storage.NewFakeStore()
+	checkA := internal.ServiceCheckConfig{Name: "A", Type: "http", Target: "http://a.example"}
+	seedHistory(t, store, CheckKey(checkA))
+
+	sched := newSchedulerForTest(store)
+	sched.UpdateServiceChecks([]internal.ServiceCheckConfig{checkA})
+
+	// Second purge invocation (simulating the startup defense-in-depth
+	// call in main.go immediately after applySchedulerSettingsFromStore)
+	// MUST be a no-op: the config is already in sync.
+	pruned, err := sched.PurgeOrphanServiceCheckHistory()
+	if err != nil {
+		t.Fatalf("PurgeOrphanServiceCheckHistory: %v", err)
+	}
+	if pruned != 0 {
+		t.Errorf("expected 0 rows pruned on second call, got %d", pruned)
+	}
+	after := historyKeys(t, store)
+	if !after[CheckKey(checkA)] {
+		t.Error("configured check A must still be in history")
+	}
+}
+
+// Issue #181 — PurgeOrphanServiceCheckHistory must tolerate a nil store
+// (defensive: a misbuilt scheduler must never panic on shutdown/startup).
+func TestPurgeOrphanServiceCheckHistory_NilStoreSafe(t *testing.T) {
+	sched := newSchedulerForTest(nil)
+	pruned, err := sched.PurgeOrphanServiceCheckHistory()
+	if err != nil {
+		t.Fatalf("PurgeOrphanServiceCheckHistory with nil store: %v", err)
+	}
+	if pruned != 0 {
+		t.Errorf("expected 0 pruned with nil store, got %d", pruned)
+	}
+}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -246,6 +246,7 @@ func (d *DB) migrate() error {
 			failure_threshold INTEGER NOT NULL DEFAULT 1,
 			failure_severity TEXT NOT NULL DEFAULT 'warning',
 			checked_at DATETIME NOT NULL,
+			details_json TEXT,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_service_checks_key_ts ON service_checks_history(check_key, checked_at DESC)`,
@@ -301,6 +302,16 @@ func (d *DB) migrate() error {
 	}
 	if err := d.ensureColumn("alerts", "snoozed_until", "DATETIME"); err != nil {
 		return fmt.Errorf("ensure alerts.snoozed_until: %w", err)
+	}
+	// details_json holds a per-type diagnostic JSON blob (HTTP status_code,
+	// DNS records, Ping rtt_ms, TCP resolved_address, failure_stage, …)
+	// persisted by the scheduler so the /service-checks log UI can render
+	// the same rich context the Test button already shows. Legacy rows
+	// pre-dating this column read back as NULL → Details == nil. A single
+	// TEXT column (vs per-key columns) keeps schema churn zero when new
+	// detail keys get added. See issue #182.
+	if err := d.ensureColumn("service_checks_history", "details_json", "TEXT"); err != nil {
+		return fmt.Errorf("ensure service_checks_history.details_json: %w", err)
 	}
 	if _, err := d.db.Exec(`CREATE INDEX IF NOT EXISTS idx_alerts_fingerprint_open ON alerts(fingerprint, resolved_at)`); err != nil {
 		return fmt.Errorf("create alerts fingerprint index: %w", err)
@@ -1623,6 +1634,13 @@ type ServiceCheckEntry struct {
 	FailureThreshold    int    `json:"failure_threshold"`
 	FailureSeverity     string `json:"failure_severity"`
 	CheckedAt           string `json:"checked_at"`
+
+	// Details carries the per-check-type diagnostic map (HTTP status_code,
+	// DNS records, Ping rtt_ms, TCP resolved_address, failure_stage, …)
+	// deserialised from the details_json column. nil on legacy rows
+	// written before the column existed, or for check types that produce
+	// no extra context. See issue #182.
+	Details map[string]any `json:"details,omitempty"`
 }
 
 // SaveServiceCheckResults appends service check run results to history.
@@ -1644,11 +1662,26 @@ func (d *DB) SaveServiceCheckResults(results []internal.ServiceCheckResult) erro
 		if parsed, err := time.Parse(time.RFC3339, result.CheckedAt); err == nil {
 			checkedAt = parsed.UTC()
 		}
+		// Serialise the per-type Details map. A nil or empty map writes
+		// SQL NULL so legacy readers and the pre-migration world stay
+		// unaffected. We do NOT fail the whole transaction on encoding
+		// errors — the core row still contains status/ms/error so losing
+		// details gracefully is preferable to losing the whole check
+		// history for a run. See issue #182.
+		var detailsPayload any // sql.NullString wrapped via any; nil = SQL NULL
+		if len(result.Details) > 0 {
+			if buf, err := json.Marshal(result.Details); err == nil {
+				detailsPayload = string(buf)
+			} else {
+				d.logger.Warn("service check details_json marshal failed; row saved without details",
+					"check", result.Name, "error", err)
+			}
+		}
 		_, err := tx.Exec(
 			`INSERT INTO service_checks_history (
 				check_key, name, check_type, target, status, response_ms, error_message,
-				consecutive_failures, failure_threshold, failure_severity, checked_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				consecutive_failures, failure_threshold, failure_severity, checked_at, details_json
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			result.Key,
 			result.Name,
 			result.Type,
@@ -1660,6 +1693,7 @@ func (d *DB) SaveServiceCheckResults(results []internal.ServiceCheckResult) erro
 			result.FailureThreshold,
 			result.FailureSeverity,
 			checkedAt,
+			detailsPayload,
 		)
 		if err != nil {
 			return err
@@ -1701,7 +1735,7 @@ func (d *DB) ListLatestServiceChecks(limit int) ([]ServiceCheckEntry, error) {
 		`SELECT check_key, name, check_type, target, status,
 				COALESCE(response_ms, 0), COALESCE(error_message, ''),
 				COALESCE(consecutive_failures, 0), COALESCE(failure_threshold, 1), COALESCE(failure_severity, 'warning'),
-				checked_at
+				checked_at, details_json
 		 FROM service_checks_history
 		 WHERE id IN (
 			SELECT MAX(id) FROM service_checks_history GROUP BY check_key
@@ -1719,6 +1753,7 @@ func (d *DB) ListLatestServiceChecks(limit int) ([]ServiceCheckEntry, error) {
 	for rows.Next() {
 		var e ServiceCheckEntry
 		var checkedAt time.Time
+		var detailsJSON sql.NullString
 		if err := rows.Scan(
 			&e.Key,
 			&e.Name,
@@ -1731,10 +1766,12 @@ func (d *DB) ListLatestServiceChecks(limit int) ([]ServiceCheckEntry, error) {
 			&e.FailureThreshold,
 			&e.FailureSeverity,
 			&checkedAt,
+			&detailsJSON,
 		); err != nil {
 			return nil, err
 		}
 		e.CheckedAt = checkedAt.UTC().Format(time.RFC3339)
+		e.Details = decodeDetailsJSON(d.logger, detailsJSON, e.Key)
 		entries = append(entries, e)
 	}
 	return entries, rows.Err()
@@ -1752,7 +1789,7 @@ func (d *DB) GetServiceCheckHistory(checkKey string, limit int) ([]ServiceCheckE
 		`SELECT check_key, name, check_type, target, status,
 				COALESCE(response_ms, 0), COALESCE(error_message, ''),
 				COALESCE(consecutive_failures, 0), COALESCE(failure_threshold, 1), COALESCE(failure_severity, 'warning'),
-				checked_at
+				checked_at, details_json
 		 FROM service_checks_history
 		 WHERE check_key = ?
 		 ORDER BY checked_at DESC
@@ -1769,6 +1806,7 @@ func (d *DB) GetServiceCheckHistory(checkKey string, limit int) ([]ServiceCheckE
 	for rows.Next() {
 		var e ServiceCheckEntry
 		var checkedAt time.Time
+		var detailsJSON sql.NullString
 		if err := rows.Scan(
 			&e.Key,
 			&e.Name,
@@ -1781,13 +1819,42 @@ func (d *DB) GetServiceCheckHistory(checkKey string, limit int) ([]ServiceCheckE
 			&e.FailureThreshold,
 			&e.FailureSeverity,
 			&checkedAt,
+			&detailsJSON,
 		); err != nil {
 			return nil, err
 		}
 		e.CheckedAt = checkedAt.UTC().Format(time.RFC3339)
+		e.Details = decodeDetailsJSON(d.logger, detailsJSON, e.Key)
 		entries = append(entries, e)
 	}
 	return entries, rows.Err()
+}
+
+// decodeDetailsJSON deserialises the details_json column from a history
+// row. Returns nil on SQL NULL, empty strings, or malformed JSON — the
+// log UI treats nil as "no extra context to render" rather than an error.
+// Corrupted rows are logged at warn level but never break list/history
+// queries, since the core row is still valuable. See issue #182.
+func decodeDetailsJSON(logger *slog.Logger, raw sql.NullString, checkKey string) map[string]any {
+	if !raw.Valid {
+		return nil
+	}
+	s := strings.TrimSpace(raw.String)
+	if s == "" || s == "null" {
+		return nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		if logger != nil {
+			logger.Warn("service check details_json unmarshal failed; row returned without details",
+				"check_key", checkKey, "error", err)
+		}
+		return nil
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
 }
 
 // PruneServiceCheckHistory deletes service check history rows older than the given duration.

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -1990,6 +1990,38 @@ func (d *DB) GetDiskHistory(serial string, limit int) ([]DiskHistoryPoint, error
 	return points, rows.Err()
 }
 
+// GetDiskHistoryInRange returns historical SMART data for a specific drive
+// whose timestamp falls within the last `window` duration. Returned rows are
+// ordered by timestamp ASC.
+//
+// Unlike GetDiskHistory (which caps by row count), this filters by time —
+// which is what the /disk/<serial> charts need so the x-axis density stays
+// legible regardless of scan frequency or retention depth. See issue #166.
+func (d *DB) GetDiskHistoryInRange(serial string, window time.Duration) ([]DiskHistoryPoint, error) {
+	cutoff := time.Now().UTC().Add(-window)
+	rows, err := d.db.Query(
+		`SELECT timestamp, temperature, reallocated, pending, udma_crc, command_timeout, power_on_hours, health_passed
+		 FROM smart_history
+		 WHERE serial = ? AND timestamp >= ?
+		 ORDER BY timestamp ASC`,
+		serial, cutoff,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var points []DiskHistoryPoint
+	for rows.Next() {
+		var p DiskHistoryPoint
+		if err := rows.Scan(&p.Timestamp, &p.Temperature, &p.Reallocated, &p.Pending, &p.UDMACRC, &p.CmdTimeout, &p.PowerHours, &p.Health); err != nil {
+			return nil, err
+		}
+		points = append(points, p)
+	}
+	return points, rows.Err()
+}
+
 // ---------- System history ----------
 
 // SystemHistoryPoint represents a single system metrics data point.

--- a/internal/storage/db_disk_history_test.go
+++ b/internal/storage/db_disk_history_test.go
@@ -1,0 +1,140 @@
+package storage
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestDB_GetDiskHistoryInRange verifies the time-windowed variant of
+// GetDiskHistory only returns rows whose timestamp falls within the
+// requested look-back window.
+//
+// Issue #166: /disk/<serial> charts need a 1D / 1W / 1M / 1Y selector.
+// Filtering by row count is not equivalent to filtering by time window,
+// so we need a separate method.
+func TestDB_GetDiskHistoryInRange(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	db, err := Open(dbPath, logger)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	// Seed a snapshot and several smart_history rows at known ages.
+	snapID := "snap-1"
+	now := time.Now().UTC()
+	if _, err := db.db.Exec(
+		`INSERT INTO snapshots (id, timestamp, duration_seconds, data) VALUES (?, ?, ?, ?)`,
+		snapID, now, 0.1, "{}",
+	); err != nil {
+		t.Fatalf("insert snapshot: %v", err)
+	}
+
+	// Ages in hours: 1h (in 1D), 23h (in 1D), 25h (out of 1D, in 1W),
+	// 48h (out of 1D, in 1W), 168h (right at 1W boundary — excluded by strict >).
+	ages := []time.Duration{
+		1 * time.Hour,
+		23 * time.Hour,
+		25 * time.Hour,
+		48 * time.Hour,
+		169 * time.Hour, // >1W ago
+	}
+	for i, age := range ages {
+		ts := now.Add(-age)
+		if _, err := db.db.Exec(
+			`INSERT INTO smart_history (snapshot_id, device, serial, model, temperature, reallocated, pending, udma_crc, command_timeout, power_on_hours, health_passed, timestamp)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			snapID, "/dev/sda", "SERIAL1", "MODEL", 30+i, int64(i), int64(0), int64(0), int64(0), int64(1000+i), true, ts,
+		); err != nil {
+			t.Fatalf("insert smart_history row %d: %v", i, err)
+		}
+	}
+
+	// 1D window (24h): expect the 1h and 23h rows only.
+	points, err := db.GetDiskHistoryInRange("SERIAL1", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("GetDiskHistoryInRange(24h): %v", err)
+	}
+	if len(points) != 2 {
+		t.Fatalf("expected 2 rows within 24h, got %d", len(points))
+	}
+	// Ordered ASC by timestamp — oldest first.
+	if !points[0].Timestamp.Before(points[1].Timestamp) {
+		t.Errorf("expected ASC order, got %v then %v", points[0].Timestamp, points[1].Timestamp)
+	}
+
+	// 1W window (168h): expect 1h, 23h, 25h, 48h (4 rows; 169h is outside).
+	pointsWeek, err := db.GetDiskHistoryInRange("SERIAL1", 168*time.Hour)
+	if err != nil {
+		t.Fatalf("GetDiskHistoryInRange(168h): %v", err)
+	}
+	if len(pointsWeek) != 4 {
+		t.Fatalf("expected 4 rows within 168h, got %d", len(pointsWeek))
+	}
+
+	// 1Y window should include all 5.
+	pointsYear, err := db.GetDiskHistoryInRange("SERIAL1", 8760*time.Hour)
+	if err != nil {
+		t.Fatalf("GetDiskHistoryInRange(1y): %v", err)
+	}
+	if len(pointsYear) != 5 {
+		t.Fatalf("expected 5 rows within 1y, got %d", len(pointsYear))
+	}
+
+	// Different serial returns nothing even within the window.
+	pointsOther, err := db.GetDiskHistoryInRange("NONEXISTENT", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("GetDiskHistoryInRange(NONEXISTENT): %v", err)
+	}
+	if len(pointsOther) != 0 {
+		t.Errorf("expected 0 rows for unknown serial, got %d", len(pointsOther))
+	}
+}
+
+// TestDB_GetDiskHistoryInRange_PreservesLegacyGetDiskHistory ensures the
+// original row-limited GetDiskHistory still works unchanged alongside the
+// new time-windowed variant. Scheduler + other callers still rely on it.
+func TestDB_GetDiskHistoryInRange_PreservesLegacyGetDiskHistory(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	db, err := Open(dbPath, logger)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	snapID := "snap-legacy"
+	now := time.Now().UTC()
+	if _, err := db.db.Exec(
+		`INSERT INTO snapshots (id, timestamp, duration_seconds, data) VALUES (?, ?, ?, ?)`,
+		snapID, now, 0.1, "{}",
+	); err != nil {
+		t.Fatalf("insert snapshot: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		ts := now.Add(-time.Duration(i) * time.Hour)
+		if _, err := db.db.Exec(
+			`INSERT INTO smart_history (snapshot_id, device, serial, model, temperature, timestamp)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+			snapID, "/dev/sda", "LEGACY", "MODEL", 35, ts,
+		); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	points, err := db.GetDiskHistory("LEGACY", 500)
+	if err != nil {
+		t.Fatalf("GetDiskHistory: %v", err)
+	}
+	if len(points) != 3 {
+		t.Errorf("legacy GetDiskHistory: expected 3 rows, got %d", len(points))
+	}
+}

--- a/internal/storage/db_service_checks_details_test.go
+++ b/internal/storage/db_service_checks_details_test.go
@@ -1,0 +1,248 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// TestSaveServiceCheckResult_PersistsDetailsJSON — a scheduled check run
+// that attaches a per-type Details map (HTTP status_code, DNS records, …)
+// must round-trip through SQLite so the /service-checks log UI can render
+// the same diagnostic context that the Test button already shows. See
+// issue #182.
+func TestSaveServiceCheckResult_PersistsDetailsJSON(t *testing.T) {
+	db := newTestDB(t)
+
+	now := time.Now().UTC()
+	recs := []string{"1.2.3.4", "5.6.7.8"}
+	results := []internal.ServiceCheckResult{{
+		Key:              "svc-http",
+		Name:             "HTTP With Details",
+		Type:             "http",
+		Target:           "https://example.com/health",
+		Status:           "down",
+		ResponseMS:       42,
+		FailureThreshold: 1,
+		FailureSeverity:  internal.SeverityWarning,
+		CheckedAt:        now.Format(time.RFC3339),
+		Details: map[string]any{
+			"status_code":   404,
+			"content_type":  "text/html; charset=utf-8",
+			"body_bytes":    int64(1234),
+			"final_url":     "https://example.com/health",
+			"failure_stage": "http_status",
+		},
+	}, {
+		Key:              "svc-dns",
+		Name:             "DNS With Records",
+		Type:             "dns",
+		Target:           "example.com",
+		Status:           "up",
+		ResponseMS:       7,
+		FailureThreshold: 1,
+		FailureSeverity:  internal.SeverityWarning,
+		CheckedAt:        now.Add(time.Second).Format(time.RFC3339),
+		Details: map[string]any{
+			"query_host": "example.com",
+			"dns_server": "1.1.1.1:53",
+			"records":    recs,
+		},
+	}}
+
+	if err := db.SaveServiceCheckResults(results); err != nil {
+		t.Fatalf("SaveServiceCheckResults: %v", err)
+	}
+
+	// ListLatestServiceChecks must echo back the Details map for both rows.
+	entries, err := db.ListLatestServiceChecks(100)
+	if err != nil {
+		t.Fatalf("ListLatestServiceChecks: %v", err)
+	}
+	byKey := make(map[string]ServiceCheckEntry, len(entries))
+	for _, e := range entries {
+		byKey[e.Key] = e
+	}
+
+	httpEntry, ok := byKey["svc-http"]
+	if !ok {
+		t.Fatalf("svc-http not in ListLatestServiceChecks result; got keys %v", mapKeys(byKey))
+	}
+	if httpEntry.Details == nil {
+		t.Fatalf("svc-http: expected Details populated, got nil (the persistence path still strips the map)")
+	}
+	// JSON round-trip turns numbers into float64 by default — assert on
+	// the concrete JSON representation rather than int.
+	if code, _ := asFloat(httpEntry.Details["status_code"]); code != 404 {
+		t.Errorf("svc-http: expected status_code=404, got %v (%T)", httpEntry.Details["status_code"], httpEntry.Details["status_code"])
+	}
+	if stage, _ := httpEntry.Details["failure_stage"].(string); stage != "http_status" {
+		t.Errorf("svc-http: expected failure_stage=http_status, got %v", httpEntry.Details["failure_stage"])
+	}
+
+	dnsEntry, ok := byKey["svc-dns"]
+	if !ok {
+		t.Fatalf("svc-dns missing from list; got keys %v", mapKeys(byKey))
+	}
+	if dnsEntry.Details == nil {
+		t.Fatalf("svc-dns: expected Details populated, got nil")
+	}
+	// DNS records round-trip as []interface{} through encoding/json.
+	records, ok := dnsEntry.Details["records"].([]interface{})
+	if !ok {
+		t.Fatalf("svc-dns: records should be []interface{}, got %T: %v", dnsEntry.Details["records"], dnsEntry.Details["records"])
+	}
+	if len(records) != 2 || records[0].(string) != "1.2.3.4" {
+		t.Fatalf("svc-dns: expected [1.2.3.4 5.6.7.8], got %v", records)
+	}
+
+	// GetServiceCheckHistory must also return Details for a per-key query.
+	hist, err := db.GetServiceCheckHistory("svc-http", 10)
+	if err != nil {
+		t.Fatalf("GetServiceCheckHistory: %v", err)
+	}
+	if len(hist) != 1 {
+		t.Fatalf("expected 1 history row for svc-http, got %d", len(hist))
+	}
+	if hist[0].Details == nil {
+		t.Fatalf("GetServiceCheckHistory: expected Details populated, got nil")
+	}
+	if code, _ := asFloat(hist[0].Details["status_code"]); code != 404 {
+		t.Errorf("GetServiceCheckHistory: expected status_code=404, got %v", hist[0].Details["status_code"])
+	}
+}
+
+// TestSaveServiceCheckResult_NilDetailsIsOK — legacy code paths (and the
+// pre-migration world) produce results with no Details map at all. Those
+// must still persist cleanly and round-trip as nil / empty so the log UI
+// doesn't choke.
+func TestSaveServiceCheckResult_NilDetailsIsOK(t *testing.T) {
+	db := newTestDB(t)
+
+	now := time.Now().UTC()
+	results := []internal.ServiceCheckResult{{
+		Key:              "svc-plain",
+		Name:             "No Details",
+		Type:             "tcp",
+		Target:           "127.0.0.1:22",
+		Status:           "up",
+		ResponseMS:       1,
+		FailureThreshold: 1,
+		FailureSeverity:  internal.SeverityWarning,
+		CheckedAt:        now.Format(time.RFC3339),
+		Details:          nil,
+	}}
+	if err := db.SaveServiceCheckResults(results); err != nil {
+		t.Fatalf("SaveServiceCheckResults: %v", err)
+	}
+	entries, err := db.ListLatestServiceChecks(100)
+	if err != nil {
+		t.Fatalf("ListLatestServiceChecks: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Details != nil {
+		t.Errorf("expected Details nil for row saved without details, got %v", entries[0].Details)
+	}
+}
+
+// TestMigration_AddsDetailsJsonColumn — Open on an existing database
+// without the details_json column must transparently add it and leave
+// historical rows with a NULL value (rendered as nil Details on read).
+func TestMigration_AddsDetailsJsonColumn(t *testing.T) {
+	db := newTestDB(t)
+
+	// Simulate a pre-migration state: the fresh newTestDB has the column.
+	// Drop it (SQLite 3.35+) to recreate a pre-migration shape, then
+	// re-run migrations to prove the ensureColumn path is idempotent and
+	// actually re-adds the column on a DB missing it.
+	if _, err := db.db.Exec(`ALTER TABLE service_checks_history DROP COLUMN details_json`); err != nil {
+		// Older SQLite builds without DROP COLUMN support — the test
+		// still serves its purpose on fresh runs (ensureColumn no-ops),
+		// but we can't assert the re-add path. Skip rather than fail.
+		t.Skipf("SQLite does not support DROP COLUMN on this build: %v", err)
+	}
+	if columnExists(t, db, "service_checks_history", "details_json") {
+		t.Fatalf("precondition: details_json should have been dropped")
+	}
+
+	// Seed a legacy row while the column is absent.
+	if _, err := db.db.Exec(
+		`INSERT INTO service_checks_history (check_key, name, check_type, target, status, response_ms, error_message, consecutive_failures, failure_threshold, failure_severity, checked_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"legacy", "Legacy Row", "http", "http://x", "up", 1, "", 0, 1, "warning", time.Now().UTC(),
+	); err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+
+	// Re-run migrations. migrate() is the internal helper the constructor
+	// calls; re-running it on an already-open DB must be a no-op for
+	// everything except the ensureColumn lines, which should add the
+	// dropped details_json column back.
+	if err := db.migrate(); err != nil {
+		t.Fatalf("migrate (re-run): %v", err)
+	}
+	if !columnExists(t, db, "service_checks_history", "details_json") {
+		t.Fatalf("runMigrations did not re-add details_json column")
+	}
+	// Legacy row must still be readable and have nil Details.
+	entries, err := db.ListLatestServiceChecks(100)
+	if err != nil {
+		t.Fatalf("ListLatestServiceChecks: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 legacy entry, got %d", len(entries))
+	}
+	if entries[0].Details != nil {
+		t.Errorf("expected legacy row Details nil after migration, got %v", entries[0].Details)
+	}
+}
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+func mapKeys(m map[string]ServiceCheckEntry) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// asFloat normalises JSON-decoded numerics: encoding/json produces float64
+// for generic map[string]any, so the assertion can't assume int.
+func asFloat(v any) (float64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return x, true
+	case int:
+		return float64(x), true
+	case int64:
+		return float64(x), true
+	}
+	return 0, false
+}
+
+func columnExists(t *testing.T, db *DB, table, column string) bool {
+	t.Helper()
+	rows, err := db.db.Query("PRAGMA table_info(" + table + ")")
+	if err != nil {
+		t.Fatalf("PRAGMA table_info: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid         int
+			name, ctype string
+			notnull, pk int
+			dflt        any
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan table_info: %v", err)
+		}
+		if name == column {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/storage/fake.go
+++ b/internal/storage/fake.go
@@ -280,6 +280,7 @@ func (f *FakeStore) ListLatestServiceChecks(limit int) ([]ServiceCheckEntry, err
 			FailureThreshold:    r.FailureThreshold,
 			FailureSeverity:     string(r.FailureSeverity),
 			CheckedAt:           r.CheckedAt,
+			Details:             cloneDetails(r.Details),
 		})
 	}
 	// Sort by CheckedAt descending.
@@ -313,6 +314,7 @@ func (f *FakeStore) GetServiceCheckHistory(checkKey string, limit int) ([]Servic
 			FailureThreshold:    r.FailureThreshold,
 			FailureSeverity:     string(r.FailureSeverity),
 			CheckedAt:           r.CheckedAt,
+			Details:             cloneDetails(r.Details),
 		})
 		if limit > 0 && len(entries) >= limit {
 			break
@@ -861,4 +863,20 @@ func (f *FakeStore) ResetVacuum() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.VacuumCalled = false
+}
+
+// cloneDetails returns a shallow copy of the per-type Details map so
+// successive Reads don't hand out the same underlying map that a later
+// Save mutates (issue #182: persisted log rows round-trip Details).
+// Returns nil for nil/empty input so reads match the DB path where NULL
+// JSON is surfaced as nil.
+func cloneDetails(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }

--- a/internal/storage/fake.go
+++ b/internal/storage/fake.go
@@ -398,6 +398,11 @@ func (f *FakeStore) GetDiskHistory(_ string, _ int) ([]DiskHistoryPoint, error) 
 	return nil, nil
 }
 
+func (f *FakeStore) GetDiskHistoryInRange(_ string, _ time.Duration) ([]DiskHistoryPoint, error) {
+	// TODO: implement for testing
+	return nil, nil
+}
+
 func (f *FakeStore) GetAvgTempDuringRange(_, _ time.Time) (float64, float64, error) {
 	// TODO: implement for testing
 	return 0, 0, nil

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -52,6 +52,7 @@ type ServiceCheckStore interface {
 // HistoryStore handles time-series history for disks, system, GPU, containers, and speed tests.
 type HistoryStore interface {
 	GetDiskHistory(serial string, limit int) ([]DiskHistoryPoint, error)
+	GetDiskHistoryInRange(serial string, window time.Duration) ([]DiskHistoryPoint, error)
 	GetAvgTempDuringRange(start, end time.Time) (float64, float64, error)
 	ListDisks() ([]DiskSummary, error)
 	GetAllDiskSparklines(pointsPerDisk int) ([]DiskSparklines, error)


### PR DESCRIPTION
## Summary

Completes v0.9.4 by bringing the two remaining bundled PRs into main after the first 5 were squash-merged directly:

- **#183 → closes #182** — persist per-type Details in service check log entries; render on expand (HTTP status code, DNS records, Ping RTT/loss, TCP resolved address, failure stage)
- **#184 → closes #181** — guarantee orphan service check history is purged on startup; defense-in-depth reconciliation

### Validated on UAT

v0.9.4-rc5 passed UAT on real Unraid hardware:
- #183: HTTP/DNS/TCP/Ping log entries show rich details when expanded
- #184: orphan Cloudflare 1.1.1.1 check cleared on boot; `startup: pruned orphan service check history` log hook active for future drift diagnostics

### Root cause for #181 NOT identified

The drift source remains unknown but the defense-in-depth purge + the `DELETE /api/v1/service-checks/{key}` endpoint give the user two working clears. Tracking issue to be filed for v0.9.5 investigation.

### Closes

Part of v0.9.4 release alongside merged PRs #167, #172, #174, #175, #177 (re-applied via stage), #178.