### PR TITLE
v0.9.4 bundle tail: decimation + log details + orphan purge (closes #165, #181, #182)

### DIFF
--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -331,6 +331,17 @@ func main() {
 
 		sched = scheduler.New(coll, store, notif, metrics, logger, interval)
 		applySchedulerSettingsFromStore(sched, persistedSettings)
+		// Defense-in-depth: guarantee the scheduler's in-memory service check
+		// set matches whatever history the DB carries, even when the settings
+		// payload failed to load or was nil (empty DB, corrupt JSON). Without
+		// this, a prior-boot orphan row in service_checks_history would
+		// continue to surface on /api/v1/service-checks as a phantom check
+		// the user cannot remove via the settings UI. Issue #181.
+		if pruned, err := sched.PurgeOrphanServiceCheckHistory(); err != nil {
+			logger.Warn("startup: purge orphan service check history", "error", err)
+		} else if pruned > 0 {
+			logger.Info("startup: pruned orphan service check history", "rows", pruned)
+		}
 		// Apply Proxmox config to collector on startup
 		if persistedSettings != nil && persistedSettings.Proxmox.Enabled {
 			coll.SetProxmoxConfig(collector.ProxmoxConfig{

--- a/internal/api/charts.go
+++ b/internal/api/charts.go
@@ -133,6 +133,63 @@ function computeYTicks(dMin,dMax,yMax,count){
   return {min:mn,max:mx,ticks:ticks};
 }
 
+/* ── decimateLabels ──────────────────────────────────────────────
+   Given N label slots spread evenly across chart-pixel-width cw, the
+   widest rendered label width maxLabelWidth, and a minimum horizontal
+   gap minGap between adjacent labels, return the set of label indices
+   to render without any two labels overlapping.
+
+   Guarantees:
+     - Index 0 (first) is always present when N>=1.
+     - Index N-1 (last) is always present when N>=2.
+     - No two consecutive returned indices i<j produce rendered labels
+       whose pixel bounding boxes intersect. (Spacing between their
+       centers is stride*(cw/(N-1)) which is >= maxLabelWidth+minGap
+       by construction — except for the final "snap to last" entry,
+       which is guaranteed spacing >= maxLabelWidth+minGap because
+       we drop the previous anchor if it would collide with the last.)
+
+   Edge cases:
+     - N<=1         → [0] (or [] if N=0)
+     - cw<=0 or L=0 → just [0, N-1] (degenerate, no width info)
+     - L+G >= cw    → [0, N-1] (only first and last fit)
+
+   This is exported as a pure function on NasChart so it can be unit-
+   tested in isolation (see internal/api/charts_decimation_test.go and
+   scripts/charts_decimation.test.js). Issue #165. */
+function decimateLabels(n,cw,maxLabelWidth,minGap){
+  if(minGap==null) minGap=12;
+  if(!(n>0)) return [];
+  if(n===1) return [0];
+  if(!(cw>0)||!(maxLabelWidth>0)) return [0,n-1];
+  var per=maxLabelWidth+minGap;
+  var intervals=n-1;
+  /* How many labels fit? (cw + gap) / (label + gap) because the last
+     label doesn't need a trailing gap. */
+  var maxLabels=Math.floor((cw+minGap)/per);
+  if(maxLabels<2) return [0,n-1];
+  if(maxLabels>=n) {
+    /* every label fits */
+    var out=[];
+    for(var i=0;i<n;i++) out.push(i);
+    return out;
+  }
+  /* Smallest stride s such that s*(cw/intervals) >= per. */
+  var stride=Math.max(1,Math.ceil(per*intervals/cw));
+  var idx=[];
+  for(var j=0;j<n;j+=stride) idx.push(j);
+  /* Always include the last label. Drop the previous anchor if it
+     would collide with the last (pixel distance < per). */
+  var last=n-1;
+  if(idx[idx.length-1]!==last){
+    var lastAnchor=idx[idx.length-1];
+    var gapPx=(last-lastAnchor)*(cw/intervals);
+    if(gapPx<per) idx.pop();
+    idx.push(last);
+  }
+  return idx;
+}
+
 /* ── drawAxes ────────────────────────────────────────────────────── */
 function drawAxes(ctx,m,w,h,yInfo,labels,opts){
   var th=theme();
@@ -151,12 +208,25 @@ function drawAxes(ctx,m,w,h,yInfo,labels,opts){
     var lbl=vy%1===0?vy.toString():vy.toFixed(1);
     ctx.fillText(lbl,m.l-8,py);
   }
-  /* x labels */
+  /* x labels — decimate to prevent overlap. Measure real label widths
+     via ctx.measureText() and derive which indices to render from
+     decimateLabels(). Fixes issue #165: the old
+       step = floor(labels.length / (cw / 50))
+     hardcoded a ~50px label budget, so datetime labels like "4/17 23:11"
+     (~65-75px in 11px sans-serif) would collide into an unreadable wall
+     of overlapping text once enough history accumulated. */
   if(labels&&labels.length){
     ctx.textAlign="center"; ctx.textBaseline="top";
-    var step=Math.max(1,Math.floor(labels.length/(cw/50)));
-    for(var j=0;j<labels.length;j+=step){
-      var px=m.l+j/(labels.length-1||1)*cw;
+    var maxLabelWidth=0;
+    for(var mi=0;mi<labels.length;mi++){
+      var lw=ctx.measureText(labels[mi]==null?"":String(labels[mi])).width;
+      if(lw>maxLabelWidth) maxLabelWidth=lw;
+    }
+    var keep=decimateLabels(labels.length,cw,maxLabelWidth,12);
+    var intervals=labels.length-1||1;
+    for(var ki=0;ki<keep.length;ki++){
+      var j=keep[ki];
+      var px=m.l+j/intervals*cw;
       ctx.fillStyle=th.text;
       ctx.fillText(labels[j],px,h-m.b+8);
     }
@@ -509,7 +579,12 @@ var NasChart={
   area:      drawArea,
   bar:       drawBar,
   gauge:     drawGauge,
-  sparkline: drawSparkline
+  sparkline: drawSparkline,
+  /* _decimateLabels is exposed for unit tests only. It is not part of
+     the public API — name is prefixed with an underscore to signal
+     "internal / subject to change". See issue #165 and
+     internal/api/charts_decimation_test.go. */
+  _decimateLabels: decimateLabels
 };
 
 window.NasChart=NasChart;

--- a/internal/api/charts_decimation_test.go
+++ b/internal/api/charts_decimation_test.go
@@ -1,0 +1,198 @@
+package api
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestChartJS_DrawAxes_UsesDecimation guards against regression of the fix
+// for issue #165 (x-axis label overlap on /disk/<serial>). drawAxes() must:
+//  1. measure real label widths via ctx.measureText(), and
+//  2. call the exported decimateLabels() helper to pick which indices to
+//     render so that no two rendered labels overlap.
+//
+// If this test fails, someone reverted drawAxes() back to an index-only
+// stride formula (e.g. the historic Math.floor(labels.length / (cw / 50))
+// that caused #165 in the first place) or bypassed decimateLabels().
+func TestChartJS_DrawAxes_UsesDecimation(t *testing.T) {
+	js := ChartJS
+	const marker = "/* x labels"
+	idx := strings.Index(js, marker)
+	if idx < 0 {
+		t.Fatalf("ChartJS: could not locate %q marker — drawAxes() structure changed unexpectedly", marker)
+	}
+	end := idx + 1400
+	if end > len(js) {
+		end = len(js)
+	}
+	xBlock := js[idx:end]
+
+	mustContain := []struct {
+		substr string
+		why    string
+	}{
+		{"measureText", "drawAxes must measure real label widths — hardcoded pixel budgets cause overlap (issue #165)"},
+		{"maxLabelWidth", "drawAxes must track the widest measured label (issue #165)"},
+		{"decimateLabels(", "drawAxes must call decimateLabels() to pick non-overlapping label indices (issue #165)"},
+	}
+	for _, tc := range mustContain {
+		if !strings.Contains(xBlock, tc.substr) {
+			t.Errorf("ChartJS x-labels block missing %q — %s", tc.substr, tc.why)
+		}
+	}
+
+	mustNotContain := []struct {
+		substr string
+		why    string
+	}{
+		{"cw/50", "the old hardcoded-50 stride formula must not come back — root cause of #165"},
+		{"labels.length/(cw/50)", "the old hardcoded-50 stride formula must not come back — root cause of #165"},
+	}
+	for _, tc := range mustNotContain {
+		if strings.Contains(xBlock, tc.substr) {
+			t.Errorf("ChartJS x-labels block still contains %q — %s", tc.substr, tc.why)
+		}
+	}
+}
+
+// TestChartJS_DecimateLabels_Behavior runs the decimateLabels function in a
+// headless node runtime against a table of representative inputs. This is
+// the "real" TDD test — it verifies the algorithm produces correct output,
+// not just that certain substrings are present.
+//
+// The test is skipped if node is not on PATH (CI and local dev both have it).
+func TestChartJS_DecimateLabels_Behavior(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not available; skipping JS behavior test")
+	}
+
+	// Runner: injects a fake window/document, evaluates ChartJS, then calls
+	// NasChart._decimateLabels with a list of cases and prints JSON results.
+	runner := `
+const cases = [
+  // name, N, cw, L, gap, expectedFirst, expectedLast, expectedMaxGapPx (<=), mustIncludeAll (bool)
+  // --- degenerate ---
+  { name: "N=0",              n: 0,  cw: 1400, L: 60, expectEmpty: true },
+  { name: "N=1",              n: 1,  cw: 1400, L: 60, expect: [0] },
+  { name: "cw=0",             n: 10, cw: 0,    L: 60, expect: [0,9] },
+  { name: "L=0",              n: 10, cw: 1400, L: 0,  expect: [0,9] },
+  { name: "label wider than chart", n: 10, cw: 50, L: 100, expect: [0,9] },
+
+  // --- all fit (1D with small N or small L) ---
+  { name: "all-fit tiny",     n: 5,  cw: 1400, L: 60, expect: [0,1,2,3,4] },
+
+  // --- stress ranges from the issue ---
+  { name: "1D @ 48 points 1400px L=60", n: 48,   cw: 1400, L: 60,
+    mustIncludeFirstLast: true, maxOverlapAllowedPx: 0, minGapPx: 60 },
+  { name: "1W @ 336 points 1400px L=60", n: 336,  cw: 1400, L: 60,
+    mustIncludeFirstLast: true, maxOverlapAllowedPx: 0, minGapPx: 60 },
+  { name: "1M @ 1440 points 1400px L=60", n: 1440, cw: 1400, L: 60,
+    mustIncludeFirstLast: true, maxOverlapAllowedPx: 0, minGapPx: 60 },
+  { name: "1Y @ 17520 points 1400px L=60", n: 17520, cw: 1400, L: 60,
+    mustIncludeFirstLast: true, maxOverlapAllowedPx: 0, minGapPx: 60 },
+
+  // --- narrow container ---
+  { name: "narrow 768px 48 points", n: 48, cw: 768, L: 60,
+    mustIncludeFirstLast: true, minGapPx: 60 },
+];
+
+// Minimal stubs for the browser APIs ChartJS touches at module-load time.
+global.window = { matchMedia: () => ({ matches: false }), devicePixelRatio: 1 };
+global.document = {
+  body: {},
+  createElement: () => ({ style: {}, appendChild: () => {} }),
+};
+global.getComputedStyle = () => ({ backgroundColor: "rgb(255,255,255)", paddingLeft: "0", paddingRight: "0" });
+global.requestAnimationFrame = () => {};
+
+const fs = require("fs");
+const path = require("path");
+const src = fs.readFileSync(path.resolve("internal/api/charts.go"), "utf8");
+const m = src.match(/var ChartJS = ` + "`" + `([\s\S]*?)` + "`" + `/);
+if (!m) { console.error("could not extract ChartJS"); process.exit(2); }
+eval(m[1]);
+const decimate = window.NasChart._decimateLabels;
+
+const results = [];
+for (const c of cases) {
+  try {
+    const got = decimate(c.n, c.cw, c.L, 12);
+    const entry = { name: c.name, got };
+
+    if (c.expectEmpty) {
+      entry.ok = Array.isArray(got) && got.length === 0;
+      if (!entry.ok) entry.why = "expected empty array";
+    } else if (c.expect) {
+      entry.ok = JSON.stringify(got) === JSON.stringify(c.expect);
+      if (!entry.ok) entry.why = "expected " + JSON.stringify(c.expect);
+    } else {
+      // Assertions derived from N,cw,L
+      entry.ok = true;
+      entry.why = "";
+      if (c.mustIncludeFirstLast) {
+        if (got[0] !== 0) { entry.ok = false; entry.why = "missing first (0) — got " + got[0]; }
+        else if (got[got.length-1] !== c.n - 1) {
+          entry.ok = false;
+          entry.why = "missing last (" + (c.n-1) + ") — got " + got[got.length-1];
+        }
+      }
+      if (entry.ok && c.minGapPx != null) {
+        // pixel gap between adjacent kept labels must be >= L + 12
+        const intervals = c.n - 1 || 1;
+        const pxPerInterval = c.cw / intervals;
+        const needPx = c.L + 12;
+        for (let i = 1; i < got.length; i++) {
+          const gap = (got[i] - got[i-1]) * pxPerInterval;
+          if (gap + 0.0001 < needPx) {
+            entry.ok = false;
+            entry.why = "pixel gap " + gap.toFixed(2) + " < required " + needPx + " between " + got[i-1] + "→" + got[i];
+            break;
+          }
+        }
+      }
+      // strictly increasing, in-range
+      for (let i = 0; i < got.length; i++) {
+        if (got[i] < 0 || got[i] >= c.n) { entry.ok = false; entry.why = "out-of-range index " + got[i]; break; }
+        if (i > 0 && got[i] <= got[i-1]) { entry.ok = false; entry.why = "not strictly increasing at " + i; break; }
+      }
+    }
+    results.push(entry);
+  } catch (err) {
+    results.push({ name: c.name, ok: false, why: "threw: " + err.message });
+  }
+}
+console.log(JSON.stringify(results));
+`
+
+	cmd := exec.Command("node", "-e", runner)
+	// run from the repo root so the readFileSync path resolves
+	cmd.Dir = findRepoRoot(t)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("node runner failed: %v\noutput:\n%s", err, string(out))
+	}
+	// Last line is the JSON blob.
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	jsonLine := lines[len(lines)-1]
+
+	// Parse by substring search (avoids encoding/json dependency bump).
+	// Each result has name + ok. We fail if any "ok":false appears.
+	if !strings.Contains(jsonLine, "\"ok\":false") && !strings.Contains(jsonLine, "\"ok\": false") {
+		t.Logf("decimateLabels behavior: all cases passed")
+		return
+	}
+	t.Errorf("decimateLabels behavior failures:\n%s", jsonLine)
+}
+
+// findRepoRoot walks up from CWD looking for go.mod.
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	// From internal/api test binary, CWD is that package. Walk up.
+	// We know ChartJS is read from "internal/api/charts.go" relative to repo root.
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/api/service_checks_log_details_test.go
+++ b/internal/api/service_checks_log_details_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestServiceChecksHTML_LogDetail_RendersPerTypeDetails guards the UI
+// changes for issue #182. When a user expands a log entry on the
+// /service-checks page, the detail panel must render the per-type
+// Details map (HTTP status_code, DNS records, TCP resolved_address,
+// Ping rtt_ms + packet_loss_pct, failure_stage for any type) so the
+// same rich context the Test button already shows is visible on
+// persisted log rows.
+//
+// We verify by cross-reference — the template must mention the exact
+// Details keys the scheduler persists. Keeps the test hermetic (no
+// headless browser), catches regressions where a refactor deletes the
+// rendering branch for one type.
+func TestServiceChecksHTML_LogDetail_RendersPerTypeDetails(t *testing.T) {
+	html := loadServiceChecksHTML(t)
+
+	// The renderer helper must exist and be invoked from the log expand
+	// path. Naming follows #154's settings.html helper so a future refactor
+	// can promote it without renaming callers.
+	mustContain(t, html, "renderServiceCheckDetails",
+		"log expand path must reference the renderServiceCheckDetails helper")
+
+	// The entry's details payload must be consumed. ServiceCheckEntry's
+	// JSON tag is "details,omitempty"; the template reads e.details.
+	mustContain(t, html, "e.details",
+		"log expand path must read e.details from the persisted entry")
+
+	// Per-type keys — match the set the scheduler runners populate.
+	// One failure here pinpoints exactly which branch regressed.
+	perTypeKeys := map[string]string{
+		"HTTP status_code":     "status_code",
+		"HTTP content_type":    "content_type",
+		"HTTP body_bytes":      "body_bytes",
+		"HTTP final_url":       "final_url",
+		"DNS records":          "records",
+		"DNS query_host":       "query_host",
+		"DNS dns_server":       "dns_server",
+		"TCP resolved_address": "resolved_address",
+		"Ping rtt_ms":          "rtt_ms",
+		"Ping packet_loss_pct": "packet_loss_pct",
+		"Shared failure_stage": "failure_stage",
+	}
+	for label, key := range perTypeKeys {
+		if !strings.Contains(html, key) {
+			t.Errorf("service_checks.html missing %s key %q — log detail panel won't render it", label, key)
+		}
+	}
+}
+
+// TestServiceChecksHTML_LogDetail_ExistingFieldsStillRendered — sanity
+// guard against accidentally losing the original fields in the detail
+// panel while wiring up the new helper. These were shipped by the
+// expand-row UI prior to #182 (Check Name, Type, Target, Status, Response
+// Time, Checked At, etc.); they must still appear.
+func TestServiceChecksHTML_LogDetail_ExistingFieldsStillRendered(t *testing.T) {
+	html := loadServiceChecksHTML(t)
+	required := []string{
+		"Check Name",
+		"Target",
+		"Response Time",
+		"Checked At",
+		"Consecutive Failures",
+		"Check Key",
+	}
+	for _, label := range required {
+		if !strings.Contains(html, label) {
+			t.Errorf("service_checks.html lost legacy detail-panel label %q during #182 wiring", label)
+		}
+	}
+}
+
+func mustContain(t *testing.T, haystack, needle, why string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("%s\n  expected substring: %q", why, needle)
+	}
+}

--- a/internal/api/templates/service_checks.html
+++ b/internal/api/templates/service_checks.html
@@ -169,6 +169,71 @@
 
   function esc(s){var d=document.createElement("div");d.textContent=s||"";return d.innerHTML;}
   function fetchJSON(url){return fetch(url).then(function(r){if(!r.ok)throw new Error(r.status);return r.json()});}
+
+  // renderServiceCheckDetails turns the per-type Details map (persisted
+  // in service_checks_history.details_json, surfaced by the API as
+  // entry.details) into a set of <div class="log-detail-item"> cells
+  // that drop into the existing log-detail-grid. Same contract as the
+  // settings.html Test-button helper from #154, so a future refactor
+  // can promote this to a shared file. See issue #182.
+  //
+  // Only the keys actually set by the scheduler runners are rendered —
+  // unknown keys are silently ignored so a forward-compat server (adds
+  // a new detail key in a future release) doesn't cause blank cells
+  // here. Numeric keys tolerate int OR float (JSON round-tripping the
+  // map through SQLite turns Go ints into JS numbers but keeps the
+  // exact value).
+  function renderServiceCheckDetails(type, details, entry) {
+    if (!details || typeof details !== "object") return "";
+    var t = (type || "").toLowerCase();
+    var out = "";
+    function cell(label, val, extraStyle) {
+      var s = extraStyle ? ' style="'+extraStyle+'"' : "";
+      return '<div class="log-detail-item"'+s+'><div class="ld-label">'+esc(label)+'</div><div class="ld-val">'+val+'</div></div>';
+    }
+    if (t === "http") {
+      if (typeof details.status_code === "number") {
+        // Colour the code so 2xx pops green, 4xx/5xx red — mirrors the
+        // Test button toast.
+        var codeColor = details.status_code >= 200 && details.status_code < 400 ? "var(--green)"
+                      : details.status_code >= 400 ? "var(--red)" : "var(--text)";
+        out += cell("HTTP Status", '<span style="color:'+codeColor+'">'+details.status_code+'</span>');
+      }
+      if (details.content_type) out += cell("Content-Type", esc(details.content_type));
+      if (typeof details.body_bytes === "number") out += cell("Body Size", details.body_bytes + " bytes");
+      // final_url is only interesting when it differs from the request
+      // (i.e. a redirect happened). Otherwise it's redundant with Target.
+      if (details.final_url && details.final_url !== details.request_url && details.final_url !== (entry && entry.target)) {
+        out += cell("Final URL", '<span style="font-size:11px;font-family:var(--font-mono);word-break:break-all">'+esc(details.final_url)+'</span>', "grid-column:1/-1");
+      }
+    } else if (t === "tcp" || t === "smb" || t === "nfs") {
+      if (details.resolved_address) out += cell("Resolved Address", '<span style="font-family:var(--font-mono)">'+esc(details.resolved_address)+'</span>');
+    } else if (t === "dns") {
+      if (details.query_host) out += cell("Query Host", '<span style="font-family:var(--font-mono)">'+esc(details.query_host)+'</span>');
+      if (details.dns_server) out += cell("DNS Server", '<span style="font-family:var(--font-mono)">'+esc(details.dns_server)+'</span>');
+      if (Array.isArray(details.records) && details.records.length) {
+        // Records listed comma-separated; the grid cell wraps on commas
+        // naturally. Span the row on many records so readability wins
+        // over grid symmetry.
+        var recVal = details.records.map(function(r){return esc(String(r));}).join(", ");
+        var span = details.records.length > 2 ? ' style="grid-column:1/-1"' : "";
+        out += '<div class="log-detail-item"'+span+'><div class="ld-label">Resolved Records</div><div class="ld-val" style="font-family:var(--font-mono);font-size:11px">'+recVal+'</div></div>';
+      }
+    } else if (t === "ping") {
+      if (details.query_host) out += cell("Host", '<span style="font-family:var(--font-mono)">'+esc(details.query_host)+'</span>');
+      if (typeof details.rtt_ms === "number") out += cell("RTT", details.rtt_ms.toFixed(2) + " ms");
+      if (typeof details.packet_loss_pct === "number") {
+        var lossColor = details.packet_loss_pct > 0 ? "var(--red)" : "var(--text)";
+        out += cell("Packet Loss", '<span style="color:'+lossColor+'">'+details.packet_loss_pct+'%</span>');
+      }
+    }
+    // failure_stage is shared across types; only meaningful on non-up
+    // results so we skip on "up" to keep the happy-path grid tight.
+    if (details.failure_stage && entry && entry.status !== "up") {
+      out += cell("Failure Stage", '<span style="color:var(--red)">'+esc(details.failure_stage)+'</span>');
+    }
+    return out;
+  }
   function pillClass(t){t=(t||"").toLowerCase();if(t==="http")return"pill-http";if(t==="tcp")return"pill-tcp";if(t==="dns")return"pill-dns";if(t==="ping")return"pill-ping";if(t==="smb"||t==="nfs")return"pill-smb";if(t==="speed")return"pill-speed";return"pill-http";}
   function fmtInterval(sec){if(sec<60)return sec+"s";if(sec<3600)return Math.floor(sec/60)+"m";return Math.floor(sec/3600)+"h";}
   function faviconHTML(type,target){
@@ -301,16 +366,13 @@
       h+='<div class="log-detail-item"><div class="ld-label">Consecutive Failures</div><div class="ld-val">'+(e.consecutive_failures||0)+' / '+(e.failure_threshold||1)+'</div></div>';
       h+='<div class="log-detail-item"><div class="ld-label">Check Key</div><div class="ld-val" style="font-size:10px;font-family:var(--font-mono);word-break:break-all;color:var(--text3)">'+esc(e.key||"—")+'</div></div>';
       if(e.error)h+='<div class="log-detail-item" style="grid-column:1/-1"><div class="ld-label">Error</div><div class="ld-val" style="font-size:12px;color:var(--red);font-weight:400;word-break:break-all">'+esc(e.error)+'</div></div>';
-      // Type-specific details
-      if((e.type||"").toLowerCase()==="http"){
-        h+='<div class="log-detail-item"><div class="ld-label">Expected Status</div><div class="ld-val">'+(e.expected_status_min||200)+' – '+(e.expected_status_max||399)+'</div></div>';
-      }
-      if((e.type||"").toLowerCase()==="dns"){
-        h+='<div class="log-detail-item"><div class="ld-label">DNS Lookup</div><div class="ld-val">'+esc(e.target||"")+'</div></div>';
-      }
-      if((e.type||"").toLowerCase()==="ping"){
-        h+='<div class="log-detail-item"><div class="ld-label">RTT</div><div class="ld-val">'+(e.response_ms||0)+' ms</div></div>';
-      }
+      // Per-type diagnostic details (HTTP status code, DNS records,
+      // Ping RTT/loss, TCP resolved address, failure_stage) from the
+      // Details map the scheduler now persists — same rich context
+      // the Test button already shows. Issue #182.
+      h+=renderServiceCheckDetails(e.type, e.details, e);
+      // Speed-type fields are top-level on the result (not in Details),
+      // so keep the dedicated block here.
       if((e.type||"").toLowerCase()==="speed"){
         h+='<div class="log-detail-item"><div class="ld-label">Download</div><div class="ld-val">'+(e.download_mbps?e.download_mbps.toFixed(1)+' Mbps':'—')+'</div></div>';
         h+='<div class="log-detail-item"><div class="ld-label">Upload</div><div class="ld-val">'+(e.upload_mbps?e.upload_mbps.toFixed(1)+' Mbps':'—')+'</div></div>';

--- a/internal/models.go
+++ b/internal/models.go
@@ -257,11 +257,13 @@ type ServiceCheckResult struct {
 	DownloadOK   *bool   `json:"download_ok,omitempty"` // nil for non-speed checks
 	UploadOK     *bool   `json:"upload_ok,omitempty"`
 
-	// Details carries per-check-type diagnostic context surfaced by the
-	// ad-hoc Test-button flow (HTTP status code, resolved IPs, DNS records,
-	// ping RTT, failure stage, etc.). It is intentionally NOT populated on
-	// the scheduled-check path — see ServiceChecker.SetCollectDetails —
-	// so every 30s run stays lean and history rows don't bloat. See #154.
+	// Details carries per-check-type diagnostic context (HTTP status code,
+	// resolved IPs, DNS records, ping RTT, failure stage, etc.). Populated
+	// when the parent ServiceChecker has SetCollectDetails(true) — both
+	// the ad-hoc Test-button flow (#154) and the scheduled path (#182,
+	// since v0.9.4) opt in. The scheduled path persists this map in the
+	// service_checks_history.details_json column so the log UI can render
+	// the same rich context the Test button already shows.
 	Details map[string]any `json:"details,omitempty"`
 }
 

--- a/internal/scheduler/checks.go
+++ b/internal/scheduler/checks.go
@@ -44,9 +44,10 @@ type ServiceChecker struct {
 	speedTestRunFn SpeedTestRunner // nil → speed checks return "no tool"
 	// collectDetails, when true, enriches RunCheck results with the
 	// per-check-type Details map (HTTP status code, resolved IPs, DNS
-	// records, etc.). The scheduled-check path (RunDueChecks) explicitly
-	// strips Details regardless of this flag — only the ad-hoc Test-button
-	// endpoint opts into this richer output. See issue #154.
+	// records, etc.). Both the ad-hoc Test-button endpoint (#154) and
+	// the scheduled path (#182, since v0.9.4) set this to true. The
+	// /service-checks log UI reads the persisted blob via
+	// service_checks_history.details_json.
 	collectDetails bool
 }
 
@@ -66,11 +67,14 @@ func (sc *ServiceChecker) SetSpeedTestRunner(fn SpeedTestRunner) {
 	sc.speedTestRunFn = fn
 }
 
-// SetCollectDetails toggles the opt-in rich-details output. Call with true
-// from the ad-hoc /service-checks/test endpoint to get diagnostic context
-// (HTTP status code, resolved IPs, DNS records, etc.) alongside the usual
-// status/response_ms/error triple. The scheduled-check path never emits
-// details — see RunDueChecks. Issue #154.
+// SetCollectDetails toggles rich-details output. When true, RunCheck
+// populates the per-type Details map (HTTP status code, resolved IPs,
+// DNS records, failure stage, etc.) alongside the usual
+// status/response_ms/error triple. Both the scheduler (issue #182) and
+// the ad-hoc /service-checks/test endpoint (issue #154) call this with
+// true; the scheduled path additionally persists the map into
+// service_checks_history.details_json so the /service-checks log UI
+// can render the rich context on expanded log rows.
 func (sc *ServiceChecker) SetCollectDetails(enabled bool) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
@@ -108,11 +112,13 @@ func (sc *ServiceChecker) RunDueChecks(checks []internal.ServiceCheckConfig, now
 	results := make([]internal.ServiceCheckResult, 0, len(due))
 	for _, check := range due {
 		result := sc.RunCheck(check, now)
-		// Scheduled path never emits Details — those are only for the
-		// ad-hoc Test-button flow. Strip them defensively in case the
-		// checker was flipped into collect-details mode elsewhere. See
-		// #154 (keeps history rows lean and JSON payloads small).
-		result.Details = nil
+		// Relaxation of the #154 invariant: the scheduled path now
+		// carries the per-type Details map through to the store so
+		// the /service-checks log UI can show HTTP status codes, DNS
+		// records, resolved addresses, etc. in expanded log rows.
+		// See issue #182. The map is only populated when the parent
+		// ServiceChecker has SetCollectDetails(true) — otherwise
+		// RunCheck returns Details == nil and this loop is a no-op.
 
 		// Track consecutive failures from store history.
 		state, ok, err := sc.store.GetLatestServiceCheckState(result.Key)

--- a/internal/scheduler/checks_details_persist_test.go
+++ b/internal/scheduler/checks_details_persist_test.go
@@ -1,0 +1,79 @@
+package scheduler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// TestRunDueChecks_HTTP_PersistsStatusCode — issue #182. Once the scheduled
+// path stops stripping Details, a 404 from the target server must round-
+// trip into the persisted history row so the /service-checks log UI can
+// render HTTP 404 alongside the status=down line.
+//
+// This is the sibling of TestRunCheck_Details_HTTP_404_StillRecordsCode,
+// but asserted at the RunDueChecks level — i.e. end-to-end through the
+// store, which is what the log UI actually reads.
+func TestRunDueChecks_HTTP_PersistsStatusCode(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	sc, store := newTestChecker()
+	sc.SetCollectDetails(true) // mirrors the scheduler-owned checker setup in #182
+
+	checks := []internal.ServiceCheckConfig{{
+		Name:    "scheduled-404",
+		Type:    internal.ServiceCheckHTTP,
+		Target:  ts.URL,
+		Enabled: true,
+	}}
+	results := sc.RunDueChecks(checks, time.Now().UTC())
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != "down" {
+		t.Fatalf("expected down, got %q", results[0].Status)
+	}
+
+	entries, err := store.ListLatestServiceChecks(10)
+	if err != nil {
+		t.Fatalf("ListLatestServiceChecks: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 persisted entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.Details == nil {
+		t.Fatalf("expected Details persisted, got nil (scheduled path still stripping)")
+	}
+	// FakeStore preserves original int; the DB path would come back as
+	// float64 via JSON. Accept either.
+	got, ok := detailsInt(e.Details["status_code"])
+	if !ok || got != 404 {
+		t.Fatalf("expected status_code=404 in persisted Details, got %v (%T)", e.Details["status_code"], e.Details["status_code"])
+	}
+	if stage, _ := e.Details["failure_stage"].(string); stage != "http_status" {
+		t.Fatalf("expected failure_stage=http_status, got %v", e.Details["failure_stage"])
+	}
+	if ct, _ := e.Details["content_type"].(string); ct == "" {
+		t.Fatalf("expected content_type populated, got %v", e.Details["content_type"])
+	}
+}
+
+func detailsInt(v any) (int, bool) {
+	switch x := v.(type) {
+	case int:
+		return x, true
+	case int64:
+		return int(x), true
+	case float64:
+		return int(x), true
+	}
+	return 0, false
+}

--- a/internal/scheduler/checks_details_test.go
+++ b/internal/scheduler/checks_details_test.go
@@ -69,19 +69,26 @@ func TestRunCheck_Details_PopulatedWhenEnabled(t *testing.T) {
 	}
 }
 
-// TestRunDueChecks_NeverPopulatesDetails — even if SetCollectDetails(true)
-// was called (ad-hoc test button flow), the scheduled-check path must NOT
-// attach Details. The scheduled path uses a fresh checker in production; we
-// still guarantee it here as defensive invariant so accidentally sharing a
-// checker wouldn't blow up history rows or JSON payloads.
-func TestRunDueChecks_NeverPopulatesDetails(t *testing.T) {
+// TestRunDueChecks_OmitsDetailsWhenCollectorOff — with SetCollectDetails
+// left at its default (false), scheduled check rows must NOT carry
+// Details. This preserves the pre-#182 on-the-wire shape for integrations
+// that haven't opted in (e.g. unit tests constructing a bare checker via
+// NewServiceChecker). Production wires details on — see scheduler.go —
+// but the default still round-trips cleanly with no payload bloat.
+//
+// Replaces the old TestRunDueChecks_NeverPopulatesDetails which asserted
+// the stricter invariant that RunDueChecks unconditionally stripped the
+// map. Issue #182 relaxed that: the scheduler now persists details so
+// the /service-checks log UI can render them on expanded log rows.
+func TestRunDueChecks_OmitsDetailsWhenCollectorOff(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()
 
 	sc, _ := newTestChecker()
-	sc.SetCollectDetails(true) // simulate an ad-hoc flag being flipped
+	// NB: SetCollectDetails deliberately not called — the default is
+	// false so a bare NewServiceChecker stays details-free.
 
 	checks := []internal.ServiceCheckConfig{{
 		Name:    "scheduled",
@@ -94,7 +101,38 @@ func TestRunDueChecks_NeverPopulatesDetails(t *testing.T) {
 		t.Fatalf("expected 1 scheduled result, got %d", len(results))
 	}
 	if len(results[0].Details) != 0 {
-		t.Fatalf("RunDueChecks must not carry Details, got: %+v", results[0].Details)
+		t.Fatalf("RunDueChecks with collectDetails=false must not carry Details, got: %+v", results[0].Details)
+	}
+}
+
+// TestRunDueChecks_CarriesDetailsWhenCollectorOn — #182: when the parent
+// checker has collectDetails enabled (as the production scheduler does
+// via scheduler.go), RunDueChecks must now propagate the Details map
+// out of RunCheck instead of stripping it as it did under #154.
+func TestRunDueChecks_CarriesDetailsWhenCollectorOn(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true) // mirrors scheduler.go's production wiring
+
+	checks := []internal.ServiceCheckConfig{{
+		Name:    "scheduled-with-details",
+		Type:    internal.ServiceCheckHTTP,
+		Target:  ts.URL,
+		Enabled: true,
+	}}
+	results := sc.RunDueChecks(checks, time.Now().UTC())
+	if len(results) != 1 {
+		t.Fatalf("expected 1 scheduled result, got %d", len(results))
+	}
+	if len(results[0].Details) == 0 {
+		t.Fatalf("RunDueChecks with collectDetails=true must propagate Details, got empty map")
+	}
+	if code, _ := results[0].Details["status_code"].(int); code != 200 {
+		t.Fatalf("expected status_code=200 in scheduled Details, got %v", results[0].Details["status_code"])
 	}
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -564,19 +564,50 @@ func (s *Scheduler) UpdateServiceChecks(checks []internal.ServiceCheckConfig) {
 	s.mu.Unlock()
 
 	// Purge orphaned history for any check that was removed from the config.
-	if s.store != nil {
-		keepKeys := make([]string, 0, len(normalized))
-		for _, c := range normalized {
-			keepKeys = append(keepKeys, CheckKey(c))
-		}
-		if pruned, err := s.store.DeleteServiceChecksNotIn(keepKeys); err != nil {
-			s.logger.Warn("prune orphaned service check history", "error", err)
-		} else if pruned > 0 {
-			s.logger.Info("pruned orphaned service check history", "rows", pruned)
-		}
-	}
+	s.pruneOrphanServiceCheckHistory(normalized)
 
 	s.logger.Info("service check config updated", "checks", len(normalized))
+}
+
+// PurgeOrphanServiceCheckHistory removes history rows for any check_key NOT
+// present in the currently configured service checks. Safe to call at any
+// time — idempotent, and a no-op when the store has no orphans.
+//
+// This is a defense-in-depth API: normally UpdateServiceChecks handles the
+// purge automatically as part of config updates. Callers that cannot
+// guarantee UpdateServiceChecks has run (e.g. startup paths where the
+// persisted settings failed to load) can invoke this directly to collapse
+// any drift between in-memory config and the history table. Issue #181.
+//
+// Returns the number of rows deleted.
+func (s *Scheduler) PurgeOrphanServiceCheckHistory() (int, error) {
+	s.mu.RLock()
+	checks := make([]internal.ServiceCheckConfig, len(s.serviceChecks))
+	copy(checks, s.serviceChecks)
+	s.mu.RUnlock()
+	return s.pruneOrphanServiceCheckHistory(checks), nil
+}
+
+// pruneOrphanServiceCheckHistory is the shared implementation for the orphan
+// purge. It derives keep-keys from the supplied (already-normalized) checks
+// and delegates to the store. Returns the count of rows pruned.
+func (s *Scheduler) pruneOrphanServiceCheckHistory(checks []internal.ServiceCheckConfig) int {
+	if s.store == nil {
+		return 0
+	}
+	keepKeys := make([]string, 0, len(checks))
+	for _, c := range checks {
+		keepKeys = append(keepKeys, CheckKey(c))
+	}
+	pruned, err := s.store.DeleteServiceChecksNotIn(keepKeys)
+	if err != nil {
+		s.logger.Warn("prune orphaned service check history", "error", err)
+		return 0
+	}
+	if pruned > 0 {
+		s.logger.Info("pruned orphaned service check history", "rows", pruned)
+	}
+	return pruned
 }
 
 // RunServiceChecksNow executes configured service checks immediately and persists results.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -130,6 +130,14 @@ func New(
 		restart:       make(chan time.Duration, 1),
 	}
 	s.checker = NewServiceChecker(store, logger)
+	// Opt into the per-type Details map on the scheduled path too —
+	// HTTP status codes, resolved IPs, DNS records, Ping RTT, failure
+	// stages are persisted into service_checks_history.details_json so
+	// the /service-checks log UI can render the same rich context the
+	// Test button already shows. Overhead is well under 1ms per check
+	// (the runners already compute these values; we just stop
+	// discarding them). See issue #182.
+	s.checker.SetCollectDetails(true)
 	s.retentionMgr = NewRetentionManager(store, store, logger)
 	return s
 }

--- a/internal/scheduler/service_checks_purge_test.go
+++ b/internal/scheduler/service_checks_purge_test.go
@@ -132,3 +132,104 @@ func TestUpdateServiceChecks_KeysDerivedFromNormalizedConfig(t *testing.T) {
 		t.Error("orphan history must be purged")
 	}
 }
+
+// Issue #181 — reproduce the UAT scenario: settings.json on disk has only
+// {A, B} but service_checks_history still contains rows for {A, B, C}
+// from a prior-boot drift. Simulate startup (call UpdateServiceChecks with
+// the loaded config) and assert C is purged — proving the existing
+// UpdateServiceChecks purge IS a correct startup defense when it runs.
+func TestScheduler_Startup_PurgesOrphanHistory(t *testing.T) {
+	store := storage.NewFakeStore()
+
+	checkA := internal.ServiceCheckConfig{Name: "A", Type: "http", Target: "http://a.example"}
+	checkB := internal.ServiceCheckConfig{Name: "B", Type: "http", Target: "http://b.example"}
+	checkC := internal.ServiceCheckConfig{Name: "Cloudflare 1.1.1.1", Type: "dns", Target: "1.1.1.1"}
+	// Seed history as if C was legitimately running in a previous
+	// container boot — the point of the bug is that its rows persist
+	// into the next boot where C no longer exists in settings.json.
+	seedHistory(t, store, CheckKey(checkA), CheckKey(checkB), CheckKey(checkC))
+
+	// Simulate main.go startup: construct scheduler, apply only the
+	// checks that remain on disk. UpdateServiceChecks MUST purge C.
+	sched := newSchedulerForTest(store)
+	sched.UpdateServiceChecks([]internal.ServiceCheckConfig{checkA, checkB})
+
+	after := historyKeys(t, store)
+	if len(after) != 2 {
+		t.Errorf("expected 2 keys in history after startup purge, got %d: %v", len(after), after)
+	}
+	if after[CheckKey(checkC)] {
+		t.Error("orphan Cloudflare 1.1.1.1 history must be purged at startup")
+	}
+	if !after[CheckKey(checkA)] || !after[CheckKey(checkB)] {
+		t.Error("configured checks A and B must be retained")
+	}
+}
+
+// Issue #181 defense-in-depth — PurgeOrphanServiceCheckHistory MUST be
+// callable directly without first invoking UpdateServiceChecks, for the
+// startup path where persisted settings failed to load (nil settings).
+// When scheduler.serviceChecks is empty, the entire history table is
+// drained: a legitimate outcome because the scheduler has no config to
+// run checks against, so any existing history is necessarily stale.
+func TestPurgeOrphanServiceCheckHistory_EmptyConfigDrainsHistory(t *testing.T) {
+	store := storage.NewFakeStore()
+	seedHistory(t, store, "orphan-1", "orphan-2", "orphan-3")
+
+	sched := newSchedulerForTest(store)
+	// No UpdateServiceChecks call — serviceChecks is the empty slice
+	// assigned in newSchedulerForTest, matching main.go's behavior when
+	// persistedSettings is nil and applySchedulerSettingsFromStore
+	// returns early.
+	pruned, err := sched.PurgeOrphanServiceCheckHistory()
+	if err != nil {
+		t.Fatalf("PurgeOrphanServiceCheckHistory: %v", err)
+	}
+	if pruned != 3 {
+		t.Errorf("expected 3 rows pruned, got %d", pruned)
+	}
+	after := historyKeys(t, store)
+	if len(after) != 0 {
+		t.Errorf("expected empty history after purge with no config, got %d keys: %v", len(after), after)
+	}
+}
+
+// Issue #181 — when the scheduler's in-memory config matches the history
+// table, PurgeOrphanServiceCheckHistory is a safe no-op. This is the
+// expected path for 99% of boots; it must not churn the DB.
+func TestPurgeOrphanServiceCheckHistory_NoopWhenConfigMatches(t *testing.T) {
+	store := storage.NewFakeStore()
+	checkA := internal.ServiceCheckConfig{Name: "A", Type: "http", Target: "http://a.example"}
+	seedHistory(t, store, CheckKey(checkA))
+
+	sched := newSchedulerForTest(store)
+	sched.UpdateServiceChecks([]internal.ServiceCheckConfig{checkA})
+
+	// Second purge invocation (simulating the startup defense-in-depth
+	// call in main.go immediately after applySchedulerSettingsFromStore)
+	// MUST be a no-op: the config is already in sync.
+	pruned, err := sched.PurgeOrphanServiceCheckHistory()
+	if err != nil {
+		t.Fatalf("PurgeOrphanServiceCheckHistory: %v", err)
+	}
+	if pruned != 0 {
+		t.Errorf("expected 0 rows pruned on second call, got %d", pruned)
+	}
+	after := historyKeys(t, store)
+	if !after[CheckKey(checkA)] {
+		t.Error("configured check A must still be in history")
+	}
+}
+
+// Issue #181 — PurgeOrphanServiceCheckHistory must tolerate a nil store
+// (defensive: a misbuilt scheduler must never panic on shutdown/startup).
+func TestPurgeOrphanServiceCheckHistory_NilStoreSafe(t *testing.T) {
+	sched := newSchedulerForTest(nil)
+	pruned, err := sched.PurgeOrphanServiceCheckHistory()
+	if err != nil {
+		t.Fatalf("PurgeOrphanServiceCheckHistory with nil store: %v", err)
+	}
+	if pruned != 0 {
+		t.Errorf("expected 0 pruned with nil store, got %d", pruned)
+	}
+}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -246,6 +246,7 @@ func (d *DB) migrate() error {
 			failure_threshold INTEGER NOT NULL DEFAULT 1,
 			failure_severity TEXT NOT NULL DEFAULT 'warning',
 			checked_at DATETIME NOT NULL,
+			details_json TEXT,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_service_checks_key_ts ON service_checks_history(check_key, checked_at DESC)`,
@@ -301,6 +302,16 @@ func (d *DB) migrate() error {
 	}
 	if err := d.ensureColumn("alerts", "snoozed_until", "DATETIME"); err != nil {
 		return fmt.Errorf("ensure alerts.snoozed_until: %w", err)
+	}
+	// details_json holds a per-type diagnostic JSON blob (HTTP status_code,
+	// DNS records, Ping rtt_ms, TCP resolved_address, failure_stage, …)
+	// persisted by the scheduler so the /service-checks log UI can render
+	// the same rich context the Test button already shows. Legacy rows
+	// pre-dating this column read back as NULL → Details == nil. A single
+	// TEXT column (vs per-key columns) keeps schema churn zero when new
+	// detail keys get added. See issue #182.
+	if err := d.ensureColumn("service_checks_history", "details_json", "TEXT"); err != nil {
+		return fmt.Errorf("ensure service_checks_history.details_json: %w", err)
 	}
 	if _, err := d.db.Exec(`CREATE INDEX IF NOT EXISTS idx_alerts_fingerprint_open ON alerts(fingerprint, resolved_at)`); err != nil {
 		return fmt.Errorf("create alerts fingerprint index: %w", err)
@@ -1623,6 +1634,13 @@ type ServiceCheckEntry struct {
 	FailureThreshold    int    `json:"failure_threshold"`
 	FailureSeverity     string `json:"failure_severity"`
 	CheckedAt           string `json:"checked_at"`
+
+	// Details carries the per-check-type diagnostic map (HTTP status_code,
+	// DNS records, Ping rtt_ms, TCP resolved_address, failure_stage, …)
+	// deserialised from the details_json column. nil on legacy rows
+	// written before the column existed, or for check types that produce
+	// no extra context. See issue #182.
+	Details map[string]any `json:"details,omitempty"`
 }
 
 // SaveServiceCheckResults appends service check run results to history.
@@ -1644,11 +1662,26 @@ func (d *DB) SaveServiceCheckResults(results []internal.ServiceCheckResult) erro
 		if parsed, err := time.Parse(time.RFC3339, result.CheckedAt); err == nil {
 			checkedAt = parsed.UTC()
 		}
+		// Serialise the per-type Details map. A nil or empty map writes
+		// SQL NULL so legacy readers and the pre-migration world stay
+		// unaffected. We do NOT fail the whole transaction on encoding
+		// errors — the core row still contains status/ms/error so losing
+		// details gracefully is preferable to losing the whole check
+		// history for a run. See issue #182.
+		var detailsPayload any // sql.NullString wrapped via any; nil = SQL NULL
+		if len(result.Details) > 0 {
+			if buf, err := json.Marshal(result.Details); err == nil {
+				detailsPayload = string(buf)
+			} else {
+				d.logger.Warn("service check details_json marshal failed; row saved without details",
+					"check", result.Name, "error", err)
+			}
+		}
 		_, err := tx.Exec(
 			`INSERT INTO service_checks_history (
 				check_key, name, check_type, target, status, response_ms, error_message,
-				consecutive_failures, failure_threshold, failure_severity, checked_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				consecutive_failures, failure_threshold, failure_severity, checked_at, details_json
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			result.Key,
 			result.Name,
 			result.Type,
@@ -1660,6 +1693,7 @@ func (d *DB) SaveServiceCheckResults(results []internal.ServiceCheckResult) erro
 			result.FailureThreshold,
 			result.FailureSeverity,
 			checkedAt,
+			detailsPayload,
 		)
 		if err != nil {
 			return err
@@ -1701,7 +1735,7 @@ func (d *DB) ListLatestServiceChecks(limit int) ([]ServiceCheckEntry, error) {
 		`SELECT check_key, name, check_type, target, status,
 				COALESCE(response_ms, 0), COALESCE(error_message, ''),
 				COALESCE(consecutive_failures, 0), COALESCE(failure_threshold, 1), COALESCE(failure_severity, 'warning'),
-				checked_at
+				checked_at, details_json
 		 FROM service_checks_history
 		 WHERE id IN (
 			SELECT MAX(id) FROM service_checks_history GROUP BY check_key
@@ -1719,6 +1753,7 @@ func (d *DB) ListLatestServiceChecks(limit int) ([]ServiceCheckEntry, error) {
 	for rows.Next() {
 		var e ServiceCheckEntry
 		var checkedAt time.Time
+		var detailsJSON sql.NullString
 		if err := rows.Scan(
 			&e.Key,
 			&e.Name,
@@ -1731,10 +1766,12 @@ func (d *DB) ListLatestServiceChecks(limit int) ([]ServiceCheckEntry, error) {
 			&e.FailureThreshold,
 			&e.FailureSeverity,
 			&checkedAt,
+			&detailsJSON,
 		); err != nil {
 			return nil, err
 		}
 		e.CheckedAt = checkedAt.UTC().Format(time.RFC3339)
+		e.Details = decodeDetailsJSON(d.logger, detailsJSON, e.Key)
 		entries = append(entries, e)
 	}
 	return entries, rows.Err()
@@ -1752,7 +1789,7 @@ func (d *DB) GetServiceCheckHistory(checkKey string, limit int) ([]ServiceCheckE
 		`SELECT check_key, name, check_type, target, status,
 				COALESCE(response_ms, 0), COALESCE(error_message, ''),
 				COALESCE(consecutive_failures, 0), COALESCE(failure_threshold, 1), COALESCE(failure_severity, 'warning'),
-				checked_at
+				checked_at, details_json
 		 FROM service_checks_history
 		 WHERE check_key = ?
 		 ORDER BY checked_at DESC
@@ -1769,6 +1806,7 @@ func (d *DB) GetServiceCheckHistory(checkKey string, limit int) ([]ServiceCheckE
 	for rows.Next() {
 		var e ServiceCheckEntry
 		var checkedAt time.Time
+		var detailsJSON sql.NullString
 		if err := rows.Scan(
 			&e.Key,
 			&e.Name,
@@ -1781,13 +1819,42 @@ func (d *DB) GetServiceCheckHistory(checkKey string, limit int) ([]ServiceCheckE
 			&e.FailureThreshold,
 			&e.FailureSeverity,
 			&checkedAt,
+			&detailsJSON,
 		); err != nil {
 			return nil, err
 		}
 		e.CheckedAt = checkedAt.UTC().Format(time.RFC3339)
+		e.Details = decodeDetailsJSON(d.logger, detailsJSON, e.Key)
 		entries = append(entries, e)
 	}
 	return entries, rows.Err()
+}
+
+// decodeDetailsJSON deserialises the details_json column from a history
+// row. Returns nil on SQL NULL, empty strings, or malformed JSON — the
+// log UI treats nil as "no extra context to render" rather than an error.
+// Corrupted rows are logged at warn level but never break list/history
+// queries, since the core row is still valuable. See issue #182.
+func decodeDetailsJSON(logger *slog.Logger, raw sql.NullString, checkKey string) map[string]any {
+	if !raw.Valid {
+		return nil
+	}
+	s := strings.TrimSpace(raw.String)
+	if s == "" || s == "null" {
+		return nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		if logger != nil {
+			logger.Warn("service check details_json unmarshal failed; row returned without details",
+				"check_key", checkKey, "error", err)
+		}
+		return nil
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
 }
 
 // PruneServiceCheckHistory deletes service check history rows older than the given duration.

--- a/internal/storage/db_service_checks_details_test.go
+++ b/internal/storage/db_service_checks_details_test.go
@@ -1,0 +1,248 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// TestSaveServiceCheckResult_PersistsDetailsJSON — a scheduled check run
+// that attaches a per-type Details map (HTTP status_code, DNS records, …)
+// must round-trip through SQLite so the /service-checks log UI can render
+// the same diagnostic context that the Test button already shows. See
+// issue #182.
+func TestSaveServiceCheckResult_PersistsDetailsJSON(t *testing.T) {
+	db := newTestDB(t)
+
+	now := time.Now().UTC()
+	recs := []string{"1.2.3.4", "5.6.7.8"}
+	results := []internal.ServiceCheckResult{{
+		Key:              "svc-http",
+		Name:             "HTTP With Details",
+		Type:             "http",
+		Target:           "https://example.com/health",
+		Status:           "down",
+		ResponseMS:       42,
+		FailureThreshold: 1,
+		FailureSeverity:  internal.SeverityWarning,
+		CheckedAt:        now.Format(time.RFC3339),
+		Details: map[string]any{
+			"status_code":   404,
+			"content_type":  "text/html; charset=utf-8",
+			"body_bytes":    int64(1234),
+			"final_url":     "https://example.com/health",
+			"failure_stage": "http_status",
+		},
+	}, {
+		Key:              "svc-dns",
+		Name:             "DNS With Records",
+		Type:             "dns",
+		Target:           "example.com",
+		Status:           "up",
+		ResponseMS:       7,
+		FailureThreshold: 1,
+		FailureSeverity:  internal.SeverityWarning,
+		CheckedAt:        now.Add(time.Second).Format(time.RFC3339),
+		Details: map[string]any{
+			"query_host": "example.com",
+			"dns_server": "1.1.1.1:53",
+			"records":    recs,
+		},
+	}}
+
+	if err := db.SaveServiceCheckResults(results); err != nil {
+		t.Fatalf("SaveServiceCheckResults: %v", err)
+	}
+
+	// ListLatestServiceChecks must echo back the Details map for both rows.
+	entries, err := db.ListLatestServiceChecks(100)
+	if err != nil {
+		t.Fatalf("ListLatestServiceChecks: %v", err)
+	}
+	byKey := make(map[string]ServiceCheckEntry, len(entries))
+	for _, e := range entries {
+		byKey[e.Key] = e
+	}
+
+	httpEntry, ok := byKey["svc-http"]
+	if !ok {
+		t.Fatalf("svc-http not in ListLatestServiceChecks result; got keys %v", mapKeys(byKey))
+	}
+	if httpEntry.Details == nil {
+		t.Fatalf("svc-http: expected Details populated, got nil (the persistence path still strips the map)")
+	}
+	// JSON round-trip turns numbers into float64 by default — assert on
+	// the concrete JSON representation rather than int.
+	if code, _ := asFloat(httpEntry.Details["status_code"]); code != 404 {
+		t.Errorf("svc-http: expected status_code=404, got %v (%T)", httpEntry.Details["status_code"], httpEntry.Details["status_code"])
+	}
+	if stage, _ := httpEntry.Details["failure_stage"].(string); stage != "http_status" {
+		t.Errorf("svc-http: expected failure_stage=http_status, got %v", httpEntry.Details["failure_stage"])
+	}
+
+	dnsEntry, ok := byKey["svc-dns"]
+	if !ok {
+		t.Fatalf("svc-dns missing from list; got keys %v", mapKeys(byKey))
+	}
+	if dnsEntry.Details == nil {
+		t.Fatalf("svc-dns: expected Details populated, got nil")
+	}
+	// DNS records round-trip as []interface{} through encoding/json.
+	records, ok := dnsEntry.Details["records"].([]interface{})
+	if !ok {
+		t.Fatalf("svc-dns: records should be []interface{}, got %T: %v", dnsEntry.Details["records"], dnsEntry.Details["records"])
+	}
+	if len(records) != 2 || records[0].(string) != "1.2.3.4" {
+		t.Fatalf("svc-dns: expected [1.2.3.4 5.6.7.8], got %v", records)
+	}
+
+	// GetServiceCheckHistory must also return Details for a per-key query.
+	hist, err := db.GetServiceCheckHistory("svc-http", 10)
+	if err != nil {
+		t.Fatalf("GetServiceCheckHistory: %v", err)
+	}
+	if len(hist) != 1 {
+		t.Fatalf("expected 1 history row for svc-http, got %d", len(hist))
+	}
+	if hist[0].Details == nil {
+		t.Fatalf("GetServiceCheckHistory: expected Details populated, got nil")
+	}
+	if code, _ := asFloat(hist[0].Details["status_code"]); code != 404 {
+		t.Errorf("GetServiceCheckHistory: expected status_code=404, got %v", hist[0].Details["status_code"])
+	}
+}
+
+// TestSaveServiceCheckResult_NilDetailsIsOK — legacy code paths (and the
+// pre-migration world) produce results with no Details map at all. Those
+// must still persist cleanly and round-trip as nil / empty so the log UI
+// doesn't choke.
+func TestSaveServiceCheckResult_NilDetailsIsOK(t *testing.T) {
+	db := newTestDB(t)
+
+	now := time.Now().UTC()
+	results := []internal.ServiceCheckResult{{
+		Key:              "svc-plain",
+		Name:             "No Details",
+		Type:             "tcp",
+		Target:           "127.0.0.1:22",
+		Status:           "up",
+		ResponseMS:       1,
+		FailureThreshold: 1,
+		FailureSeverity:  internal.SeverityWarning,
+		CheckedAt:        now.Format(time.RFC3339),
+		Details:          nil,
+	}}
+	if err := db.SaveServiceCheckResults(results); err != nil {
+		t.Fatalf("SaveServiceCheckResults: %v", err)
+	}
+	entries, err := db.ListLatestServiceChecks(100)
+	if err != nil {
+		t.Fatalf("ListLatestServiceChecks: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Details != nil {
+		t.Errorf("expected Details nil for row saved without details, got %v", entries[0].Details)
+	}
+}
+
+// TestMigration_AddsDetailsJsonColumn — Open on an existing database
+// without the details_json column must transparently add it and leave
+// historical rows with a NULL value (rendered as nil Details on read).
+func TestMigration_AddsDetailsJsonColumn(t *testing.T) {
+	db := newTestDB(t)
+
+	// Simulate a pre-migration state: the fresh newTestDB has the column.
+	// Drop it (SQLite 3.35+) to recreate a pre-migration shape, then
+	// re-run migrations to prove the ensureColumn path is idempotent and
+	// actually re-adds the column on a DB missing it.
+	if _, err := db.db.Exec(`ALTER TABLE service_checks_history DROP COLUMN details_json`); err != nil {
+		// Older SQLite builds without DROP COLUMN support — the test
+		// still serves its purpose on fresh runs (ensureColumn no-ops),
+		// but we can't assert the re-add path. Skip rather than fail.
+		t.Skipf("SQLite does not support DROP COLUMN on this build: %v", err)
+	}
+	if columnExists(t, db, "service_checks_history", "details_json") {
+		t.Fatalf("precondition: details_json should have been dropped")
+	}
+
+	// Seed a legacy row while the column is absent.
+	if _, err := db.db.Exec(
+		`INSERT INTO service_checks_history (check_key, name, check_type, target, status, response_ms, error_message, consecutive_failures, failure_threshold, failure_severity, checked_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"legacy", "Legacy Row", "http", "http://x", "up", 1, "", 0, 1, "warning", time.Now().UTC(),
+	); err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+
+	// Re-run migrations. migrate() is the internal helper the constructor
+	// calls; re-running it on an already-open DB must be a no-op for
+	// everything except the ensureColumn lines, which should add the
+	// dropped details_json column back.
+	if err := db.migrate(); err != nil {
+		t.Fatalf("migrate (re-run): %v", err)
+	}
+	if !columnExists(t, db, "service_checks_history", "details_json") {
+		t.Fatalf("runMigrations did not re-add details_json column")
+	}
+	// Legacy row must still be readable and have nil Details.
+	entries, err := db.ListLatestServiceChecks(100)
+	if err != nil {
+		t.Fatalf("ListLatestServiceChecks: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 legacy entry, got %d", len(entries))
+	}
+	if entries[0].Details != nil {
+		t.Errorf("expected legacy row Details nil after migration, got %v", entries[0].Details)
+	}
+}
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+func mapKeys(m map[string]ServiceCheckEntry) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// asFloat normalises JSON-decoded numerics: encoding/json produces float64
+// for generic map[string]any, so the assertion can't assume int.
+func asFloat(v any) (float64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return x, true
+	case int:
+		return float64(x), true
+	case int64:
+		return float64(x), true
+	}
+	return 0, false
+}
+
+func columnExists(t *testing.T, db *DB, table, column string) bool {
+	t.Helper()
+	rows, err := db.db.Query("PRAGMA table_info(" + table + ")")
+	if err != nil {
+		t.Fatalf("PRAGMA table_info: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid         int
+			name, ctype string
+			notnull, pk int
+			dflt        any
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan table_info: %v", err)
+		}
+		if name == column {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/storage/fake.go
+++ b/internal/storage/fake.go
@@ -280,6 +280,7 @@ func (f *FakeStore) ListLatestServiceChecks(limit int) ([]ServiceCheckEntry, err
 			FailureThreshold:    r.FailureThreshold,
 			FailureSeverity:     string(r.FailureSeverity),
 			CheckedAt:           r.CheckedAt,
+			Details:             cloneDetails(r.Details),
 		})
 	}
 	// Sort by CheckedAt descending.
@@ -313,6 +314,7 @@ func (f *FakeStore) GetServiceCheckHistory(checkKey string, limit int) ([]Servic
 			FailureThreshold:    r.FailureThreshold,
 			FailureSeverity:     string(r.FailureSeverity),
 			CheckedAt:           r.CheckedAt,
+			Details:             cloneDetails(r.Details),
 		})
 		if limit > 0 && len(entries) >= limit {
 			break
@@ -861,4 +863,20 @@ func (f *FakeStore) ResetVacuum() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.VacuumCalled = false
+}
+
+// cloneDetails returns a shallow copy of the per-type Details map so
+// successive Reads don't hand out the same underlying map that a later
+// Save mutates (issue #182: persisted log rows round-trip Details).
+// Returns nil for nil/empty input so reads match the DB path where NULL
+// JSON is surfaced as nil.
+func cloneDetails(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }


### PR DESCRIPTION
Cherry-picks the 5 commits for #165 (chart label decimation), #182 (log entry details), and #181 (orphan scheduler purge) onto main after the original stage-branch-based PRs (#177, #183, #184) couldn't be cleanly merged.

## Contents
- `087ba16` fix(charts): decimate x-axis labels (#165) — supersedes #173
- `3ce1b23` feat(service-checks): persist per-type Details map in history (#182)
- `f00f448` feat(service-checks): enable Details collection on scheduled path (#182)
- `f755ee9` feat(service-checks): render per-type Details on expanded log rows (#182)
- `3de8933` fix(scheduler): guarantee orphan service-check history is purged on startup (#181)

All commits validated via v0.9.4-rc5 UAT on real Unraid hardware.

Closes #165, #181, #182.