### PR TITLE
fix(dashboard): compute 'Last scan X ago' from scan timestamp (#179)

### DIFF
--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -1509,14 +1509,27 @@ function setupGlobals() {
   window.loadContainerChart = function(hours, save) { charts.loadContainers(hours, save); };
   window.loadSpeedTestChart = function(hours, save) { charts.loadSpeedTest(hours, save); };
 
-  // Refresh indicator timer
+  // Refresh indicator timer — ticks the "X ago" text next to the Last
+  // scan timestamp. Elapsed time is computed from the actual scan
+  // timestamp (_statusData.last_scan, RFC3339) rather than from
+  // page-load / last-poll time; see issue #179. If we counted from
+  // _lastFetchTime, opening the page 10 minutes after a scan would
+  // show "just now" and a refresh would reset the counter — the
+  // exact bug the user reported.
   setInterval(function() {
     var el = document.getElementById("refresh-ago");
-    if (!el || !_lastFetchTime) return;
-    var secs = Math.round((Date.now() - _lastFetchTime) / 1000);
+    if (!el) return;
+    var scanTs = _statusData && _statusData.last_scan;
+    if (!scanTs) { el.textContent = ""; return; }
+    var scanMs = new Date(scanTs).getTime();
+    if (!scanMs || isNaN(scanMs)) { el.textContent = ""; return; }
+    var secs = Math.round((Date.now() - scanMs) / 1000);
+    if (secs < 0) secs = 0; // clock skew guard
     if (secs < 5) el.textContent = "just now";
     else if (secs < 60) el.textContent = secs + "s ago";
-    else el.textContent = Math.floor(secs / 60) + "m ago";
+    else if (secs < 3600) el.textContent = Math.floor(secs / 60) + "m ago";
+    else if (secs < 86400) el.textContent = Math.floor(secs / 3600) + "h ago";
+    else el.textContent = Math.floor(secs / 86400) + "d ago";
   }, 1000);
 }
 

--- a/internal/api/dashboard_last_scan_ago_test.go
+++ b/internal/api/dashboard_last_scan_ago_test.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestDashboardJS_LastScanAgoCountsFromScanTimestamp locks in the fix for
+// issue #179: the "X minutes ago" indicator next to "Last scan:" on the
+// dashboard must compute its elapsed time from the actual scan timestamp
+// provided by the server (status.last_scan, RFC3339), NOT from
+// page-load/last-poll time.
+//
+// Before the fix, the setInterval that updates #refresh-ago used
+// _lastFetchTime — which is Date.now() set on every poll and on every
+// initial loadAll(). That means:
+//
+//   - Opening the dashboard 10 minutes after the last scan showed
+//     "just now" and ticked forward from there — dead wrong.
+//   - A page refresh reset the counter to 0 even though nothing had
+//     actually re-scanned — the bug report's exact reproduction.
+//
+// The fix is to derive the elapsed seconds from _statusData.last_scan
+// (RFC3339 string) parsed as a Date. That string is the same source as
+// the human-readable timestamp already rendered in <strong>, so the
+// counter and the absolute timestamp are now guaranteed to agree.
+//
+// This is a grep-based cross-reference test (see AGENTS.md §4b). The JS
+// lives in a Go string literal (DashboardJS) that is served verbatim at
+// /js/dashboard.js, so asserting on substrings of the literal is how we
+// guard the client-side behavior from Go-side tests without spinning up
+// a browser.
+func TestDashboardJS_LastScanAgoCountsFromScanTimestamp(t *testing.T) {
+	js := DashboardJS
+
+	// Invariant 1: the refresh-ago interval body must reference the
+	// scan timestamp source, not just _lastFetchTime. We scope the
+	// check to the block that sets #refresh-ago text so unrelated
+	// uses of _lastFetchTime elsewhere (the poll debounce uses it
+	// too) don't false-pass.
+	agoBlock := extractRefreshAgoBlock(t, js)
+
+	if !strings.Contains(agoBlock, "last_scan") {
+		t.Errorf("refresh-ago interval must derive elapsed time from _statusData.last_scan (the RFC3339 scan timestamp), but the block doesn't reference last_scan:\n%s", agoBlock)
+	}
+
+	// Invariant 2: must parse the timestamp via `new Date(...)`.
+	// Without this, we'd be comparing a string to a number and the
+	// counter would produce NaN/garbage.
+	if !regexp.MustCompile(`new Date\s*\(`).MatchString(agoBlock) {
+		t.Errorf("refresh-ago interval must parse the scan timestamp via `new Date(...)` so the RFC3339 string becomes a comparable epoch-ms value; block:\n%s", agoBlock)
+	}
+
+	// Invariant 3: guard against the regressed behavior. The ago text
+	// must NOT be computed from _lastFetchTime (that was the bug).
+	// We allow _lastFetchTime to appear in the *guard* (`if !el` etc.)
+	// but not in the subtraction that feeds `secs`.
+	//
+	// The simplest durable check: the subtraction `Date.now() - _lastFetchTime`
+	// must not appear inside the block. That exact idiom is what
+	// produced the bug.
+	badPattern := regexp.MustCompile(`Date\.now\s*\(\s*\)\s*-\s*_lastFetchTime`)
+	if badPattern.MatchString(agoBlock) {
+		t.Errorf("refresh-ago interval still computes elapsed time as `Date.now() - _lastFetchTime` — this is the exact regression issue #179 was filed against. Use the scan timestamp instead:\n%s", agoBlock)
+	}
+}
+
+// TestDashboardJS_LastScanAgoHandlesMissingTimestamp guards the empty-state
+// path. When the server has never scanned, status.last_scan is empty and
+// the absolute timestamp renders as "Never". The counter must not then
+// display bogus text like "NaNm ago" or "56 years ago" (epoch-zero parse).
+// The block should simply clear the element or short-circuit.
+func TestDashboardJS_LastScanAgoHandlesMissingTimestamp(t *testing.T) {
+	js := DashboardJS
+	agoBlock := extractRefreshAgoBlock(t, js)
+
+	// There must be a guard that checks truthiness of the scan
+	// timestamp before doing arithmetic. Any of the common idioms
+	// are acceptable: an early return, a ternary, or a falsy check
+	// on the parsed value. We require at least one `return` inside
+	// the block so the empty-state path short-circuits; the existing
+	// `if (!el || !_lastFetchTime) return;` guard already matches
+	// this shape — we just need the equivalent for the scan
+	// timestamp after the fix.
+	if !strings.Contains(agoBlock, "return") {
+		t.Errorf("refresh-ago interval must short-circuit (early return) when the scan timestamp is missing, otherwise the counter would render NaN or a 56-year-ago epoch value on a fresh install; block:\n%s", agoBlock)
+	}
+}
+
+// extractRefreshAgoBlock returns the JS body of the setInterval callback
+// that updates #refresh-ago. Scoping assertions to this block prevents
+// unrelated uses of _lastFetchTime (used elsewhere for poll cadence)
+// from false-passing the test.
+func extractRefreshAgoBlock(t *testing.T, js string) string {
+	t.Helper()
+	// The setInterval sits immediately below a comment line
+	// "// Refresh indicator timer" in dashboard.go. The callback
+	// is a single short function; we grab from that marker to
+	// the next "}, 1000);" which closes the interval.
+	marker := "Refresh indicator timer"
+	start := strings.Index(js, marker)
+	if start < 0 {
+		t.Fatalf("could not locate %q in DashboardJS — the refresh-ago setInterval was renamed or moved. Update the test helper.", marker)
+	}
+	end := strings.Index(js[start:], "}, 1000)")
+	if end < 0 {
+		t.Fatalf("could not find closing `}, 1000)` for refresh-ago setInterval — structure changed, update the helper.")
+	}
+	return js[start : start+end]
+}


### PR DESCRIPTION
Closes #179

## Bug

The dashboard renders `Last scan: <timestamp> <X ago>` in the header. The `X ago` counter was computed as `Date.now() - _lastFetchTime`, where `_lastFetchTime` is set to `Date.now()` on every status poll AND on initial page load. Consequences:

- Opening the dashboard 10 minutes after the last scan showed `just now` and ticked forward from there — disagreeing with the absolute timestamp rendered right next to it.
- Refreshing the page reset the counter to 0 even though nothing had re-scanned — the exact reproduction in the bug report.

## Fix

The setInterval in `internal/api/dashboard.go` (the shared `DashboardJS` module served at `/js/dashboard.js`) now derives elapsed time from `_statusData.last_scan` — the RFC3339 string the server already emits in `/api/v1/status` and that renders as the human-readable timestamp next to the counter. The two UI elements now share the exact same source of truth.

Other improvements in the same block:

- Added `h ago` / `d ago` thresholds so long-idle installs don't display `"9999m ago"`.
- Empty-state (no prior scan) clears the counter instead of rendering `NaN` or a 56-year-ago epoch value.
- Clock-skew guard (`secs < 0 → 0`).

## Before / after

|                            | Before                                    | After                                    |
| -------------------------- | ----------------------------------------- | ---------------------------------------- |
| Source                     | `_lastFetchTime` (page-load / poll wall)  | `_statusData.last_scan` (scan timestamp) |
| Fresh page, scan 10m old   | `just now`, ticking from 0                | `10m ago`                                |
| Refresh page               | Counter resets to 0                       | Counter unchanged                        |
| Never-scanned install      | `just now`                                | (empty)                                  |
| Long idle (e.g. 2d)        | `2880m ago`                               | `2d ago`                                 |

## Tests

Added `internal/api/dashboard_last_scan_ago_test.go` with two grep-based cross-reference tests (§4b pattern):

1. `TestDashboardJS_LastScanAgoCountsFromScanTimestamp` — asserts the refresh-ago interval body references `last_scan`, parses it via `new Date(...)`, and does NOT contain the regressed `Date.now() - _lastFetchTime` idiom.
2. `TestDashboardJS_LastScanAgoHandlesMissingTimestamp` — asserts the block short-circuits (early `return`) when the scan timestamp is missing.

Both tests scope their assertions to the exact refresh-ago block (via a helper that extracts between the `Refresh indicator timer` marker and `}, 1000)`) so unrelated uses of `_lastFetchTime` elsewhere in `DashboardJS` can't false-pass.

## Pre-push checks (§4b)

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all packages pass

## Diff size

- `internal/api/dashboard.go`: +17 / -5 lines
- `internal/api/dashboard_last_scan_ago_test.go`: +111 lines (new test file)