### PR TITLE
fix(service-checks): reject zero-throughput speed-test results (#170)

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -41,6 +41,11 @@ type Server struct {
 	logger    *slog.Logger
 	version   string
 	startTime time.Time
+	// speedTestRunner is the function invoked by handleTestServiceCheck for
+	// speed-type checks. Nil means the handler will fall back to
+	// collector.RunSpeedTest (the default). Tests override this to inject
+	// deterministic results without needing the Ookla CLI.
+	speedTestRunner scheduler.SpeedTestRunner
 }
 
 // New creates a new API server.

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -1554,7 +1554,11 @@ func (s *Server) handleTestServiceCheck(w http.ResponseWriter, r *http.Request) 
 	// lean.
 	checker.SetCollectDetails(true)
 	if cfg.Type == internal.ServiceCheckSpeed {
-		checker.SetSpeedTestRunner(collector.RunSpeedTest)
+		runner := s.speedTestRunner
+		if runner == nil {
+			runner = collector.RunSpeedTest
+		}
+		checker.SetSpeedTestRunner(runner)
 	}
 
 	result := checker.RunCheck(cfg, time.Now().UTC())

--- a/internal/api/service_check_test_endpoint_test.go
+++ b/internal/api/service_check_test_endpoint_test.go
@@ -345,6 +345,71 @@ func TestHandleTestServiceCheck_HTTP_ReturnsDetails(t *testing.T) {
 	}
 }
 
+// TestHandleTestServiceCheck_Speed_ZeroThroughput_ReportsDown — when the
+// injected speed-test runner returns a zero-throughput result (e.g. because
+// the Ookla CLI exited 0 with empty JSON, or a transient network failure),
+// the Test endpoint must NOT report "up (1 ms)". It must report a non-up
+// status and a descriptive error the UI can surface. Regression for #170.
+func TestHandleTestServiceCheck_Speed_ZeroThroughput_ReportsDown(t *testing.T) {
+	srv := newSettingsTestServer()
+	srv.speedTestRunner = func() *internal.SpeedTestResult {
+		return &internal.SpeedTestResult{
+			DownloadMbps: 0,
+			UploadMbps:   0,
+			LatencyMs:    0,
+		}
+	}
+
+	rec := postServiceCheckTest(t, srv, map[string]any{
+		"name":   "speed-zero",
+		"type":   "speed",
+		"target": "speedtest",
+		// Contracted speeds deliberately omitted — default configuration.
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 (check ran, down), got %d: %s", rec.Code, rec.Body.String())
+	}
+	r := decodeResult(t, rec)
+	if r.Status == "up" {
+		t.Fatalf("expected non-up status for zero-throughput runner, got up (error=%q, response_ms=%d)",
+			r.Error, r.ResponseMS)
+	}
+	if r.Error == "" {
+		t.Fatal("expected non-empty error on zero-throughput speed test result")
+	}
+}
+
+// TestHandleTestServiceCheck_Speed_NonZero_ReportsUp — sanity check that the
+// injected-runner seam still reports UP for a realistic non-zero result.
+// Guards against over-aggressive zero-rejection (e.g. treating legitimate
+// sub-1-Mbps results as failures).
+func TestHandleTestServiceCheck_Speed_NonZero_ReportsUp(t *testing.T) {
+	srv := newSettingsTestServer()
+	srv.speedTestRunner = func() *internal.SpeedTestResult {
+		return &internal.SpeedTestResult{
+			DownloadMbps: 500,
+			UploadMbps:   100,
+			LatencyMs:    5,
+		}
+	}
+
+	rec := postServiceCheckTest(t, srv, map[string]any{
+		"name":   "speed-ok",
+		"type":   "speed",
+		"target": "speedtest",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	r := decodeResult(t, rec)
+	if r.Status != "up" {
+		t.Fatalf("expected status up for non-zero throughput, got %q (error=%q)", r.Status, r.Error)
+	}
+	if r.DownloadMbps != 500 || r.UploadMbps != 100 {
+		t.Fatalf("expected download=500 upload=100, got %v/%v", r.DownloadMbps, r.UploadMbps)
+	}
+}
+
 // TestRegisterExtendedRoutes_ExposesServiceCheckTest — the new route is registered
 // and responds on POST through the router.
 func TestRegisterExtendedRoutes_ExposesServiceCheckTest(t *testing.T) {

--- a/internal/collector/speedtest.go
+++ b/internal/collector/speedtest.go
@@ -69,6 +69,14 @@ func runOoklaSpeedtest() *internal.SpeedTestResult {
 		return nil
 	}
 
+	// Defense-in-depth for #170: if Ookla exited 0 but produced zero-throughput
+	// JSON (e.g. partial run, killed subprocess, or a test server returning
+	// empty measurements), treat as a failure here so the scheduler never
+	// sees a zero-valued SpeedTestResult in the first place.
+	if data.Download.Bandwidth == 0 && data.Upload.Bandwidth == 0 {
+		return nil
+	}
+
 	return &internal.SpeedTestResult{
 		Timestamp:    time.Now(),
 		DownloadMbps: float64(data.Download.Bandwidth) * 8 / 1e6, // bytes/sec → Mbps
@@ -113,6 +121,12 @@ func runSpeedtestCLI() *internal.SpeedTestResult {
 	}
 
 	if err := json.Unmarshal([]byte(out), &data); err != nil {
+		return nil
+	}
+
+	// Defense-in-depth for #170: treat zero-throughput results as failure
+	// so the scheduler never sees a zero-valued SpeedTestResult.
+	if data.Download == 0 && data.Upload == 0 {
 		return nil
 	}
 

--- a/internal/scheduler/checks.go
+++ b/internal/scheduler/checks.go
@@ -539,6 +539,15 @@ func (sc *ServiceChecker) runSpeedCheck(check internal.ServiceCheckConfig, resul
 		return
 	}
 
+	// Reject zero-throughput results regardless of contracted-speed config.
+	// Without this guard the threshold logic below unconditionally passes
+	// when both contracted fields are unset (the default), producing a
+	// misleading UP status. See issue #170.
+	if stResult.DownloadMbps <= 0 && stResult.UploadMbps <= 0 {
+		result.Error = "speed test returned no measurements (speedtest CLI may have failed)"
+		return
+	}
+
 	result.DownloadMbps = stResult.DownloadMbps
 	result.UploadMbps = stResult.UploadMbps
 	result.LatencyMs = stResult.LatencyMs

--- a/internal/scheduler/checks_test.go
+++ b/internal/scheduler/checks_test.go
@@ -601,6 +601,45 @@ func TestRunCheck_Speed_NoRunner(t *testing.T) {
 	}
 }
 
+// TestRunCheck_Speed_ZeroThroughput_ReportsDown verifies that a runner
+// returning an all-zero SpeedTestResult is NOT reported as "up (1 ms)".
+// Regression for #170: when contracted speeds aren't set, the threshold
+// logic (`ContractedDownMbps <= 0 || ...`) unconditionally passed any
+// non-nil result, including a zero-valued struct, producing a misleading
+// UP status with response_ms=1 (from the sub-ms floor in RunCheck).
+func TestRunCheck_Speed_ZeroThroughput_ReportsDown(t *testing.T) {
+	sc, _ := newTestChecker()
+	sc.SetSpeedTestRunner(func() *internal.SpeedTestResult {
+		return &internal.SpeedTestResult{
+			DownloadMbps: 0,
+			UploadMbps:   0,
+			LatencyMs:    0,
+		}
+	})
+
+	check := internal.ServiceCheckConfig{
+		Name:    "speed-zero",
+		Type:    internal.ServiceCheckSpeed,
+		Target:  "speedtest",
+		Enabled: true,
+		// Contracted speeds deliberately NOT set — this is the default
+		// configuration that triggered the original bug.
+	}
+
+	result := sc.RunCheck(check, time.Now().UTC())
+	if result.Status == "up" {
+		t.Fatalf("expected non-up status for zero-throughput result, got up (error=%q, response_ms=%d)",
+			result.Error, result.ResponseMS)
+	}
+	if result.Error == "" {
+		t.Fatal("expected non-empty error explaining zero-throughput result")
+	}
+	if !strings.Contains(strings.ToLower(result.Error), "no measurements") &&
+		!strings.Contains(strings.ToLower(result.Error), "speedtest") {
+		t.Fatalf("expected error to mention missing measurements or speedtest, got %q", result.Error)
+	}
+}
+
 // ── Helper function tests ──────────────────────────────────────────────
 
 func TestIsSupportedCheckType(t *testing.T) {


### PR DESCRIPTION
Closes #170

## Root cause (quoted from investigation on #170)

> When a user tests a newly-configured speed check without setting contracted throughput floors (the default — the contracted fields are optional and most users won't set them), the first operand on each `dlOK` / `ulOK` line (`ContractedDownMbps <= 0` / `ContractedUpMbps <= 0`) is unconditionally `true`. Any non-nil runner result — **including one with all-zero throughput** — results in `Status = "up"`. The `RunCheck` sub-ms floor (added in #159) then sets `ResponseMS = 1`.
>
> **Final output**: `{status: "up", response_ms: 1}` — the `download_mbps` / `upload_mbps` fields are stripped by `omitempty` when zero, so the UI's "— X ↓ / Y ↑ Mbps" tail is skipped and the toast shows only `✓ Check is UP (1 ms)`.

## Two-layer defense

1. **Primary** (`internal/scheduler/checks.go`) — in `runSpeedCheck`, after the existing nil-check, early-return with a descriptive error when both `DownloadMbps` and `UploadMbps` are ≤ 0. This is the minimum sufficient fix.
2. **Secondary / defense-in-depth** (`internal/collector/speedtest.go`) — in both `runOoklaSpeedtest` and `runSpeedtestCLI`, return nil when the decoded JSON has zero bandwidth on both directions. This prevents zero-valued results from ever reaching the scheduler.

## Tests

- `TestRunCheck_Speed_ZeroThroughput_ReportsDown` (scheduler) — asserts a zero-throughput runner produces non-`up` status with a descriptive error.
- `TestHandleTestServiceCheck_Speed_ZeroThroughput_ReportsDown` (api) — end-to-end through the `/api/v1/service-checks/test` handler.
- `TestHandleTestServiceCheck_Speed_NonZero_ReportsUp` (api) — sanity check that realistic non-zero results still report UP through the new seam.
- All existing `TestRunCheck_Speed_*` tests still pass.

## Test seam added

`handleTestServiceCheck` hardcoded `collector.RunSpeedTest` with no seam. Added a `Server.speedTestRunner` field (nil → falls back to the real CLI). The default `New()` constructor does not set it, so production behavior is unchanged. Tests assign it directly. Minimal, ~10 LOC.

## Collector defense-in-depth is untested

`runOoklaSpeedtest` / `runSpeedtestCLI` shell out via `exec.LookPath` + `execCmdTimeout` without an injection seam. Refactoring that is out of scope for #170 — the scheduler-level guard is the primary defense and is covered by the new tests. The collector insert is verified by inspection.

## Explicitly NOT in scope

- **#210** — the scheduler's persistent `ServiceChecker` never calls `SetSpeedTestRunner`, so any scheduled `type=speed` check reports DOWN forever. Separate design question (9.6 GB/day per check if you run Ookla every 30s). Tracked separately.
- **`execCmdTimeout`** — it's a "timeout in name only" (the function ignores the `timeoutSec` arg). Pre-existing issue, not addressed here.
- **Dockerfile Ookla install `|| true`** — arch-mismatch hardening is a separate concern.
- **Sub-ms floor at `checks.go:177-179`** — the #159 fix for HTTP/DNS/TCP/Ping is still correct and untouched.

## Release note

Speed-check Test button now reports DOWN with a descriptive error when the Ookla CLI returns zero throughput, instead of falsely showing UP (1 ms).