### PR TITLE
v0.9.5 release bundle (7 issues across 8 PRs)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -93,9 +93,18 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # `:latest` is deliberately NOT produced here. See the `promote-to-latest`
+          # job below: `:latest` is retagged from the most recent stable `vX.Y.Z`
+          # build AFTER it succeeds, making `:latest` byte-identical to the latest
+          # release by construction instead of a main-branch rebuild that can race
+          # (#199, postmortem: #194).
+          #
+          # `:nightly` is always enabled on pushes: main-branch pushes advance it
+          # on every merge, and tag pushes (including RC tags) also update it so
+          # anyone tracking pre-release work gets the newest build. PR events
+          # compute the tag list but don't push (see the build-push step).
           tags: |
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-            type=raw,value=nightly,enable=${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=raw,value=nightly
             type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc') }}
 
@@ -111,3 +120,34 @@ jobs:
           build-args: |
             VERSION=${{ steps.version.outputs.value }}
           no-cache: true
+
+  # After a successful stable tag build (vX.Y.Z, NOT vX.Y.Z-rcN), retag that
+  # image as `:latest`. This makes `:latest` byte-identical to `:X.Y.Z` by
+  # construction — no rebuild, no race, no VERSION=dev failure mode. See #199.
+  #
+  # `docker buildx imagetools create` with a single source manifest list
+  # performs a carbon copy (per the Docker docs), preserving all platforms
+  # (amd64 + arm64) in the new tag.
+  promote-to-latest:
+    needs: build-and-push
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc')
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Retag v${{ github.ref_name }} as :latest
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Born from an [OpenCode diagnostic skill](https://github.com/mcdays94/opencode-se
 ## What It Does
 
 ### Diagnostics
-- **SMART Health**: Per-drive health, temperature, reallocated sectors, pending sectors, UDMA CRC errors, power-on hours, ATA port mapping, with **Backblaze failure-rate thresholds** (Q4-2025 data, 337k+ drives)
+- **SMART Health**: Per-drive health, temperature, reallocated sectors, pending sectors, UDMA CRC errors, power-on hours, ATA port mapping, with **Backblaze failure-rate thresholds** (Q4-2025 data, 337k+ drives). By default, NAS Doctor respects drive standby and skips spun-down drives rather than waking them for SMART reads — history will show gaps for drives that spin down, which is intentional (reduces wear). Flip **Wake drives for SMART check** in Settings → Advanced to restore every-cycle polling (v0.9.4 behaviour).
 - **Historical Sparklines**: CPU, memory, I/O wait, and per-drive temperature trends inline on the dashboard
 - **Disk Space**: Usage per mount point with color-coded thresholds
 - **System**: CPU, memory, load average, I/O wait, uptime, platform detection
@@ -493,7 +493,7 @@ All configurable from the web UI at `/settings`, organized with a sticky section
 
 - **General**: Scan interval (preset or custom with cron preview), theme selection, app icon
 - **Webhooks**: Add/remove/test Discord, Slack, Gotify, Ntfy, or generic HTTP webhooks with optional custom headers and HMAC signing
-- **Notification Rules**: Dropdown-driven rule builder with 12 categories, live target selection, threshold inputs, one-click presets, quiet hours, and maintenance windows
+- **Notification Rules**: Dropdown-driven rule builder with 13 categories, live target selection, threshold inputs, one-click presets, quiet hours, and maintenance windows
 - **Service Checks**: HTTP, TCP, DNS, Ping/ICMP, SMB/NFS uptime monitoring with per-check configurable intervals (30s–1h)
 - **Fleet**: Add/remove remote NAS Doctor instances with optional API key auth
 - **Dashboard Sections**: Toggle visibility of individual sections (SMART, Docker, ZFS, UPS, Parity, Network, Tunnels, etc.)

--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -364,6 +364,13 @@ func main() {
 			})
 			logger.Info("kubernetes integration loaded", "url", persistedSettings.Kubernetes.URL, "in_cluster", persistedSettings.Kubernetes.InCluster)
 		}
+		// Apply SMART standby-awareness preference on startup (#198). Default
+		// (false) uses `-n standby` so spun-down drives aren't woken by scans.
+		if persistedSettings != nil {
+			coll.SetSMARTConfig(collector.SMARTConfig{
+				WakeDrives: persistedSettings.WakeDrivesForSMART,
+			})
+		}
 		sched.Start()
 		defer sched.Stop()
 	}

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -49,6 +49,12 @@ type Settings struct {
 	ChartRangeHours   int                     `json:"chart_range_hours"`         // Persisted chart time range (1, 24, 168)
 	SectionHeights    map[string]int          `json:"section_heights,omitempty"` // Persisted section resize heights (section name → px)
 	SectionOrder      map[string][]string     `json:"section_order,omitempty"`   // Persisted drag-and-drop column order ({"cols": [["findings","docker"], ...]})
+
+	// WakeDrivesForSMART, when true, opts back into pre-v0.9.5 behaviour of
+	// reading SMART from spun-down drives each scan cycle (waking them).
+	// Default (false) is standby-aware: smartctl runs with `-n standby` and
+	// skips sleeping drives. See issue #198.
+	WakeDrivesForSMART bool `json:"wake_drives_for_smart,omitempty"`
 }
 
 const currentSettingsVersion = 1
@@ -805,6 +811,11 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 			Token:     settings.Kubernetes.Token,
 			Alias:     settings.Kubernetes.Alias,
 			InCluster: settings.Kubernetes.InCluster,
+		})
+
+		// Update SMART config on the collector (#198)
+		s.collector.SetSMARTConfig(collector.SMARTConfig{
+			WakeDrives: settings.WakeDrivesForSMART,
 		})
 
 		// Update log forwarding

--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -1509,14 +1509,27 @@ function setupGlobals() {
   window.loadContainerChart = function(hours, save) { charts.loadContainers(hours, save); };
   window.loadSpeedTestChart = function(hours, save) { charts.loadSpeedTest(hours, save); };
 
-  // Refresh indicator timer
+  // Refresh indicator timer — ticks the "X ago" text next to the Last
+  // scan timestamp. Elapsed time is computed from the actual scan
+  // timestamp (_statusData.last_scan, RFC3339) rather than from
+  // page-load / last-poll time; see issue #179. If we counted from
+  // _lastFetchTime, opening the page 10 minutes after a scan would
+  // show "just now" and a refresh would reset the counter — the
+  // exact bug the user reported.
   setInterval(function() {
     var el = document.getElementById("refresh-ago");
-    if (!el || !_lastFetchTime) return;
-    var secs = Math.round((Date.now() - _lastFetchTime) / 1000);
+    if (!el) return;
+    var scanTs = _statusData && _statusData.last_scan;
+    if (!scanTs) { el.textContent = ""; return; }
+    var scanMs = new Date(scanTs).getTime();
+    if (!scanMs || isNaN(scanMs)) { el.textContent = ""; return; }
+    var secs = Math.round((Date.now() - scanMs) / 1000);
+    if (secs < 0) secs = 0; // clock skew guard
     if (secs < 5) el.textContent = "just now";
     else if (secs < 60) el.textContent = secs + "s ago";
-    else el.textContent = Math.floor(secs / 60) + "m ago";
+    else if (secs < 3600) el.textContent = Math.floor(secs / 60) + "m ago";
+    else if (secs < 86400) el.textContent = Math.floor(secs / 3600) + "h ago";
+    else el.textContent = Math.floor(secs / 86400) + "d ago";
   }, 1000);
 }
 

--- a/internal/api/dashboard_last_scan_ago_test.go
+++ b/internal/api/dashboard_last_scan_ago_test.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestDashboardJS_LastScanAgoCountsFromScanTimestamp locks in the fix for
+// issue #179: the "X minutes ago" indicator next to "Last scan:" on the
+// dashboard must compute its elapsed time from the actual scan timestamp
+// provided by the server (status.last_scan, RFC3339), NOT from
+// page-load/last-poll time.
+//
+// Before the fix, the setInterval that updates #refresh-ago used
+// _lastFetchTime — which is Date.now() set on every poll and on every
+// initial loadAll(). That means:
+//
+//   - Opening the dashboard 10 minutes after the last scan showed
+//     "just now" and ticked forward from there — dead wrong.
+//   - A page refresh reset the counter to 0 even though nothing had
+//     actually re-scanned — the bug report's exact reproduction.
+//
+// The fix is to derive the elapsed seconds from _statusData.last_scan
+// (RFC3339 string) parsed as a Date. That string is the same source as
+// the human-readable timestamp already rendered in <strong>, so the
+// counter and the absolute timestamp are now guaranteed to agree.
+//
+// This is a grep-based cross-reference test (see AGENTS.md §4b). The JS
+// lives in a Go string literal (DashboardJS) that is served verbatim at
+// /js/dashboard.js, so asserting on substrings of the literal is how we
+// guard the client-side behavior from Go-side tests without spinning up
+// a browser.
+func TestDashboardJS_LastScanAgoCountsFromScanTimestamp(t *testing.T) {
+	js := DashboardJS
+
+	// Invariant 1: the refresh-ago interval body must reference the
+	// scan timestamp source, not just _lastFetchTime. We scope the
+	// check to the block that sets #refresh-ago text so unrelated
+	// uses of _lastFetchTime elsewhere (the poll debounce uses it
+	// too) don't false-pass.
+	agoBlock := extractRefreshAgoBlock(t, js)
+
+	if !strings.Contains(agoBlock, "last_scan") {
+		t.Errorf("refresh-ago interval must derive elapsed time from _statusData.last_scan (the RFC3339 scan timestamp), but the block doesn't reference last_scan:\n%s", agoBlock)
+	}
+
+	// Invariant 2: must parse the timestamp via `new Date(...)`.
+	// Without this, we'd be comparing a string to a number and the
+	// counter would produce NaN/garbage.
+	if !regexp.MustCompile(`new Date\s*\(`).MatchString(agoBlock) {
+		t.Errorf("refresh-ago interval must parse the scan timestamp via `new Date(...)` so the RFC3339 string becomes a comparable epoch-ms value; block:\n%s", agoBlock)
+	}
+
+	// Invariant 3: guard against the regressed behavior. The ago text
+	// must NOT be computed from _lastFetchTime (that was the bug).
+	// We allow _lastFetchTime to appear in the *guard* (`if !el` etc.)
+	// but not in the subtraction that feeds `secs`.
+	//
+	// The simplest durable check: the subtraction `Date.now() - _lastFetchTime`
+	// must not appear inside the block. That exact idiom is what
+	// produced the bug.
+	badPattern := regexp.MustCompile(`Date\.now\s*\(\s*\)\s*-\s*_lastFetchTime`)
+	if badPattern.MatchString(agoBlock) {
+		t.Errorf("refresh-ago interval still computes elapsed time as `Date.now() - _lastFetchTime` — this is the exact regression issue #179 was filed against. Use the scan timestamp instead:\n%s", agoBlock)
+	}
+}
+
+// TestDashboardJS_LastScanAgoHandlesMissingTimestamp guards the empty-state
+// path. When the server has never scanned, status.last_scan is empty and
+// the absolute timestamp renders as "Never". The counter must not then
+// display bogus text like "NaNm ago" or "56 years ago" (epoch-zero parse).
+// The block should simply clear the element or short-circuit.
+func TestDashboardJS_LastScanAgoHandlesMissingTimestamp(t *testing.T) {
+	js := DashboardJS
+	agoBlock := extractRefreshAgoBlock(t, js)
+
+	// There must be a guard that checks truthiness of the scan
+	// timestamp before doing arithmetic. Any of the common idioms
+	// are acceptable: an early return, a ternary, or a falsy check
+	// on the parsed value. We require at least one `return` inside
+	// the block so the empty-state path short-circuits; the existing
+	// `if (!el || !_lastFetchTime) return;` guard already matches
+	// this shape — we just need the equivalent for the scan
+	// timestamp after the fix.
+	if !strings.Contains(agoBlock, "return") {
+		t.Errorf("refresh-ago interval must short-circuit (early return) when the scan timestamp is missing, otherwise the counter would render NaN or a 56-year-ago epoch value on a fresh install; block:\n%s", agoBlock)
+	}
+}
+
+// extractRefreshAgoBlock returns the JS body of the setInterval callback
+// that updates #refresh-ago. Scoping assertions to this block prevents
+// unrelated uses of _lastFetchTime (used elsewhere for poll cadence)
+// from false-passing the test.
+func extractRefreshAgoBlock(t *testing.T, js string) string {
+	t.Helper()
+	// The setInterval sits immediately below a comment line
+	// "// Refresh indicator timer" in dashboard.go. The callback
+	// is a single short function; we grab from that marker to
+	// the next "}, 1000);" which closes the interval.
+	marker := "Refresh indicator timer"
+	start := strings.Index(js, marker)
+	if start < 0 {
+		t.Fatalf("could not locate %q in DashboardJS — the refresh-ago setInterval was renamed or moved. Update the test helper.", marker)
+	}
+	end := strings.Index(js[start:], "}, 1000)")
+	if end < 0 {
+		t.Fatalf("could not find closing `}, 1000)` for refresh-ago setInterval — structure changed, update the helper.")
+	}
+	return js[start : start+end]
+}

--- a/internal/api/service_checks_autorefresh_test.go
+++ b/internal/api/service_checks_autorefresh_test.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestServiceChecksHTML_AutoRefreshPausesWhenRowExpanded guards the fix
+// for issue #187. The Service Checks page used to call
+// `setInterval(loadAll, 60000)` unconditionally, which rebuilt the log
+// table DOM every minute — collapsing any log row the user had expanded
+// to inspect diagnostic details (status codes, DNS records, etc. added
+// in #182/#183).
+//
+// The fix pauses the auto-refresh tick while any log row is expanded,
+// and resumes once all rows are collapsed. This is a grep-based cross-
+// reference test: it can't simulate a live tick, but it asserts the
+// structural invariants that MUST be present for the fix to work. If a
+// future refactor removes any of these, the guard silently no-ops and
+// the bug regresses without any other test noticing.
+//
+// Invariants:
+//  1. `setInterval` does NOT pass `loadAll` directly as its callback.
+//     There must be an anonymous function or wrapper in between that
+//     can early-return when rows are expanded. Direct
+//     `setInterval(loadAll, N)` is the exact pre-fix code path.
+//  2. The template declares an expanded-row state (`expandedRows`).
+//     Without a shared state, the refresh guard has nothing to consult.
+//  3. `toggleLogDetail` — the click handler on each log row — mutates
+//     that state. If the handler ignores the state, it never changes
+//     and the guard triggers either always or never.
+//  4. A visual affordance (`refresh-paused`) exists somewhere in the
+//     template so the user can tell WHY data isn't ticking forward.
+//     Acceptance criterion from the issue body.
+func TestServiceChecksHTML_AutoRefreshPausesWhenRowExpanded(t *testing.T) {
+	html := loadServiceChecksHTML(t)
+
+	// Invariant 1: the refresh tick is wrapped, not a direct callback.
+	// `setInterval(loadAll,` (with optional whitespace) is the exact
+	// pattern that caused the bug; we reject it outright.
+	directCall := regexp.MustCompile(`setInterval\s*\(\s*loadAll\s*,`)
+	if directCall.MatchString(html) {
+		t.Error("setInterval(loadAll, ...) passes loadAll directly as the tick callback — " +
+			"there's no way for the tick to early-return when a log row is expanded (#187)")
+	}
+
+	// A setInterval call must still exist — we didn't want to delete
+	// auto-refresh entirely, just guard it.
+	if !strings.Contains(html, "setInterval(") {
+		t.Error("service_checks.html has no setInterval call — auto-refresh was removed entirely, which is not the intended fix")
+	}
+
+	// Invariant 2: expanded-row state variable exists.
+	if !strings.Contains(html, "expandedRows") {
+		t.Error("service_checks.html does not declare `expandedRows` state — the refresh guard has nothing to consult (#187)")
+	}
+
+	// Invariant 3: toggleLogDetail updates expandedRows.
+	toggleBody := extractFuncBody(t, html, "window.toggleLogDetail=function(")
+	if !strings.Contains(toggleBody, "expandedRows") {
+		t.Errorf("window.toggleLogDetail does not reference `expandedRows` — the click handler "+
+			"never updates expanded state, so the refresh guard can't know when rows are open. Body was:\n  %s", toggleBody)
+	}
+
+	// Invariant 4: a visible "paused" affordance exists. The user
+	// needs to know why the page isn't auto-refreshing.
+	if !strings.Contains(html, "refresh-paused") {
+		t.Error("service_checks.html has no `refresh-paused` indicator element or class — " +
+			"users will see stale data with no explanation (#187 acceptance criterion)")
+	}
+}
+
+// extractFuncBody returns the body (between { and the matching }) of
+// the first JS function whose declaration starts with `prefix`. Balances
+// braces so nested objects/functions inside the body don't confuse the
+// extraction. Fails the test if the prefix is not present.
+func extractFuncBody(t *testing.T, html, prefix string) string {
+	t.Helper()
+	start := strings.Index(html, prefix)
+	if start < 0 {
+		t.Fatalf("function prefix %q not found in service_checks.html — template was restructured?", prefix)
+	}
+	// Find the opening `{` that closes the function signature.
+	openBrace := strings.Index(html[start:], "){")
+	if openBrace < 0 {
+		t.Fatalf("function %q has no opening brace — malformed JS?", prefix)
+	}
+	cursor := start + openBrace + 2 // position just after `){`
+	depth := 1
+	for cursor < len(html) && depth > 0 {
+		switch html[cursor] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return html[start+openBrace+2 : cursor]
+			}
+		}
+		cursor++
+	}
+	t.Fatalf("function %q never closed — brace mismatch in service_checks.html", prefix)
+	return ""
+}

--- a/internal/api/service_checks_protocol_hint_test.go
+++ b/internal/api/service_checks_protocol_hint_test.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestServiceChecksHTML_RendersProtocolHint guards the UI cross-reference
+// for issue #188. The Go ProtocolHint helper (internal/scheduler/
+// protocol_hints.go) populates a protocol_hint key on TCP service
+// check Details; the expanded log entry renderer in service_checks.html
+// and the Test button toast renderer in settings.html must both
+// consume that key to draw a badge.
+//
+// Classic §4b trap: a future refactor renames the key on one side only
+// and the badge silently disappears. This test locks the key name in
+// place on the JS side; the Go side is locked in the ProtocolHint
+// unit tests.
+func TestServiceChecksHTML_RendersProtocolHint(t *testing.T) {
+	html := loadServiceChecksHTML(t)
+	if !strings.Contains(html, "protocol_hint") {
+		t.Errorf("service_checks.html expanded log renderer missing protocol_hint key — TCP protocol badge will not render (issue #188)")
+	}
+}
+
+func TestSettingsHTML_TestButtonTCPProtocolHint(t *testing.T) {
+	html := loadSettingsHTML(t)
+	// The TCP renderer in the Test-button toast helper must consume
+	// protocol_hint so the toast mirrors the badge shown in the
+	// expanded log row. Scoped to the renderServiceCheckDetails
+	// function by string match on both tokens — settings.html is
+	// 3k+ lines and grepping for the key alone could false-positive
+	// on unrelated content in a future expansion.
+	if !strings.Contains(html, "renderServiceCheckDetails") {
+		t.Fatal("settings.html missing renderServiceCheckDetails helper — Test button toast detail rendering broken")
+	}
+	if !strings.Contains(html, "protocol_hint") {
+		t.Errorf("settings.html Test-button renderer missing protocol_hint key — toast won't show protocol badge (issue #188)")
+	}
+}

--- a/internal/api/settings_wake_drives_for_smart_test.go
+++ b/internal/api/settings_wake_drives_for_smart_test.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSettingsHTMLIncludesWakeDrivesForSMARTToggle verifies the settings
+// template ships the Advanced section with the wake-drives toggle +
+// disclaimer required by issue #198.
+//
+// This is a cross-reference test: it confirms the HTML mentions every
+// symbol the JS load/save wiring expects, so a future refactor that
+// renames one side can't silently break the round-trip.
+func TestSettingsHTMLIncludesWakeDrivesForSMARTToggle(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read settings.html: %v", err)
+	}
+	content := string(data)
+
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		// Advanced card anchor so the sticky section nav can link to it.
+		{"advanced card anchor", `id="card-advanced"`},
+		// Section nav link to the advanced card.
+		{"advanced nav link", `href="#card-advanced"`},
+		// Disclosure element — using <details>/<summary> per the issue's
+		// guidance (no extra JS needed).
+		{"details element", `<details`},
+		{"summary element", `<summary`},
+		// The toggle control + its stable id for load/save wiring.
+		{"wake-drives toggle id", `id="wake-drives-for-smart"`},
+		// Load path reads the JSON field name.
+		{"load binds field", `data.wake_drives_for_smart`},
+		// Save payload writes the JSON field name.
+		{"save sends field", `wake_drives_for_smart:`},
+		// Disclaimer text must communicate the wear trade-off. We keep
+		// the assertion loose so copy can be edited, but pin the key
+		// concepts: spin-ups and opt-in intent.
+		{"disclaimer mentions spin-ups", `spin-up`},
+		{"disclaimer mentions scan interval", `30-min`},
+	}
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(content, tc.substr) {
+				t.Errorf("settings.html missing %q — expected substring: %q", tc.name, tc.substr)
+			}
+		})
+	}
+}
+
+// TestSettingsRoundTrip_WakeDrivesForSMART exercises the GET/PUT cycle for
+// the new setting to make sure it persists and is returned by handleGetSettings.
+func TestSettingsRoundTrip_WakeDrivesForSMART(t *testing.T) {
+	s := newSettingsTestServer()
+
+	// PUT enabling the flag.
+	put := Settings{
+		ScanInterval:       "30m",
+		Theme:              ThemeMidnight,
+		WakeDrivesForSMART: true,
+	}
+	body, _ := json.Marshal(put)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.handleUpdateSettings(rr, req)
+	if rr.Code != http.StatusOK {
+		b, _ := io.ReadAll(rr.Body)
+		t.Fatalf("PUT returned %d: %s", rr.Code, b)
+	}
+
+	// GET and verify the flag survived the round-trip.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	rr2 := httptest.NewRecorder()
+	s.handleGetSettings(rr2, req2)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("GET returned %d", rr2.Code)
+	}
+	var got Settings
+	if err := json.Unmarshal(rr2.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse GET response: %v", err)
+	}
+	if !got.WakeDrivesForSMART {
+		t.Errorf("WakeDrivesForSMART did not round-trip; got false, wanted true")
+	}
+}
+
+// TestSettingsDefault_WakeDrivesForSMARTIsFalse guards against a regression
+// where the default flips; the whole point of #198 is that default=false
+// means drives in standby are NOT woken by SMART scans.
+func TestSettingsDefault_WakeDrivesForSMARTIsFalse(t *testing.T) {
+	d := defaultSettings()
+	if d.WakeDrivesForSMART {
+		t.Errorf("defaultSettings().WakeDrivesForSMART must be false (standby-aware by default, issue #198)")
+	}
+}

--- a/internal/api/templates/service_checks.html
+++ b/internal/api/templates/service_checks.html
@@ -207,7 +207,19 @@
         out += cell("Final URL", '<span style="font-size:11px;font-family:var(--font-mono);word-break:break-all">'+esc(details.final_url)+'</span>', "grid-column:1/-1");
       }
     } else if (t === "tcp" || t === "smb" || t === "nfs") {
-      if (details.resolved_address) out += cell("Resolved Address", '<span style="font-family:var(--font-mono)">'+esc(details.resolved_address)+'</span>');
+      if (details.resolved_address) {
+        // Pin the protocol badge (SSH, HTTPS, MySQL, …) to the
+        // Resolved Address cell so users see at-a-glance what they
+        // actually dialed. Populated by the Go ProtocolHint helper
+        // when the port is in the well-known table (issue #188).
+        // Keep the badge tight and muted so it reads as metadata,
+        // not as a status pill.
+        var addrHTML = '<span style="font-family:var(--font-mono)">'+esc(details.resolved_address)+'</span>';
+        if (details.protocol_hint) {
+          addrHTML += ' <span class="protocol-hint-badge" style="display:inline-block;margin-left:6px;padding:1px 6px;border-radius:4px;background:var(--surface-2,#1a1a1a);border:1px solid var(--border);color:var(--text2);font-size:10px;font-family:var(--font-mono);font-weight:600;letter-spacing:0.3px;vertical-align:middle">'+esc(details.protocol_hint)+'</span>';
+        }
+        out += cell("Resolved Address", addrHTML);
+      }
     } else if (t === "dns") {
       if (details.query_host) out += cell("Query Host", '<span style="font-family:var(--font-mono)">'+esc(details.query_host)+'</span>');
       if (details.dns_server) out += cell("DNS Server", '<span style="font-family:var(--font-mono)">'+esc(details.dns_server)+'</span>');

--- a/internal/api/templates/service_checks.html
+++ b/internal/api/templates/service_checks.html
@@ -83,6 +83,12 @@
 /* Orphan badge */
 .orphan-badge{font-size:9px;padding:1px 6px;border-radius:999px;background:rgba(217,119,6,0.12);color:var(--amber);margin-left:6px}
 .btn-delete-check{font-size:10px;padding:2px 8px;border:1px solid var(--border);border-radius:var(--radius);background:var(--surface);color:var(--red);cursor:pointer;margin-left:auto}
+/* Auto-refresh paused indicator (#187). Shown while any log row is
+   expanded so the user knows data won't tick forward until they
+   collapse. Hidden by default; toggled by JS via .hidden. */
+.refresh-paused{display:inline-flex;align-items:center;gap:5px;font-size:11px;padding:2px 8px;border-radius:999px;background:rgba(217,119,6,0.12);color:var(--amber);margin-right:10px;vertical-align:middle}
+.refresh-paused.hidden{display:none}
+.refresh-paused::before{content:"";display:inline-block;width:6px;height:6px;border-radius:50%;background:var(--amber)}
 </style>
 </head>
 <body>
@@ -129,6 +135,7 @@
     <div><span class="filter-label">Time range</span><br>
       <select id="f-range" onchange="applyFilters()"><option value="1h">Last hour</option><option value="6h">Last 6 hours</option><option value="24h" selected>Last 24 hours</option><option value="7d">Last 7 days</option><option value="30d">Last 30 days</option></select></div>
     <div style="margin-left:auto;align-self:flex-end">
+      <span id="refresh-paused-indicator" class="refresh-paused hidden" title="Auto-refresh paused while a log entry is expanded. Collapse all entries to resume.">Refresh paused</span>
       <span id="log-count" style="font-size:12px;color:var(--text3)"></span>
     </div>
   </div>
@@ -166,6 +173,21 @@
   var allLogs=[];          // merged+filtered log entries for the table
   var currentPage=0;
   var activeFilter="";
+  // expandedRows tracks which log-detail row IDs are currently open.
+  // Auto-refresh (setInterval → loadAll) is skipped while any row is
+  // expanded so the user's expanded inspection isn't collapsed by a
+  // DOM rebuild mid-read. See #187. On explicit user actions that
+  // intentionally rebuild the table (filter change, pagination), we
+  // clear this set since the old row IDs no longer refer to the same
+  // entries.
+  var expandedRows={};
+  function anyRowExpanded(){for(var k in expandedRows){if(expandedRows[k])return true;}return false;}
+  function updatePausedIndicator(){
+    var el=document.getElementById("refresh-paused-indicator");
+    if(!el)return;
+    if(anyRowExpanded())el.classList.remove("hidden");
+    else el.classList.add("hidden");
+  }
 
   function esc(s){var d=document.createElement("div");d.textContent=s||"";return d.innerHTML;}
   function fetchJSON(url){return fetch(url).then(function(r){if(!r.ok)throw new Error(r.status);return r.json()});}
@@ -322,6 +344,11 @@
     }
     allLogs.sort(function(a,b){return(b.checked_at||"").localeCompare(a.checked_at||"");});
     currentPage=0;
+    // Filter change rebuilds the table with potentially different
+    // entries at each row index; stale expandedRows entries would
+    // wrongly keep auto-refresh paused. #187.
+    expandedRows={};
+    updatePausedIndicator();
     renderLogTable();
   };
 
@@ -385,9 +412,25 @@
     tbody.innerHTML=h;
   }
 
-  window.prevPage=function(){if(currentPage>0){currentPage--;renderLogTable();}};
-  window.nextPage=function(){currentPage++;renderLogTable();};
-  window.toggleLogDetail=function(id){var el=document.getElementById(id);if(el)el.classList.toggle("open");};
+  // prevPage/nextPage/applyFilters rebuild the log table DOM, which
+  // strips the "open" class from every detail row. Clear the tracked
+  // expandedRows set so anyRowExpanded() reflects reality — otherwise
+  // auto-refresh would stay paused forever after paginating away from
+  // an expanded row. #187.
+  window.prevPage=function(){if(currentPage>0){currentPage--;expandedRows={};updatePausedIndicator();renderLogTable();}};
+  window.nextPage=function(){currentPage++;expandedRows={};updatePausedIndicator();renderLogTable();};
+  window.toggleLogDetail=function(id){
+    var el=document.getElementById(id);
+    if(!el)return;
+    el.classList.toggle("open");
+    // Mirror the DOM "open" class into expandedRows so the refresh
+    // tick can consult it. Using the classList as source of truth
+    // (rather than pre-computing) handles both open and close paths
+    // with one branch. #187.
+    if(el.classList.contains("open"))expandedRows[id]=true;
+    else delete expandedRows[id];
+    updatePausedIndicator();
+  };
 
   window.filterByCheck=function(key){
     var sel=document.getElementById("f-check");
@@ -476,7 +519,16 @@
   }
 
   loadAll();
-  setInterval(loadAll,60000);
+  // Auto-refresh guard (#187): skip the tick if the user has any log
+  // row expanded. loadAll() rebuilds the entire log table DOM, which
+  // would collapse the row mid-read. The pause is announced by the
+  // "refresh-paused" badge in the filter bar; it resumes automatically
+  // once all rows are collapsed (see window.toggleLogDetail and the
+  // renderLogTable-callers which clear expandedRows).
+  setInterval(function(){
+    if(anyRowExpanded())return;
+    loadAll();
+  },60000);
 })();
 </script>
 </body>

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -1839,7 +1839,14 @@ function renderServiceCheckDetails(type, details, result) {
     }
     if (details.failure_stage) lines.push("Failed at: " + details.failure_stage);
   } else if (type === "tcp" || type === "smb" || type === "nfs") {
-    if (details.resolved_address) lines.push("Connected to: " + details.resolved_address);
+    if (details.resolved_address) {
+      // Append the protocol badge inline — toast is a plain-text
+      // multi-line string so we bracket the label instead of using
+      // HTML. Populated by the Go ProtocolHint helper (issue #188).
+      var addrLine = "Connected to: " + details.resolved_address;
+      if (details.protocol_hint) addrLine += " [" + details.protocol_hint + "]";
+      lines.push(addrLine);
+    }
     if (details.failure_stage) lines.push("Failed at: " + details.failure_stage);
   } else if (type === "dns") {
     if (details.query_host) lines.push("Queried: " + details.query_host);

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -63,6 +63,7 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
     <a href="#card-replacement-cost" class="btn btn-secondary btn-sm" style="text-decoration:none">Replacement Cost</a>
     <a href="#card-speedtest" class="btn btn-secondary btn-sm" style="text-decoration:none">Speed Test</a>
     <a href="#card-backup" class="btn btn-secondary btn-sm" style="text-decoration:none">Backup</a>
+    <a href="#card-advanced" class="btn btn-secondary btn-sm" style="text-decoration:none">Advanced</a>
   </div>
 
   <!-- 1. General -->
@@ -877,6 +878,27 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
     </div>
   </div>
 
+  <!-- 9. Advanced -->
+  <div class="card" id="card-advanced">
+    <div class="card-title">Advanced</div>
+    <div class="card-desc">Expert-only knobs. Defaults are safe — only change these if you understand the trade-offs.</div>
+    <details style="margin-top:8px">
+      <summary style="cursor:pointer;padding:6px 0;font-weight:600;font-size:13px;color:var(--text)">Show advanced options</summary>
+      <div style="margin-top:14px;padding-top:12px;border-top:1px solid var(--border)">
+        <div class="toggle-wrap">
+          <div class="toggle" id="wake-drives-for-smart" onclick="this.classList.toggle('on');saveSettings()"><div class="toggle-knob"></div></div>
+          <span class="toggle-label">Wake drives for SMART check</span>
+        </div>
+        <p style="font-size:12px;color:var(--text2);margin-top:8px;line-height:1.5;max-width:720px">
+          By default, NAS Doctor skips drives that are in standby — SMART history will show gaps when drives are sleeping, and that's intentional (reduces wear).
+          Enabling this option forces smartctl to <strong>wake spun-down drives</strong> on every scan cycle.
+          At the default 30-min scan interval, that's roughly 48 extra spin-ups per drive per day.
+          Only enable if your drives never spin down, or if you deliberately need every-cycle SMART monitoring and accept the wear cost.
+        </p>
+      </div>
+    </details>
+  </div>
+
   <!-- Alerts, Incidents, Trends, and Notification History have moved to /alerts -->
   <div class="card" style="background:transparent;border-style:dashed;text-align:center;padding:20px">
     <div style="font-size:13px;color:var(--text2)">Alerts, Incidents, Trends, and Notification History have moved to their own dedicated page.</div>
@@ -1174,6 +1196,11 @@ function loadSettings() {
       /* Drive replacement cost per TB */
       var costEl = document.getElementById("cost-per-tb");
       if (costEl) costEl.value = (data.cost_per_tb && data.cost_per_tb > 0) ? data.cost_per_tb : "";
+      /* Advanced: wake drives for SMART (#198) */
+      var wakeEl = document.getElementById("wake-drives-for-smart");
+      if (wakeEl) {
+        if (data.wake_drives_for_smart) wakeEl.classList.add("on"); else wakeEl.classList.remove("on");
+      }
       /* Proxmox VE */
       var pve = data.proxmox || {};
       if (pve.enabled) document.getElementById("pve-toggle").classList.add("on"); else document.getElementById("pve-toggle").classList.remove("on");
@@ -1285,7 +1312,8 @@ function buildSettingsPayload() {
     api_key: document.getElementById("api-key-display").value.trim(),
     fleet: fleetServers || base.fleet || [],
     dismissed_findings: base.dismissed_findings || [],
-    cost_per_tb: parseFloat(document.getElementById("cost-per-tb") && document.getElementById("cost-per-tb").value) || 0
+    cost_per_tb: parseFloat(document.getElementById("cost-per-tb") && document.getElementById("cost-per-tb").value) || 0,
+    wake_drives_for_smart: !!(document.getElementById("wake-drives-for-smart") && document.getElementById("wake-drives-for-smart").classList.contains("on"))
   };
 }
 

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -889,7 +889,7 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
           <div class="toggle" id="wake-drives-for-smart" onclick="this.classList.toggle('on');saveSettings()"><div class="toggle-knob"></div></div>
           <span class="toggle-label">Wake drives for SMART check</span>
         </div>
-        <p style="font-size:12px;color:var(--text2);margin-top:8px;line-height:1.5;max-width:720px">
+        <p style="font-size:12px;color:var(--text2);margin-top:8px;line-height:1.5">
           By default, NAS Doctor skips drives that are in standby — SMART history will show gaps when drives are sleeping, and that's intentional (reduces wear).
           Enabling this option forces smartctl to <strong>wake spun-down drives</strong> on every scan cycle.
           At the default 30-min scan interval, that's roughly 48 extra spin-ups per drive per day.

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -17,6 +17,7 @@ type Collector struct {
 	logger        *slog.Logger
 	proxmoxConfig ProxmoxConfig
 	kubeConfig    KubeConfig
+	smartConfig   SMARTConfig
 }
 
 // SetProxmoxConfig updates the Proxmox VE API connection settings.
@@ -27,6 +28,12 @@ func (c *Collector) SetProxmoxConfig(cfg ProxmoxConfig) {
 // SetKubeConfig updates the Kubernetes cluster connection settings.
 func (c *Collector) SetKubeConfig(cfg KubeConfig) {
 	c.kubeConfig = cfg
+}
+
+// SetSMARTConfig updates SMART-collector behaviour flags — primarily the
+// WakeDrives toggle introduced for issue #198.
+func (c *Collector) SetSMARTConfig(cfg SMARTConfig) {
+	c.smartConfig = cfg
 }
 
 // New creates a new Collector with the given host path mappings.
@@ -62,8 +69,8 @@ func (c *Collector) Collect() (*internal.Snapshot, error) {
 	snap.Disks = disks
 
 	// SMART data
-	c.logger.Info("collecting SMART data")
-	smart, err := collectSMART()
+	c.logger.Info("collecting SMART data", "wake_drives", c.smartConfig.WakeDrives)
+	smart, err := collectSMART(c.smartConfig)
 	if err != nil {
 		c.logger.Warn("SMART collection partial failure", "error", err)
 	}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -70,7 +70,7 @@ func (c *Collector) Collect() (*internal.Snapshot, error) {
 
 	// SMART data
 	c.logger.Info("collecting SMART data", "wake_drives", c.smartConfig.WakeDrives)
-	smart, err := collectSMART(c.smartConfig)
+	smart, err := collectSMART(c.smartConfig, c.logger)
 	if err != nil {
 		c.logger.Warn("SMART collection partial failure", "error", err)
 	}

--- a/internal/collector/smart.go
+++ b/internal/collector/smart.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mcdays94/nas-doctor/internal"
 )
@@ -32,6 +33,7 @@ type SMARTConfig struct {
 var errDriveInStandby = errors.New("drive in standby; skipped SMART read")
 
 func collectSMART(cfg SMARTConfig, logger *slog.Logger) ([]internal.SMARTInfo, error) {
+	startedAt := time.Now()
 	devices := discoverDrives()
 	if len(devices) == 0 {
 		// Fallback: try smartctl --scan. (The --scan subcommand does not
@@ -46,6 +48,17 @@ func collectSMART(cfg SMARTConfig, logger *slog.Logger) ([]internal.SMARTInfo, e
 		}
 	}
 	if len(devices) == 0 {
+		// Emit the summary even for the no-drive edge case so operators
+		// see a consistent per-cycle line in the logs (issue #203).
+		if logger != nil {
+			logger.Info("SMART collection complete",
+				"total", 0,
+				"active", 0,
+				"standby", 0,
+				"failed", 0,
+				"duration", time.Since(startedAt).Round(time.Millisecond).String(),
+			)
+		}
 		return nil, fmt.Errorf("no drives discovered")
 	}
 
@@ -77,6 +90,23 @@ func collectSMART(cfg SMARTConfig, logger *slog.Logger) ([]internal.SMARTInfo, e
 		}
 		results = append(results, info)
 	}
+
+	// Per-cycle INFO summary (issue #203). `standby` and `skipped` are
+	// disjoint counters (both branches use `continue` before incrementing
+	// either one), so total = active + standby + failed holds by
+	// construction, where active=len(results) and failed=skipped.
+	// Emit this before any error-return paths below so the summary fires
+	// even when the cycle ultimately fails.
+	if logger != nil {
+		logger.Info("SMART collection complete",
+			"total", len(devices),
+			"active", len(results),
+			"standby", standby,
+			"failed", skipped,
+			"duration", time.Since(startedAt).Round(time.Millisecond).String(),
+		)
+	}
+
 	// If every discovered drive is in standby and nothing else failed,
 	// that's a legitimate outcome (all disks asleep); return no error and
 	// an empty slice so the caller can persist an empty SMART snapshot

--- a/internal/collector/smart.go
+++ b/internal/collector/smart.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -30,7 +31,7 @@ type SMARTConfig struct {
 // that should create a history row or surface in logs.
 var errDriveInStandby = errors.New("drive in standby; skipped SMART read")
 
-func collectSMART(cfg SMARTConfig) ([]internal.SMARTInfo, error) {
+func collectSMART(cfg SMARTConfig, logger *slog.Logger) ([]internal.SMARTInfo, error) {
 	devices := discoverDrives()
 	if len(devices) == 0 {
 		// Fallback: try smartctl --scan. (The --scan subcommand does not
@@ -57,6 +58,11 @@ func collectSMART(cfg SMARTConfig) ([]internal.SMARTInfo, error) {
 			if errors.Is(err, errDriveInStandby) {
 				// Expected when `-n standby` is in effect and the drive
 				// is spun down. Not an error; no history row created.
+				// Emit an INFO log so operators can see per-cycle which
+				// drives were skipped for standby (issue #202).
+				if logger != nil {
+					logger.Info("skipped SMART read: drive in standby", "device", dev)
+				}
 				standby++
 				continue
 			}

--- a/internal/collector/smart.go
+++ b/internal/collector/smart.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,10 +12,30 @@ import (
 	"github.com/mcdays94/nas-doctor/internal"
 )
 
-func collectSMART() ([]internal.SMARTInfo, error) {
+// SMARTConfig controls SMART-collector behaviour that may need to change
+// based on user preference. See issue #198 for the v0.9.5 default shift.
+type SMARTConfig struct {
+	// WakeDrives, when true, instructs smartctl to read SMART attributes
+	// even on spun-down drives — the v0.9.4 and earlier behaviour. When
+	// false (the new default), smartctl is invoked with `-n standby`,
+	// which causes it to skip (exit 2) any drive currently in standby.
+	// Users who prefer every-cycle SMART reads can opt back in via the
+	// Settings → Advanced UI.
+	WakeDrives bool
+}
+
+// errDriveInStandby is returned by readSMARTDevice when smartctl reported
+// that the target drive is spun down and therefore no SMART data was read.
+// The SMART collector treats this as "skip silently" rather than an error
+// that should create a history row or surface in logs.
+var errDriveInStandby = errors.New("drive in standby; skipped SMART read")
+
+func collectSMART(cfg SMARTConfig) ([]internal.SMARTInfo, error) {
 	devices := discoverDrives()
 	if len(devices) == 0 {
-		// Fallback: try smartctl --scan
+		// Fallback: try smartctl --scan. (The --scan subcommand does not
+		// itself wake drives; it just enumerates what's attached, so no
+		// standby flag needed here.)
 		out, _ := execCmd("smartctl", "--scan")
 		for _, line := range strings.Split(out, "\n") {
 			fields := strings.Fields(line)
@@ -29,10 +50,16 @@ func collectSMART() ([]internal.SMARTInfo, error) {
 
 	var results []internal.SMARTInfo
 	var lastErr error
-	var skipped int
+	var skipped, standby int
 	for _, dev := range devices {
-		info, err := readSMARTDevice(dev)
+		info, err := readSMARTDevice(dev, cfg.WakeDrives)
 		if err != nil {
+			if errors.Is(err, errDriveInStandby) {
+				// Expected when `-n standby` is in effect and the drive
+				// is spun down. Not an error; no history row created.
+				standby++
+				continue
+			}
 			lastErr = err
 			skipped++
 			continue
@@ -44,8 +71,12 @@ func collectSMART() ([]internal.SMARTInfo, error) {
 		}
 		results = append(results, info)
 	}
+	// If every discovered drive is in standby and nothing else failed,
+	// that's a legitimate outcome (all disks asleep); return no error and
+	// an empty slice so the caller can persist an empty SMART snapshot
+	// rather than treating it as a collection failure.
 	if len(results) == 0 && lastErr != nil {
-		return nil, fmt.Errorf("all %d drives failed SMART read (%d skipped), last error: %w", len(devices), skipped, lastErr)
+		return nil, fmt.Errorf("all %d drives failed SMART read (%d skipped, %d standby), last error: %w", len(devices), skipped, standby, lastErr)
 	}
 	return results, nil
 }
@@ -90,12 +121,34 @@ func discoverDrives() []string {
 // readSMARTDevice uses `smartctl --json` for reliable parsing.
 // Note: smartctl returns non-zero exit codes even on success (bit-masked status).
 // We check the output content instead of relying on the exit code.
-func readSMARTDevice(device string) (internal.SMARTInfo, error) {
+//
+// When wakeDrives is false (the v0.9.5+ default), each smartctl invocation
+// is prefixed with `-n standby` so spun-down drives are not woken by the
+// scan cycle. If smartctl reports the drive is in standby, this function
+// returns errDriveInStandby, which the caller (collectSMART) treats as a
+// silent skip rather than a collection failure.
+func readSMARTDevice(device string, wakeDrives bool) (internal.SMARTInfo, error) {
 	info := internal.SMARTInfo{Device: device}
+
+	// smartctlArgs builds the argument slice for a smartctl call,
+	// prefixing `-n standby` when the user has not opted into waking
+	// spun-down drives.
+	smartctlArgs := func(extra ...string) []string {
+		if wakeDrives {
+			return extra
+		}
+		// Prepend -n standby. Order matters less than presence, but we
+		// keep it at the front so it's visible to anyone grepping the
+		// argv of a running smartctl.
+		return append([]string{"-n", "standby"}, extra...)
+	}
 
 	// Try JSON output first (smartctl 7.0+)
 	// Ignore exit code — smartctl uses bitmask exit codes even for successful reads
-	out, _ := execCmd("smartctl", "--json=c", "-a", device)
+	out, _ := execCmd("smartctl", smartctlArgs("--json=c", "-a", device)...)
+	if !wakeDrives && looksLikeStandbyOutput(out) {
+		return info, errDriveInStandby
+	}
 	if strings.Contains(out, "json_format_version") {
 		return parseSMARTJSON(device, out)
 	}
@@ -105,7 +158,10 @@ func readSMARTDevice(device string) (internal.SMARTInfo, error) {
 		strings.Contains(out, "INQUIRY failed") || strings.Contains(out, "unable to detect device") ||
 		out == "" {
 		for _, devType := range []string{"sat", "auto", "scsi"} {
-			out2, _ := execCmd("smartctl", "--json=c", "-a", "-d", devType, device)
+			out2, _ := execCmd("smartctl", smartctlArgs("--json=c", "-a", "-d", devType, device)...)
+			if !wakeDrives && looksLikeStandbyOutput(out2) {
+				return info, errDriveInStandby
+			}
 			if strings.Contains(out2, "json_format_version") {
 				return parseSMARTJSON(device, out2)
 			}
@@ -118,7 +174,10 @@ func readSMARTDevice(device string) (internal.SMARTInfo, error) {
 	}
 
 	// Fallback to text parsing (also ignore exit code)
-	out, _ = execCmd("smartctl", "-a", device)
+	out, _ = execCmd("smartctl", smartctlArgs("-a", device)...)
+	if !wakeDrives && looksLikeStandbyOutput(out) {
+		return info, errDriveInStandby
+	}
 	if out == "" {
 		return info, fmt.Errorf("smartctl returned no output for %s", device)
 	}
@@ -126,6 +185,31 @@ func readSMARTDevice(device string) (internal.SMARTInfo, error) {
 		return info, fmt.Errorf("unsupported device (USB bridge): %s", device)
 	}
 	return parseSMARTText(device, out), nil
+}
+
+// looksLikeStandbyOutput returns true when smartctl's output indicates the
+// target drive is spun down and was therefore skipped under `-n standby`.
+// Covers both the text-mode banner ("Device is in STANDBY mode, exit(2)")
+// and the --json=c response where power_mode carries STANDBY without the
+// json_format_version header that accompanies a full SMART read.
+func looksLikeStandbyOutput(out string) bool {
+	if out == "" {
+		return false
+	}
+	// Text-mode marker — most common on Unraid / typical Linux installs.
+	if strings.Contains(out, "STANDBY mode") || strings.Contains(out, "in standby mode") {
+		return true
+	}
+	// JSON-mode marker: smartctl emits a small envelope with power_mode
+	// set to STANDBY and no attribute table. Be conservative and require
+	// the absence of json_format_version (which only appears in a full
+	// read) so we don't mis-classify a model name containing "STANDBY".
+	if strings.Contains(out, `"power_mode"`) &&
+		strings.Contains(strings.ToUpper(out), "STANDBY") &&
+		!strings.Contains(out, "json_format_version") {
+		return true
+	}
+	return false
 }
 
 type smartctlJSON struct {

--- a/internal/collector/smart_standby_test.go
+++ b/internal/collector/smart_standby_test.go
@@ -1,0 +1,167 @@
+package collector
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// swapExecCmd replaces the package-level execCmd with a fake for the duration
+// of a test. Returns a restore function; callers should defer restore().
+//
+// execCmd is defined as a package-level var in system.go specifically so
+// tests can swap it out — the smartctl flag surface is otherwise difficult
+// to unit-test (would require either building a fake binary on PATH or
+// mocking exec.Command).
+func swapExecCmd(fn func(name string, args ...string) (string, error)) (restore func()) {
+	orig := execCmd
+	execCmd = fn
+	return func() { execCmd = orig }
+}
+
+// TestReadSMARTDevice_DefaultAddsStandbyFlag verifies the v0.9.5+ default:
+// every smartctl invocation from the SMART collector must include `-n standby`
+// unless the WakeDrivesForSMART setting is explicitly enabled. Without this,
+// scans wake spun-down drives every scan cycle (issue #198).
+func TestReadSMARTDevice_DefaultAddsStandbyFlag(t *testing.T) {
+	var calls [][]string
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		calls = append(calls, append([]string{name}, args...))
+		// Return nothing matching json_format_version so readSMARTDevice
+		// exercises all fallback paths (initial JSON, device-type loop,
+		// text fallback).
+		return "", nil
+	})()
+
+	_, _ = readSMARTDevice("/dev/sda", false /* wakeDrives */)
+
+	if len(calls) == 0 {
+		t.Fatal("expected at least one smartctl call")
+	}
+	for i, call := range calls {
+		if call[0] != "smartctl" {
+			t.Errorf("call %d: expected smartctl binary, got %q", i, call[0])
+			continue
+		}
+		joined := strings.Join(call, " ")
+		if !strings.Contains(joined, "-n standby") {
+			t.Errorf("call %d missing `-n standby` flag (wakeDrives=false): %s", i, joined)
+		}
+	}
+}
+
+// TestReadSMARTDevice_WakeDrivesOmitsStandbyFlag verifies the opt-out: when
+// the user explicitly enables WakeDrivesForSMART, the `-n standby` flag must
+// NOT be passed (restoring v0.9.4 and earlier behavior).
+func TestReadSMARTDevice_WakeDrivesOmitsStandbyFlag(t *testing.T) {
+	var calls [][]string
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		calls = append(calls, append([]string{name}, args...))
+		return "", nil
+	})()
+
+	_, _ = readSMARTDevice("/dev/sda", true /* wakeDrives */)
+
+	if len(calls) == 0 {
+		t.Fatal("expected at least one smartctl call")
+	}
+	for i, call := range calls {
+		joined := strings.Join(call, " ")
+		if strings.Contains(joined, "-n standby") {
+			t.Errorf("call %d included `-n standby` flag despite wakeDrives=true: %s", i, joined)
+		}
+	}
+}
+
+// TestReadSMARTDevice_StandbyOutputReturnsSentinel verifies that when
+// smartctl reports the drive is in standby (via `-n standby` skip), we
+// return errDriveInStandby so collectSMART can silently skip the drive
+// rather than log an error or create a broken history row.
+func TestReadSMARTDevice_StandbyOutputReturnsSentinel(t *testing.T) {
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		// Typical smartctl text output when -n standby skips the drive.
+		return "smartctl 7.3 2022-02-28 r5338 [x86_64-linux-6.1.0] (local build)\n" +
+			"Copyright (C) 2002-22, Bruce Allen, Christian Franke, www.smartmontools.org\n\n" +
+			"Device is in STANDBY mode, exit(2)\n", nil
+	})()
+
+	_, err := readSMARTDevice("/dev/sda", false)
+	if !errors.Is(err, errDriveInStandby) {
+		t.Errorf("expected errDriveInStandby, got %v", err)
+	}
+}
+
+// TestReadSMARTDevice_StandbyJSONReturnsSentinel verifies standby detection
+// for the --json=c invocation path (smartctl emits a JSON object with
+// power_mode=STANDBY even when skipping).
+func TestReadSMARTDevice_StandbyJSONReturnsSentinel(t *testing.T) {
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		// Minimal JSON smartctl returns when -n standby skips — no
+		// json_format_version (so we shouldn't accidentally parse it as
+		// a successful SMART read), with an explicit power_mode signal.
+		return `{"power_mode":"STANDBY","exit_status":2}`, nil
+	})()
+
+	_, err := readSMARTDevice("/dev/sda", false)
+	if !errors.Is(err, errDriveInStandby) {
+		t.Errorf("expected errDriveInStandby for JSON-mode standby output, got %v", err)
+	}
+}
+
+// TestReadSMARTDevice_WakeDrivesTrueIgnoresStandbyHeuristic ensures the
+// standby-detection heuristic only runs when wakeDrives=false. When the
+// setting is enabled, we never pass -n standby, so STANDBY should not
+// appear in output; but even if some attribute text happened to contain
+// the word, we must not short-circuit.
+func TestReadSMARTDevice_WakeDrivesTrueIgnoresStandbyHeuristic(t *testing.T) {
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		// Deliberately include the word STANDBY in output (e.g. as part
+		// of a device-type attribute description) to prove wakeDrives=true
+		// never returns errDriveInStandby.
+		return `{"json_format_version":[1,0,0],"model_name":"STANDBY Pro 2TB","user_capacity":{"bytes":2000000000000}}`, nil
+	})()
+
+	info, err := readSMARTDevice("/dev/sda", true)
+	if errors.Is(err, errDriveInStandby) {
+		t.Errorf("unexpected errDriveInStandby when wakeDrives=true: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Model != "STANDBY Pro 2TB" {
+		t.Errorf("expected parsed model=%q, got %q", "STANDBY Pro 2TB", info.Model)
+	}
+}
+
+// TestCollectSMART_PropagatesWakeDrivesFlag wires the top-level collectSMART
+// entry to the readSMARTDevice seam by checking whether the standby flag is
+// threaded through the SMARTConfig struct.
+func TestCollectSMART_PropagatesWakeDrivesFlag(t *testing.T) {
+	// Use a discovery-minimal approach: we can't replace discoverDrives
+	// without another seam, so we verify the SMARTConfig struct exists
+	// and the field name is stable. More integration-like behaviour is
+	// exercised by the readSMARTDevice tests above.
+	cfg := SMARTConfig{WakeDrives: true}
+	if !cfg.WakeDrives {
+		t.Errorf("SMARTConfig.WakeDrives did not round-trip")
+	}
+	// Also make sure the zero value is false (default behavior = standby-aware).
+	var zero SMARTConfig
+	if zero.WakeDrives {
+		t.Errorf("SMARTConfig zero value should have WakeDrives=false; got true")
+	}
+
+	// Sanity-check that the Collector exposes a setter so the API/main
+	// plumbing can reach the field.
+	var c Collector
+	c.SetSMARTConfig(cfg)
+	if !c.smartConfig.WakeDrives {
+		t.Errorf("SetSMARTConfig did not persist cfg")
+	}
+}
+
+// compile-time guard: SMARTInfo remains the return type of readSMARTDevice
+// (catches accidental signature drift).
+var _ = internal.SMARTInfo{}

--- a/internal/collector/smart_summary_test.go
+++ b/internal/collector/smart_summary_test.go
@@ -1,0 +1,172 @@
+package collector
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestCollectSMART_EmitsSummaryLogFormat is a grep-based cross-reference
+// that pins the summary log line's field names. The v0.9.5 UAT feedback
+// (issue #203) asked for a single per-cycle line with total/active/standby/
+// failed/duration, and operators' log pipelines depend on that format not
+// drifting. If someone renames a field, this test fails loudly.
+func TestCollectSMART_EmitsSummaryLogFormat(t *testing.T) {
+	data, err := os.ReadFile("smart.go")
+	if err != nil {
+		t.Fatalf("read smart.go: %v", err)
+	}
+	src := string(data)
+
+	if !strings.Contains(src, `"SMART collection complete"`) {
+		t.Errorf("smart.go missing summary log message %q — if you renamed it, update the log pipeline docs too", "SMART collection complete")
+	}
+	for _, field := range []string{`"total"`, `"active"`, `"standby"`, `"failed"`, `"duration"`} {
+		if !strings.Contains(src, field) {
+			t.Errorf("smart.go summary log missing required field %s", field)
+		}
+	}
+}
+
+// TestCollectSMART_SummaryLogCounters exercises collectSMART against a fake
+// execCmd that returns a mix of active + standby + failed drives, and
+// asserts the resulting INFO summary has the expected counter math.
+//
+// We rely on the smartctl --scan fallback to inject a controlled device
+// list: discoverDrives() on a dev box either returns real /dev/sd* paths
+// or nothing, but when it returns nothing collectSMART falls back to
+// `smartctl --scan`, which our fake execCmd fully controls.
+func TestCollectSMART_SummaryLogCounters(t *testing.T) {
+	// If discoverDrives() finds real drives on the test host, we can't
+	// deterministically control the counter math. Detect and skip.
+	if len(discoverDrives()) > 0 {
+		t.Skip("host has real drives discoverable via /dev/sd*; cannot run deterministic fake-execCmd test")
+	}
+
+	// Craft smartctl responses per device. --scan enumerates 3 fake devs.
+	// /dev/fake0 → active (full JSON read)
+	// /dev/fake1 → standby
+	// /dev/fake2 → empty output across all fallbacks → counted as failed
+	fakeActiveJSON := `{"json_format_version":[1,0,0],"model_name":"FakeDrive 1TB","serial_number":"SN-ACTIVE","user_capacity":{"bytes":1000000000000},"temperature":{"current":30},"power_on_time":{"hours":100}}`
+	fakeStandbyOut := "smartctl 7.3 2022-02-28\n\nDevice is in STANDBY mode, exit(2)\n"
+
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		// --scan enumerates devices
+		if len(args) == 1 && args[0] == "--scan" {
+			return "/dev/fake0 -d sat # /dev/fake0, SAT\n" +
+				"/dev/fake1 -d sat # /dev/fake1, SAT\n" +
+				"/dev/fake2 -d sat # /dev/fake2, SAT\n", nil
+		}
+		// Route per-device smartctl calls based on which /dev/fakeN
+		// appears in the argv (it's always the trailing positional arg
+		// or penultimate for `-d TYPE DEV` forms).
+		argv := strings.Join(args, " ")
+		switch {
+		case strings.Contains(argv, "/dev/fake0"):
+			return fakeActiveJSON, nil
+		case strings.Contains(argv, "/dev/fake1"):
+			return fakeStandbyOut, nil
+		case strings.Contains(argv, "/dev/fake2"):
+			return "", nil // no output → falls through → counted as failed
+		}
+		return "", nil
+	})()
+
+	// Capture log output as structured JSON so we can parse the summary
+	// line's fields.
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	_, _ = collectSMART(SMARTConfig{WakeDrives: false}, logger)
+
+	// Scan log lines for the summary.
+	var summary map[string]any
+	for _, line := range strings.Split(buf.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if msg, _ := rec["msg"].(string); msg == "SMART collection complete" {
+			summary = rec
+			break
+		}
+	}
+	if summary == nil {
+		t.Fatalf("no 'SMART collection complete' log line emitted; got:\n%s", buf.String())
+	}
+
+	// JSON numbers decode as float64.
+	gotInt := func(field string) int {
+		v, ok := summary[field]
+		if !ok {
+			t.Fatalf("summary log missing %q field; got: %v", field, summary)
+		}
+		f, ok := v.(float64)
+		if !ok {
+			t.Fatalf("summary field %q is not a number: %v (%T)", field, v, v)
+		}
+		return int(f)
+	}
+
+	if got := gotInt("total"); got != 3 {
+		t.Errorf("total = %d, want 3", got)
+	}
+	if got := gotInt("active"); got != 1 {
+		t.Errorf("active = %d, want 1", got)
+	}
+	if got := gotInt("standby"); got != 1 {
+		t.Errorf("standby = %d, want 1", got)
+	}
+	if got := gotInt("failed"); got != 1 {
+		t.Errorf("failed = %d, want 1", got)
+	}
+	if _, ok := summary["duration"].(string); !ok {
+		t.Errorf("duration field missing or not a string: %v", summary["duration"])
+	}
+}
+
+// TestCollectSMART_SummaryLogEmittedOnNoDrives verifies the no-drive edge
+// case still emits a summary (with all-zero counters) before the error
+// return. Operators should always see one summary per cycle.
+func TestCollectSMART_SummaryLogEmittedOnNoDrives(t *testing.T) {
+	if len(discoverDrives()) > 0 {
+		t.Skip("host has real drives discoverable via /dev/sd*")
+	}
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		// --scan returns nothing → collectSMART returns the "no drives
+		// discovered" error, but must log first.
+		return "", nil
+	})()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	_, err := collectSMART(SMARTConfig{}, logger)
+	if err == nil {
+		t.Fatal("expected 'no drives discovered' error")
+	}
+	if !strings.Contains(buf.String(), `"SMART collection complete"`) {
+		t.Errorf("expected summary log even on no-drive edge case; got:\n%s", buf.String())
+	}
+}
+
+// TestCollectSMART_NilLoggerTolerated guards the nil-logger defensive
+// check on the summary-emit path.
+func TestCollectSMART_NilLoggerTolerated(t *testing.T) {
+	if len(discoverDrives()) > 0 {
+		t.Skip("host has real drives discoverable via /dev/sd*")
+	}
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		return "", nil
+	})()
+
+	// Should not panic despite logger=nil.
+	_, _ = collectSMART(SMARTConfig{}, nil)
+}

--- a/internal/collector/system.go
+++ b/internal/collector/system.go
@@ -328,7 +328,11 @@ func extractHexID(s string) string {
 	return candidate
 }
 
-func execCmd(name string, args ...string) (string, error) {
+// execCmd shells out to a command and returns combined stdout+stderr plus
+// any exec error. Defined as a package-level var (rather than a plain
+// function) so tests can swap in a fake implementation — see
+// smart_standby_test.go for the seam usage.
+var execCmd = func(name string, args ...string) (string, error) {
 	cmd := exec.Command(name, args...)
 	out, err := cmd.CombinedOutput()
 	return string(out), err

--- a/internal/scheduler/checks.go
+++ b/internal/scheduler/checks.go
@@ -419,6 +419,18 @@ func (sc *ServiceChecker) runTCPCheck(ctx context.Context, check internal.Servic
 	}
 	if result.Details != nil {
 		result.Details["resolved_address"] = addr
+		// protocol_hint is purely informational — drives the small
+		// badge in the expanded log entry + Test toast (issue #188).
+		// Absent from the map when the port is not in the
+		// well-known table so the JS renderer can use key-presence
+		// to decide whether to draw the badge.
+		if _, portStr, splitErr := net.SplitHostPort(addr); splitErr == nil {
+			if portNum, convErr := strconv.Atoi(portStr); convErr == nil {
+				if hint := ProtocolHint(portNum); hint != "" {
+					result.Details["protocol_hint"] = hint
+				}
+			}
+		}
 	}
 	dialer := net.Dialer{Timeout: time.Duration(timeoutSec) * time.Second}
 	conn, err := dialer.DialContext(ctx, "tcp", addr)

--- a/internal/scheduler/protocol_hints.go
+++ b/internal/scheduler/protocol_hints.go
@@ -1,0 +1,54 @@
+package scheduler
+
+// protocol_hints.go — the well-known-port → protocol label map used to
+// decorate TCP service check results with a small badge (SSH, HTTPS,
+// MySQL, …) in the expanded log entry and the Test button toast.
+//
+// Scope intentionally narrow: the common homelab / self-host
+// protocols listed in issue #188. The full IANA registry is overkill
+// here — an unknown port returns "" and the UI skips the badge.
+// Keep this table in sync with:
+//   - the docs table in the issue body,
+//   - the protocol_hint JS doc-comment in service_checks.html /
+//     settings.html renderServiceCheckDetails helpers.
+
+// wellKnownProtocols maps the TCP port number to a human-readable
+// protocol label. The labels match the issue body verbatim so the UI
+// badge text exactly mirrors the published doc.
+var wellKnownProtocols = map[int]string{
+	22:    "SSH",
+	25:    "SMTP",
+	53:    "DNS",
+	80:    "HTTP",
+	110:   "POP3",
+	143:   "IMAP",
+	389:   "LDAP",
+	443:   "HTTPS",
+	445:   "SMB",
+	465:   "SMTPS",
+	587:   "SMTP (submission)",
+	636:   "LDAPS",
+	993:   "IMAPS",
+	995:   "POP3S",
+	1433:  "MSSQL",
+	3306:  "MySQL",
+	3389:  "RDP",
+	5432:  "PostgreSQL",
+	5672:  "AMQP",
+	6379:  "Redis",
+	8080:  "HTTP (alt)",
+	8443:  "HTTPS (alt)",
+	9200:  "Elasticsearch",
+	27017: "MongoDB",
+}
+
+// ProtocolHint returns the well-known-protocol label for a TCP port,
+// or the empty string when the port is not in the curated table.
+// Informational only — callers must not gate check behaviour on the
+// return value. Negative / out-of-range / zero ports always return "".
+func ProtocolHint(port int) string {
+	if port <= 0 || port > 65535 {
+		return ""
+	}
+	return wellKnownProtocols[port]
+}

--- a/internal/scheduler/protocol_hints_test.go
+++ b/internal/scheduler/protocol_hints_test.go
@@ -1,0 +1,145 @@
+// Package scheduler — protocol_hints_test.go covers ProtocolHint, the
+// well-known-port → label map surfaced on TCP service check Details so
+// the dashboard can render a small protocol badge (e.g. "SSH" for :22,
+// "HTTPS" for :443) in the expanded log entry and the Test button
+// toast. Purely informational; does not affect check execution.
+//
+// See issue #188.
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// TestProtocolHint_KnownPorts walks the published port → badge table
+// from the issue body. Any drift between the table here and the Go
+// implementation means the docs lie. Kept verbose on purpose: one
+// case per row so a failure points at the exact offending port.
+func TestProtocolHint_KnownPorts(t *testing.T) {
+	cases := []struct {
+		port int
+		want string
+	}{
+		{22, "SSH"},
+		{25, "SMTP"},
+		{53, "DNS"},
+		{80, "HTTP"},
+		{110, "POP3"},
+		{143, "IMAP"},
+		{389, "LDAP"},
+		{443, "HTTPS"},
+		{445, "SMB"},
+		{465, "SMTPS"},
+		{587, "SMTP (submission)"},
+		{636, "LDAPS"},
+		{993, "IMAPS"},
+		{995, "POP3S"},
+		{1433, "MSSQL"},
+		{3306, "MySQL"},
+		{3389, "RDP"},
+		{5432, "PostgreSQL"},
+		{5672, "AMQP"},
+		{6379, "Redis"},
+		{8080, "HTTP (alt)"},
+		{8443, "HTTPS (alt)"},
+		{9200, "Elasticsearch"},
+		{27017, "MongoDB"},
+	}
+	for _, c := range cases {
+		if got := ProtocolHint(c.port); got != c.want {
+			t.Errorf("ProtocolHint(%d) = %q, want %q", c.port, got, c.want)
+		}
+	}
+}
+
+// TestProtocolHint_UnknownPorts — any port not in the published table
+// must return "" so the UI can skip the badge entirely. We exercise a
+// spread (privileged, ephemeral, nonsense) to keep the implementation
+// honest: no "default to HTTP" shortcuts.
+func TestProtocolHint_UnknownPorts(t *testing.T) {
+	for _, port := range []int{0, -1, 1, 23, 21, 999, 8000, 8081, 9999, 65535, 65536} {
+		if got := ProtocolHint(port); got != "" {
+			t.Errorf("ProtocolHint(%d) = %q, want empty string", port, got)
+		}
+	}
+}
+
+// TestRunCheck_TCP_PopulatesProtocolHint — when a TCP check resolves
+// to a well-known port, the Details map carries protocol_hint so the
+// dashboard and Test toast can render a badge. Uses a real listener
+// on 127.0.0.1:<ephemeral> for the happy path, and a hardcoded
+// target ending in :22 for the hint-set path (connect will fail —
+// the hint is computed from the TARGET port, not the connection
+// result, so failure_stage coexists with protocol_hint).
+func TestRunCheck_TCP_PopulatesProtocolHint(t *testing.T) {
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+
+	// Target port 22 is well-known (SSH). We point at 127.0.0.1:22
+	// rather than a real SSH server — the dial will almost certainly
+	// fail on CI, which is fine: the hint is derived from the
+	// resolved_address, not from the connection outcome.
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:       "tcp-ssh-hint",
+		Type:       internal.ServiceCheckTCP,
+		Target:     "127.0.0.1:22",
+		Enabled:    true,
+		TimeoutSec: 1,
+	}, time.Now().UTC())
+
+	hint, ok := result.Details["protocol_hint"].(string)
+	if !ok {
+		t.Fatalf("expected protocol_hint to be a string in Details, got %T (%v); full Details=%+v",
+			result.Details["protocol_hint"], result.Details["protocol_hint"], result.Details)
+	}
+	if hint != "SSH" {
+		t.Fatalf("expected protocol_hint=SSH for port 22, got %q", hint)
+	}
+}
+
+// TestRunCheck_TCP_UnknownPort_NoProtocolHint — the hint key must be
+// ABSENT (not empty-string) when the port is not in the well-known
+// table. The UI renderer uses key-presence to decide whether to draw
+// the badge, so an empty-string value would render an empty badge.
+func TestRunCheck_TCP_UnknownPort_NoProtocolHint(t *testing.T) {
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+
+	// Port 9999 is not in the table; pick a target that will also
+	// not connect so we don't need to stand up a listener.
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:       "tcp-no-hint",
+		Type:       internal.ServiceCheckTCP,
+		Target:     "127.0.0.1:9999",
+		Enabled:    true,
+		TimeoutSec: 1,
+	}, time.Now().UTC())
+
+	if v, present := result.Details["protocol_hint"]; present {
+		t.Fatalf("expected protocol_hint to be absent for port 9999, got %v", v)
+	}
+}
+
+// TestRunCheck_TCP_SMB_ImpliedPortHint — SMB checks default to port
+// 445 when none is specified. The hint should reflect the defaulted
+// port (SMB) so users get a badge even for port-less SMB targets.
+func TestRunCheck_TCP_SMB_ImpliedPortHint(t *testing.T) {
+	sc, _ := newTestChecker()
+	sc.SetCollectDetails(true)
+
+	result := sc.RunCheck(internal.ServiceCheckConfig{
+		Name:       "smb-implied-445",
+		Type:       internal.ServiceCheckSMB,
+		Target:     "127.0.0.1", // no explicit port → runner defaults to 445
+		Enabled:    true,
+		TimeoutSec: 1,
+	}, time.Now().UTC())
+
+	hint, ok := result.Details["protocol_hint"].(string)
+	if !ok || hint != "SMB" {
+		t.Fatalf("expected protocol_hint=SMB for defaulted SMB port 445, got %v", result.Details["protocol_hint"])
+	}
+}


### PR DESCRIPTION
## v0.9.5 release

Bundle of 7 user-facing issues + supporting infrastructure, UAT-validated on real Unraid hardware through rc1 → rc4.

### User-visible changes

| Issue | What |
|---|---|
| #179 | Dashboard 'Last Scan' counter now counts from actual scan timestamp, not page load |
| #187 | Service Checks auto-refresh pauses while a log row is expanded (with visible 'refresh paused' affordance) |
| #188 | TCP expanded log shows well-known protocol badge (22→SSH, 443→HTTPS, 3306→MySQL, etc.) |
| #198 | SMART scans now respect drive standby by default (`-n standby`). Advanced setting 'Wake drives for SMART check' restores v0.9.4 behavior for users who want every-cycle SMART reads. Major win for drive wear on Unraid |

### Infrastructure

| Issue | What |
|---|---|
| #199 | docker.yml restructure: `:latest` is now a retag of `:X.Y.Z` via `docker buildx imagetools create` after each non-RC stable tag build. Main-branch pushes now publish `:nightly`. Eliminates the race condition + VERSION=dev failure modes that hit v0.9.4 |

### Observability

- Per-drive INFO log when SMART skips a drive in standby (#202)
- Summary log at end of each SMART cycle: `{total, active, standby, failed, duration}` (#203)
- README updated with SMART standby behavior + `:latest` semantic change note

### Breaking: `:latest` docker tag semantics

After this release, `:latest` tracks the most recent tagged release (`v0.9.5`, next `v0.9.6`, etc.) — NOT main-branch HEAD. Users who want continuous main-branch builds should switch to `:nightly`.

### UAT validation

- rc1: 3 UX fixes validated
- rc2: added SMART standby + retag workflow, SMART skipping behavior validated via API history comparison (all drives active at time of UAT, so the log-skip path wasn't hit but code reviewed and verified)
- rc3: UI width polish, per-drive standby log, README scour
- rc4: SMART summary log validated in live scans — format + field math confirmed

### Known follow-ups

- #206: one `/dev/sd?` device consistently failing SMART read on user's UAT. Not a v0.9.5 regression — summary log just surfaced what was previously invisible. Filed for v0.9.6.
- #204: Docker container hide (user request during UAT)
- #205: Uptime Kuma integration (feature request filed during UAT; v0.10.0 candidate)

Closes #179, #187, #188, #198, #199. Partially addresses #127 (Advanced settings foundation).