### PR TITLE
fix(service-checks): pause auto-refresh while log row is expanded (#187)

### DIFF
--- a/internal/api/service_checks_autorefresh_test.go
+++ b/internal/api/service_checks_autorefresh_test.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestServiceChecksHTML_AutoRefreshPausesWhenRowExpanded guards the fix
+// for issue #187. The Service Checks page used to call
+// `setInterval(loadAll, 60000)` unconditionally, which rebuilt the log
+// table DOM every minute — collapsing any log row the user had expanded
+// to inspect diagnostic details (status codes, DNS records, etc. added
+// in #182/#183).
+//
+// The fix pauses the auto-refresh tick while any log row is expanded,
+// and resumes once all rows are collapsed. This is a grep-based cross-
+// reference test: it can't simulate a live tick, but it asserts the
+// structural invariants that MUST be present for the fix to work. If a
+// future refactor removes any of these, the guard silently no-ops and
+// the bug regresses without any other test noticing.
+//
+// Invariants:
+//  1. `setInterval` does NOT pass `loadAll` directly as its callback.
+//     There must be an anonymous function or wrapper in between that
+//     can early-return when rows are expanded. Direct
+//     `setInterval(loadAll, N)` is the exact pre-fix code path.
+//  2. The template declares an expanded-row state (`expandedRows`).
+//     Without a shared state, the refresh guard has nothing to consult.
+//  3. `toggleLogDetail` — the click handler on each log row — mutates
+//     that state. If the handler ignores the state, it never changes
+//     and the guard triggers either always or never.
+//  4. A visual affordance (`refresh-paused`) exists somewhere in the
+//     template so the user can tell WHY data isn't ticking forward.
+//     Acceptance criterion from the issue body.
+func TestServiceChecksHTML_AutoRefreshPausesWhenRowExpanded(t *testing.T) {
+	html := loadServiceChecksHTML(t)
+
+	// Invariant 1: the refresh tick is wrapped, not a direct callback.
+	// `setInterval(loadAll,` (with optional whitespace) is the exact
+	// pattern that caused the bug; we reject it outright.
+	directCall := regexp.MustCompile(`setInterval\s*\(\s*loadAll\s*,`)
+	if directCall.MatchString(html) {
+		t.Error("setInterval(loadAll, ...) passes loadAll directly as the tick callback — " +
+			"there's no way for the tick to early-return when a log row is expanded (#187)")
+	}
+
+	// A setInterval call must still exist — we didn't want to delete
+	// auto-refresh entirely, just guard it.
+	if !strings.Contains(html, "setInterval(") {
+		t.Error("service_checks.html has no setInterval call — auto-refresh was removed entirely, which is not the intended fix")
+	}
+
+	// Invariant 2: expanded-row state variable exists.
+	if !strings.Contains(html, "expandedRows") {
+		t.Error("service_checks.html does not declare `expandedRows` state — the refresh guard has nothing to consult (#187)")
+	}
+
+	// Invariant 3: toggleLogDetail updates expandedRows.
+	toggleBody := extractFuncBody(t, html, "window.toggleLogDetail=function(")
+	if !strings.Contains(toggleBody, "expandedRows") {
+		t.Errorf("window.toggleLogDetail does not reference `expandedRows` — the click handler "+
+			"never updates expanded state, so the refresh guard can't know when rows are open. Body was:\n  %s", toggleBody)
+	}
+
+	// Invariant 4: a visible "paused" affordance exists. The user
+	// needs to know why the page isn't auto-refreshing.
+	if !strings.Contains(html, "refresh-paused") {
+		t.Error("service_checks.html has no `refresh-paused` indicator element or class — " +
+			"users will see stale data with no explanation (#187 acceptance criterion)")
+	}
+}
+
+// extractFuncBody returns the body (between { and the matching }) of
+// the first JS function whose declaration starts with `prefix`. Balances
+// braces so nested objects/functions inside the body don't confuse the
+// extraction. Fails the test if the prefix is not present.
+func extractFuncBody(t *testing.T, html, prefix string) string {
+	t.Helper()
+	start := strings.Index(html, prefix)
+	if start < 0 {
+		t.Fatalf("function prefix %q not found in service_checks.html — template was restructured?", prefix)
+	}
+	// Find the opening `{` that closes the function signature.
+	openBrace := strings.Index(html[start:], "){")
+	if openBrace < 0 {
+		t.Fatalf("function %q has no opening brace — malformed JS?", prefix)
+	}
+	cursor := start + openBrace + 2 // position just after `){`
+	depth := 1
+	for cursor < len(html) && depth > 0 {
+		switch html[cursor] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return html[start+openBrace+2 : cursor]
+			}
+		}
+		cursor++
+	}
+	t.Fatalf("function %q never closed — brace mismatch in service_checks.html", prefix)
+	return ""
+}

--- a/internal/api/templates/service_checks.html
+++ b/internal/api/templates/service_checks.html
@@ -83,6 +83,12 @@
 /* Orphan badge */
 .orphan-badge{font-size:9px;padding:1px 6px;border-radius:999px;background:rgba(217,119,6,0.12);color:var(--amber);margin-left:6px}
 .btn-delete-check{font-size:10px;padding:2px 8px;border:1px solid var(--border);border-radius:var(--radius);background:var(--surface);color:var(--red);cursor:pointer;margin-left:auto}
+/* Auto-refresh paused indicator (#187). Shown while any log row is
+   expanded so the user knows data won't tick forward until they
+   collapse. Hidden by default; toggled by JS via .hidden. */
+.refresh-paused{display:inline-flex;align-items:center;gap:5px;font-size:11px;padding:2px 8px;border-radius:999px;background:rgba(217,119,6,0.12);color:var(--amber);margin-right:10px;vertical-align:middle}
+.refresh-paused.hidden{display:none}
+.refresh-paused::before{content:"";display:inline-block;width:6px;height:6px;border-radius:50%;background:var(--amber)}
 </style>
 </head>
 <body>
@@ -129,6 +135,7 @@
     <div><span class="filter-label">Time range</span><br>
       <select id="f-range" onchange="applyFilters()"><option value="1h">Last hour</option><option value="6h">Last 6 hours</option><option value="24h" selected>Last 24 hours</option><option value="7d">Last 7 days</option><option value="30d">Last 30 days</option></select></div>
     <div style="margin-left:auto;align-self:flex-end">
+      <span id="refresh-paused-indicator" class="refresh-paused hidden" title="Auto-refresh paused while a log entry is expanded. Collapse all entries to resume.">Refresh paused</span>
       <span id="log-count" style="font-size:12px;color:var(--text3)"></span>
     </div>
   </div>
@@ -166,6 +173,21 @@
   var allLogs=[];          // merged+filtered log entries for the table
   var currentPage=0;
   var activeFilter="";
+  // expandedRows tracks which log-detail row IDs are currently open.
+  // Auto-refresh (setInterval → loadAll) is skipped while any row is
+  // expanded so the user's expanded inspection isn't collapsed by a
+  // DOM rebuild mid-read. See #187. On explicit user actions that
+  // intentionally rebuild the table (filter change, pagination), we
+  // clear this set since the old row IDs no longer refer to the same
+  // entries.
+  var expandedRows={};
+  function anyRowExpanded(){for(var k in expandedRows){if(expandedRows[k])return true;}return false;}
+  function updatePausedIndicator(){
+    var el=document.getElementById("refresh-paused-indicator");
+    if(!el)return;
+    if(anyRowExpanded())el.classList.remove("hidden");
+    else el.classList.add("hidden");
+  }
 
   function esc(s){var d=document.createElement("div");d.textContent=s||"";return d.innerHTML;}
   function fetchJSON(url){return fetch(url).then(function(r){if(!r.ok)throw new Error(r.status);return r.json()});}
@@ -322,6 +344,11 @@
     }
     allLogs.sort(function(a,b){return(b.checked_at||"").localeCompare(a.checked_at||"");});
     currentPage=0;
+    // Filter change rebuilds the table with potentially different
+    // entries at each row index; stale expandedRows entries would
+    // wrongly keep auto-refresh paused. #187.
+    expandedRows={};
+    updatePausedIndicator();
     renderLogTable();
   };
 
@@ -385,9 +412,25 @@
     tbody.innerHTML=h;
   }
 
-  window.prevPage=function(){if(currentPage>0){currentPage--;renderLogTable();}};
-  window.nextPage=function(){currentPage++;renderLogTable();};
-  window.toggleLogDetail=function(id){var el=document.getElementById(id);if(el)el.classList.toggle("open");};
+  // prevPage/nextPage/applyFilters rebuild the log table DOM, which
+  // strips the "open" class from every detail row. Clear the tracked
+  // expandedRows set so anyRowExpanded() reflects reality — otherwise
+  // auto-refresh would stay paused forever after paginating away from
+  // an expanded row. #187.
+  window.prevPage=function(){if(currentPage>0){currentPage--;expandedRows={};updatePausedIndicator();renderLogTable();}};
+  window.nextPage=function(){currentPage++;expandedRows={};updatePausedIndicator();renderLogTable();};
+  window.toggleLogDetail=function(id){
+    var el=document.getElementById(id);
+    if(!el)return;
+    el.classList.toggle("open");
+    // Mirror the DOM "open" class into expandedRows so the refresh
+    // tick can consult it. Using the classList as source of truth
+    // (rather than pre-computing) handles both open and close paths
+    // with one branch. #187.
+    if(el.classList.contains("open"))expandedRows[id]=true;
+    else delete expandedRows[id];
+    updatePausedIndicator();
+  };
 
   window.filterByCheck=function(key){
     var sel=document.getElementById("f-check");
@@ -476,7 +519,16 @@
   }
 
   loadAll();
-  setInterval(loadAll,60000);
+  // Auto-refresh guard (#187): skip the tick if the user has any log
+  // row expanded. loadAll() rebuilds the entire log table DOM, which
+  // would collapse the row mid-read. The pause is announced by the
+  // "refresh-paused" badge in the filter bar; it resumes automatically
+  // once all rows are collapsed (see window.toggleLogDetail and the
+  // renderLogTable-callers which clear expandedRows).
+  setInterval(function(){
+    if(anyRowExpanded())return;
+    loadAll();
+  },60000);
 })();
 </script>
 </body>


### PR DESCRIPTION
Closes #187

## Summary

The Service Checks page auto-refreshes every 60s by rebuilding the entire log table DOM. Any row the user had expanded to inspect diagnostic details (HTTP status codes, DNS records, ping RTT, etc. — surfaced by #182/#183) was silently collapsed mid-read. Annoying during debugging sessions.

This implements **option A** from the issue body: pause auto-refresh while any row is expanded, resume once all rows collapse, and show a small "Refresh paused" affordance in the filter bar so the user knows why data isn't ticking forward.

## Changes

- **State**: `expandedRows` map (object-as-set) tracks which `log-detail-<N>` row IDs are currently open.
- **Click handler** (`window.toggleLogDetail`) uses the resulting DOM `.open` class as source of truth to add/remove from the map, then calls `updatePausedIndicator()`.
- **Refresh tick** (`setInterval`) is wrapped in an anonymous function that early-returns when `anyRowExpanded()` is true. No more `setInterval(loadAll, 60000)` direct callback.
- **User-initiated rebuilds** (`applyFilters`, `prevPage`, `nextPage`) wipe `expandedRows` because the row IDs they reference are stale after the table re-renders with different content — otherwise auto-refresh would stay paused forever after paginating away from an expanded row.
- **Visual affordance**: `.refresh-paused` amber pill in the filter bar, shown only while rows are expanded, with a tooltip explaining the pause.

## Detection strategy

"Any row expanded" is tracked via an incremental map mutated on each toggle, **not** a DOM walk on tick. Both would work, but the map is cheaper and lets the visual indicator update synchronously with the click.

## Test coverage

New cross-reference test `TestServiceChecksHTML_AutoRefreshPausesWhenRowExpanded` in `internal/api/service_checks_autorefresh_test.go` asserts four structural invariants that must all hold for the fix to function:

1. `setInterval` does **not** pass `loadAll` directly (the pre-fix pattern).
2. `expandedRows` state variable exists.
3. `window.toggleLogDetail` references `expandedRows`.
4. A `refresh-paused` element/class exists in the template.

If a future refactor removes any of them, the guard silently becomes a no-op — this test catches that.

## Pre-push checks

- `go build ./...` ✅
- `go test ./...` ✅ (full suite)
- Cross-reference test fails on the pre-fix template (verified in RED commit `24d37a3`) and passes after the fix (`0567089`).

## Line count + minimal-diff confirmation

```
 internal/api/templates/service_checks.html | 60 ++++++++++++++++++++++++++++--
 1 file changed, 56 insertions(+), 4 deletions(-)
```

Diff is **additive and localized** to the auto-refresh code path — no touching of the heartbeat cards, badge rendering, or detail-row rendering. This keeps merge conflicts with #188 (TCP protocol badge, in parallel) trivial.

## Follow-ups (not in scope)

- Option C from the issue (partial DOM updates instead of full rebuild) remains the right long-term answer. Left for a future PR.
- Playwright visual validation was optional per the dispatch note; skipped in favor of the grep-based cross-reference test. Happy to add one if maintainer prefers.