### PR TITLE
hotfix(ci): fix docker :latest race + VERSION=dev regression (v0.9.4 postmortem)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,17 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+# Serialize builds per ref. Rapid-fire squash merges to main (or a rebase force-push)
+# would previously trigger parallel docker builds, each racing to push `:latest`.
+# Whichever PUSH finished last won, which did NOT have to be the latest commit — we
+# shipped v0.9.4 with `:latest` stuck on the 3rd-of-5 squash-merge commit for this
+# exact reason. `cancel-in-progress: true` guarantees "last push to main wins":
+# new push arrives → any running build on the same ref is canceled → new build runs
+# to completion → deterministic `:latest`.
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -30,6 +41,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Default (fetch-depth:1, fetch-tags:false) leaves `git describe --tags`
+          # failing on main branch builds, which silently falls through to
+          # VERSION=dev baked into the binary. We need the full history + tags so
+          # the "Determine version" step can find the latest v* tag and bake it
+          # into the image. This also costs <5s extra on repos this size.
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
## What broke

v0.9.4's `:latest` image on GHCR is currently pointing at the image built from commit `471a2501` — the **3rd of 5 rapid squash-merge commits**. That image is missing:

- #167 Test button rich diagnostics
- #174 save regression fix
- #177 chart label decimation (from #186)
- #183 per-type log details (from #186)
- #184 startup orphan purge (from #186)

Additionally, the embedded VERSION in the image is `dev` instead of `0.9.4` because the default checkout doesn't fetch tags, so `git describe --tags` falls through to the `|| echo "dev"` fallback.

## Why it broke

1. **Race**: 5 squash merges within ~13s triggered 5 parallel docker builds. Each tries to push `:latest`. Whichever PUSH completes LAST wins, regardless of commit order. The #175 build (471a2501) won, not the expected 621d2ba.
2. **Checkout defaults**: `actions/checkout@v4` uses `fetch-depth: 1` and `fetch-tags: false` by default. On main-branch builds, `git describe --tags --abbrev=0` has no tags to find, returns an error, hits the shell fallback → VERSION=dev.

## The fix

`concurrency.cancel-in-progress: true` serializes per-ref builds and guarantees deterministic `last push wins`. `fetch-depth: 0` + `fetch-tags: true` let the version-detection shell find the latest `v*` tag.

## What happens when this merges

Pushing this to main will re-trigger docker.yml **on the fixed workflow definition** (since that includes the workflow file itself). The new main-branch build will push `:latest` with:
- Correct content (commit 621d2ba + this hotfix)
- VERSION=0.9.4 baked in (since v0.9.4 tag now exists)
- Previous racing builds canceled cleanly

Users who already pulled the broken `:latest` will get the correct image on their next update.

## Followup

After this lands, I'll verify `:latest` digest matches `:0.9.4` digest (they should be byte-identical modulo timestamps) and confirm the dashboard shows 0.9.4 + all v0.9.4 features.