### PR TITLE
service-checks: show protocol badge for well-known TCP ports

### DIFF
--- a/internal/api/service_checks_protocol_hint_test.go
+++ b/internal/api/service_checks_protocol_hint_test.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestServiceChecksHTML_RendersProtocolHint guards the UI cross-reference
+// for issue #188. The Go ProtocolHint helper (internal/scheduler/
+// protocol_hints.go) populates a protocol_hint key on TCP service
+// check Details; the expanded log entry renderer in service_checks.html
+// and the Test button toast renderer in settings.html must both
+// consume that key to draw a badge.
+//
+// Classic §4b trap: a future refactor renames the key on one side only
+// and the badge silently disappears. This test locks the key name in
+// place on the JS side; the Go side is locked in the ProtocolHint
+// unit tests.
+func TestServiceChecksHTML_RendersProtocolHint(t *testing.T) {
+	html := loadServiceChecksHTML(t)
+	if !strings.Contains(html, "protocol_hint") {
+		t.Errorf("service_checks.html expanded log renderer missing protocol_hint key — TCP protocol badge will not render (issue #188)")
+	}
+}
+
+func TestSettingsHTML_TestButtonTCPProtocolHint(t *testing.T) {
+	html := loadSettingsHTML(t)
+	// The TCP renderer in the Test-button toast helper must consume
+	// protocol_hint so the toast mirrors the badge shown in the
+	// expanded log row. Scoped to the renderServiceCheckDetails
+	// function by string match on both tokens — settings.html is
+	// 3k+ lines and grepping for the key alone could false-positive
+	// on unrelated content in a future expansion.
+	if !strings.Contains(html, "renderServiceCheckDetails") {
+		t.Fatal("settings.html missing renderServiceCheckDetails helper — Test button toast detail rendering broken")
+	}
+	if !strings.Contains(html, "protocol_hint") {
+		t.Errorf("settings.html Test-button renderer missing protocol_hint key — toast won't show protocol badge (issue #188)")
+	}
+}

--- a/internal/api/templates/service_checks.html
+++ b/internal/api/templates/service_checks.html
@@ -207,7 +207,19 @@
         out += cell("Final URL", '<span style="font-size:11px;font-family:var(--font-mono);word-break:break-all">'+esc(details.final_url)+'</span>', "grid-column:1/-1");
       }
     } else if (t === "tcp" || t === "smb" || t === "nfs") {
-      if (details.resolved_address) out += cell("Resolved Address", '<span style="font-family:var(--font-mono)">'+esc(details.resolved_address)+'</span>');
+      if (details.resolved_address) {
+        // Pin the protocol badge (SSH, HTTPS, MySQL, …) to the
+        // Resolved Address cell so users see at-a-glance what they
+        // actually dialed. Populated by the Go ProtocolHint helper
+        // when the port is in the well-known table (issue #188).
+        // Keep the badge tight and muted so it reads as metadata,
+        // not as a status pill.
+        var addrHTML = '<span style="font-family:var(--font-mono)">'+esc(details.resolved_address)+'</span>';
+        if (details.protocol_hint) {
+          addrHTML += ' <span class="protocol-hint-badge" style="display:inline-block;margin-left:6px;padding:1px 6px;border-radius:4px;background:var(--surface-2,#1a1a1a);border:1px solid var(--border);color:var(--text2);font-size:10px;font-family:var(--font-mono);font-weight:600;letter-spacing:0.3px;vertical-align:middle">'+esc(details.protocol_hint)+'</span>';
+        }
+        out += cell("Resolved Address", addrHTML);
+      }
     } else if (t === "dns") {
       if (details.query_host) out += cell("Query Host", '<span style="font-family:var(--font-mono)">'+esc(details.query_host)+'</span>');
       if (details.dns_server) out += cell("DNS Server", '<span style="font-family:var(--font-mono)">'+esc(details.dns_server)+'</span>');

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -1839,7 +1839,14 @@ function renderServiceCheckDetails(type, details, result) {
     }
     if (details.failure_stage) lines.push("Failed at: " + details.failure_stage);
   } else if (type === "tcp" || type === "smb" || type === "nfs") {
-    if (details.resolved_address) lines.push("Connected to: " + details.resolved_address);
+    if (details.resolved_address) {
+      // Append the protocol badge inline — toast is a plain-text
+      // multi-line string so we bracket the label instead of using
+      // HTML. Populated by the Go ProtocolHint helper (issue #188).
+      var addrLine = "Connected to: " + details.resolved_address;
+      if (details.protocol_hint) addrLine += " [" + details.protocol_hint + "]";
+      lines.push(addrLine);
+    }
     if (details.failure_stage) lines.push("Failed at: " + details.failure_stage);
   } else if (type === "dns") {
     if (details.query_host) lines.push("Queried: " + details.query_host);

--- a/internal/scheduler/checks.go
+++ b/internal/scheduler/checks.go
@@ -419,6 +419,18 @@ func (sc *ServiceChecker) runTCPCheck(ctx context.Context, check internal.Servic
 	}
 	if result.Details != nil {
 		result.Details["resolved_address"] = addr
+		// protocol_hint is purely informational — drives the small
+		// badge in the expanded log entry + Test toast (issue #188).
+		// Absent from the map when the port is not in the
+		// well-known table so the JS renderer can use key-presence
+		// to decide whether to draw the badge.
+		if _, portStr, splitErr := net.SplitHostPort(addr); splitErr == nil {
+			if portNum, convErr := strconv.Atoi(portStr); convErr == nil {
+				if hint := ProtocolHint(portNum); hint != "" {
+					result.Details["protocol_hint"] = hint
+				}
+			}
+		}
 	}
 	dialer := net.Dialer{Timeout: time.Duration(timeoutSec) * time.Second}
 	conn, err := dialer.DialContext(ctx, "tcp", addr)

--- a/internal/scheduler/protocol_hints.go
+++ b/internal/scheduler/protocol_hints.go
@@ -1,0 +1,54 @@
+package scheduler
+
+// protocol_hints.go — the well-known-port → protocol label map used to
+// decorate TCP service check results with a small badge (SSH, HTTPS,
+// MySQL, …) in the expanded log entry and the Test button toast.
+//
+// Scope intentionally narrow: the common homelab / self-host
+// protocols listed in issue #188. The full IANA registry is overkill
+// here — an unknown port returns "" and the UI skips the badge.
+// Keep this table in sync with:
+//   - the docs table in the issue body,
+//   - the protocol_hint JS doc-comment in service_checks.html /
+//     settings.html renderServiceCheckDetails helpers.
+
+// wellKnownProtocols maps the TCP port number to a human-readable
+// protocol label. The labels match the issue body verbatim so the UI
+// badge text exactly mirrors the published doc.
+var wellKnownProtocols = map[int]string{
+	22:    "SSH",
+	25:    "SMTP",
+	53:    "DNS",
+	80:    "HTTP",
+	110:   "POP3",
+	143:   "IMAP",
+	389:   "LDAP",
+	443:   "HTTPS",
+	445:   "SMB",
+	465:   "SMTPS",
+	587:   "SMTP (submission)",
+	636:   "LDAPS",
+	993:   "IMAPS",
+	995:   "POP3S",
+	1433:  "MSSQL",
+	3306:  "MySQL",
+	3389:  "RDP",
+	5432:  "PostgreSQL",
+	5672:  "AMQP",
+	6379:  "Redis",
+	8080:  "HTTP (alt)",
+	8443:  "HTTPS (alt)",
+	9200:  "Elasticsearch",
+	27017: "MongoDB",
+}
+
+// ProtocolHint returns the well-known-protocol label for a TCP port,
+// or the empty string when the port is not in the curated table.
+// Informational only — callers must not gate check behaviour on the
+// return value. Negative / out-of-range / zero ports always return "".
+func ProtocolHint(port int) string {
+	if port <= 0 || port > 65535 {
+		return ""
+	}
+	return wellKnownProtocols[port]
+}

--- a/internal/scheduler/protocol_hints_test.go
+++ b/internal/scheduler/protocol_hints_test.go
@@ -1,0 +1,145 @@
+// Package scheduler — protocol_hints_test.go covers ProtocolHint, the
+// well-known-port → label map surfaced on TCP service check Details so
+// the dashboard can render a small protocol badge (e.g. "SSH" for :22,
+// "HTTPS" for :443) in the expanded log entry and the Test button
+// toast. Purely informational; does not affect check execution.
+//
+// See issue #188.
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// TestProtocolHint_KnownPorts walks the published port → badge table
+// from the issue body. Any drift between the table here and the Go
+// implementation means the docs lie. Kept verbose on purpose: one
+// case per row so a failure points at the exact offending port.
+func TestProtocolHint_KnownPorts(t *testing.T) {
+	cases := []struct {
+		port int
+		want string
+	}{
+		{22, "SSH"},
+		{25, "SMTP"},
+		{53, "DNS"},
+		{80, "HTTP"},
+		{110, "POP3"},
+		{143, "IMAP"},
+		{389, "LDAP"},
+		{443, "HTTPS"},
+		{445, "SMB"},
+		{465, "SMTPS"},
+		{587, "SMTP (submission)"},
+		{636, "LDAPS"},
+		{993, "IMAPS"},
+		{995, "POP3S"},
+		{1433, "MSSQL"},
+		{3306, "MySQL"},
+		{3389, "RDP"},
+		{5432, "PostgreSQL"},
+		{5672, "AMQP"},
+		{6379, "Redis"},
+		{8080, "HTTP (alt)"},
+		{8443, "HTTPS (alt)"},
+		{9200, "Elasticsearch"},
+		{27017, "MongoDB"},
+	}
+	for _, c := range cases {
+		if got := ProtocolHint(c.port); got != c.want {
+			t.Errorf("ProtocolHint(%d) = %q, want %q", c.port, got, c.want)
+		}
+	}
+}
+
+// TestProtocolHint_UnknownPorts — any port not in the published table
+// must return "" so the UI can skip the badge entirely. We exercise a
+// spread (privileged, ephemeral, nonsense) to keep the implementation
+// honest: no "default to HTTP" shortcuts.
+func TestProtocolHint_UnknownPorts(t *testing.T) {
+	for _, port := range []int{0, -1, 1, 23, 21, 999, 8000, 8081, 9999, 65535, 65536} {
+		if got := ProtocolHint(port); got != "" {
+			t.Errorf("ProtocolHint(%d) = %q, want empty string", port, got)
+		}
+	}
+}
+
+// TestRunCheck_TCP_PopulatesProtocolHint — when a TCP check resolves
+// to a well-known port, the Details map carries protocol_hint so the
+// dashboard and Test toast can render a badge. Uses a real listener
+// on 127.0.0.1:<ephemeral> for the happy path, and a hardcoded
+// target ending in :22 for the hint-set path (connect will fail —
+// the hint is computed from the TARGET port, not the connection
+// result, so failure_stage coexists with protocol_hint).
+func TestRunCheck_TCP_PopulatesProtocolHint(t *testing.T) {
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+
+	// Target port 22 is well-known (SSH). We point at 127.0.0.1:22
+	// rather than a real SSH server — the dial will almost certainly
+	// fail on CI, which is fine: the hint is derived from the
+	// resolved_address, not from the connection outcome.
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:       "tcp-ssh-hint",
+		Type:       internal.ServiceCheckTCP,
+		Target:     "127.0.0.1:22",
+		Enabled:    true,
+		TimeoutSec: 1,
+	}, time.Now().UTC())
+
+	hint, ok := result.Details["protocol_hint"].(string)
+	if !ok {
+		t.Fatalf("expected protocol_hint to be a string in Details, got %T (%v); full Details=%+v",
+			result.Details["protocol_hint"], result.Details["protocol_hint"], result.Details)
+	}
+	if hint != "SSH" {
+		t.Fatalf("expected protocol_hint=SSH for port 22, got %q", hint)
+	}
+}
+
+// TestRunCheck_TCP_UnknownPort_NoProtocolHint — the hint key must be
+// ABSENT (not empty-string) when the port is not in the well-known
+// table. The UI renderer uses key-presence to decide whether to draw
+// the badge, so an empty-string value would render an empty badge.
+func TestRunCheck_TCP_UnknownPort_NoProtocolHint(t *testing.T) {
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+
+	// Port 9999 is not in the table; pick a target that will also
+	// not connect so we don't need to stand up a listener.
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:       "tcp-no-hint",
+		Type:       internal.ServiceCheckTCP,
+		Target:     "127.0.0.1:9999",
+		Enabled:    true,
+		TimeoutSec: 1,
+	}, time.Now().UTC())
+
+	if v, present := result.Details["protocol_hint"]; present {
+		t.Fatalf("expected protocol_hint to be absent for port 9999, got %v", v)
+	}
+}
+
+// TestRunCheck_TCP_SMB_ImpliedPortHint — SMB checks default to port
+// 445 when none is specified. The hint should reflect the defaulted
+// port (SMB) so users get a badge even for port-less SMB targets.
+func TestRunCheck_TCP_SMB_ImpliedPortHint(t *testing.T) {
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:       "smb-implied-445",
+		Type:       internal.ServiceCheckSMB,
+		Target:     "127.0.0.1", // no explicit port → runner defaults to 445
+		Enabled:    true,
+		TimeoutSec: 1,
+	}, time.Now().UTC())
+
+	hint, ok := result.Details["protocol_hint"].(string)
+	if !ok || hint != "SMB" {
+		t.Fatalf("expected protocol_hint=SMB for defaulted SMB port 445, got %v", result.Details["protocol_hint"])
+	}
+}


### PR DESCRIPTION
Closes #188.

## Summary
Adds a small protocol label badge (SSH, HTTPS, MySQL, Redis, …) to TCP/SMB/NFS service checks when the target port is in the curated well-known-port table. Purely informational — does not affect check execution.

Rendered in both places the issue calls out:
- **Expanded log entry** on `/service-checks` (next to Resolved Address)
- **Test button toast** in Settings (bracketed after "Connected to: …")

## Port → badge table (all 24 from the issue body)
`22 SSH`, `25 SMTP`, `53 DNS`, `80 HTTP`, `110 POP3`, `143 IMAP`, `389 LDAP`, `443 HTTPS`, `445 SMB`, `465 SMTPS`, `587 SMTP (submission)`, `636 LDAPS`, `993 IMAPS`, `995 POP3S`, `1433 MSSQL`, `3306 MySQL`, `3389 RDP`, `5432 PostgreSQL`, `5672 AMQP`, `6379 Redis`, `8080 HTTP (alt)`, `8443 HTTPS (alt)`, `9200 Elasticsearch`, `27017 MongoDB`.

Unknown ports → key is absent (not empty-string) so the UI key-presence check skips drawing the badge cleanly.

## Implementation
- `internal/scheduler/protocol_hints.go` — new `ProtocolHint(port int) string` helper backed by a `map[int]string`.
- `internal/scheduler/checks.go` — TCP runner (which covers `tcp`/`smb`/`nfs` via the shared code path) calls `ProtocolHint` on the resolved port and sets `details["protocol_hint"]` when non-empty. Works for both explicit `host:port` targets and SMB/NFS default-port paths (:445 / :2049).
- `internal/api/templates/service_checks.html` — appends a small muted badge to the Resolved Address cell.
- `internal/api/templates/settings.html` — appends `[<hint>]` to the "Connected to:" toast line.

## Tests (7 new tests, all green)
- `TestProtocolHint_KnownPorts` — row-per-port walk of all 24 entries
- `TestProtocolHint_UnknownPorts` — 0, -1, 65536, and spot ports → all return ""
- `TestRunCheck_TCP_PopulatesProtocolHint` — TCP target `127.0.0.1:22` → `protocol_hint=SSH`
- `TestRunCheck_TCP_UnknownPort_NoProtocolHint` — port 9999 → key absent
- `TestRunCheck_TCP_SMB_ImpliedPortHint` — SMB check with no explicit port → defaults to 445 → hint=SMB
- `TestServiceChecksHTML_RendersProtocolHint` + `TestSettingsHTML_TestButtonTCPProtocolHint` — §4b cross-reference guards locking the key name on both HTML templates so a future rename breaks loudly

## Pre-push checks
- `go build ./...` ✓
- `go vet ./...` ✓
- `go test ./...` ✓ (full suite clean)
- Existing TCP Details tests (`TestRunCheck_Details_TCP_ResolvedAddress`, `TestRunCheck_Details_TCP_Closed_RecordsAddress`) still pass — the new key is additive.

## Coordination
Per dispatch: diff is localized to the `tcp/smb/nfs` arm of each details-renderer, so merge with #187 (auto-refresh fix, same file) should be trivial.

## LOC
- Go prod: ~60 lines (protocol_hints.go + 12-line TCP runner block)
- Go tests: ~145 lines (protocol_hints_test.go) + 40 lines (cross-reference test)
- JS/HTML: ~20 lines across the two templates