### PR TITLE
feat(dashboard): allow hiding specific Docker containers from the section (#204)

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -300,7 +300,52 @@ func (s *Server) handleLatestSnapshot(w http.ResponseWriter, r *http.Request) {
 	}
 	// Enrich parity checks with avg/max array temperature from smart_history
 	s.enrichParityTemps(snap)
+	// Apply user's Docker hidden-containers filter (issue #204). Scope is
+	// intentionally narrow: only DockerInfo.Containers is filtered — Top
+	// Processes container attribution is preserved so users still see
+	// which container is chewing CPU even when the Docker tile hides it.
+	s.applyDockerHiddenContainers(snap)
 	writeJSON(w, http.StatusOK, snap)
+}
+
+// applyDockerHiddenContainers filters out containers in the user's hidden
+// list from the snapshot's Docker.Containers slice and stamps the hidden
+// count onto DockerInfo.HiddenCount for the frontend header. Mutates the
+// snapshot in place. Issue #204.
+//
+// Scope boundary — this function must NOT modify snap.System.TopProcesses.
+// Users want to know which container is chewing CPU even when they've
+// hidden the Docker tile for scroll-length reasons.
+func (s *Server) applyDockerHiddenContainers(snap *internal.Snapshot) {
+	if snap == nil {
+		return
+	}
+	settings := s.getSettings()
+	if len(settings.DockerHiddenContainers) == 0 {
+		return
+	}
+	hidden := make(map[string]struct{}, len(settings.DockerHiddenContainers))
+	for _, n := range settings.DockerHiddenContainers {
+		trimmed := strings.TrimSpace(n)
+		if trimmed == "" {
+			continue
+		}
+		hidden[trimmed] = struct{}{}
+	}
+	if len(hidden) == 0 {
+		return
+	}
+	kept := snap.Docker.Containers[:0:0]
+	hiddenCount := 0
+	for _, c := range snap.Docker.Containers {
+		if _, match := hidden[c.Name]; match {
+			hiddenCount++
+			continue
+		}
+		kept = append(kept, c)
+	}
+	snap.Docker.Containers = kept
+	snap.Docker.HiddenCount = hiddenCount
 }
 
 // enrichParityTemps computes avg/max array temperature during each parity check

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -55,6 +55,14 @@ type Settings struct {
 	// Default (false) is standby-aware: smartctl runs with `-n standby` and
 	// skips sleeping drives. See issue #198.
 	WakeDrivesForSMART bool `json:"wake_drives_for_smart,omitempty"`
+
+	// DockerHiddenContainers is a list of container names that should be
+	// omitted from the Docker Containers dashboard section. Exact-match
+	// only (MVP — glob/regex is a follow-up). Stats history is still
+	// collected for hidden containers, and Top Processes container
+	// attribution is NOT affected — this is a rendering preference for
+	// the Docker section tile only. See issue #204.
+	DockerHiddenContainers []string `json:"docker_hidden_containers,omitempty"`
 }
 
 const currentSettingsVersion = 1

--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -446,9 +446,15 @@ sections.docker = function(sn, st) {
     var containers = docker.containers;
     var runningCsMerged = containers.filter(function(c) { return c.state === "running"; });
     var stoppedCs = containers.filter(function(c) { return c.state !== "running"; });
+    /* Header count string — when hidden_count > 0 show "(N shown, M hidden)"
+       so the user knows the Advanced-settings filter is in effect (#204). */
+    var hiddenCount = (docker.hidden_count || 0);
+    var countStr = hiddenCount > 0
+      ? (containers.length + ' shown, ' + hiddenCount + ' hidden')
+      : String(containers.length);
     h += '<div>';
     if (mergedContainers && runningCsMerged.length > 0) {
-      h += '<div class="section-title" style="display:flex;align-items:center;justify-content:space-between">Docker Containers (' + containers.length + ')';
+      h += '<div class="section-title" style="display:flex;align-items:center;justify-content:space-between">Docker Containers (' + countStr + ')';
       h += sections._rangeButtons("cmetrics", "loadContainerChart", _chartRange);
       h += '</div>';
       for (var cmi = 0; cmi < runningCsMerged.length; cmi++) {
@@ -460,7 +466,7 @@ sections.docker = function(sn, st) {
         h += '</div>';
       }
     } else {
-      h += '<div class="section-title">Docker Containers (' + containers.length + ')</div>';
+      h += '<div class="section-title">Docker Containers (' + countStr + ')</div>';
       h += '<div class="table-wrap">';
       h += '<table><thead><tr>';
       h += '<th>Name</th><th>Image</th><th>Status</th><th>CPU</th><th>Memory</th><th>Uptime</th>';

--- a/internal/api/settings_docker_hidden_containers_test.go
+++ b/internal/api/settings_docker_hidden_containers_test.go
@@ -1,0 +1,403 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// TestSettingsDefault_DockerHiddenContainersIsEmpty verifies that a fresh
+// defaultSettings() has no hidden containers — i.e. the current "show
+// everything" behavior is preserved for new installs and upgraders alike.
+// Issue #204.
+func TestSettingsDefault_DockerHiddenContainersIsEmpty(t *testing.T) {
+	d := defaultSettings()
+	if len(d.DockerHiddenContainers) != 0 {
+		t.Errorf("defaultSettings().DockerHiddenContainers = %v; want empty (nil or []) — hiding must be opt-in (#204)", d.DockerHiddenContainers)
+	}
+}
+
+// TestSettings_DockerHiddenContainers_RoundTrip exercises the PUT/GET cycle
+// for the new field against the real settings handlers, guarding against
+// JSON tag typos.
+func TestSettings_DockerHiddenContainers_RoundTrip(t *testing.T) {
+	srv := newSettingsTestServer()
+
+	putBody := map[string]interface{}{
+		"scan_interval":            "30m",
+		"theme":                    "midnight",
+		"docker_hidden_containers": []string{"watchtower", "portainer-agent"},
+	}
+	buf, _ := json.Marshal(putBody)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(buf))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.handleUpdateSettings(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT /api/v1/settings returned %d: %s", rec.Code, rec.Body.String())
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	rec2 := httptest.NewRecorder()
+	srv.handleGetSettings(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/settings returned %d", rec2.Code)
+	}
+	body, _ := io.ReadAll(rec2.Body)
+	var got Settings
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("parse GET response: %v", err)
+	}
+	want := []string{"watchtower", "portainer-agent"}
+	if !reflect.DeepEqual(got.DockerHiddenContainers, want) {
+		t.Errorf("DockerHiddenContainers round-trip failed: got %v, want %v", got.DockerHiddenContainers, want)
+	}
+}
+
+// TestHandleLatestSnapshot_FiltersHiddenDockerContainers verifies that the
+// snapshot endpoint strips hidden containers from DockerInfo.Containers
+// before serializing the response. Filtering server-side keeps hidden
+// container names off the wire entirely.
+//
+// Scope boundary (see issue #204): only the Docker section's container
+// list is filtered. Top Processes container attribution is explicitly
+// preserved — see TestHandleLatestSnapshot_DoesNotFilterTopProcessesContainerAttribution.
+func TestHandleLatestSnapshot_FiltersHiddenDockerContainers(t *testing.T) {
+	srv := newSettingsTestServer()
+
+	// Configure hidden containers.
+	settings := defaultSettings()
+	settings.DockerHiddenContainers = []string{"watchtower", "portainer-agent"}
+	data, _ := json.Marshal(settings)
+	if err := srv.store.SetConfig(settingsConfigKey, string(data)); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+
+	// Seed a snapshot with 5 containers, 2 of which should be hidden.
+	snap := &internal.Snapshot{
+		ID: "test-snap",
+		Docker: internal.DockerInfo{
+			Available: true,
+			Containers: []internal.ContainerInfo{
+				{ID: "a", Name: "plex", State: "running"},
+				{ID: "b", Name: "sonarr", State: "running"},
+				{ID: "c", Name: "watchtower", State: "running"},
+				{ID: "d", Name: "portainer-agent", State: "running"},
+				{ID: "e", Name: "radarr", State: "running"},
+			},
+		},
+	}
+	if err := srv.store.SaveSnapshot(snap); err != nil {
+		t.Fatalf("save snapshot: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshot/latest", nil)
+	rec := httptest.NewRecorder()
+	srv.handleLatestSnapshot(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/snapshot/latest returned %d: %s", rec.Code, rec.Body.String())
+	}
+	var got internal.Snapshot
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse snapshot: %v", err)
+	}
+
+	names := make([]string, 0, len(got.Docker.Containers))
+	for _, c := range got.Docker.Containers {
+		names = append(names, c.Name)
+	}
+	for _, hidden := range []string{"watchtower", "portainer-agent"} {
+		for _, n := range names {
+			if n == hidden {
+				t.Errorf("hidden container %q leaked into snapshot response: %v", hidden, names)
+			}
+		}
+	}
+	wantVisible := map[string]bool{"plex": true, "sonarr": true, "radarr": true}
+	if len(names) != len(wantVisible) {
+		t.Errorf("expected %d visible containers, got %d: %v", len(wantVisible), len(names), names)
+	}
+	for _, n := range names {
+		if !wantVisible[n] {
+			t.Errorf("unexpected container in response: %q", n)
+		}
+	}
+	if got.Docker.HiddenCount != 2 {
+		t.Errorf("DockerInfo.HiddenCount = %d; want 2", got.Docker.HiddenCount)
+	}
+}
+
+// TestHandleLatestSnapshot_NoHiddenContainersPreservesAllContainers is the
+// regression guard: when DockerHiddenContainers is empty (the default), the
+// full container list must survive the snapshot endpoint unchanged and
+// HiddenCount must be zero.
+func TestHandleLatestSnapshot_NoHiddenContainersPreservesAllContainers(t *testing.T) {
+	srv := newSettingsTestServer()
+
+	snap := &internal.Snapshot{
+		ID: "test-snap",
+		Docker: internal.DockerInfo{
+			Available: true,
+			Containers: []internal.ContainerInfo{
+				{ID: "a", Name: "plex", State: "running"},
+				{ID: "b", Name: "sonarr", State: "running"},
+				{ID: "c", Name: "watchtower", State: "running"},
+			},
+		},
+	}
+	if err := srv.store.SaveSnapshot(snap); err != nil {
+		t.Fatalf("save snapshot: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshot/latest", nil)
+	rec := httptest.NewRecorder()
+	srv.handleLatestSnapshot(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/snapshot/latest returned %d: %s", rec.Code, rec.Body.String())
+	}
+	var got internal.Snapshot
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse snapshot: %v", err)
+	}
+	if len(got.Docker.Containers) != 3 {
+		t.Errorf("expected 3 containers when no hiding configured, got %d", len(got.Docker.Containers))
+	}
+	if got.Docker.HiddenCount != 0 {
+		t.Errorf("DockerInfo.HiddenCount = %d; want 0 when no hiding configured", got.Docker.HiddenCount)
+	}
+}
+
+// TestHandleLatestSnapshot_DoesNotFilterTopProcessesContainerAttribution
+// is the scope-boundary guard for issue #204. Even when a container is
+// in DockerHiddenContainers, any TopProcess attributed to that container
+// must STILL carry the container name in the response.
+//
+// Rationale: users want to know WHICH container is chewing CPU even when
+// they've hidden the container-list tile for scroll-length reasons. The
+// hiding is a rendering preference, not a data-suppression directive.
+func TestHandleLatestSnapshot_DoesNotFilterTopProcessesContainerAttribution(t *testing.T) {
+	srv := newSettingsTestServer()
+
+	settings := defaultSettings()
+	settings.DockerHiddenContainers = []string{"watchtower"}
+	data, _ := json.Marshal(settings)
+	if err := srv.store.SetConfig(settingsConfigKey, string(data)); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+
+	snap := &internal.Snapshot{
+		ID: "test-snap",
+		System: internal.SystemInfo{
+			TopProcesses: []internal.ProcessInfo{
+				{PID: 100, Command: "watchtower", ContainerName: "watchtower", ContainerID: "abc", CPU: 42.0},
+				{PID: 200, Command: "plexmediaserver", ContainerName: "plex", ContainerID: "def", CPU: 30.0},
+			},
+		},
+		Docker: internal.DockerInfo{Available: true},
+	}
+	if err := srv.store.SaveSnapshot(snap); err != nil {
+		t.Fatalf("save snapshot: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshot/latest", nil)
+	rec := httptest.NewRecorder()
+	srv.handleLatestSnapshot(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/snapshot/latest returned %d", rec.Code)
+	}
+	var got internal.Snapshot
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse snapshot: %v", err)
+	}
+	if len(got.System.TopProcesses) != 2 {
+		t.Fatalf("expected 2 top processes, got %d", len(got.System.TopProcesses))
+	}
+	found := false
+	for _, p := range got.System.TopProcesses {
+		if p.PID == 100 {
+			found = true
+			if p.ContainerName != "watchtower" {
+				t.Errorf("hidden container attribution was stripped from top process: ContainerName=%q, want %q (scope boundary violation: filter must NOT apply to Top Processes)", p.ContainerName, "watchtower")
+			}
+		}
+	}
+	if !found {
+		t.Error("top process with PID 100 (attributed to hidden container 'watchtower') was dropped from response; it should still appear")
+	}
+}
+
+// TestDockerInfo_HiddenCountJSONField verifies the new HiddenCount field
+// on DockerInfo serializes as docker_hidden_count so the frontend can
+// render "Containers (N shown, M hidden)" headers.
+func TestDockerInfo_HiddenCountJSONField(t *testing.T) {
+	d := internal.DockerInfo{HiddenCount: 3}
+	b, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	v, ok := m["hidden_count"]
+	if !ok {
+		t.Fatalf("DockerInfo JSON missing hidden_count; got keys %v", keysOf(m))
+	}
+	if fv, ok := v.(float64); !ok || int(fv) != 3 {
+		t.Errorf("hidden_count = %v; want 3", v)
+	}
+}
+
+func keysOf(m map[string]interface{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestSettingsHTMLIncludesDockerHiddenContainersInput verifies the settings
+// page template ships the Advanced-section input for docker_hidden_containers
+// with the load/save wiring. Cross-reference test: any future refactor that
+// renames one side without the other will break this.
+func TestSettingsHTMLIncludesDockerHiddenContainersInput(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.html: %v", err)
+	}
+	content := string(data)
+
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		// Input element with the stable id used by load/save.
+		{"input element", `id="docker-hidden-containers"`},
+		// Lives inside the Advanced card (regression: not inside Dashboard Sections).
+		{"advanced card anchor", `id="card-advanced"`},
+		// Load path reads the JSON field.
+		{"load binds field", `data.docker_hidden_containers`},
+		// Save payload emits the JSON field.
+		{"save sends field", `docker_hidden_containers:`},
+		// Helper text should mention this affects the Docker section only.
+		{"helper mentions docker section", `Docker Containers section`},
+	}
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(content, tc.substr) {
+				t.Errorf("settings.html missing %q — expected substring: %q", tc.name, tc.substr)
+			}
+		})
+	}
+}
+
+// TestDashboardJS_DockerSectionHeaderShowsHiddenCount verifies the client-
+// side Docker section renderer reads hidden_count and renders the
+// "(N shown, M hidden)" header format.
+func TestDashboardJS_DockerSectionHeaderShowsHiddenCount(t *testing.T) {
+	js := DashboardJS
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		// Renderer must read hidden_count off the docker payload.
+		{"reads hidden_count", "hidden_count"},
+		// And include both words in the header format.
+		{"header format — hidden word", "hidden"},
+		{"header format — shown word", "shown"},
+	}
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(js, tc.substr) {
+				t.Errorf("DashboardJS missing %q — expected substring: %q", tc.name, tc.substr)
+			}
+		})
+	}
+}
+
+// TestSettingsHTML_DockerHiddenContainers_ParseHelperHandlesWhitespace is
+// a cross-reference test: the JS parseHiddenContainerList helper must be
+// tolerant of trailing commas and whitespace, which is how real users
+// type comma-separated lists. Verifying the helper is shipped (and its
+// trim + empty-drop behavior is still present) guards against a future
+// refactor that strips the trimming logic.
+func TestSettingsHTML_DockerHiddenContainers_ParseHelperHandlesWhitespace(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.html: %v", err)
+	}
+	content := string(data)
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		{"helper is defined", "function parseHiddenContainerList"},
+		{"helper trims entries", ".trim()"},
+		{"helper drops empty entries", "if (t) out.push(t)"},
+		{"helper splits on comma", `.split(",")`},
+	}
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(content, tc.substr) {
+				t.Errorf("settings.html missing %q — expected substring: %q", tc.name, tc.substr)
+			}
+		})
+	}
+}
+
+// TestSettings_DockerHiddenContainers_EmptyArrayDoesNotFilter verifies that
+// an explicitly-empty list (as opposed to nil) behaves identically to nil:
+// nothing is filtered, HiddenCount is zero. Guards against a future
+// refactor that conflates nil vs [] in an "is hiding configured" check.
+func TestSettings_DockerHiddenContainers_EmptyArrayDoesNotFilter(t *testing.T) {
+	srv := newSettingsTestServer()
+
+	settings := defaultSettings()
+	settings.DockerHiddenContainers = []string{} // explicit empty, not nil
+	data, _ := json.Marshal(settings)
+	if err := srv.store.SetConfig(settingsConfigKey, string(data)); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+
+	snap := &internal.Snapshot{
+		ID: "test-snap",
+		Docker: internal.DockerInfo{
+			Available: true,
+			Containers: []internal.ContainerInfo{
+				{ID: "a", Name: "plex", State: "running"},
+				{ID: "b", Name: "watchtower", State: "running"},
+			},
+		},
+	}
+	if err := srv.store.SaveSnapshot(snap); err != nil {
+		t.Fatalf("save snapshot: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshot/latest", nil)
+	rec := httptest.NewRecorder()
+	srv.handleLatestSnapshot(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("snapshot returned %d", rec.Code)
+	}
+	var got internal.Snapshot
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse snapshot: %v", err)
+	}
+	if len(got.Docker.Containers) != 2 {
+		t.Errorf("empty DockerHiddenContainers should not filter; got %d containers, want 2", len(got.Docker.Containers))
+	}
+	if got.Docker.HiddenCount != 0 {
+		t.Errorf("HiddenCount = %d; want 0 for empty hidden list", got.Docker.HiddenCount)
+	}
+}

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -895,6 +895,15 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
           At the default 30-min scan interval, that's roughly 48 extra spin-ups per drive per day.
           Only enable if your drives never spin down, or if you deliberately need every-cycle SMART monitoring and accept the wear cost.
         </p>
+        <div style="margin-top:18px;padding-top:14px;border-top:1px solid var(--border)">
+          <label for="docker-hidden-containers" style="display:block;font-weight:600;font-size:13px;color:var(--text);margin-bottom:4px">Hide Docker containers from dashboard</label>
+          <input type="text" id="docker-hidden-containers" placeholder="watchtower, portainer-agent, cloudflared" style="width:100%" onchange="saveSettings()" />
+          <p style="font-size:12px;color:var(--text2);margin-top:8px;line-height:1.5">
+            Comma-separated container names (exact match). These will be excluded from the <strong>Docker Containers section</strong> only.
+            Stats history is still collected and alerts still fire — the containers are hidden from the tile, not suppressed.
+            Top Processes container attribution is not affected: if a hidden container is chewing CPU you'll still see its name there.
+          </p>
+        </div>
       </div>
     </details>
   </div>
@@ -1201,6 +1210,12 @@ function loadSettings() {
       if (wakeEl) {
         if (data.wake_drives_for_smart) wakeEl.classList.add("on"); else wakeEl.classList.remove("on");
       }
+      /* Advanced: hide Docker containers from dashboard (#204) */
+      var hideEl = document.getElementById("docker-hidden-containers");
+      if (hideEl) {
+        var hidden = data.docker_hidden_containers;
+        hideEl.value = Array.isArray(hidden) ? hidden.join(", ") : "";
+      }
       /* Proxmox VE */
       var pve = data.proxmox || {};
       if (pve.enabled) document.getElementById("pve-toggle").classList.add("on"); else document.getElementById("pve-toggle").classList.remove("on");
@@ -1313,8 +1328,25 @@ function buildSettingsPayload() {
     fleet: fleetServers || base.fleet || [],
     dismissed_findings: base.dismissed_findings || [],
     cost_per_tb: parseFloat(document.getElementById("cost-per-tb") && document.getElementById("cost-per-tb").value) || 0,
-    wake_drives_for_smart: !!(document.getElementById("wake-drives-for-smart") && document.getElementById("wake-drives-for-smart").classList.contains("on"))
+    wake_drives_for_smart: !!(document.getElementById("wake-drives-for-smart") && document.getElementById("wake-drives-for-smart").classList.contains("on")),
+    docker_hidden_containers: parseHiddenContainerList(document.getElementById("docker-hidden-containers") && document.getElementById("docker-hidden-containers").value)
   };
+}
+
+/* ---------- Helpers: hidden Docker containers (#204) ---------- */
+/* Parse a user-entered comma-separated list into a clean string array.
+   Trims whitespace, drops empty entries so "plex, , watchtower, " becomes
+   ["plex","watchtower"]. Returns [] rather than null so the JSON payload
+   stays consistent with a non-omitempty array on the server. */
+function parseHiddenContainerList(s) {
+  if (!s || typeof s !== "string") return [];
+  var parts = s.split(",");
+  var out = [];
+  for (var i = 0; i < parts.length; i++) {
+    var t = parts[i].trim();
+    if (t) out.push(t);
+  }
+  return out;
 }
 
 function saveSettings() {

--- a/internal/models.go
+++ b/internal/models.go
@@ -346,6 +346,11 @@ type SMARTInfo struct {
 type DockerInfo struct {
 	Available  bool            `json:"available"`
 	Containers []ContainerInfo `json:"containers"`
+	// HiddenCount reports how many running containers were filtered out
+	// by the user's DockerHiddenContainers setting when serving the
+	// dashboard snapshot. Not persisted in the stored snapshot — it is
+	// stamped onto the response only. See issue #204.
+	HiddenCount int `json:"hidden_count,omitempty"`
 }
 
 type ContainerInfo struct {


### PR DESCRIPTION
Closes #204

## Summary

Adds an Advanced-section setting that lets users hide specific Docker containers from the Docker Containers dashboard tile. Users with 30+ containers can now quiet watchtower / portainer-agent / cloudflared / etc and focus on high-value services without scrolling.

## UX

- **Location**: Settings → Advanced disclosure (same `<details>` block introduced in v0.9.5 for `wake_drives_for_smart`, issue #198/#201).
- **Input**: comma-separated container names, exact match (MVP; glob can be a follow-up).
- **Header feedback**: when any are hidden the Docker section title reads `Docker Containers (14 shown, 3 hidden)` so the filter is visibly in effect. When nothing is hidden the existing `Docker Containers (14)` format is unchanged.

## Scope boundary (intentional)

**The filter applies to the Docker Containers section only.** Top Processes container attribution is *not* affected — if a hidden container is chewing CPU, its name still appears in Top Processes. Rationale: users want to know which container is the culprit even when they've hidden the list tile for scroll-length reasons. A scope-boundary test (`TestHandleLatestSnapshot_DoesNotFilterTopProcessesContainerAttribution`) locks this in so a future "consistency" refactor can't silently extend the filter.

## Data lifecycle

Stats history (`container_stats_history`) continues to collect for hidden containers. Alerts on hidden containers still fire. This is rendering-only — same pattern as the v0.9.2 Backup section opt-out (#132).

## Implementation

- Backend: filter is applied server-side in `handleLatestSnapshot`, so hidden container names never leave the backend at all. `DockerInfo.HiddenCount` is stamped onto the response so the frontend can render the `(N shown, M hidden)` header.
- Frontend: the Advanced-section input parses the comma-separated string into a trimmed `[]string`, round-trips cleanly through the settings JSON.

## Tests

9 new tests in `internal/api/settings_docker_hidden_containers_test.go`:

- `TestSettingsDefault_DockerHiddenContainersIsEmpty` — hiding is opt-in
- `TestSettings_DockerHiddenContainers_RoundTrip` — JSON tag guard
- `TestHandleLatestSnapshot_FiltersHiddenDockerContainers` — filter works
- `TestHandleLatestSnapshot_NoHiddenContainersPreservesAllContainers` — regression guard
- `TestHandleLatestSnapshot_DoesNotFilterTopProcessesContainerAttribution` — **scope boundary guard**
- `TestDockerInfo_HiddenCountJSONField` — JSON field name guard
- `TestSettingsHTMLIncludesDockerHiddenContainersInput` — UI cross-reference
- `TestDashboardJS_DockerSectionHeaderShowsHiddenCount` — header format
- `TestSettingsHTML_DockerHiddenContainers_ParseHelperHandlesWhitespace` — whitespace handling
- `TestSettings_DockerHiddenContainers_EmptyArrayDoesNotFilter` — nil vs [] parity