### PR TITLE
feat(speedtest): add "Disabled" option to interval dropdown (#180)

### DIFF
--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -152,6 +152,32 @@ type LogForwardDestination struct {
 
 const settingsConfigKey = "settings"
 
+// parseSpeedTestInterval converts the wire-level value of
+// Settings.SpeedTestInterval into a Duration for the scheduler. It
+// returns (duration, true) on success and (0, false) when the input
+// does not represent a concrete interval.
+//
+// Two distinct success cases:
+//   - "disabled" → scheduler.SpeedTestIntervalDisabled (issue #180)
+//   - any time.ParseDuration-compatible string, e.g. "4h", "30m"
+//
+// Keyword values used by the schedule path ("weekly", "monthly") are
+// deliberately rejected here — they're consumed by SetSpeedTestSchedule,
+// not SetSpeedTestInterval.
+func parseSpeedTestInterval(v string) (time.Duration, bool) {
+	if v == "" {
+		return 0, false
+	}
+	if v == "disabled" {
+		return scheduler.SpeedTestIntervalDisabled, true
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return 0, false
+	}
+	return d, true
+}
+
 // defaultSettings returns the default settings used when none are persisted.
 func defaultSettings() Settings {
 	return Settings{
@@ -744,11 +770,13 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		if d, err := time.ParseDuration(settings.ScanInterval); err == nil {
 			s.scheduler.UpdateInterval(d)
 		}
-		// Update speed test interval and schedule
-		if settings.SpeedTestInterval != "" {
-			if d, err := time.ParseDuration(settings.SpeedTestInterval); err == nil {
-				s.scheduler.SetSpeedTestInterval(d)
-			}
+		// Update speed test interval and schedule. The wire format accepts
+		// real duration strings ("4h", "30m") AND the sentinel "disabled"
+		// for users on metered connections who want the standalone loop
+		// turned off entirely (issue #180). Keyword values ("weekly",
+		// "monthly") are consumed by SetSpeedTestSchedule below, not here.
+		if d, ok := parseSpeedTestInterval(settings.SpeedTestInterval); ok {
+			s.scheduler.SetSpeedTestInterval(d)
 		}
 		s.scheduler.SetSpeedTestSchedule(settings.SpeedTestSchedule, settings.SpeedTestDay, settings.SpeedTestInterval)
 		// Update retention config

--- a/internal/api/settings_speedtest_disabled_test.go
+++ b/internal/api/settings_speedtest_disabled_test.go
@@ -1,0 +1,146 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal/scheduler"
+)
+
+// Issue #180 — "Disabled" option in the speed-test interval dropdown.
+//
+// These tests assert the UI + wire-level + handler contracts that
+// complement the scheduler-side sentinel:
+//
+//   - settings.html renders a <option value="disabled">Disabled</option>
+//     inside the speedtest-interval dropdown.
+//   - parseSpeedTestInterval("disabled") returns the scheduler sentinel.
+//   - The Settings PUT/GET round-trip persists speedtest_interval="disabled".
+//   - The default Settings value is NOT "disabled" on a fresh install
+//     (strictly opt-in; existing users keep the 4-hour default on upgrade).
+
+// TestSettingsHTMLHasDisabledOption verifies the speed-test interval
+// dropdown includes a Disabled option wired with the JSON string
+// sentinel "disabled". This is a template cross-reference test: without
+// it, the wire format and the dropdown markup could drift apart silently.
+func TestSettingsHTMLHasDisabledOption(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read settings.html: %v", err)
+	}
+	content := string(data)
+
+	// The dropdown block should contain <option value="disabled">Disabled</option>.
+	// Use case-exact matching so a future typo (e.g. "Disable", "off")
+	// is caught immediately.
+	if !strings.Contains(content, `value="disabled"`) {
+		t.Error(`settings.html missing option value="disabled" on the speed-test interval dropdown (issue #180)`)
+	}
+	if !strings.Contains(content, `>Disabled<`) {
+		t.Error(`settings.html missing visible label ">Disabled<" on the speed-test interval dropdown (issue #180)`)
+	}
+
+	// The existing options must all still be present — no regression in
+	// the dropdown's existing contract.
+	for _, val := range []string{`value="30m"`, `value="1h"`, `value="4h"`, `value="24h"`, `value="weekly"`, `value="monthly"`} {
+		if !strings.Contains(content, val) {
+			t.Errorf("settings.html no longer contains existing dropdown option %q", val)
+		}
+	}
+}
+
+// TestParseSpeedTestInterval_Disabled asserts the helper that converts
+// the wire-level string to a scheduler Duration returns the sentinel
+// for the "disabled" string, and a normal parsed duration for valid
+// time strings.
+func TestParseSpeedTestInterval_Disabled(t *testing.T) {
+	d, ok := parseSpeedTestInterval("disabled")
+	if !ok {
+		t.Fatal(`parseSpeedTestInterval("disabled") returned ok=false; want true`)
+	}
+	if d != scheduler.SpeedTestIntervalDisabled {
+		t.Errorf(`parseSpeedTestInterval("disabled") = %v; want SpeedTestIntervalDisabled (%v)`, d, scheduler.SpeedTestIntervalDisabled)
+	}
+}
+
+func TestParseSpeedTestInterval_Duration(t *testing.T) {
+	d, ok := parseSpeedTestInterval("4h")
+	if !ok {
+		t.Fatal(`parseSpeedTestInterval("4h") returned ok=false; want true`)
+	}
+	if d != 4*time.Hour {
+		t.Errorf(`parseSpeedTestInterval("4h") = %v; want 4h`, d)
+	}
+}
+
+func TestParseSpeedTestInterval_Invalid(t *testing.T) {
+	// Keyword values like "weekly"/"monthly" are interpreted by
+	// SetSpeedTestSchedule (not SetSpeedTestInterval), so the parser
+	// reports them as not-a-duration rather than falsely accepting them.
+	if _, ok := parseSpeedTestInterval("weekly"); ok {
+		t.Error(`parseSpeedTestInterval("weekly") returned ok=true; want false (keywords are handled by the schedule path)`)
+	}
+	if _, ok := parseSpeedTestInterval(""); ok {
+		t.Error(`parseSpeedTestInterval("") returned ok=true; want false`)
+	}
+	if _, ok := parseSpeedTestInterval("garbage"); ok {
+		t.Error(`parseSpeedTestInterval("garbage") returned ok=true; want false`)
+	}
+}
+
+// TestSettingsRoundTrip_SpeedTestDisabled exercises the GET/PUT cycle
+// to make sure the "disabled" wire value persists and is returned by
+// handleGetSettings. Without this, a user picking Disabled would save
+// the value, see it reload, but the scheduler would never learn.
+func TestSettingsRoundTrip_SpeedTestDisabled(t *testing.T) {
+	s := newSettingsTestServer()
+
+	put := Settings{
+		ScanInterval:      "30m",
+		Theme:             ThemeMidnight,
+		SpeedTestInterval: "disabled",
+	}
+	body, _ := json.Marshal(put)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.handleUpdateSettings(rr, req)
+	if rr.Code != http.StatusOK {
+		b, _ := io.ReadAll(rr.Body)
+		t.Fatalf("PUT returned %d: %s", rr.Code, b)
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	rr2 := httptest.NewRecorder()
+	s.handleGetSettings(rr2, req2)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("GET returned %d", rr2.Code)
+	}
+	var got Settings
+	if err := json.Unmarshal(rr2.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse GET response: %v", err)
+	}
+	if got.SpeedTestInterval != "disabled" {
+		t.Errorf(`SpeedTestInterval did not round-trip; got %q, want "disabled"`, got.SpeedTestInterval)
+	}
+}
+
+// TestDefaultSettings_SpeedTestNotDisabled guards against a regression
+// where the default flips to Disabled. Fresh installs and upgrades must
+// keep whatever the current standalone-loop default is (nil/empty at
+// the Settings layer; the scheduler supplies its own 4h default).
+func TestDefaultSettings_SpeedTestNotDisabled(t *testing.T) {
+	d := defaultSettings()
+	if d.SpeedTestInterval == "disabled" {
+		t.Error(`defaultSettings().SpeedTestInterval = "disabled"; want empty or a positive duration (issue #180 is opt-in)`)
+	}
+}

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -796,6 +796,7 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
           <option value="24h">Once a day</option>
           <option value="weekly">Once a week</option>
           <option value="monthly">Once a month</option>
+          <option value="disabled">Disabled</option>
         </select>
       </div>
       <div style="display:flex;gap:8px">
@@ -1072,6 +1073,7 @@ function updateSpeedTestPreview() {
   var freq = document.getElementById("speedtest-interval").value;
   var el = document.getElementById("st-preview");
   if (!el) return;
+  if (freq === "disabled") { el.textContent = "Speed tests are disabled. The dashboard widget will stop updating. The Test button on speed-type service checks continues to work on-demand."; return; }
   var labels = {"30m":"every 30 minutes","1h":"every hour","2h":"every 2 hours","4h":"every 4 hours","6h":"every 6 hours","12h":"every 12 hours"};
   if (labels[freq]) { el.textContent = "Speed tests run " + labels[freq] + ". First test runs 2 minutes after startup."; return; }
   var time = (document.getElementById("st-time").value || "03:00").trim();

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -70,6 +70,19 @@ type AlertingConfig struct {
 	DefaultCooldownSec int                         `json:"default_cooldown_sec,omitempty"`
 }
 
+// SpeedTestIntervalDisabled is the sentinel value for the standalone
+// speed-test loop's interval that means "do not run". When this is set,
+// runSpeedTest is a no-op — no Ookla invocation, no speedtest_history
+// writes, no bandwidth consumption. It maps to the "Disabled" option in
+// the settings UI (issue #180, for users on metered connections).
+//
+// A negative duration is chosen because it cannot collide with any real
+// positive interval and explicitly survives the 5-minute minimum clamp
+// in SetSpeedTestInterval. Zero is NOT used as the sentinel because
+// zero-value Duration fields would accidentally opt users into the
+// disabled state.
+const SpeedTestIntervalDisabled time.Duration = -1
+
 // Scheduler periodically runs diagnostic collections and analysis.
 type Scheduler struct {
 	collector         *collector.Collector
@@ -82,6 +95,7 @@ type Scheduler struct {
 	speedTestSchedule []string // specific HH:MM times, overrides interval when set
 	speedTestDay      string   // "monday"-"sunday" or "1","15" for monthly
 	speedTestFreq     string   // "24h", "weekly", "monthly" — only when schedule is set
+	speedTestRunner   SpeedTestRunner
 	retention         RetentionConfig
 	alerting          AlertingConfig
 	serviceChecks     []internal.ServiceCheckConfig
@@ -129,6 +143,7 @@ func New(
 		stop:          make(chan struct{}),
 		restart:       make(chan time.Duration, 1),
 	}
+	s.speedTestRunner = collector.RunSpeedTest
 	s.checker = NewServiceChecker(store, logger)
 	// Opt into the per-type Details map on the scheduled path too —
 	// HTTP status codes, resolved IPs, DNS records, Ping RTT, failure
@@ -255,14 +270,36 @@ func (s *Scheduler) Start() {
 
 // UpdateInterval dynamically changes the scan interval without restarting.
 // SetSpeedTestInterval updates how often the speed test runs.
+//
+// The disabled sentinel (SpeedTestIntervalDisabled) is preserved as-is
+// so users on metered connections can turn the loop off. All other
+// values are clamped to a 5-minute minimum to protect bandwidth.
 func (s *Scheduler) SetSpeedTestInterval(d time.Duration) {
-	if d < 5*time.Minute {
+	if d != SpeedTestIntervalDisabled && d < 5*time.Minute {
 		d = 5 * time.Minute
 	}
 	s.mu.Lock()
 	s.speedTestInterval = d
 	s.mu.Unlock()
-	s.logger.Info("speed test interval updated", "interval", d)
+	if d == SpeedTestIntervalDisabled {
+		s.logger.Info("speed test loop disabled by user setting (issue #180)")
+	} else {
+		s.logger.Info("speed test interval updated", "interval", d)
+	}
+}
+
+// SetSpeedTestRunner injects the function used by runSpeedTest to execute
+// the actual network test. This makes the scheduler's standalone speed-test
+// loop testable (the default runner is collector.RunSpeedTest, which shells
+// out to Ookla or speedtest-cli and cannot be intercepted from a unit test).
+//
+// Production code should not need to call this — New() wires up the
+// default. Tests use it to observe whether the loop invoked the runner
+// (or skipped it, when disabled).
+func (s *Scheduler) SetSpeedTestRunner(fn SpeedTestRunner) {
+	s.mu.Lock()
+	s.speedTestRunner = fn
+	s.mu.Unlock()
 }
 
 // SetSpeedTestSchedule sets specific times of day to run speed tests.
@@ -869,9 +906,26 @@ func (s *Scheduler) collectProcessStats() {
 }
 
 // runSpeedTest executes a network speed test and stores the result.
+//
+// If the interval is set to the disabled sentinel (issue #180), this is
+// a no-op: no runner invocation, no DB write, no bandwidth. The Test
+// button (handleTestServiceCheck) is unaffected — it builds its own
+// ServiceChecker and does not route through here.
 func (s *Scheduler) runSpeedTest() {
+	s.mu.RLock()
+	interval := s.speedTestInterval
+	runner := s.speedTestRunner
+	s.mu.RUnlock()
+	if interval == SpeedTestIntervalDisabled {
+		s.logger.Debug("speed test skipped: disabled by user setting")
+		return
+	}
+	if runner == nil {
+		s.logger.Info("speed test: no runner configured")
+		return
+	}
 	s.logger.Info("running speed test")
-	result := collector.RunSpeedTest()
+	result := runner()
 	if result == nil {
 		s.logger.Info("speed test: no speedtest tool available (install speedtest or speedtest-cli)")
 		return

--- a/internal/scheduler/speedtest_disabled_test.go
+++ b/internal/scheduler/speedtest_disabled_test.go
@@ -1,0 +1,123 @@
+package scheduler
+
+import (
+	"log/slog"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// Issue #180 — "Disabled" option in the speed-test interval dropdown.
+//
+// Design:
+//   - scheduler.SpeedTestIntervalDisabled is a sentinel Duration that
+//     represents "do not run the standalone speed-test loop".
+//   - When the scheduler's speedTestInterval is set to this sentinel,
+//     runSpeedTest() is a no-op: no Ookla invocation, no DB writes.
+//   - SetSpeedTestInterval must preserve the sentinel (it's NOT subject
+//     to the 5-minute minimum clamp that applies to real intervals).
+//   - The Test button (handleTestServiceCheck) is unaffected — it builds
+//     its own ServiceChecker with SetSpeedTestRunner, so a disabled
+//     standalone loop does not break on-demand runs.
+//
+// The Scheduler's runSpeedTest() previously called collector.RunSpeedTest()
+// directly, which is impossible to intercept from a test. These tests
+// drive the addition of a runner-injection hook (mirroring the pattern
+// already used by ServiceChecker.SetSpeedTestRunner).
+
+// newSpeedTestSchedulerForTest builds a minimal scheduler suitable for
+// exercising runSpeedTest() in isolation. The returned scheduler has an
+// injectable speed-test runner (set it with SetSpeedTestRunner) so tests
+// can observe whether the runner was invoked or skipped.
+func newSpeedTestSchedulerForTest(interval time.Duration, runner SpeedTestRunner) *Scheduler {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	s := &Scheduler{
+		store:             storage.NewFakeStore(),
+		logger:            logger,
+		interval:          time.Hour,
+		speedTestInterval: interval,
+		serviceChecks:     []internal.ServiceCheckConfig{},
+		stop:              make(chan struct{}),
+		restart:           make(chan time.Duration, 1),
+	}
+	s.SetSpeedTestRunner(runner)
+	return s
+}
+
+// When the interval is set to the disabled sentinel, runSpeedTest must
+// be a no-op and never invoke the runner.
+func TestRunSpeedTest_SkippedWhenDisabled(t *testing.T) {
+	var calls int32
+	runner := func() *internal.SpeedTestResult {
+		atomic.AddInt32(&calls, 1)
+		return &internal.SpeedTestResult{DownloadMbps: 100}
+	}
+
+	s := newSpeedTestSchedulerForTest(SpeedTestIntervalDisabled, runner)
+	s.runSpeedTest()
+
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Errorf("runSpeedTest invoked runner %d time(s) when disabled; want 0 (issue #180)", got)
+	}
+}
+
+// When the interval is a normal positive duration, runSpeedTest must
+// invoke the runner exactly once. This is the happy path — a control
+// test that proves the skip guard in the disabled case is doing real
+// work, not just broken plumbing.
+func TestRunSpeedTest_RunsWhenEnabled(t *testing.T) {
+	var calls int32
+	runner := func() *internal.SpeedTestResult {
+		atomic.AddInt32(&calls, 1)
+		return &internal.SpeedTestResult{DownloadMbps: 100}
+	}
+
+	s := newSpeedTestSchedulerForTest(4*time.Hour, runner)
+	s.runSpeedTest()
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("runSpeedTest invoked runner %d time(s) when enabled; want 1", got)
+	}
+}
+
+// SetSpeedTestInterval must preserve the disabled sentinel rather than
+// clamping it up to the 5-minute minimum. Without this, calling
+// SetSpeedTestInterval(SpeedTestIntervalDisabled) would silently re-enable
+// the loop at 5-minute resolution — a data-exfiltration regression for
+// metered-connection users.
+func TestSetSpeedTestInterval_PreservesDisabledSentinel(t *testing.T) {
+	s := newSpeedTestSchedulerForTest(4*time.Hour, func() *internal.SpeedTestResult { return nil })
+
+	s.SetSpeedTestInterval(SpeedTestIntervalDisabled)
+
+	s.mu.RLock()
+	got := s.speedTestInterval
+	s.mu.RUnlock()
+
+	if got != SpeedTestIntervalDisabled {
+		t.Errorf("SetSpeedTestInterval(disabled) stored %v; want %v (sentinel must survive the clamp)", got, SpeedTestIntervalDisabled)
+	}
+}
+
+// The default scheduler constructed via New() must NOT start in the
+// disabled state. Opt-in only — existing users keep their current
+// 4-hour default on upgrade.
+func TestNewScheduler_DefaultIntervalNotDisabled(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	s := New(nil, storage.NewFakeStore(), nil, nil, logger, time.Hour)
+
+	s.mu.RLock()
+	got := s.speedTestInterval
+	s.mu.RUnlock()
+
+	if got == SpeedTestIntervalDisabled {
+		t.Errorf("newly constructed scheduler must not default to disabled (issue #180 is opt-in)")
+	}
+	if got <= 0 {
+		t.Errorf("default speedTestInterval = %v; want a positive duration", got)
+	}
+}


### PR DESCRIPTION
Closes #180.

Adds a **Disabled** option to the Speed Test interval dropdown so users on metered connections can stop the standalone 4-hour loop from chewing bandwidth. Strictly opt-in — existing users keep their current interval on upgrade.

## Sentinel choice

- **Const**: `scheduler.SpeedTestIntervalDisabled time.Duration = -1`
- **Wire format**: JSON string `"disabled"` in the existing `speedtest_interval` field
- **Why negative**: a negative duration cannot collide with any real positive interval, and explicitly bypasses the 5-minute minimum clamp in `SetSpeedTestInterval` (which a zero value would not — zero would silently re-enable a 5-minute loop). Zero is also risky because zero-valued `time.Duration` fields could accidentally opt users into the disabled state via struct defaults.

## What changes

- `internal/scheduler/scheduler.go` — sentinel const, new `speedTestRunner` field + `SetSpeedTestRunner` hook (mirrors the existing `ServiceChecker.SetSpeedTestRunner` pattern so the loop is testable), `SetSpeedTestInterval` preserves the sentinel, `runSpeedTest` short-circuits when disabled.
- `internal/api/api_extended.go` — new `parseSpeedTestInterval(string) (Duration, bool)` helper that maps `"disabled"` to the sentinel and everything else through `time.ParseDuration`; `handleUpdateSettings` uses it instead of inlining the parse.
- `internal/api/templates/settings.html` — `<option value="disabled">Disabled</option>` on the existing dropdown + preview text explaining that on-demand Test-button runs still work.

## What does NOT change

- **Test button**: unchanged. `handleTestServiceCheck` builds its own `ServiceChecker` via `SetSpeedTestRunner` and does not consult `scheduler.speedTestInterval`, so on-demand speed tests work regardless of the Disabled setting.
- **Speed-type service checks**: unchanged. They run on the independent 30s service-check loop, not the standalone speed-test loop. Tracked separately in #210.
- **Defaults**: new installs keep the existing 4-hour default. `TestDefaultSettings_SpeedTestNotDisabled` guards against regressing this.
- **All other dropdown options** (30m / 1h / 2h / 4h / 6h / 12h / 24h / weekly / monthly): preserved. The template test asserts each one still renders.

## Tests

RED-GREEN in four commits.

**Scheduler tests** (`internal/scheduler/speedtest_disabled_test.go`, 4 new):
- `TestRunSpeedTest_SkippedWhenDisabled` — runner is never invoked when the sentinel is set
- `TestRunSpeedTest_RunsWhenEnabled` — control test, normal interval still invokes the runner
- `TestSetSpeedTestInterval_PreservesDisabledSentinel` — the sentinel survives the 5-minute clamp
- `TestNewScheduler_DefaultIntervalNotDisabled` — fresh install is not disabled

**API tests** (`internal/api/settings_speedtest_disabled_test.go`, 6 new):
- `TestSettingsHTMLHasDisabledOption` — template cross-reference for the new option + all existing options
- `TestParseSpeedTestInterval_{Disabled,Duration,Invalid}` — helper correctness, including rejection of keyword values (`weekly`, `monthly` are schedule-path)
- `TestSettingsRoundTrip_SpeedTestDisabled` — PUT/GET preserves `"disabled"` so the UI reload matches
- `TestDefaultSettings_SpeedTestNotDisabled` — opt-in defense

All tests pass:

```
$ go build ./...
$ go test ./...
ok  	github.com/mcdays94/nas-doctor/cmd/nas-doctor
ok  	github.com/mcdays94/nas-doctor/internal/api
ok  	github.com/mcdays94/nas-doctor/internal/scheduler
...
```

## Surprises

The Scheduler previously called `collector.RunSpeedTest()` directly from `runSpeedTest`, so there was no way to observe whether the loop was being skipped in a unit test. Adding `SetSpeedTestRunner` (wired to `collector.RunSpeedTest` by default in `New`) was the cleanest way to get test coverage of the skip guard — it mirrors a pattern already used by `ServiceChecker`, so no new architectural concept.

The scheduler's outer goroutine still calls `s.runSpeedTest()` on its ticker schedule; rather than adding a second guard in the goroutine, I put the single guard inside `runSpeedTest` itself. That way the "is this disabled?" decision lives in one place and both the initial 2-minute post-startup fire and the ticker-driven invocations honour it uniformly.