### PR TITLE
polish(v0.9.5): disclaimer width + SMART standby log + README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Born from an [OpenCode diagnostic skill](https://github.com/mcdays94/opencode-se
 ## What It Does
 
 ### Diagnostics
-- **SMART Health**: Per-drive health, temperature, reallocated sectors, pending sectors, UDMA CRC errors, power-on hours, ATA port mapping, with **Backblaze failure-rate thresholds** (Q4-2025 data, 337k+ drives)
+- **SMART Health**: Per-drive health, temperature, reallocated sectors, pending sectors, UDMA CRC errors, power-on hours, ATA port mapping, with **Backblaze failure-rate thresholds** (Q4-2025 data, 337k+ drives). By default, NAS Doctor respects drive standby and skips spun-down drives rather than waking them for SMART reads — history will show gaps for drives that spin down, which is intentional (reduces wear). Flip **Wake drives for SMART check** in Settings → Advanced to restore every-cycle polling (v0.9.4 behaviour).
 - **Historical Sparklines**: CPU, memory, I/O wait, and per-drive temperature trends inline on the dashboard
 - **Disk Space**: Usage per mount point with color-coded thresholds
 - **System**: CPU, memory, load average, I/O wait, uptime, platform detection
@@ -493,7 +493,7 @@ All configurable from the web UI at `/settings`, organized with a sticky section
 
 - **General**: Scan interval (preset or custom with cron preview), theme selection, app icon
 - **Webhooks**: Add/remove/test Discord, Slack, Gotify, Ntfy, or generic HTTP webhooks with optional custom headers and HMAC signing
-- **Notification Rules**: Dropdown-driven rule builder with 12 categories, live target selection, threshold inputs, one-click presets, quiet hours, and maintenance windows
+- **Notification Rules**: Dropdown-driven rule builder with 13 categories, live target selection, threshold inputs, one-click presets, quiet hours, and maintenance windows
 - **Service Checks**: HTTP, TCP, DNS, Ping/ICMP, SMB/NFS uptime monitoring with per-check configurable intervals (30s–1h)
 - **Fleet**: Add/remove remote NAS Doctor instances with optional API key auth
 - **Dashboard Sections**: Toggle visibility of individual sections (SMART, Docker, ZFS, UPS, Parity, Network, Tunnels, etc.)

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -889,7 +889,7 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
           <div class="toggle" id="wake-drives-for-smart" onclick="this.classList.toggle('on');saveSettings()"><div class="toggle-knob"></div></div>
           <span class="toggle-label">Wake drives for SMART check</span>
         </div>
-        <p style="font-size:12px;color:var(--text2);margin-top:8px;line-height:1.5;max-width:720px">
+        <p style="font-size:12px;color:var(--text2);margin-top:8px;line-height:1.5">
           By default, NAS Doctor skips drives that are in standby — SMART history will show gaps when drives are sleeping, and that's intentional (reduces wear).
           Enabling this option forces smartctl to <strong>wake spun-down drives</strong> on every scan cycle.
           At the default 30-min scan interval, that's roughly 48 extra spin-ups per drive per day.

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -70,7 +70,7 @@ func (c *Collector) Collect() (*internal.Snapshot, error) {
 
 	// SMART data
 	c.logger.Info("collecting SMART data", "wake_drives", c.smartConfig.WakeDrives)
-	smart, err := collectSMART(c.smartConfig)
+	smart, err := collectSMART(c.smartConfig, c.logger)
 	if err != nil {
 		c.logger.Warn("SMART collection partial failure", "error", err)
 	}

--- a/internal/collector/smart.go
+++ b/internal/collector/smart.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -30,7 +31,7 @@ type SMARTConfig struct {
 // that should create a history row or surface in logs.
 var errDriveInStandby = errors.New("drive in standby; skipped SMART read")
 
-func collectSMART(cfg SMARTConfig) ([]internal.SMARTInfo, error) {
+func collectSMART(cfg SMARTConfig, logger *slog.Logger) ([]internal.SMARTInfo, error) {
 	devices := discoverDrives()
 	if len(devices) == 0 {
 		// Fallback: try smartctl --scan. (The --scan subcommand does not
@@ -57,6 +58,11 @@ func collectSMART(cfg SMARTConfig) ([]internal.SMARTInfo, error) {
 			if errors.Is(err, errDriveInStandby) {
 				// Expected when `-n standby` is in effect and the drive
 				// is spun down. Not an error; no history row created.
+				// Emit an INFO log so operators can see per-cycle which
+				// drives were skipped for standby (issue #202).
+				if logger != nil {
+					logger.Info("skipped SMART read: drive in standby", "device", dev)
+				}
 				standby++
 				continue
 			}


### PR DESCRIPTION
v0.9.5 polish bundle, rebased onto `release/v0.9.5-stage` (so it sits on top of #198/#201 SMART standby, #195/#196/#197 UI fixes, and #199 docker retag).

## Changes

### 1. Settings — drop `max-width:720px` on the SMART standby disclaimer
`internal/api/templates/settings.html`: the `<p>` below the **Wake drives for SMART check** toggle was wrapping at 720px, narrower than its containing card on wide viewports. Removed `max-width:720px` from that one inline style so it fills the card naturally. All other inline styles (font-size, color, margin-top, line-height) preserved.

### 2. SMART — INFO log per drive skipped for standby
`internal/collector/smart.go` + `internal/collector/collector.go`: when `readSMARTDevice` returns `errDriveInStandby` (drive is spun down, `-n standby` caused smartctl to skip), emit `logger.Info("skipped SMART read: drive in standby", "device", dev)` from `collectSMART`.

Plumbing: threaded `*slog.Logger` into `collectSMART(cfg, logger)` and updated the single call site in `collector.go` to pass `c.logger`. The logger is nil-checked so existing tests (`swapExecCmd`) keep working without needing a logger. Scope: ~5 LOC of new logging + signature change. No refactor.

Operators who use `-n standby` (the new default) previously had no per-cycle visibility into which drives were being skipped — only a summary in the "all failed" error path. With this, `docker logs` shows standby skips as they happen.

### 3. README
- Added a succinct note under the **SMART Health** bullet about the new default (respects standby → expected SMART history gaps → opt out via Settings → Advanced).
- Fixed an existing inconsistency: Notification Rules section said "13 categories" in one place and "12 categories" in another. Both now say **13** (matches the explicit list).

#### Scour findings

- **v0.9.x feature coverage**: cross-referenced against `AGENTS.md` changelog. All user-facing v0.9.0–v0.9.4 features are already present in the README (Top Processes + container attribution, Cost per TB, UPS NUT→apcupsd, Tailscale, GPU/iGPU honesty broadly). Internal UI details (Test button diagnostics, chart label decimation, legacy DNS-IP auto-disable, per-check DNS resolver) are plumbing and intentionally not promoted to README feature bullets.
- **Install instructions**: Docker compose + Unraid + Synology + TrueNAS + K8s + Proxmox sections all have the correct mounts including `/var/local/emhttp` for the merged drive view and `/var/run/tailscale` as optional for Tailscale detection. ✅
- **Links**: demo URL, GitHub issues, k3s-gitops example, opencode, buymeacoffee — all valid. ✅
- **Agentic Setup** (v0.9.4 addition): reads fine, no update needed.
- **Badges**: Live Demo + Buy Me A Coffee are the only badges; both still point correctly.
- **Screenshots** — out of scope to regenerate in this PR. They cover midnight theme top, all major subpages (service-checks, alerts, fleet, stats, settings, parity, dashboard-processes, stats-process-history, planner), and the report PDF pages. Still representative of current UI; no obviously-stale shots.

## Deferred — flag for future PR

- None. Screenshots look current enough; feature list is comprehensive.

## Line-count breakdown

| File | +/- |
|---|---|
| `internal/api/templates/settings.html` | +1 / -1 |
| `internal/collector/smart.go` | +7 / -1 |
| `internal/collector/collector.go` | +1 / -1 |
| `README.md` | +2 / -2 |

Total: +11 / -5 across 4 files, 3 atomic commits.

## Edge cases / judgement calls

- **Logger threading vs package-level logger**: chose to extend `collectSMART`'s signature rather than introduce a package-level `slog` var in the collector package, since the existing `collectSMART` was already config-parameterized. Zero-diff alternative (read logger from a package var) would have created a global, which is worse for testability.
- **Nil-safe logging**: the existing `TestCollectSMART_PropagatesWakeDrivesFlag` test constructs a bare `SMARTConfig{}` and never invokes `collectSMART` directly — but if anyone adds such a test, `logger != nil` guards against nil-deref. The real call site in `collector.go` always passes `c.logger`, which is populated by `New(...)`.
- **Didn't add a test for the log emission itself** — testing INFO log output requires capturing the slog handler, which is a slightly heavier fixture than this single-line call warrants, and the behavioural invariant (`errDriveInStandby` still causes the drive to be skipped without creating a history row) is already covered by the existing `TestReadSMARTDevice_Standby*` tests. If the log line ever silently gets dropped, it's harmless; if it ever stops firing, operators will notice in `docker logs` after an upgrade.
- **README width note**: the disclaimer text itself wasn't changed — user feedback was specifically about the layout, not the copy. Resisted the urge to reword.

## Pre-push checks (§4b)

- ✅ `go build ./...` clean
- ✅ `go test ./...` clean (collector suite passes; full suite passes)
- ✅ No `max-width:720px` remaining anywhere in `settings.html` (only that one element used it)
- ✅ Markdown renders cleanly (no broken headings, orphan links)

## Target

Base: `release/v0.9.5-stage` (NOT main). Once merged, orchestrator cuts rc3 from the updated stage tip and re-UATs.