### PR TITLE
feat(smart): add per-cycle summary log (active/standby/failed/duration)

### DIFF
--- a/internal/collector/smart.go
+++ b/internal/collector/smart.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mcdays94/nas-doctor/internal"
 )
@@ -32,6 +33,7 @@ type SMARTConfig struct {
 var errDriveInStandby = errors.New("drive in standby; skipped SMART read")
 
 func collectSMART(cfg SMARTConfig, logger *slog.Logger) ([]internal.SMARTInfo, error) {
+	startedAt := time.Now()
 	devices := discoverDrives()
 	if len(devices) == 0 {
 		// Fallback: try smartctl --scan. (The --scan subcommand does not
@@ -46,6 +48,17 @@ func collectSMART(cfg SMARTConfig, logger *slog.Logger) ([]internal.SMARTInfo, e
 		}
 	}
 	if len(devices) == 0 {
+		// Emit the summary even for the no-drive edge case so operators
+		// see a consistent per-cycle line in the logs (issue #203).
+		if logger != nil {
+			logger.Info("SMART collection complete",
+				"total", 0,
+				"active", 0,
+				"standby", 0,
+				"failed", 0,
+				"duration", time.Since(startedAt).Round(time.Millisecond).String(),
+			)
+		}
 		return nil, fmt.Errorf("no drives discovered")
 	}
 
@@ -77,6 +90,23 @@ func collectSMART(cfg SMARTConfig, logger *slog.Logger) ([]internal.SMARTInfo, e
 		}
 		results = append(results, info)
 	}
+
+	// Per-cycle INFO summary (issue #203). `standby` and `skipped` are
+	// disjoint counters (both branches use `continue` before incrementing
+	// either one), so total = active + standby + failed holds by
+	// construction, where active=len(results) and failed=skipped.
+	// Emit this before any error-return paths below so the summary fires
+	// even when the cycle ultimately fails.
+	if logger != nil {
+		logger.Info("SMART collection complete",
+			"total", len(devices),
+			"active", len(results),
+			"standby", standby,
+			"failed", skipped,
+			"duration", time.Since(startedAt).Round(time.Millisecond).String(),
+		)
+	}
+
 	// If every discovered drive is in standby and nothing else failed,
 	// that's a legitimate outcome (all disks asleep); return no error and
 	// an empty slice so the caller can persist an empty SMART snapshot

--- a/internal/collector/smart_summary_test.go
+++ b/internal/collector/smart_summary_test.go
@@ -1,0 +1,172 @@
+package collector
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestCollectSMART_EmitsSummaryLogFormat is a grep-based cross-reference
+// that pins the summary log line's field names. The v0.9.5 UAT feedback
+// (issue #203) asked for a single per-cycle line with total/active/standby/
+// failed/duration, and operators' log pipelines depend on that format not
+// drifting. If someone renames a field, this test fails loudly.
+func TestCollectSMART_EmitsSummaryLogFormat(t *testing.T) {
+	data, err := os.ReadFile("smart.go")
+	if err != nil {
+		t.Fatalf("read smart.go: %v", err)
+	}
+	src := string(data)
+
+	if !strings.Contains(src, `"SMART collection complete"`) {
+		t.Errorf("smart.go missing summary log message %q — if you renamed it, update the log pipeline docs too", "SMART collection complete")
+	}
+	for _, field := range []string{`"total"`, `"active"`, `"standby"`, `"failed"`, `"duration"`} {
+		if !strings.Contains(src, field) {
+			t.Errorf("smart.go summary log missing required field %s", field)
+		}
+	}
+}
+
+// TestCollectSMART_SummaryLogCounters exercises collectSMART against a fake
+// execCmd that returns a mix of active + standby + failed drives, and
+// asserts the resulting INFO summary has the expected counter math.
+//
+// We rely on the smartctl --scan fallback to inject a controlled device
+// list: discoverDrives() on a dev box either returns real /dev/sd* paths
+// or nothing, but when it returns nothing collectSMART falls back to
+// `smartctl --scan`, which our fake execCmd fully controls.
+func TestCollectSMART_SummaryLogCounters(t *testing.T) {
+	// If discoverDrives() finds real drives on the test host, we can't
+	// deterministically control the counter math. Detect and skip.
+	if len(discoverDrives()) > 0 {
+		t.Skip("host has real drives discoverable via /dev/sd*; cannot run deterministic fake-execCmd test")
+	}
+
+	// Craft smartctl responses per device. --scan enumerates 3 fake devs.
+	// /dev/fake0 → active (full JSON read)
+	// /dev/fake1 → standby
+	// /dev/fake2 → empty output across all fallbacks → counted as failed
+	fakeActiveJSON := `{"json_format_version":[1,0,0],"model_name":"FakeDrive 1TB","serial_number":"SN-ACTIVE","user_capacity":{"bytes":1000000000000},"temperature":{"current":30},"power_on_time":{"hours":100}}`
+	fakeStandbyOut := "smartctl 7.3 2022-02-28\n\nDevice is in STANDBY mode, exit(2)\n"
+
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		// --scan enumerates devices
+		if len(args) == 1 && args[0] == "--scan" {
+			return "/dev/fake0 -d sat # /dev/fake0, SAT\n" +
+				"/dev/fake1 -d sat # /dev/fake1, SAT\n" +
+				"/dev/fake2 -d sat # /dev/fake2, SAT\n", nil
+		}
+		// Route per-device smartctl calls based on which /dev/fakeN
+		// appears in the argv (it's always the trailing positional arg
+		// or penultimate for `-d TYPE DEV` forms).
+		argv := strings.Join(args, " ")
+		switch {
+		case strings.Contains(argv, "/dev/fake0"):
+			return fakeActiveJSON, nil
+		case strings.Contains(argv, "/dev/fake1"):
+			return fakeStandbyOut, nil
+		case strings.Contains(argv, "/dev/fake2"):
+			return "", nil // no output → falls through → counted as failed
+		}
+		return "", nil
+	})()
+
+	// Capture log output as structured JSON so we can parse the summary
+	// line's fields.
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	_, _ = collectSMART(SMARTConfig{WakeDrives: false}, logger)
+
+	// Scan log lines for the summary.
+	var summary map[string]any
+	for _, line := range strings.Split(buf.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if msg, _ := rec["msg"].(string); msg == "SMART collection complete" {
+			summary = rec
+			break
+		}
+	}
+	if summary == nil {
+		t.Fatalf("no 'SMART collection complete' log line emitted; got:\n%s", buf.String())
+	}
+
+	// JSON numbers decode as float64.
+	gotInt := func(field string) int {
+		v, ok := summary[field]
+		if !ok {
+			t.Fatalf("summary log missing %q field; got: %v", field, summary)
+		}
+		f, ok := v.(float64)
+		if !ok {
+			t.Fatalf("summary field %q is not a number: %v (%T)", field, v, v)
+		}
+		return int(f)
+	}
+
+	if got := gotInt("total"); got != 3 {
+		t.Errorf("total = %d, want 3", got)
+	}
+	if got := gotInt("active"); got != 1 {
+		t.Errorf("active = %d, want 1", got)
+	}
+	if got := gotInt("standby"); got != 1 {
+		t.Errorf("standby = %d, want 1", got)
+	}
+	if got := gotInt("failed"); got != 1 {
+		t.Errorf("failed = %d, want 1", got)
+	}
+	if _, ok := summary["duration"].(string); !ok {
+		t.Errorf("duration field missing or not a string: %v", summary["duration"])
+	}
+}
+
+// TestCollectSMART_SummaryLogEmittedOnNoDrives verifies the no-drive edge
+// case still emits a summary (with all-zero counters) before the error
+// return. Operators should always see one summary per cycle.
+func TestCollectSMART_SummaryLogEmittedOnNoDrives(t *testing.T) {
+	if len(discoverDrives()) > 0 {
+		t.Skip("host has real drives discoverable via /dev/sd*")
+	}
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		// --scan returns nothing → collectSMART returns the "no drives
+		// discovered" error, but must log first.
+		return "", nil
+	})()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	_, err := collectSMART(SMARTConfig{}, logger)
+	if err == nil {
+		t.Fatal("expected 'no drives discovered' error")
+	}
+	if !strings.Contains(buf.String(), `"SMART collection complete"`) {
+		t.Errorf("expected summary log even on no-drive edge case; got:\n%s", buf.String())
+	}
+}
+
+// TestCollectSMART_NilLoggerTolerated guards the nil-logger defensive
+// check on the summary-emit path.
+func TestCollectSMART_NilLoggerTolerated(t *testing.T) {
+	if len(discoverDrives()) > 0 {
+		t.Skip("host has real drives discoverable via /dev/sd*")
+	}
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		return "", nil
+	})()
+
+	// Should not panic despite logger=nil.
+	_, _ = collectSMART(SMARTConfig{}, nil)
+}


### PR DESCRIPTION
Closes #203.

## Summary

Adds a single INFO-level log line at the end of each SMART collection cycle, giving operators per-cycle confirmation that scans ran without flooding the log with per-drive lines.

## Log format

```
INFO SMART collection complete total=12 active=10 standby=2 failed=0 duration=834ms
```

Fields:
- `total` — drives discovered this cycle
- `active` — drives that returned a SMART snapshot (persisted to history)
- `standby` — drives skipped because `-n standby` reported them spun down
- `failed` — drives that errored or returned empty data (neither active nor standby)
- `duration` — wall-clock time for the whole cycle, rounded to ms

`total = active + standby + failed` holds by construction (the two skip branches use `continue` before incrementing distinct counters).

## Edge cases handled

- **Zero drives discovered** (both `discoverDrives()` and `smartctl --scan` return nothing): the summary still fires with all-zero counters BEFORE the `no drives discovered` error is returned, so operators always see one summary per cycle.
- **All drives fail**: the summary fires before the `all N drives failed` error path too.
- **Nil logger**: defensively nil-guarded on the emit site.

## Tests (4 added)

1. `TestCollectSMART_EmitsSummaryLogFormat` — grep-based format guard pinning the log message + all five field names.
2. `TestCollectSMART_SummaryLogCounters` — log-capture behavioural test using fake `execCmd` that injects 3 devices via `smartctl --scan` (1 active JSON, 1 standby, 1 empty/failed) and asserts the emitted summary has `total=3 active=1 standby=1 failed=1` with a string `duration`.
3. `TestCollectSMART_SummaryLogEmittedOnNoDrives` — asserts the summary fires on the zero-drive edge case.
4. `TestCollectSMART_NilLoggerTolerated` — nil-logger regression guard.

The behavioural tests skip cleanly if run on a host where `discoverDrives()` finds real `/dev/sd*` paths (so CI on a Linux runner with drives won't flake).

## Pre-push checks (§4b)

- `go build ./...` ✓
- `go vet ./...` ✓
- `go test ./...` ✓ (all packages green, including rc2 standby tests and rc3 polish)

## Base branch

Targeting `release/v0.9.5-stage` per the v0.9.5 bundled-release workflow.