### PR TITLE
ci(docker): promote :latest as retag of stable release, add :nightly (#199)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -93,9 +93,18 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # `:latest` is deliberately NOT produced here. See the `promote-to-latest`
+          # job below: `:latest` is retagged from the most recent stable `vX.Y.Z`
+          # build AFTER it succeeds, making `:latest` byte-identical to the latest
+          # release by construction instead of a main-branch rebuild that can race
+          # (#199, postmortem: #194).
+          #
+          # `:nightly` is always enabled on pushes: main-branch pushes advance it
+          # on every merge, and tag pushes (including RC tags) also update it so
+          # anyone tracking pre-release work gets the newest build. PR events
+          # compute the tag list but don't push (see the build-push step).
           tags: |
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-            type=raw,value=nightly,enable=${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=raw,value=nightly
             type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc') }}
 
@@ -111,3 +120,34 @@ jobs:
           build-args: |
             VERSION=${{ steps.version.outputs.value }}
           no-cache: true
+
+  # After a successful stable tag build (vX.Y.Z, NOT vX.Y.Z-rcN), retag that
+  # image as `:latest`. This makes `:latest` byte-identical to `:X.Y.Z` by
+  # construction — no rebuild, no race, no VERSION=dev failure mode. See #199.
+  #
+  # `docker buildx imagetools create` with a single source manifest list
+  # performs a carbon copy (per the Docker docs), preserving all platforms
+  # (amd64 + arm64) in the new tag.
+  promote-to-latest:
+    needs: build-and-push
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc')
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Retag v${{ github.ref_name }} as :latest
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}


### PR DESCRIPTION
Closes #199

## Summary

Eliminates the main-branch-rebuild race condition that shipped v0.9.4 with `:latest` stuck on the 3rd-of-5 squash-merge commit (postmortem #194). Replaces the rebuild-on-main approach with an atomic retag of the most recent stable release.

## Tag semantics after this change

| Trigger | Tags published |
|---|---|
| PR build | none (build-only validation, from #164) |
| Main-branch push | `:nightly` |
| RC tag push (`vX.Y.Z-rcN`) | `:X.Y.Z-rcN`, `:nightly` |
| Stable tag push (`vX.Y.Z`) | `:X.Y.Z`, `:X.Y`, `:nightly`, then `:latest` retagged from `:X.Y.Z` |

`:latest` is now **byte-identical** to the most recent stable release by construction — no rebuild, no race, no VERSION=dev failure mode.

## How `:latest` gets set

A new `promote-to-latest` job runs after `build-and-push` succeeds, gated on `startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc')`. It runs:

```bash
docker buildx imagetools create \
  --tag ghcr.io/mcdays94/nas-doctor:latest \
  ghcr.io/mcdays94/nas-doctor:${VERSION}
```

Per the [Docker docs](https://docs.docker.com/reference/cli/docker/buildx/imagetools/create/): *"If only one source is specified and that source is a manifest list or image index, create performs a carbon copy."* So the multi-arch manifest list (amd64 + arm64) is preserved intact — it's a server-side manifest-level retag, not a pull/push of layers.

## What is preserved

- Multi-arch build (linux/amd64, linux/arm64) — unchanged
- PR build-only validation from #164 — `push: false` on PRs still works (meta step computes `:nightly` but build-push-action skips the push)
- Concurrency serialization from #192 — `cancel-in-progress: true` still applies to `build-and-push`
- `fetch-depth: 0 + fetch-tags: true + --match="v*"` from #192/#193 — untouched

## Nightly rule consolidation

Previously there were two mutually-exclusive `type=raw,value=nightly` rules (one for non-main, one for... the inverse of the `:latest` enable). Collapsed to a single unconditional `type=raw,value=nightly` since:

- PR events compute the tag list but don't push (so no stray `:nightly` push from PRs)
- Main pushes, RC tag pushes, and stable tag pushes all SHOULD update `:nightly` (anyone tracking bleeding edge wants the newest build regardless of its origin)

## Self-validating on v0.9.5 ship

This PR is a workflow-only change; it has no effect until the next `v*` tag is pushed. When v0.9.5 is tagged, the new workflow will:

1. Build + push `:0.9.5`, `:0.9`, `:nightly` via `build-and-push`
2. Run `promote-to-latest`, which retags `:0.9.5` → `:latest`

Post-release verification per AGENTS.md §Release-time gotchas (compare `:latest` and `:0.9.5` digests, confirm footer version in UAT) is still recommended the first time this new flow runs.

## Verification performed

- YAML parses cleanly (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- `go build ./...` passes (no Go changes but sanity-checked)
- Confirmed `docker buildx imagetools create` preserves multi-arch manifests when given a single manifest-list source (Docker docs, quoted above)
- Verified README doesn't claim `:latest` tracks main — it only shows `:latest` in pull examples, which remains correct (users will get the most recent stable)

## Breaking change for users

Anyone currently pulling `:latest` expecting main-branch-cutting-edge needs to switch to `:nightly`. For the vast majority (Unraid CA users), this is strictly better — they now only get tagged stable releases on `:latest`. To be documented in the v0.9.5 release notes.

## Scope

+42 / -2 lines, one file (`.github/workflows/docker.yml`).