### PR TITLE
SMART: use -n standby by default; add Advanced toggle to opt in to waking drives (#198)

### DIFF
--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -364,6 +364,13 @@ func main() {
 			})
 			logger.Info("kubernetes integration loaded", "url", persistedSettings.Kubernetes.URL, "in_cluster", persistedSettings.Kubernetes.InCluster)
 		}
+		// Apply SMART standby-awareness preference on startup (#198). Default
+		// (false) uses `-n standby` so spun-down drives aren't woken by scans.
+		if persistedSettings != nil {
+			coll.SetSMARTConfig(collector.SMARTConfig{
+				WakeDrives: persistedSettings.WakeDrivesForSMART,
+			})
+		}
 		sched.Start()
 		defer sched.Stop()
 	}

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -49,6 +49,12 @@ type Settings struct {
 	ChartRangeHours   int                     `json:"chart_range_hours"`         // Persisted chart time range (1, 24, 168)
 	SectionHeights    map[string]int          `json:"section_heights,omitempty"` // Persisted section resize heights (section name → px)
 	SectionOrder      map[string][]string     `json:"section_order,omitempty"`   // Persisted drag-and-drop column order ({"cols": [["findings","docker"], ...]})
+
+	// WakeDrivesForSMART, when true, opts back into pre-v0.9.5 behaviour of
+	// reading SMART from spun-down drives each scan cycle (waking them).
+	// Default (false) is standby-aware: smartctl runs with `-n standby` and
+	// skips sleeping drives. See issue #198.
+	WakeDrivesForSMART bool `json:"wake_drives_for_smart,omitempty"`
 }
 
 const currentSettingsVersion = 1
@@ -805,6 +811,11 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 			Token:     settings.Kubernetes.Token,
 			Alias:     settings.Kubernetes.Alias,
 			InCluster: settings.Kubernetes.InCluster,
+		})
+
+		// Update SMART config on the collector (#198)
+		s.collector.SetSMARTConfig(collector.SMARTConfig{
+			WakeDrives: settings.WakeDrivesForSMART,
 		})
 
 		// Update log forwarding

--- a/internal/api/settings_wake_drives_for_smart_test.go
+++ b/internal/api/settings_wake_drives_for_smart_test.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSettingsHTMLIncludesWakeDrivesForSMARTToggle verifies the settings
+// template ships the Advanced section with the wake-drives toggle +
+// disclaimer required by issue #198.
+//
+// This is a cross-reference test: it confirms the HTML mentions every
+// symbol the JS load/save wiring expects, so a future refactor that
+// renames one side can't silently break the round-trip.
+func TestSettingsHTMLIncludesWakeDrivesForSMARTToggle(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read settings.html: %v", err)
+	}
+	content := string(data)
+
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		// Advanced card anchor so the sticky section nav can link to it.
+		{"advanced card anchor", `id="card-advanced"`},
+		// Section nav link to the advanced card.
+		{"advanced nav link", `href="#card-advanced"`},
+		// Disclosure element — using <details>/<summary> per the issue's
+		// guidance (no extra JS needed).
+		{"details element", `<details`},
+		{"summary element", `<summary`},
+		// The toggle control + its stable id for load/save wiring.
+		{"wake-drives toggle id", `id="wake-drives-for-smart"`},
+		// Load path reads the JSON field name.
+		{"load binds field", `data.wake_drives_for_smart`},
+		// Save payload writes the JSON field name.
+		{"save sends field", `wake_drives_for_smart:`},
+		// Disclaimer text must communicate the wear trade-off. We keep
+		// the assertion loose so copy can be edited, but pin the key
+		// concepts: spin-ups and opt-in intent.
+		{"disclaimer mentions spin-ups", `spin-up`},
+		{"disclaimer mentions scan interval", `30-min`},
+	}
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(content, tc.substr) {
+				t.Errorf("settings.html missing %q — expected substring: %q", tc.name, tc.substr)
+			}
+		})
+	}
+}
+
+// TestSettingsRoundTrip_WakeDrivesForSMART exercises the GET/PUT cycle for
+// the new setting to make sure it persists and is returned by handleGetSettings.
+func TestSettingsRoundTrip_WakeDrivesForSMART(t *testing.T) {
+	s := newSettingsTestServer()
+
+	// PUT enabling the flag.
+	put := Settings{
+		ScanInterval:       "30m",
+		Theme:              ThemeMidnight,
+		WakeDrivesForSMART: true,
+	}
+	body, _ := json.Marshal(put)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.handleUpdateSettings(rr, req)
+	if rr.Code != http.StatusOK {
+		b, _ := io.ReadAll(rr.Body)
+		t.Fatalf("PUT returned %d: %s", rr.Code, b)
+	}
+
+	// GET and verify the flag survived the round-trip.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	rr2 := httptest.NewRecorder()
+	s.handleGetSettings(rr2, req2)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("GET returned %d", rr2.Code)
+	}
+	var got Settings
+	if err := json.Unmarshal(rr2.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse GET response: %v", err)
+	}
+	if !got.WakeDrivesForSMART {
+		t.Errorf("WakeDrivesForSMART did not round-trip; got false, wanted true")
+	}
+}
+
+// TestSettingsDefault_WakeDrivesForSMARTIsFalse guards against a regression
+// where the default flips; the whole point of #198 is that default=false
+// means drives in standby are NOT woken by SMART scans.
+func TestSettingsDefault_WakeDrivesForSMARTIsFalse(t *testing.T) {
+	d := defaultSettings()
+	if d.WakeDrivesForSMART {
+		t.Errorf("defaultSettings().WakeDrivesForSMART must be false (standby-aware by default, issue #198)")
+	}
+}

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -63,6 +63,7 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
     <a href="#card-replacement-cost" class="btn btn-secondary btn-sm" style="text-decoration:none">Replacement Cost</a>
     <a href="#card-speedtest" class="btn btn-secondary btn-sm" style="text-decoration:none">Speed Test</a>
     <a href="#card-backup" class="btn btn-secondary btn-sm" style="text-decoration:none">Backup</a>
+    <a href="#card-advanced" class="btn btn-secondary btn-sm" style="text-decoration:none">Advanced</a>
   </div>
 
   <!-- 1. General -->
@@ -877,6 +878,27 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
     </div>
   </div>
 
+  <!-- 9. Advanced -->
+  <div class="card" id="card-advanced">
+    <div class="card-title">Advanced</div>
+    <div class="card-desc">Expert-only knobs. Defaults are safe — only change these if you understand the trade-offs.</div>
+    <details style="margin-top:8px">
+      <summary style="cursor:pointer;padding:6px 0;font-weight:600;font-size:13px;color:var(--text)">Show advanced options</summary>
+      <div style="margin-top:14px;padding-top:12px;border-top:1px solid var(--border)">
+        <div class="toggle-wrap">
+          <div class="toggle" id="wake-drives-for-smart" onclick="this.classList.toggle('on');saveSettings()"><div class="toggle-knob"></div></div>
+          <span class="toggle-label">Wake drives for SMART check</span>
+        </div>
+        <p style="font-size:12px;color:var(--text2);margin-top:8px;line-height:1.5;max-width:720px">
+          By default, NAS Doctor skips drives that are in standby — SMART history will show gaps when drives are sleeping, and that's intentional (reduces wear).
+          Enabling this option forces smartctl to <strong>wake spun-down drives</strong> on every scan cycle.
+          At the default 30-min scan interval, that's roughly 48 extra spin-ups per drive per day.
+          Only enable if your drives never spin down, or if you deliberately need every-cycle SMART monitoring and accept the wear cost.
+        </p>
+      </div>
+    </details>
+  </div>
+
   <!-- Alerts, Incidents, Trends, and Notification History have moved to /alerts -->
   <div class="card" style="background:transparent;border-style:dashed;text-align:center;padding:20px">
     <div style="font-size:13px;color:var(--text2)">Alerts, Incidents, Trends, and Notification History have moved to their own dedicated page.</div>
@@ -1174,6 +1196,11 @@ function loadSettings() {
       /* Drive replacement cost per TB */
       var costEl = document.getElementById("cost-per-tb");
       if (costEl) costEl.value = (data.cost_per_tb && data.cost_per_tb > 0) ? data.cost_per_tb : "";
+      /* Advanced: wake drives for SMART (#198) */
+      var wakeEl = document.getElementById("wake-drives-for-smart");
+      if (wakeEl) {
+        if (data.wake_drives_for_smart) wakeEl.classList.add("on"); else wakeEl.classList.remove("on");
+      }
       /* Proxmox VE */
       var pve = data.proxmox || {};
       if (pve.enabled) document.getElementById("pve-toggle").classList.add("on"); else document.getElementById("pve-toggle").classList.remove("on");
@@ -1285,7 +1312,8 @@ function buildSettingsPayload() {
     api_key: document.getElementById("api-key-display").value.trim(),
     fleet: fleetServers || base.fleet || [],
     dismissed_findings: base.dismissed_findings || [],
-    cost_per_tb: parseFloat(document.getElementById("cost-per-tb") && document.getElementById("cost-per-tb").value) || 0
+    cost_per_tb: parseFloat(document.getElementById("cost-per-tb") && document.getElementById("cost-per-tb").value) || 0,
+    wake_drives_for_smart: !!(document.getElementById("wake-drives-for-smart") && document.getElementById("wake-drives-for-smart").classList.contains("on"))
   };
 }
 

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -17,6 +17,7 @@ type Collector struct {
 	logger        *slog.Logger
 	proxmoxConfig ProxmoxConfig
 	kubeConfig    KubeConfig
+	smartConfig   SMARTConfig
 }
 
 // SetProxmoxConfig updates the Proxmox VE API connection settings.
@@ -27,6 +28,12 @@ func (c *Collector) SetProxmoxConfig(cfg ProxmoxConfig) {
 // SetKubeConfig updates the Kubernetes cluster connection settings.
 func (c *Collector) SetKubeConfig(cfg KubeConfig) {
 	c.kubeConfig = cfg
+}
+
+// SetSMARTConfig updates SMART-collector behaviour flags — primarily the
+// WakeDrives toggle introduced for issue #198.
+func (c *Collector) SetSMARTConfig(cfg SMARTConfig) {
+	c.smartConfig = cfg
 }
 
 // New creates a new Collector with the given host path mappings.
@@ -62,8 +69,8 @@ func (c *Collector) Collect() (*internal.Snapshot, error) {
 	snap.Disks = disks
 
 	// SMART data
-	c.logger.Info("collecting SMART data")
-	smart, err := collectSMART()
+	c.logger.Info("collecting SMART data", "wake_drives", c.smartConfig.WakeDrives)
+	smart, err := collectSMART(c.smartConfig)
 	if err != nil {
 		c.logger.Warn("SMART collection partial failure", "error", err)
 	}

--- a/internal/collector/smart.go
+++ b/internal/collector/smart.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,10 +12,30 @@ import (
 	"github.com/mcdays94/nas-doctor/internal"
 )
 
-func collectSMART() ([]internal.SMARTInfo, error) {
+// SMARTConfig controls SMART-collector behaviour that may need to change
+// based on user preference. See issue #198 for the v0.9.5 default shift.
+type SMARTConfig struct {
+	// WakeDrives, when true, instructs smartctl to read SMART attributes
+	// even on spun-down drives — the v0.9.4 and earlier behaviour. When
+	// false (the new default), smartctl is invoked with `-n standby`,
+	// which causes it to skip (exit 2) any drive currently in standby.
+	// Users who prefer every-cycle SMART reads can opt back in via the
+	// Settings → Advanced UI.
+	WakeDrives bool
+}
+
+// errDriveInStandby is returned by readSMARTDevice when smartctl reported
+// that the target drive is spun down and therefore no SMART data was read.
+// The SMART collector treats this as "skip silently" rather than an error
+// that should create a history row or surface in logs.
+var errDriveInStandby = errors.New("drive in standby; skipped SMART read")
+
+func collectSMART(cfg SMARTConfig) ([]internal.SMARTInfo, error) {
 	devices := discoverDrives()
 	if len(devices) == 0 {
-		// Fallback: try smartctl --scan
+		// Fallback: try smartctl --scan. (The --scan subcommand does not
+		// itself wake drives; it just enumerates what's attached, so no
+		// standby flag needed here.)
 		out, _ := execCmd("smartctl", "--scan")
 		for _, line := range strings.Split(out, "\n") {
 			fields := strings.Fields(line)
@@ -29,10 +50,16 @@ func collectSMART() ([]internal.SMARTInfo, error) {
 
 	var results []internal.SMARTInfo
 	var lastErr error
-	var skipped int
+	var skipped, standby int
 	for _, dev := range devices {
-		info, err := readSMARTDevice(dev)
+		info, err := readSMARTDevice(dev, cfg.WakeDrives)
 		if err != nil {
+			if errors.Is(err, errDriveInStandby) {
+				// Expected when `-n standby` is in effect and the drive
+				// is spun down. Not an error; no history row created.
+				standby++
+				continue
+			}
 			lastErr = err
 			skipped++
 			continue
@@ -44,8 +71,12 @@ func collectSMART() ([]internal.SMARTInfo, error) {
 		}
 		results = append(results, info)
 	}
+	// If every discovered drive is in standby and nothing else failed,
+	// that's a legitimate outcome (all disks asleep); return no error and
+	// an empty slice so the caller can persist an empty SMART snapshot
+	// rather than treating it as a collection failure.
 	if len(results) == 0 && lastErr != nil {
-		return nil, fmt.Errorf("all %d drives failed SMART read (%d skipped), last error: %w", len(devices), skipped, lastErr)
+		return nil, fmt.Errorf("all %d drives failed SMART read (%d skipped, %d standby), last error: %w", len(devices), skipped, standby, lastErr)
 	}
 	return results, nil
 }
@@ -90,12 +121,34 @@ func discoverDrives() []string {
 // readSMARTDevice uses `smartctl --json` for reliable parsing.
 // Note: smartctl returns non-zero exit codes even on success (bit-masked status).
 // We check the output content instead of relying on the exit code.
-func readSMARTDevice(device string) (internal.SMARTInfo, error) {
+//
+// When wakeDrives is false (the v0.9.5+ default), each smartctl invocation
+// is prefixed with `-n standby` so spun-down drives are not woken by the
+// scan cycle. If smartctl reports the drive is in standby, this function
+// returns errDriveInStandby, which the caller (collectSMART) treats as a
+// silent skip rather than a collection failure.
+func readSMARTDevice(device string, wakeDrives bool) (internal.SMARTInfo, error) {
 	info := internal.SMARTInfo{Device: device}
+
+	// smartctlArgs builds the argument slice for a smartctl call,
+	// prefixing `-n standby` when the user has not opted into waking
+	// spun-down drives.
+	smartctlArgs := func(extra ...string) []string {
+		if wakeDrives {
+			return extra
+		}
+		// Prepend -n standby. Order matters less than presence, but we
+		// keep it at the front so it's visible to anyone grepping the
+		// argv of a running smartctl.
+		return append([]string{"-n", "standby"}, extra...)
+	}
 
 	// Try JSON output first (smartctl 7.0+)
 	// Ignore exit code — smartctl uses bitmask exit codes even for successful reads
-	out, _ := execCmd("smartctl", "--json=c", "-a", device)
+	out, _ := execCmd("smartctl", smartctlArgs("--json=c", "-a", device)...)
+	if !wakeDrives && looksLikeStandbyOutput(out) {
+		return info, errDriveInStandby
+	}
 	if strings.Contains(out, "json_format_version") {
 		return parseSMARTJSON(device, out)
 	}
@@ -105,7 +158,10 @@ func readSMARTDevice(device string) (internal.SMARTInfo, error) {
 		strings.Contains(out, "INQUIRY failed") || strings.Contains(out, "unable to detect device") ||
 		out == "" {
 		for _, devType := range []string{"sat", "auto", "scsi"} {
-			out2, _ := execCmd("smartctl", "--json=c", "-a", "-d", devType, device)
+			out2, _ := execCmd("smartctl", smartctlArgs("--json=c", "-a", "-d", devType, device)...)
+			if !wakeDrives && looksLikeStandbyOutput(out2) {
+				return info, errDriveInStandby
+			}
 			if strings.Contains(out2, "json_format_version") {
 				return parseSMARTJSON(device, out2)
 			}
@@ -118,7 +174,10 @@ func readSMARTDevice(device string) (internal.SMARTInfo, error) {
 	}
 
 	// Fallback to text parsing (also ignore exit code)
-	out, _ = execCmd("smartctl", "-a", device)
+	out, _ = execCmd("smartctl", smartctlArgs("-a", device)...)
+	if !wakeDrives && looksLikeStandbyOutput(out) {
+		return info, errDriveInStandby
+	}
 	if out == "" {
 		return info, fmt.Errorf("smartctl returned no output for %s", device)
 	}
@@ -126,6 +185,31 @@ func readSMARTDevice(device string) (internal.SMARTInfo, error) {
 		return info, fmt.Errorf("unsupported device (USB bridge): %s", device)
 	}
 	return parseSMARTText(device, out), nil
+}
+
+// looksLikeStandbyOutput returns true when smartctl's output indicates the
+// target drive is spun down and was therefore skipped under `-n standby`.
+// Covers both the text-mode banner ("Device is in STANDBY mode, exit(2)")
+// and the --json=c response where power_mode carries STANDBY without the
+// json_format_version header that accompanies a full SMART read.
+func looksLikeStandbyOutput(out string) bool {
+	if out == "" {
+		return false
+	}
+	// Text-mode marker — most common on Unraid / typical Linux installs.
+	if strings.Contains(out, "STANDBY mode") || strings.Contains(out, "in standby mode") {
+		return true
+	}
+	// JSON-mode marker: smartctl emits a small envelope with power_mode
+	// set to STANDBY and no attribute table. Be conservative and require
+	// the absence of json_format_version (which only appears in a full
+	// read) so we don't mis-classify a model name containing "STANDBY".
+	if strings.Contains(out, `"power_mode"`) &&
+		strings.Contains(strings.ToUpper(out), "STANDBY") &&
+		!strings.Contains(out, "json_format_version") {
+		return true
+	}
+	return false
 }
 
 type smartctlJSON struct {

--- a/internal/collector/smart_standby_test.go
+++ b/internal/collector/smart_standby_test.go
@@ -1,0 +1,167 @@
+package collector
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// swapExecCmd replaces the package-level execCmd with a fake for the duration
+// of a test. Returns a restore function; callers should defer restore().
+//
+// execCmd is defined as a package-level var in system.go specifically so
+// tests can swap it out — the smartctl flag surface is otherwise difficult
+// to unit-test (would require either building a fake binary on PATH or
+// mocking exec.Command).
+func swapExecCmd(fn func(name string, args ...string) (string, error)) (restore func()) {
+	orig := execCmd
+	execCmd = fn
+	return func() { execCmd = orig }
+}
+
+// TestReadSMARTDevice_DefaultAddsStandbyFlag verifies the v0.9.5+ default:
+// every smartctl invocation from the SMART collector must include `-n standby`
+// unless the WakeDrivesForSMART setting is explicitly enabled. Without this,
+// scans wake spun-down drives every scan cycle (issue #198).
+func TestReadSMARTDevice_DefaultAddsStandbyFlag(t *testing.T) {
+	var calls [][]string
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		calls = append(calls, append([]string{name}, args...))
+		// Return nothing matching json_format_version so readSMARTDevice
+		// exercises all fallback paths (initial JSON, device-type loop,
+		// text fallback).
+		return "", nil
+	})()
+
+	_, _ = readSMARTDevice("/dev/sda", false /* wakeDrives */)
+
+	if len(calls) == 0 {
+		t.Fatal("expected at least one smartctl call")
+	}
+	for i, call := range calls {
+		if call[0] != "smartctl" {
+			t.Errorf("call %d: expected smartctl binary, got %q", i, call[0])
+			continue
+		}
+		joined := strings.Join(call, " ")
+		if !strings.Contains(joined, "-n standby") {
+			t.Errorf("call %d missing `-n standby` flag (wakeDrives=false): %s", i, joined)
+		}
+	}
+}
+
+// TestReadSMARTDevice_WakeDrivesOmitsStandbyFlag verifies the opt-out: when
+// the user explicitly enables WakeDrivesForSMART, the `-n standby` flag must
+// NOT be passed (restoring v0.9.4 and earlier behavior).
+func TestReadSMARTDevice_WakeDrivesOmitsStandbyFlag(t *testing.T) {
+	var calls [][]string
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		calls = append(calls, append([]string{name}, args...))
+		return "", nil
+	})()
+
+	_, _ = readSMARTDevice("/dev/sda", true /* wakeDrives */)
+
+	if len(calls) == 0 {
+		t.Fatal("expected at least one smartctl call")
+	}
+	for i, call := range calls {
+		joined := strings.Join(call, " ")
+		if strings.Contains(joined, "-n standby") {
+			t.Errorf("call %d included `-n standby` flag despite wakeDrives=true: %s", i, joined)
+		}
+	}
+}
+
+// TestReadSMARTDevice_StandbyOutputReturnsSentinel verifies that when
+// smartctl reports the drive is in standby (via `-n standby` skip), we
+// return errDriveInStandby so collectSMART can silently skip the drive
+// rather than log an error or create a broken history row.
+func TestReadSMARTDevice_StandbyOutputReturnsSentinel(t *testing.T) {
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		// Typical smartctl text output when -n standby skips the drive.
+		return "smartctl 7.3 2022-02-28 r5338 [x86_64-linux-6.1.0] (local build)\n" +
+			"Copyright (C) 2002-22, Bruce Allen, Christian Franke, www.smartmontools.org\n\n" +
+			"Device is in STANDBY mode, exit(2)\n", nil
+	})()
+
+	_, err := readSMARTDevice("/dev/sda", false)
+	if !errors.Is(err, errDriveInStandby) {
+		t.Errorf("expected errDriveInStandby, got %v", err)
+	}
+}
+
+// TestReadSMARTDevice_StandbyJSONReturnsSentinel verifies standby detection
+// for the --json=c invocation path (smartctl emits a JSON object with
+// power_mode=STANDBY even when skipping).
+func TestReadSMARTDevice_StandbyJSONReturnsSentinel(t *testing.T) {
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		// Minimal JSON smartctl returns when -n standby skips — no
+		// json_format_version (so we shouldn't accidentally parse it as
+		// a successful SMART read), with an explicit power_mode signal.
+		return `{"power_mode":"STANDBY","exit_status":2}`, nil
+	})()
+
+	_, err := readSMARTDevice("/dev/sda", false)
+	if !errors.Is(err, errDriveInStandby) {
+		t.Errorf("expected errDriveInStandby for JSON-mode standby output, got %v", err)
+	}
+}
+
+// TestReadSMARTDevice_WakeDrivesTrueIgnoresStandbyHeuristic ensures the
+// standby-detection heuristic only runs when wakeDrives=false. When the
+// setting is enabled, we never pass -n standby, so STANDBY should not
+// appear in output; but even if some attribute text happened to contain
+// the word, we must not short-circuit.
+func TestReadSMARTDevice_WakeDrivesTrueIgnoresStandbyHeuristic(t *testing.T) {
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		// Deliberately include the word STANDBY in output (e.g. as part
+		// of a device-type attribute description) to prove wakeDrives=true
+		// never returns errDriveInStandby.
+		return `{"json_format_version":[1,0,0],"model_name":"STANDBY Pro 2TB","user_capacity":{"bytes":2000000000000}}`, nil
+	})()
+
+	info, err := readSMARTDevice("/dev/sda", true)
+	if errors.Is(err, errDriveInStandby) {
+		t.Errorf("unexpected errDriveInStandby when wakeDrives=true: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Model != "STANDBY Pro 2TB" {
+		t.Errorf("expected parsed model=%q, got %q", "STANDBY Pro 2TB", info.Model)
+	}
+}
+
+// TestCollectSMART_PropagatesWakeDrivesFlag wires the top-level collectSMART
+// entry to the readSMARTDevice seam by checking whether the standby flag is
+// threaded through the SMARTConfig struct.
+func TestCollectSMART_PropagatesWakeDrivesFlag(t *testing.T) {
+	// Use a discovery-minimal approach: we can't replace discoverDrives
+	// without another seam, so we verify the SMARTConfig struct exists
+	// and the field name is stable. More integration-like behaviour is
+	// exercised by the readSMARTDevice tests above.
+	cfg := SMARTConfig{WakeDrives: true}
+	if !cfg.WakeDrives {
+		t.Errorf("SMARTConfig.WakeDrives did not round-trip")
+	}
+	// Also make sure the zero value is false (default behavior = standby-aware).
+	var zero SMARTConfig
+	if zero.WakeDrives {
+		t.Errorf("SMARTConfig zero value should have WakeDrives=false; got true")
+	}
+
+	// Sanity-check that the Collector exposes a setter so the API/main
+	// plumbing can reach the field.
+	var c Collector
+	c.SetSMARTConfig(cfg)
+	if !c.smartConfig.WakeDrives {
+		t.Errorf("SetSMARTConfig did not persist cfg")
+	}
+}
+
+// compile-time guard: SMARTInfo remains the return type of readSMARTDevice
+// (catches accidental signature drift).
+var _ = internal.SMARTInfo{}

--- a/internal/collector/system.go
+++ b/internal/collector/system.go
@@ -328,7 +328,11 @@ func extractHexID(s string) string {
 	return candidate
 }
 
-func execCmd(name string, args ...string) (string, error) {
+// execCmd shells out to a command and returns combined stdout+stderr plus
+// any exec error. Defined as a package-level var (rather than a plain
+// function) so tests can swap in a fake implementation — see
+// smart_standby_test.go for the seam usage.
+var execCmd = func(name string, args ...string) (string, error) {
 	cmd := exec.Command(name, args...)
 	out, err := cmd.CombinedOutput()
 	return string(out), err


### PR DESCRIPTION
Closes #198

## Summary

Before this PR, every diagnostic scan (default every 30 min) woke spun-down drives to read SMART. That's ~48 unnecessary spin-ups per drive per day — real wear for Unraid users.

This PR flips the default: `smartctl` is now invoked with `-n standby` on all three call sites in `internal/collector/smart.go`, so spun-down drives are silently skipped. A user-visible opt-out ("Wake drives for SMART check") is added under a new **Advanced** section in Settings for anyone who wants the v0.9.4 behavior back (e.g., drives that never sleep, or deliberately paying the wear cost for fresher data).

## ⚠️ Behavior change (for the release notes)

> SMART scans now skip drives that are in standby. SMART history will have gaps when drives are sleeping — this is intentional and reduces wear. Users who want every-cycle SMART reads can enable **Wake drives for SMART check** in *Settings → Advanced*.

## Changes

### Collector (`internal/collector/`)
- `smart.go`:
  - `readSMARTDevice(device, wakeDrives bool)` prefixes `-n standby` to all three smartctl invocations (initial `--json=c -a`, device-type fallback loop, text fallback) unless the user opts out.
  - New `errDriveInStandby` sentinel + `looksLikeStandbyOutput` heuristic so a spun-down drive is a silent skip, not a history row or error log. Detects both text-mode ("Device is in STANDBY mode, exit(2)") and JSON-mode (`"power_mode":"STANDBY"` without `json_format_version`) output.
  - `collectSMART(cfg SMARTConfig)` takes the config and routes `errDriveInStandby` into a separate counter so "all drives asleep" isn't a collection failure.
  - New `SMARTConfig{ WakeDrives bool }` type mirroring `ProxmoxConfig` / `KubeConfig`.
- `collector.go`: `Collector.smartConfig` field + `SetSMARTConfig()` setter. `Collect()` logs the flag and threads it through.
- `system.go`: `execCmd` promoted from `func` to package-level `var` so tests can swap it. No runtime behavior change.

### API (`internal/api/api_extended.go`)
- New `Settings.WakeDrivesForSMART bool` (`json:"wake_drives_for_smart,omitempty"`, default `false`).
- `handleUpdateSettings` forwards the flag to `collector.SetSMARTConfig` on every save, matching the Proxmox/Kubernetes patterns.

### Startup (`cmd/nas-doctor/main.go`)
- Applies the persisted `WakeDrivesForSMART` to the collector on boot so the preference survives container restarts.

### UI (`internal/api/templates/settings.html`)
- New **Advanced** card (`id="card-advanced"`) after the Backup card, with a sticky-nav link. Uses native `<details>`/`<summary>` — no extra JS.
- First (and for now only) entry inside: `#wake-drives-for-smart` toggle + plain-language disclaimer explaining the ~48 spin-ups/day trade-off and when to enable it.
- Load/save JS wired to the `wake_drives_for_smart` JSON field.

## Tests

- `internal/collector/smart_standby_test.go` (new):
  - `TestReadSMARTDevice_DefaultAddsStandbyFlag` — asserts every smartctl call receives `-n standby` when `wakeDrives=false`.
  - `TestReadSMARTDevice_WakeDrivesOmitsStandbyFlag` — asserts no smartctl call receives `-n standby` when `wakeDrives=true`.
  - `TestReadSMARTDevice_StandbyOutputReturnsSentinel` — text-mode standby output → `errDriveInStandby`.
  - `TestReadSMARTDevice_StandbyJSONReturnsSentinel` — JSON-mode standby output → `errDriveInStandby`.
  - `TestReadSMARTDevice_WakeDrivesTrueIgnoresStandbyHeuristic` — proves a drive model name containing "STANDBY" is not mis-classified when the feature is opted out of.
  - `TestCollectSMART_PropagatesWakeDrivesFlag` — `SMARTConfig` round-trips through `Collector.SetSMARTConfig`.
- `internal/api/settings_wake_drives_for_smart_test.go` (new):
  - `TestSettingsHTMLIncludesWakeDrivesForSMARTToggle` — 9 cross-reference sub-tests for card anchor, nav link, `<details>`/`<summary>`, toggle id, JS load/save wiring, and disclaimer text.
  - `TestSettingsRoundTrip_WakeDrivesForSMART` — PUT + GET through the real handlers against `FakeStore`.
  - `TestSettingsDefault_WakeDrivesForSMARTIsFalse` — regression guard against anyone flipping the default.

## Pre-push checks (§4b)

- ✅ `go build ./...`
- ✅ `go vet ./...`
- ✅ `go test ./...` (all packages green)
- No Dockerfile / CI workflow / migration / manifest changes — behavior is purely in-process.
- UI cross-reference: every string set by the JS load/save path is asserted to exist in the HTML via the template test.