### PR TITLE
feat(service-checks): rewire type=speed around speedtest_history + ship defaults + widget pending state (#210)

### DIFF
--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -157,8 +157,16 @@ func defaultSettings() Settings {
 	return Settings{
 		SettingsVersion: currentSettingsVersion,
 		ScanInterval:    "30m",
-		Theme:           ThemeMidnight,
-		Icon:            "icon3",
+		// Speed test default cadence: once a day at 03:00 local time.
+		// Previously defaulted to 4h, which meant ~10 GB/month of speed-test
+		// bandwidth for a home NAS — unfriendly for metered connections and
+		// overkill for threshold alerting (speed trends don't move hour-to-hour).
+		// Daily@3am runs during a low-usage window. Users can tune or disable
+		// entirely from Settings → Speed Test. See #210.
+		SpeedTestInterval: "24h",
+		SpeedTestSchedule: []string{"03:00"},
+		Theme:             ThemeMidnight,
+		Icon:              "icon3",
 		Notifications: SettingsNotifications{
 			Webhooks:           []internal.WebhookConfig{},
 			Policies:           []scheduler.AlertPolicy{},
@@ -171,8 +179,26 @@ func defaultSettings() Settings {
 			},
 			DefaultCooldownSec: 900,
 		},
+		// Fresh installs ship with one default "Internet Speed" service check
+		// so the speed-test feature is discoverable from day one. Blank
+		// contracted-speed thresholds mean the check acts as a heartbeat
+		// (reports up whenever speedtest_history has fresh data) rather than
+		// firing false alerts. Users tune thresholds in Settings → Service
+		// Checks once they know their line's sustained speed. See #210.
+		//
+		// Note: the seed only applies when no settings have been persisted
+		// yet (fresh install). Existing users who have ever saved settings
+		// keep their current service-check list verbatim — the unmarshal in
+		// getSettings() replaces this default with the persisted value.
 		ServiceChecks: SettingsServiceChecks{
-			Checks: []internal.ServiceCheckConfig{},
+			Checks: []internal.ServiceCheckConfig{{
+				Name:        "Internet Speed",
+				Type:        "speed",
+				Target:      "speedtest",
+				Enabled:     true,
+				IntervalSec: 60,
+				MarginPct:   10,
+			}},
 		},
 		LogPush: SettingsLogForward{
 			Enabled:      false,

--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -728,6 +728,15 @@ sections.speedtest = function(sn) {
     h += '</div>';
     h += '<canvas id="speedtest-chart" style="width:100%;height:80px"></canvas>';
     h += '</div>';
+  } else if (spd && spd.last_attempt && spd.last_attempt.status === 'pending') {
+    // Fresh-install gap: scheduler has kicked off the first-ever speed
+    // test but Ookla hasn't returned yet (~30-60s window). Render the
+    // running state so the user knows the feature is actually doing
+    // something, rather than silently rendering an empty tile.
+    h += '<div>';
+    h += '<div class="section-title">Speed Test</div>';
+    h += '<div style="font-size:13px;color:var(--text-tertiary);font-style:italic">Running initial speed test&hellip;</div>';
+    h += '</div>';
   }
   h += '</div>';
   return h;

--- a/internal/api/dashboard_speedtest_pending_test.go
+++ b/internal/api/dashboard_speedtest_pending_test.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #210 (item 6): the speed-test widget must render a "Running
+// initial speed test..." state when the scheduler has marked an attempt
+// as pending but no history row has landed yet. This is the fresh-
+// install first-boot gap — without this branch, the widget silently
+// rendered an empty tile and users had no signal that the feature
+// was active.
+//
+// This is a cross-reference test: we grep the embedded DashboardJS
+// string constant for the pending-branch invariants. Lets future
+// refactors catch if the pending render path disappears or regresses
+// in form.
+
+func TestDashboardJS_SpeedTestWidget_HasPendingRenderBranch(t *testing.T) {
+	js := DashboardJS
+
+	// The pending branch must inspect spd.last_attempt.status.
+	if !strings.Contains(js, "spd.last_attempt") {
+		t.Error("DashboardJS: speedtest widget does not reference spd.last_attempt; pending-state render path is missing")
+	}
+	if !strings.Contains(js, "'pending'") {
+		t.Error("DashboardJS: no string literal 'pending' found; pending-state discriminator is missing")
+	}
+
+	// The user-visible copy. If this string changes (e.g. translations),
+	// update the test — but at least the refactor has to touch the test,
+	// not silently disappear.
+	if !strings.Contains(js, "Running initial speed test") {
+		t.Error("DashboardJS: speedtest widget does not render 'Running initial speed test' copy for pending state")
+	}
+}
+
+// Regression guard: the existing happy-path render (spd.available &&
+// spd.latest) must survive the pending-branch addition. If the widget
+// ever renders ONLY the pending state it would be a regression — users
+// with real data need to keep seeing their charts.
+func TestDashboardJS_SpeedTestWidget_HappyPathIntact(t *testing.T) {
+	js := DashboardJS
+
+	if !strings.Contains(js, "spd.available && spd.latest") {
+		t.Error("DashboardJS: speedtest widget happy-path gate 'spd.available && spd.latest' missing; users with real speed data would see pending render instead of their chart")
+	}
+	// The download_mbps render is a load-bearing piece of the happy path.
+	if !strings.Contains(js, "download_mbps.toFixed") {
+		t.Error("DashboardJS: speedtest widget no longer renders download_mbps; happy path is broken")
+	}
+}

--- a/internal/api/default_speed_settings_test.go
+++ b/internal/api/default_speed_settings_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestDefaultSettings_SpeedTestCadence_DailyAt03 locks in the v0.9.6 default
+// speed-test cadence change: once a day at 03:00 local time, down from the
+// previous 4-hour interval. See #210.
+//
+// Existing users who have ever saved settings keep their current cadence
+// verbatim — this default only applies to fresh installs (no persisted
+// settings blob). The fresh-install path is exercised in
+// TestGetSettings_NoStoredConfig_ReturnsDefaults below.
+func TestDefaultSettings_SpeedTestCadence_DailyAt03(t *testing.T) {
+	settings := defaultSettings()
+
+	if settings.SpeedTestInterval != "24h" {
+		t.Errorf("SpeedTestInterval = %q, want %q", settings.SpeedTestInterval, "24h")
+	}
+
+	if len(settings.SpeedTestSchedule) != 1 || settings.SpeedTestSchedule[0] != "03:00" {
+		t.Errorf("SpeedTestSchedule = %v, want [\"03:00\"]", settings.SpeedTestSchedule)
+	}
+
+	// SpeedTestDay is only meaningful for weekly/monthly modes. Daily should
+	// leave it empty so the UI doesn't show stale weekday-picker state.
+	if settings.SpeedTestDay != "" {
+		t.Errorf("SpeedTestDay = %q, want empty for daily cadence", settings.SpeedTestDay)
+	}
+}
+
+// TestDefaultSettings_ShipsDefaultSpeedCheck locks in the v0.9.6 fresh-install
+// behavior: one pre-configured "Internet Speed" service check with blank
+// contracted-speed thresholds (heartbeat mode). See #210.
+func TestDefaultSettings_ShipsDefaultSpeedCheck(t *testing.T) {
+	settings := defaultSettings()
+
+	if len(settings.ServiceChecks.Checks) != 1 {
+		t.Fatalf("default settings has %d service checks, want 1", len(settings.ServiceChecks.Checks))
+	}
+
+	seed := settings.ServiceChecks.Checks[0]
+	if seed.Name != "Internet Speed" {
+		t.Errorf("seed.Name = %q, want %q", seed.Name, "Internet Speed")
+	}
+	if seed.Type != "speed" {
+		t.Errorf("seed.Type = %q, want %q", seed.Type, "speed")
+	}
+	if !seed.Enabled {
+		t.Error("seed.Enabled = false; the whole point of shipping this check is that it's visible on fresh install")
+	}
+
+	// Blank contracted-speed thresholds are LOAD-BEARING: they make the
+	// check report "up" whenever speedtest_history has fresh data, acting
+	// as a speed-test heartbeat rather than firing false alerts. Users
+	// tune these once they know their line's sustained speed.
+	if seed.ContractedDownMbps != 0 {
+		t.Errorf("seed.ContractedDownMbps = %v, want 0 (heartbeat mode)", seed.ContractedDownMbps)
+	}
+	if seed.ContractedUpMbps != 0 {
+		t.Errorf("seed.ContractedUpMbps = %v, want 0 (heartbeat mode)", seed.ContractedUpMbps)
+	}
+}
+
+// TestDefaultSettings_PersistedChecksOverrideSeed is the critical invariant:
+// existing users who have saved any service-check configuration (even an
+// empty list) must NOT see the shipped-default "Internet Speed" check
+// resurrect on upgrade. Only genuine fresh installs (no persisted settings)
+// get the seed.
+//
+// Mechanically this works because getSettings() starts with defaultSettings()
+// and then json.Unmarshal's the persisted blob onto it. Any non-nil "checks"
+// field in the blob replaces the default slice wholesale.
+func TestDefaultSettings_PersistedEmptyChecksOverridesSeed(t *testing.T) {
+	// Simulate a persisted settings blob with an empty check list —
+	// the exact shape a user would have after deleting all their
+	// service checks in the UI.
+	persisted := `{"service_checks":{"checks":[]}}`
+
+	settings := defaultSettings()
+	if err := json.Unmarshal([]byte(persisted), &settings); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if len(settings.ServiceChecks.Checks) != 0 {
+		t.Errorf("persisted empty checks did not override default; got %d checks, want 0", len(settings.ServiceChecks.Checks))
+	}
+}
+
+// TestDefaultSettings_PersistedNonEmptyChecksOverrideSeed covers the other
+// side: a user with their own check list should see EXACTLY their list on
+// reload, not their list plus the default.
+func TestDefaultSettings_PersistedNonEmptyChecksOverrideSeed(t *testing.T) {
+	persisted := `{"service_checks":{"checks":[{"name":"My HTTP Check","type":"http","target":"https://example.com","enabled":true}]}}`
+
+	settings := defaultSettings()
+	if err := json.Unmarshal([]byte(persisted), &settings); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if len(settings.ServiceChecks.Checks) != 1 {
+		t.Fatalf("got %d checks, want 1 (persisted check only)", len(settings.ServiceChecks.Checks))
+	}
+	if settings.ServiceChecks.Checks[0].Name != "My HTTP Check" {
+		t.Errorf("check name = %q, want %q (persisted value)", settings.ServiceChecks.Checks[0].Name, "My HTTP Check")
+	}
+}

--- a/internal/models.go
+++ b/internal/models.go
@@ -575,6 +575,24 @@ type BackupJob struct {
 type SpeedTestInfo struct {
 	Available bool             `json:"available"`
 	Latest    *SpeedTestResult `json:"latest,omitempty"`
+	// LastAttempt is the scheduler's most recent speed-test outcome,
+	// carried alongside Latest so the dashboard widget can render
+	// "Running initial speed test…" when the first-ever test is in
+	// flight (status=pending with no Latest yet) and so the widget
+	// can distinguish a truly-broken state from a never-ran state.
+	// Populated on every runSpeedTest tick (success/failed/pending/
+	// disabled). See #210.
+	LastAttempt *SpeedTestAttempt `json:"last_attempt,omitempty"`
+}
+
+// SpeedTestAttempt mirrors storage.LastSpeedTestAttempt as an API-facing
+// type. The status values are a closed set: "success", "failed",
+// "pending", "disabled". Widget + scheduled type=speed check switch on
+// Status to decide what to render / report. See #210.
+type SpeedTestAttempt struct {
+	Timestamp time.Time `json:"timestamp"`
+	Status    string    `json:"status"`
+	ErrorMsg  string    `json:"error_msg,omitempty"`
 }
 
 type SpeedTestResult struct {

--- a/internal/scheduler/checks.go
+++ b/internal/scheduler/checks.go
@@ -523,28 +523,116 @@ func extractPacketLossPercent(out string) float64 {
 	return -1
 }
 
-func (sc *ServiceChecker) runSpeedCheck(check internal.ServiceCheckConfig, result *internal.ServiceCheckResult, start time.Time) {
-	sc.mu.Lock()
-	runner := sc.speedTestRunFn
-	sc.mu.Unlock()
-
-	if runner == nil {
-		result.Error = "no speedtest tool available (install speedtest or speedtest-cli)"
+// runSpeedCheck evaluates a type=speed service check by reading the
+// shared LastSpeedTestAttempt state + latest speedtest_history row
+// rather than invoking Ookla directly. This is option B from issue
+// #210: one Ookla run per scheduler cadence, many threshold checks
+// reading from it. Before #210 the scheduled path invoked a runner
+// that was never wired up in production (ServiceChecker.
+// SetSpeedTestRunner was only called on the ad-hoc Test-button path),
+// so every scheduled type=speed check reported DOWN forever. See the
+// issue for full design rationale.
+//
+// Status-to-result mapping:
+//   - success → read latest speedtest_history row, apply thresholds.
+//     Zero-throughput rows (dl==0 && ul==0) are treated as failed.
+//   - pending → up ("speed test in progress"). Used by widget first-boot.
+//   - failed → down with the stored error message.
+//   - disabled → down ("speed test disabled in settings").
+//   - missing or stale (>30d) → down.
+//
+// Blank thresholds (ContractedDownMbps == 0 && ContractedUpMbps == 0)
+// short-circuit the success path to status=up without threshold math.
+// This is the shape of the default shipped "Internet Speed" check —
+// a heartbeat that fires only when the speed test itself fails.
+//
+// TODO(#215): fleet-instance targeting reads local speedtest_history only.
+// A fleet-targeted speed check should read the remote peer's history via
+// the fleet API. Tracked separately.
+func (sc *ServiceChecker) runSpeedCheck(check internal.ServiceCheckConfig, result *internal.ServiceCheckResult, _ time.Time) {
+	att, err := sc.store.GetLastSpeedTestAttempt()
+	if err != nil {
+		result.Error = "failed to read speed test state: " + err.Error()
+		return
+	}
+	if att == nil {
+		result.Error = "no speed test has run yet"
 		return
 	}
 
-	stResult := runner()
-	if stResult == nil {
-		result.Error = "no speedtest tool available (install speedtest or speedtest-cli)"
+	// Defense-in-depth: any attempt older than 30 days indicates the
+	// scheduler has wedged or the speed-test loop hasn't run in a month.
+	// Don't trust the stored status; report down with a clear reason.
+	// Not user-tunable — the cap is generous enough to cover weekly
+	// cadences and the longest "Disabled" gaps that still update the
+	// row on startup.
+	const staleThreshold = 30 * 24 * time.Hour
+	if !att.Timestamp.IsZero() && time.Since(att.Timestamp) > staleThreshold {
+		result.Error = "speed test state is stale (no run in over 30 days)"
 		return
 	}
 
-	result.DownloadMbps = stResult.DownloadMbps
-	result.UploadMbps = stResult.UploadMbps
-	result.LatencyMs = stResult.LatencyMs
-	result.ResponseMS = int64(stResult.LatencyMs)
+	switch att.Status {
+	case "disabled":
+		result.Error = "speed test disabled in settings"
+		return
+	case "failed":
+		if att.ErrorMsg != "" {
+			result.Error = att.ErrorMsg
+		} else {
+			result.Error = "speed test failed"
+		}
+		return
+	case "pending":
+		// First run in progress. Widget shows "Running initial speed
+		// test…"; the check reports up so users don't see a big red
+		// down marker flicker while waiting for the first result.
+		result.Status = "up"
+		return
+	case "success":
+		// Fall through below.
+	default:
+		// Unknown/empty status — treat as missing.
+		result.Error = "unknown speed test state: " + att.Status
+		return
+	}
 
-	// Apply margin of error (default 10%).
+	// Success path — read the latest history row and apply thresholds.
+	points, histErr := sc.store.GetSpeedTestHistory(48)
+	if histErr != nil {
+		result.Error = "failed to read speed test history: " + histErr.Error()
+		return
+	}
+	if len(points) == 0 {
+		// Attempt says success but no history row — inconsistent state;
+		// treat as stale/missing so notifications don't fire.
+		result.Error = "speed test success recorded but no history row found"
+		return
+	}
+	// GetSpeedTestHistory returns ascending order (see fake.go + db.go
+	// query); take the last element for the newest row.
+	latest := points[len(points)-1]
+
+	// Zero-throughput rows indicate a corrupt or pre-#170 bug. Ookla
+	// sometimes returned all-zeros on parse failure before the collector
+	// fix landed; ancient DBs may still have such rows. Treat them as
+	// failed so contracted-speed alerts aren't silently suppressed.
+	if latest.DownloadMbps == 0 && latest.UploadMbps == 0 {
+		result.Error = "latest speed test result is zero (possibly corrupt)"
+		return
+	}
+
+	result.DownloadMbps = latest.DownloadMbps
+	result.UploadMbps = latest.UploadMbps
+	result.LatencyMs = latest.LatencyMs
+	result.ResponseMS = int64(latest.LatencyMs)
+
+	// Blank thresholds → heartbeat mode: success = up, no threshold math.
+	if check.ContractedDownMbps <= 0 && check.ContractedUpMbps <= 0 {
+		result.Status = "up"
+		return
+	}
+
 	margin := check.MarginPct
 	if margin <= 0 {
 		margin = 10
@@ -554,8 +642,8 @@ func (sc *ServiceChecker) runSpeedCheck(check internal.ServiceCheckConfig, resul
 	dlThreshold := check.ContractedDownMbps * marginFactor
 	ulThreshold := check.ContractedUpMbps * marginFactor
 
-	dlOK := check.ContractedDownMbps <= 0 || stResult.DownloadMbps >= dlThreshold
-	ulOK := check.ContractedUpMbps <= 0 || stResult.UploadMbps >= ulThreshold
+	dlOK := check.ContractedDownMbps <= 0 || latest.DownloadMbps >= dlThreshold
+	ulOK := check.ContractedUpMbps <= 0 || latest.UploadMbps >= ulThreshold
 	result.DownloadOK = &dlOK
 	result.UploadOK = &ulOK
 
@@ -569,11 +657,11 @@ func (sc *ServiceChecker) runSpeedCheck(check internal.ServiceCheckConfig, resul
 			which = "download"
 		}
 		result.Error = fmt.Sprintf("%s below contracted speed (%.0f/%.0f Mbps, threshold %.0f with %.0f%% margin)",
-			which, stResult.DownloadMbps, stResult.UploadMbps,
+			which, latest.DownloadMbps, latest.UploadMbps,
 			check.ContractedDownMbps, margin)
 	default:
 		result.Error = fmt.Sprintf("both download and upload below contracted speed (%.0f/%.0f Mbps, contracted %.0f/%.0f with %.0f%% margin)",
-			stResult.DownloadMbps, stResult.UploadMbps,
+			latest.DownloadMbps, latest.UploadMbps,
 			check.ContractedDownMbps, check.ContractedUpMbps, margin)
 	}
 }

--- a/internal/scheduler/checks_speed_history_test.go
+++ b/internal/scheduler/checks_speed_history_test.go
@@ -1,0 +1,276 @@
+package scheduler
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// Issue #210 — rewrite runSpeedCheck to read from LastSpeedTestAttempt
+// + latest speedtest_history row instead of invoking Ookla directly.
+// The scheduled ServiceChecker.SetSpeedTestRunner wiring is left in
+// place for the ad-hoc Test-button path but is no longer consulted by
+// the scheduled path.
+
+// TestRunCheck_Speed_UsesLastAttempt_SuccessWithHistory_AppliesThresholds
+// validates that when the stored attempt is "success" and a recent
+// history row exists, the check applies contracted thresholds + margin
+// to derive the up/degraded/down status.
+func TestRunCheck_Speed_UsesLastAttempt_SuccessWithHistory_AppliesThresholds(t *testing.T) {
+	sc, store := newTestChecker()
+
+	now := time.Now().UTC()
+	_ = store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
+		Timestamp: now.Add(-5 * time.Minute),
+		Status:    "success",
+	})
+	_ = store.SaveSpeedTest("test-1", &internal.SpeedTestResult{
+		Timestamp:    now.Add(-5 * time.Minute),
+		DownloadMbps: 500,
+		UploadMbps:   100,
+		LatencyMs:    5,
+	})
+
+	check := internal.ServiceCheckConfig{
+		Name:               "speed-ok",
+		Type:               internal.ServiceCheckSpeed,
+		Enabled:            true,
+		ContractedDownMbps: 400,
+		ContractedUpMbps:   80,
+		MarginPct:          10,
+	}
+
+	result := sc.RunCheck(check, now)
+	if result.Status != "up" {
+		t.Fatalf("expected status=up, got %q (error=%q)", result.Status, result.Error)
+	}
+	if result.DownloadMbps != 500 {
+		t.Errorf("DownloadMbps = %.0f, want 500", result.DownloadMbps)
+	}
+	if result.UploadMbps != 100 {
+		t.Errorf("UploadMbps = %.0f, want 100", result.UploadMbps)
+	}
+	if result.DownloadOK == nil || !*result.DownloadOK {
+		t.Error("DownloadOK should be true")
+	}
+	if result.UploadOK == nil || !*result.UploadOK {
+		t.Error("UploadOK should be true")
+	}
+}
+
+// Download below contracted threshold with upload passing → degraded.
+func TestRunCheck_Speed_UsesLastAttempt_SuccessWithHistory_DownloadBelow(t *testing.T) {
+	sc, store := newTestChecker()
+
+	now := time.Now().UTC()
+	_ = store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
+		Timestamp: now.Add(-1 * time.Minute),
+		Status:    "success",
+	})
+	_ = store.SaveSpeedTest("test-1", &internal.SpeedTestResult{
+		Timestamp:    now.Add(-1 * time.Minute),
+		DownloadMbps: 100, // below 400 * 0.9 = 360
+		UploadMbps:   100,
+		LatencyMs:    5,
+	})
+
+	check := internal.ServiceCheckConfig{
+		Name:               "speed-dl-low",
+		Type:               internal.ServiceCheckSpeed,
+		Enabled:            true,
+		ContractedDownMbps: 400,
+		ContractedUpMbps:   80,
+		MarginPct:          10,
+	}
+
+	result := sc.RunCheck(check, now)
+	if result.Status != "degraded" {
+		t.Fatalf("expected degraded, got %q (error=%q)", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Error, "download below contracted speed") {
+		t.Errorf("expected download-related error, got %q", result.Error)
+	}
+}
+
+// Blank thresholds (both zero) → report up unconditionally on success.
+// This is the default shape of the shipped-by-default "Internet Speed"
+// check — a heartbeat rather than a threshold alert.
+func TestRunCheck_Speed_UsesLastAttempt_SuccessBlankThresholds_Up(t *testing.T) {
+	sc, store := newTestChecker()
+
+	now := time.Now().UTC()
+	_ = store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
+		Timestamp: now.Add(-1 * time.Minute),
+		Status:    "success",
+	})
+	_ = store.SaveSpeedTest("test-1", &internal.SpeedTestResult{
+		Timestamp:    now.Add(-1 * time.Minute),
+		DownloadMbps: 50, // would fail any non-zero threshold
+		UploadMbps:   10,
+		LatencyMs:    20,
+	})
+
+	check := internal.ServiceCheckConfig{
+		Name:    "speed-heartbeat",
+		Type:    internal.ServiceCheckSpeed,
+		Enabled: true,
+		// Thresholds blank — zero values.
+	}
+
+	result := sc.RunCheck(check, now)
+	if result.Status != "up" {
+		t.Fatalf("expected up with blank thresholds, got %q (error=%q)", result.Status, result.Error)
+	}
+}
+
+// Status "failed" → check reports down with the stored error message.
+func TestRunCheck_Speed_UsesLastAttempt_Failed_ReportsStoredError(t *testing.T) {
+	sc, store := newTestChecker()
+
+	now := time.Now().UTC()
+	_ = store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
+		Timestamp: now.Add(-2 * time.Minute),
+		Status:    "failed",
+		ErrorMsg:  "ookla binary not found",
+	})
+
+	check := internal.ServiceCheckConfig{
+		Name:    "speed-fail",
+		Type:    internal.ServiceCheckSpeed,
+		Enabled: true,
+	}
+
+	result := sc.RunCheck(check, now)
+	if result.Status != "down" {
+		t.Fatalf("expected down, got %q", result.Status)
+	}
+	if !strings.Contains(result.Error, "ookla binary not found") {
+		t.Errorf("expected stored error to surface, got %q", result.Error)
+	}
+}
+
+// Status "pending" → check reports up with an "in progress" message.
+func TestRunCheck_Speed_UsesLastAttempt_Pending_ReportsInProgress(t *testing.T) {
+	sc, store := newTestChecker()
+
+	now := time.Now().UTC()
+	_ = store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
+		Timestamp: now.Add(-30 * time.Second),
+		Status:    "pending",
+	})
+
+	check := internal.ServiceCheckConfig{
+		Name:    "speed-pending",
+		Type:    internal.ServiceCheckSpeed,
+		Enabled: true,
+	}
+
+	result := sc.RunCheck(check, now)
+	if result.Status != "up" {
+		t.Fatalf("expected up while pending, got %q (error=%q)", result.Status, result.Error)
+	}
+}
+
+// Status "disabled" → check reports down with "disabled in settings".
+func TestRunCheck_Speed_UsesLastAttempt_Disabled_ReportsDown(t *testing.T) {
+	sc, store := newTestChecker()
+
+	now := time.Now().UTC()
+	_ = store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
+		Timestamp: now.Add(-1 * time.Hour),
+		Status:    "disabled",
+	})
+
+	check := internal.ServiceCheckConfig{
+		Name:    "speed-disabled",
+		Type:    internal.ServiceCheckSpeed,
+		Enabled: true,
+	}
+
+	result := sc.RunCheck(check, now)
+	if result.Status != "down" {
+		t.Fatalf("expected down, got %q", result.Status)
+	}
+	if !strings.Contains(result.Error, "disabled") {
+		t.Errorf("expected 'disabled' in error, got %q", result.Error)
+	}
+}
+
+// Attempt state older than 30 days → stale, reports down.
+func TestRunCheck_Speed_UsesLastAttempt_Stale_ReportsDown(t *testing.T) {
+	sc, store := newTestChecker()
+
+	now := time.Now().UTC()
+	_ = store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
+		Timestamp: now.Add(-40 * 24 * time.Hour),
+		Status:    "success",
+	})
+
+	check := internal.ServiceCheckConfig{
+		Name:               "speed-stale",
+		Type:               internal.ServiceCheckSpeed,
+		Enabled:            true,
+		ContractedDownMbps: 100,
+		ContractedUpMbps:   10,
+	}
+
+	result := sc.RunCheck(check, now)
+	if result.Status != "down" {
+		t.Fatalf("expected down on stale state, got %q", result.Status)
+	}
+	if !strings.Contains(result.Error, "stale") {
+		t.Errorf("expected 'stale' in error, got %q", result.Error)
+	}
+}
+
+// No attempt state stored yet (fresh install pre-first tick) → reports
+// down with a "no speed test run yet" message.
+func TestRunCheck_Speed_UsesLastAttempt_NoStateYet_ReportsDown(t *testing.T) {
+	sc, _ := newTestChecker()
+
+	check := internal.ServiceCheckConfig{
+		Name:    "speed-fresh",
+		Type:    internal.ServiceCheckSpeed,
+		Enabled: true,
+	}
+
+	result := sc.RunCheck(check, time.Now().UTC())
+	if result.Status != "down" {
+		t.Fatalf("expected down on missing state, got %q", result.Status)
+	}
+	if result.Error == "" {
+		t.Error("expected non-empty error on missing state")
+	}
+}
+
+// Corrupt/old history row where download+upload are both zero on a
+// success-tagged attempt should be treated as failed, not up.
+func TestRunCheck_Speed_UsesLastAttempt_SuccessButZeroHistory_ReportsDown(t *testing.T) {
+	sc, store := newTestChecker()
+
+	now := time.Now().UTC()
+	_ = store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
+		Timestamp: now.Add(-1 * time.Minute),
+		Status:    "success",
+	})
+	_ = store.SaveSpeedTest("test-1", &internal.SpeedTestResult{
+		Timestamp:    now.Add(-1 * time.Minute),
+		DownloadMbps: 0,
+		UploadMbps:   0,
+		LatencyMs:    0,
+	})
+
+	check := internal.ServiceCheckConfig{
+		Name:    "speed-zero",
+		Type:    internal.ServiceCheckSpeed,
+		Enabled: true,
+	}
+
+	result := sc.RunCheck(check, now)
+	if result.Status != "down" {
+		t.Fatalf("expected down on zero-throughput history, got %q (error=%q)", result.Status, result.Error)
+	}
+}

--- a/internal/scheduler/checks_test.go
+++ b/internal/scheduler/checks_test.go
@@ -481,16 +481,38 @@ func TestRunDueChecks_UnsupportedType_Skipped(t *testing.T) {
 }
 
 // ── Speed check tests ──────────────────────────────────────────────────
+//
+// As of issue #210 the scheduled type=speed service check reads from
+// the shared LastSpeedTestAttempt state + latest speedtest_history row
+// rather than running Ookla via SetSpeedTestRunner. These tests are
+// the classic threshold cases updated to seed the store instead of
+// injecting a runner; the extended state-machine coverage lives in
+// checks_speed_history_test.go.
+
+// seedSpeedTestSuccess writes a "success" attempt + a matching history
+// row so RunCheck's success path has data to read.
+func seedSpeedTestSuccess(t *testing.T, store *storage.FakeStore, dl, ul, latency float64) {
+	t.Helper()
+	now := time.Now().UTC()
+	if err := store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
+		Timestamp: now,
+		Status:    "success",
+	}); err != nil {
+		t.Fatalf("SaveSpeedTestAttempt: %v", err)
+	}
+	if err := store.SaveSpeedTest("seed", &internal.SpeedTestResult{
+		Timestamp:    now,
+		DownloadMbps: dl,
+		UploadMbps:   ul,
+		LatencyMs:    latency,
+	}); err != nil {
+		t.Fatalf("SaveSpeedTest: %v", err)
+	}
+}
 
 func TestRunCheck_Speed_AboveThreshold_Up(t *testing.T) {
-	sc, _ := newTestChecker()
-	sc.SetSpeedTestRunner(func() *internal.SpeedTestResult {
-		return &internal.SpeedTestResult{
-			DownloadMbps: 500,
-			UploadMbps:   100,
-			LatencyMs:    5,
-		}
-	})
+	sc, store := newTestChecker()
+	seedSpeedTestSuccess(t, store, 500, 100, 5)
 
 	check := internal.ServiceCheckConfig{
 		Name:               "speed-ok",
@@ -521,14 +543,8 @@ func TestRunCheck_Speed_AboveThreshold_Up(t *testing.T) {
 }
 
 func TestRunCheck_Speed_BelowThreshold_Degraded(t *testing.T) {
-	sc, _ := newTestChecker()
-	sc.SetSpeedTestRunner(func() *internal.SpeedTestResult {
-		return &internal.SpeedTestResult{
-			DownloadMbps: 500,
-			UploadMbps:   30, // below 80 * 0.9 = 72
-			LatencyMs:    5,
-		}
-	})
+	sc, store := newTestChecker()
+	seedSpeedTestSuccess(t, store, 500, 30 /* below 80 * 0.9 = 72 */, 5)
 
 	check := internal.ServiceCheckConfig{
 		Name:               "speed-degraded",
@@ -550,14 +566,8 @@ func TestRunCheck_Speed_BelowThreshold_Degraded(t *testing.T) {
 }
 
 func TestRunCheck_Speed_BothBelow_Down(t *testing.T) {
-	sc, _ := newTestChecker()
-	sc.SetSpeedTestRunner(func() *internal.SpeedTestResult {
-		return &internal.SpeedTestResult{
-			DownloadMbps: 50, // below 400 * 0.9 = 360
-			UploadMbps:   10, // below 80 * 0.9 = 72
-			LatencyMs:    100,
-		}
-	})
+	sc, store := newTestChecker()
+	seedSpeedTestSuccess(t, store, 50 /* below 400*0.9=360 */, 10 /* below 80*0.9=72 */, 100)
 
 	check := internal.ServiceCheckConfig{
 		Name:               "speed-down",
@@ -570,9 +580,6 @@ func TestRunCheck_Speed_BothBelow_Down(t *testing.T) {
 	}
 
 	result := sc.RunCheck(check, time.Now().UTC())
-	// When both are below threshold, the status is "down" (not "degraded" — no side passes).
-	// Actually from the code: default case when neither dlOK nor ulOK → no explicit "down" set,
-	// it stays as the initial "down".
 	if result.Status != "down" {
 		t.Fatalf("expected status down, got %s (error=%q)", result.Status, result.Error)
 	}
@@ -581,12 +588,15 @@ func TestRunCheck_Speed_BothBelow_Down(t *testing.T) {
 	}
 }
 
-func TestRunCheck_Speed_NoRunner(t *testing.T) {
+// Pre-#210 this asserted "no speedtest tool available" when the runner
+// was nil. Under option B there is no runner — the equivalent failure
+// mode is "no attempt recorded yet" (fresh install, pre-first tick).
+func TestRunCheck_Speed_NoAttemptRecorded(t *testing.T) {
 	sc, _ := newTestChecker()
-	// No speed test runner set (default nil).
+	// No attempt state seeded.
 
 	check := internal.ServiceCheckConfig{
-		Name:    "speed-no-tool",
+		Name:    "speed-fresh",
 		Type:    internal.ServiceCheckSpeed,
 		Target:  "speedtest",
 		Enabled: true,
@@ -594,10 +604,10 @@ func TestRunCheck_Speed_NoRunner(t *testing.T) {
 
 	result := sc.RunCheck(check, time.Now().UTC())
 	if result.Status != "down" {
-		t.Fatalf("expected status down when no speed test runner, got %s", result.Status)
+		t.Fatalf("expected status down when no attempt recorded, got %s", result.Status)
 	}
-	if !strings.Contains(result.Error, "no speedtest tool available") {
-		t.Fatalf("expected 'no speedtest tool available' error, got %q", result.Error)
+	if result.Error == "" {
+		t.Fatal("expected non-empty error when no attempt recorded")
 	}
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -912,12 +912,21 @@ func (s *Scheduler) collectProcessStats() {
 //   - failed → runner returned nil (Ookla missing, network error,
 //     zero-throughput parse failure per #170); attempt flips to
 //     status=failed with a descriptive error message.
+//
+// Each branch persists the attempt to the store AND mirrors it onto
+// s.latest.SpeedTest.LastAttempt so the dashboard widget can pick it
+// up from the next /api/v1/snapshot/latest call without a separate
+// DB round-trip. The cached-snapshot mirror is best-effort: if
+// s.latest is still nil (first scan hasn't completed), the store
+// copy is canonical and the snapshot will pick it up on rebuild.
 func (s *Scheduler) runSpeedTest() {
 	// Disabled branch: check current state first; only write on transition.
 	s.mu.RLock()
 	interval := s.speedTestInterval
 	runner := s.speedTestRunFn
 	s.mu.RUnlock()
+
+	now := time.Now().UTC()
 
 	if interval == SpeedTestIntervalDisabled {
 		// Idempotent: if the last stored status is already "disabled",
@@ -928,23 +937,13 @@ func (s *Scheduler) runSpeedTest() {
 			return
 		}
 		s.logger.Info("speed test: disabled in settings, recording state")
-		if err := s.store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
-			Timestamp: time.Now().UTC(),
-			Status:    "disabled",
-		}); err != nil {
-			s.logger.Warn("failed to save disabled attempt state", "error", err)
-		}
+		s.recordSpeedTestAttempt(now, "disabled", "")
 		return
 	}
 
 	// Write pending state first so the widget + scheduled check see
 	// "in progress" for the duration of the Ookla invocation.
-	if err := s.store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
-		Timestamp: time.Now().UTC(),
-		Status:    "pending",
-	}); err != nil {
-		s.logger.Warn("failed to save pending attempt state", "error", err)
-	}
+	s.recordSpeedTestAttempt(now, "pending", "")
 
 	s.logger.Info("running speed test")
 	var result *internal.SpeedTestResult
@@ -954,13 +953,8 @@ func (s *Scheduler) runSpeedTest() {
 
 	if result == nil {
 		s.logger.Info("speed test failed: no speedtest tool available or zero-throughput result")
-		if err := s.store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
-			Timestamp: time.Now().UTC(),
-			Status:    "failed",
-			ErrorMsg:  "no speedtest tool available (install speedtest or speedtest-cli) or test returned zero throughput",
-		}); err != nil {
-			s.logger.Warn("failed to save failed attempt state", "error", err)
-		}
+		s.recordSpeedTestAttempt(time.Now().UTC(), "failed",
+			"no speedtest tool available (install speedtest or speedtest-cli) or test returned zero throughput")
 		return
 	}
 
@@ -973,21 +967,64 @@ func (s *Scheduler) runSpeedTest() {
 	if err := s.store.SaveSpeedTest("speedtest-"+time.Now().Format("20060102-150405"), result); err != nil {
 		s.logger.Warn("failed to save speed test result", "error", err)
 	}
+	s.recordSpeedTestSuccess(time.Now().UTC(), result)
+}
+
+// recordSpeedTestAttempt persists the attempt state to the store AND
+// mirrors it onto s.latest.SpeedTest.LastAttempt (if the cached
+// snapshot exists) so the dashboard widget sees the current state on
+// the next /api/v1/snapshot/latest call. Preserves any existing
+// s.latest.SpeedTest.Latest value — only overwrites LastAttempt.
+//
+// Does NOT write speedtest_history: that's the caller's responsibility
+// (only the success branch of runSpeedTest writes a history row).
+func (s *Scheduler) recordSpeedTestAttempt(ts time.Time, status, errorMsg string) {
 	if err := s.store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
-		Timestamp: time.Now().UTC(),
+		Timestamp: ts,
+		Status:    status,
+		ErrorMsg:  errorMsg,
+	}); err != nil {
+		s.logger.Warn("failed to save attempt state", "status", status, "error", err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.latest == nil {
+		return
+	}
+	if s.latest.SpeedTest == nil {
+		s.latest.SpeedTest = &internal.SpeedTestInfo{}
+	}
+	s.latest.SpeedTest.LastAttempt = &internal.SpeedTestAttempt{
+		Timestamp: ts,
+		Status:    status,
+		ErrorMsg:  errorMsg,
+	}
+}
+
+// recordSpeedTestSuccess is the success-branch counterpart: writes the
+// attempt row AND updates s.latest.SpeedTest.{Latest,LastAttempt,
+// Available} atomically so the widget sees Latest + LastAttempt
+// transition together.
+func (s *Scheduler) recordSpeedTestSuccess(ts time.Time, result *internal.SpeedTestResult) {
+	if err := s.store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
+		Timestamp: ts,
 		Status:    "success",
 	}); err != nil {
 		s.logger.Warn("failed to save success attempt state", "error", err)
 	}
-	// Update the cached snapshot's speed test field
 	s.mu.Lock()
-	if s.latest != nil {
-		s.latest.SpeedTest = &internal.SpeedTestInfo{
-			Available: true,
-			Latest:    result,
-		}
+	defer s.mu.Unlock()
+	if s.latest == nil {
+		return
 	}
-	s.mu.Unlock()
+	s.latest.SpeedTest = &internal.SpeedTestInfo{
+		Available: true,
+		Latest:    result,
+		LastAttempt: &internal.SpeedTestAttempt{
+			Timestamp: ts,
+			Status:    "success",
+		},
+	}
 }
 
 func (s *Scheduler) runDueServiceChecks() {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -70,6 +70,13 @@ type AlertingConfig struct {
 	DefaultCooldownSec int                         `json:"default_cooldown_sec,omitempty"`
 }
 
+// SpeedTestIntervalDisabled is a sentinel value written to
+// speedTestInterval when the user picks "Disabled" in the settings
+// dropdown (#180). The scheduler's runSpeedTest treats this as
+// "skip invocation, record status=disabled once" rather than trying
+// to interpret a negative duration as a real interval. See #210.
+const SpeedTestIntervalDisabled time.Duration = -1
+
 // Scheduler periodically runs diagnostic collections and analysis.
 type Scheduler struct {
 	collector         *collector.Collector
@@ -82,11 +89,15 @@ type Scheduler struct {
 	speedTestSchedule []string // specific HH:MM times, overrides interval when set
 	speedTestDay      string   // "monday"-"sunday" or "1","15" for monthly
 	speedTestFreq     string   // "24h", "weekly", "monthly" — only when schedule is set
-	retention         RetentionConfig
-	alerting          AlertingConfig
-	serviceChecks     []internal.ServiceCheckConfig
-	checker           *ServiceChecker
-	retentionMgr      *RetentionManager
+	// speedTestRunFn is an injectable runner (tests swap this; production
+	// uses collector.RunSpeedTest via the default in New). Keeping it on
+	// the struct lets tests exercise runSpeedTest without spawning Ookla.
+	speedTestRunFn SpeedTestRunner
+	retention      RetentionConfig
+	alerting       AlertingConfig
+	serviceChecks  []internal.ServiceCheckConfig
+	checker        *ServiceChecker
+	retentionMgr   *RetentionManager
 
 	logForwarder *logfwd.Forwarder
 
@@ -115,6 +126,7 @@ func New(
 		logger:            logger,
 		interval:          interval,
 		speedTestInterval: 4 * time.Hour,
+		speedTestRunFn:    collector.RunSpeedTest,
 		retention: RetentionConfig{
 			SnapshotDays:  90,
 			MaxDBSizeMB:   500,
@@ -255,14 +267,29 @@ func (s *Scheduler) Start() {
 
 // UpdateInterval dynamically changes the scan interval without restarting.
 // SetSpeedTestInterval updates how often the speed test runs.
+//
+// The SpeedTestIntervalDisabled sentinel (#180/#210) short-circuits the
+// sanity clamp and is preserved as-is; the runSpeedTest branch treats it
+// as "skip + record disabled".
 func (s *Scheduler) SetSpeedTestInterval(d time.Duration) {
-	if d < 5*time.Minute {
+	if d != SpeedTestIntervalDisabled && d < 5*time.Minute {
 		d = 5 * time.Minute
 	}
 	s.mu.Lock()
 	s.speedTestInterval = d
 	s.mu.Unlock()
 	s.logger.Info("speed test interval updated", "interval", d)
+}
+
+// SetSpeedTestRunnerFn injects a custom speed-test runner. Production
+// wiring calls collector.RunSpeedTest via the constructor default;
+// tests pass a deterministic stub. Introduced as part of #210 so
+// runSpeedTest can record attempt state without spawning Ookla in
+// unit tests.
+func (s *Scheduler) SetSpeedTestRunnerFn(fn SpeedTestRunner) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.speedTestRunFn = fn
 }
 
 // SetSpeedTestSchedule sets specific times of day to run speed tests.
@@ -868,14 +895,75 @@ func (s *Scheduler) collectProcessStats() {
 	s.mu.Unlock()
 }
 
-// runSpeedTest executes a network speed test and stores the result.
+// runSpeedTest executes a network speed test and records the attempt
+// state in the store.
+//
+// Records one of four outcomes on every invocation, except the disabled
+// branch which is idempotent (first call writes status=disabled, later
+// calls no-op so the tick loop doesn't churn a row every minute):
+//
+//   - disabled → interval == SpeedTestIntervalDisabled (#180): skip the
+//     run entirely; record status=disabled once.
+//   - pending → written BEFORE invoking the runner so the dashboard
+//     widget and scheduled type=speed check can render the in-progress
+//     state during the ~30-60 second window Ookla takes to complete.
+//   - success → runner returned a result; saved to speedtest_history
+//     and the attempt state flips to status=success.
+//   - failed → runner returned nil (Ookla missing, network error,
+//     zero-throughput parse failure per #170); attempt flips to
+//     status=failed with a descriptive error message.
 func (s *Scheduler) runSpeedTest() {
-	s.logger.Info("running speed test")
-	result := collector.RunSpeedTest()
-	if result == nil {
-		s.logger.Info("speed test: no speedtest tool available (install speedtest or speedtest-cli)")
+	// Disabled branch: check current state first; only write on transition.
+	s.mu.RLock()
+	interval := s.speedTestInterval
+	runner := s.speedTestRunFn
+	s.mu.RUnlock()
+
+	if interval == SpeedTestIntervalDisabled {
+		// Idempotent: if the last stored status is already "disabled",
+		// don't write again. This matters because the 1-minute tick
+		// loop may call this path many times and we don't want to
+		// churn a row per tick.
+		if existing, err := s.store.GetLastSpeedTestAttempt(); err == nil && existing != nil && existing.Status == "disabled" {
+			return
+		}
+		s.logger.Info("speed test: disabled in settings, recording state")
+		if err := s.store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
+			Timestamp: time.Now().UTC(),
+			Status:    "disabled",
+		}); err != nil {
+			s.logger.Warn("failed to save disabled attempt state", "error", err)
+		}
 		return
 	}
+
+	// Write pending state first so the widget + scheduled check see
+	// "in progress" for the duration of the Ookla invocation.
+	if err := s.store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
+		Timestamp: time.Now().UTC(),
+		Status:    "pending",
+	}); err != nil {
+		s.logger.Warn("failed to save pending attempt state", "error", err)
+	}
+
+	s.logger.Info("running speed test")
+	var result *internal.SpeedTestResult
+	if runner != nil {
+		result = runner()
+	}
+
+	if result == nil {
+		s.logger.Info("speed test failed: no speedtest tool available or zero-throughput result")
+		if err := s.store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
+			Timestamp: time.Now().UTC(),
+			Status:    "failed",
+			ErrorMsg:  "no speedtest tool available (install speedtest or speedtest-cli) or test returned zero throughput",
+		}); err != nil {
+			s.logger.Warn("failed to save failed attempt state", "error", err)
+		}
+		return
+	}
+
 	s.logger.Info("speed test complete",
 		"download", fmt.Sprintf("%.1f Mbps", result.DownloadMbps),
 		"upload", fmt.Sprintf("%.1f Mbps", result.UploadMbps),
@@ -884,6 +972,12 @@ func (s *Scheduler) runSpeedTest() {
 	// Store in DB
 	if err := s.store.SaveSpeedTest("speedtest-"+time.Now().Format("20060102-150405"), result); err != nil {
 		s.logger.Warn("failed to save speed test result", "error", err)
+	}
+	if err := s.store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
+		Timestamp: time.Now().UTC(),
+		Status:    "success",
+	}); err != nil {
+		s.logger.Warn("failed to save success attempt state", "error", err)
 	}
 	// Update the cached snapshot's speed test field
 	s.mu.Lock()

--- a/internal/scheduler/scheduler_speed_attempt_test.go
+++ b/internal/scheduler/scheduler_speed_attempt_test.go
@@ -1,0 +1,169 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// Issue #210 — scheduler.runSpeedTest writes LastSpeedTestAttempt
+// before and after invoking the speed-test runner, so downstream
+// consumers (the scheduled type=speed service check, the dashboard
+// widget) see the outcome even when the runner itself has no DB
+// side effect.
+
+// On a successful run the recorded state should be {status=success,
+// error_msg=""}, and a speedtest_history row must also exist.
+func TestScheduler_SpeedTest_RecordsSuccess(t *testing.T) {
+	store := storage.NewFakeStore()
+	sched := newSchedulerForTest(store)
+	sched.SetSpeedTestRunnerFn(func() *internal.SpeedTestResult {
+		return &internal.SpeedTestResult{
+			Timestamp:    time.Now().UTC(),
+			DownloadMbps: 400,
+			UploadMbps:   50,
+			LatencyMs:    15,
+		}
+	})
+
+	sched.runSpeedTest()
+
+	att, err := store.GetLastSpeedTestAttempt()
+	if err != nil {
+		t.Fatalf("GetLastSpeedTestAttempt: %v", err)
+	}
+	if att == nil {
+		t.Fatal("expected attempt state to be recorded, got nil")
+	}
+	if att.Status != "success" {
+		t.Errorf("Status = %q, want success", att.Status)
+	}
+	if att.ErrorMsg != "" {
+		t.Errorf("ErrorMsg = %q, want empty", att.ErrorMsg)
+	}
+	points, err := store.GetSpeedTestHistory(1)
+	if err != nil {
+		t.Fatalf("GetSpeedTestHistory: %v", err)
+	}
+	if len(points) != 1 {
+		t.Fatalf("expected 1 speedtest_history row, got %d", len(points))
+	}
+}
+
+// When the runner returns nil (Ookla missing / network down) the
+// attempt state should flip to {status=failed, error_msg=<reason>}.
+// No speedtest_history row is written.
+func TestScheduler_SpeedTest_RecordsFailure(t *testing.T) {
+	store := storage.NewFakeStore()
+	sched := newSchedulerForTest(store)
+	sched.SetSpeedTestRunnerFn(func() *internal.SpeedTestResult {
+		return nil
+	})
+
+	sched.runSpeedTest()
+
+	att, err := store.GetLastSpeedTestAttempt()
+	if err != nil {
+		t.Fatalf("GetLastSpeedTestAttempt: %v", err)
+	}
+	if att == nil {
+		t.Fatal("expected attempt state after failure, got nil")
+	}
+	if att.Status != "failed" {
+		t.Errorf("Status = %q, want failed", att.Status)
+	}
+	if att.ErrorMsg == "" {
+		t.Error("expected non-empty ErrorMsg on failure")
+	}
+	points, err := store.GetSpeedTestHistory(1)
+	if err != nil {
+		t.Fatalf("GetSpeedTestHistory: %v", err)
+	}
+	if len(points) != 0 {
+		t.Errorf("expected 0 history rows on failure, got %d", len(points))
+	}
+}
+
+// Before invoking the runner, runSpeedTest writes a "pending" attempt
+// state so the widget + scheduled check can render the in-progress
+// condition correctly for the first-boot gap.
+func TestScheduler_SpeedTest_WritesPendingBeforeRun(t *testing.T) {
+	store := storage.NewFakeStore()
+	sched := newSchedulerForTest(store)
+
+	observed := make(chan string, 1)
+	sched.SetSpeedTestRunnerFn(func() *internal.SpeedTestResult {
+		// When the runner runs, the pending state must already be visible.
+		att, _ := store.GetLastSpeedTestAttempt()
+		if att != nil {
+			observed <- att.Status
+		} else {
+			observed <- "<nil>"
+		}
+		return &internal.SpeedTestResult{DownloadMbps: 100, UploadMbps: 10, LatencyMs: 5}
+	})
+
+	sched.runSpeedTest()
+
+	select {
+	case got := <-observed:
+		if got != "pending" {
+			t.Fatalf("mid-run attempt status = %q, want pending", got)
+		}
+	default:
+		t.Fatal("runner did not observe attempt state")
+	}
+
+	// After the run completes the status should be success, not pending.
+	att, _ := store.GetLastSpeedTestAttempt()
+	if att == nil || att.Status != "success" {
+		t.Fatalf("post-run status = %v, want success", att)
+	}
+}
+
+// When the speed-test interval is set to the Disabled sentinel, the
+// scheduler should record status=disabled once and skip invocation.
+// Repeated calls must not churn writes (idempotent).
+func TestScheduler_SpeedTest_DisabledWritesOnce(t *testing.T) {
+	store := storage.NewFakeStore()
+	sched := newSchedulerForTest(store)
+	sched.SetSpeedTestInterval(SpeedTestIntervalDisabled)
+
+	invocations := 0
+	sched.SetSpeedTestRunnerFn(func() *internal.SpeedTestResult {
+		invocations++
+		return &internal.SpeedTestResult{DownloadMbps: 1}
+	})
+
+	sched.runSpeedTest()
+	sched.runSpeedTest()
+	sched.runSpeedTest()
+
+	if invocations != 0 {
+		t.Errorf("runner should not be invoked when disabled, got %d calls", invocations)
+	}
+
+	att, err := store.GetLastSpeedTestAttempt()
+	if err != nil {
+		t.Fatalf("GetLastSpeedTestAttempt: %v", err)
+	}
+	if att == nil {
+		t.Fatal("expected attempt state, got nil")
+	}
+	if att.Status != "disabled" {
+		t.Errorf("Status = %q, want disabled", att.Status)
+	}
+
+	// Idempotency: the timestamp from the first disabled write should not
+	// move on subsequent calls (no churn). We approximate this by saving
+	// an earlier timestamp and confirming it survives a redundant call.
+	baseline := att.Timestamp
+	time.Sleep(5 * time.Millisecond)
+	sched.runSpeedTest()
+	att2, _ := store.GetLastSpeedTestAttempt()
+	if !att2.Timestamp.Equal(baseline) {
+		t.Errorf("disabled attempt timestamp changed on second call (not idempotent): %v → %v", baseline, att2.Timestamp)
+	}
+}

--- a/internal/scheduler/scheduler_speed_latest_test.go
+++ b/internal/scheduler/scheduler_speed_latest_test.go
@@ -1,0 +1,178 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// Issue #210 (item 6): the scheduler must mirror LastSpeedTestAttempt
+// onto s.latest.SpeedTest.LastAttempt in EVERY branch (pending, failed,
+// disabled, success), not just success, so the dashboard widget picks
+// up the state via /api/v1/snapshot/latest without a separate DB
+// round-trip.
+
+// Before the runner invokes, a pending attempt must be visible on
+// s.latest.SpeedTest.LastAttempt. This is the "Running initial speed
+// test..." render condition. At this point Latest is nil (no Ookla
+// result yet), so the widget distinguishes pending-first-boot from
+// stable-running by the presence of Latest.
+func TestScheduler_SpeedTest_MirrorsPendingOnLatest(t *testing.T) {
+	store := storage.NewFakeStore()
+	sched := newSchedulerForTest(store)
+	sched.latest = &internal.Snapshot{} // simulate first scan already ran
+
+	observed := make(chan *internal.SpeedTestAttempt, 1)
+	sched.SetSpeedTestRunnerFn(func() *internal.SpeedTestResult {
+		// When the runner fires, s.latest.SpeedTest.LastAttempt must
+		// already be populated as pending — the scheduler writes
+		// pending BEFORE invoking the runner.
+		sched.mu.RLock()
+		defer sched.mu.RUnlock()
+		if sched.latest != nil && sched.latest.SpeedTest != nil {
+			observed <- sched.latest.SpeedTest.LastAttempt
+		} else {
+			observed <- nil
+		}
+		return &internal.SpeedTestResult{DownloadMbps: 100, UploadMbps: 10, LatencyMs: 5}
+	})
+
+	sched.runSpeedTest()
+
+	select {
+	case got := <-observed:
+		if got == nil {
+			t.Fatal("pending attempt not mirrored onto s.latest.SpeedTest.LastAttempt before runner invocation")
+		}
+		if got.Status != "pending" {
+			t.Errorf("mid-run LastAttempt.Status = %q, want pending", got.Status)
+		}
+	default:
+		t.Fatal("runner did not observe cached-snapshot state")
+	}
+}
+
+// After a successful run, s.latest.SpeedTest.{Latest,LastAttempt,
+// Available} must all be populated and coherent. The widget's happy
+// path reads Latest; LastAttempt.Status=success is a redundant signal
+// that the check/widget trust.
+func TestScheduler_SpeedTest_MirrorsSuccessOnLatest(t *testing.T) {
+	store := storage.NewFakeStore()
+	sched := newSchedulerForTest(store)
+	sched.latest = &internal.Snapshot{}
+
+	sched.SetSpeedTestRunnerFn(func() *internal.SpeedTestResult {
+		return &internal.SpeedTestResult{DownloadMbps: 200, UploadMbps: 20, LatencyMs: 10}
+	})
+
+	sched.runSpeedTest()
+
+	sched.mu.RLock()
+	defer sched.mu.RUnlock()
+	if sched.latest == nil || sched.latest.SpeedTest == nil {
+		t.Fatal("expected s.latest.SpeedTest to be non-nil after success")
+	}
+	spd := sched.latest.SpeedTest
+	if !spd.Available {
+		t.Error("SpeedTest.Available = false after success; widget's happy path gate will skip")
+	}
+	if spd.Latest == nil {
+		t.Fatal("SpeedTest.Latest is nil after success; expected the runner result")
+	}
+	if spd.Latest.DownloadMbps != 200 {
+		t.Errorf("SpeedTest.Latest.DownloadMbps = %v, want 200", spd.Latest.DownloadMbps)
+	}
+	if spd.LastAttempt == nil {
+		t.Fatal("SpeedTest.LastAttempt is nil after success; expected success marker")
+	}
+	if spd.LastAttempt.Status != "success" {
+		t.Errorf("LastAttempt.Status = %q, want success", spd.LastAttempt.Status)
+	}
+}
+
+// After a failed run, s.latest.SpeedTest.LastAttempt must surface the
+// failure so the widget can render a descriptive state (not just
+// silently fall back to an empty tile). Latest stays nil.
+func TestScheduler_SpeedTest_MirrorsFailureOnLatest(t *testing.T) {
+	store := storage.NewFakeStore()
+	sched := newSchedulerForTest(store)
+	sched.latest = &internal.Snapshot{}
+
+	sched.SetSpeedTestRunnerFn(func() *internal.SpeedTestResult {
+		return nil // simulate Ookla missing or zero-throughput guard hit
+	})
+
+	sched.runSpeedTest()
+
+	sched.mu.RLock()
+	defer sched.mu.RUnlock()
+	if sched.latest.SpeedTest == nil {
+		t.Fatal("expected s.latest.SpeedTest to be non-nil after failure (LastAttempt should still ride there)")
+	}
+	spd := sched.latest.SpeedTest
+	if spd.Latest != nil {
+		t.Error("SpeedTest.Latest should be nil after failure")
+	}
+	if spd.LastAttempt == nil {
+		t.Fatal("SpeedTest.LastAttempt is nil after failure")
+	}
+	if spd.LastAttempt.Status != "failed" {
+		t.Errorf("LastAttempt.Status = %q, want failed", spd.LastAttempt.Status)
+	}
+	if spd.LastAttempt.ErrorMsg == "" {
+		t.Error("LastAttempt.ErrorMsg is empty on failure; widget + service check depend on a descriptive message")
+	}
+}
+
+// Disabled branch: s.latest.SpeedTest.LastAttempt shows status=disabled
+// so the widget can optionally render a muted state (future UI work;
+// current widget does not render anything for disabled, which is fine).
+func TestScheduler_SpeedTest_MirrorsDisabledOnLatest(t *testing.T) {
+	store := storage.NewFakeStore()
+	sched := newSchedulerForTest(store)
+	sched.latest = &internal.Snapshot{}
+	sched.SetSpeedTestInterval(SpeedTestIntervalDisabled)
+
+	sched.runSpeedTest()
+
+	sched.mu.RLock()
+	defer sched.mu.RUnlock()
+	if sched.latest.SpeedTest == nil {
+		t.Fatal("expected s.latest.SpeedTest to be non-nil after disabled transition")
+	}
+	if sched.latest.SpeedTest.LastAttempt == nil {
+		t.Fatal("LastAttempt is nil after disabled transition")
+	}
+	if sched.latest.SpeedTest.LastAttempt.Status != "disabled" {
+		t.Errorf("LastAttempt.Status = %q, want disabled", sched.latest.SpeedTest.LastAttempt.Status)
+	}
+}
+
+// Edge case: if s.latest is nil (first scan hasn't completed yet —
+// scheduler hasn't populated the cached snapshot), the attempt must
+// still be written to the store so the service check can read it.
+// No panic on the nil dereference.
+func TestScheduler_SpeedTest_NilLatest_StoreStillUpdated(t *testing.T) {
+	store := storage.NewFakeStore()
+	sched := newSchedulerForTest(store)
+	// Do NOT set sched.latest — leave it nil.
+
+	sched.SetSpeedTestRunnerFn(func() *internal.SpeedTestResult {
+		return &internal.SpeedTestResult{DownloadMbps: 50}
+	})
+
+	// Should not panic.
+	sched.runSpeedTest()
+
+	att, err := store.GetLastSpeedTestAttempt()
+	if err != nil {
+		t.Fatalf("GetLastSpeedTestAttempt: %v", err)
+	}
+	if att == nil {
+		t.Fatal("attempt not written to store when s.latest is nil")
+	}
+	if att.Status != "success" {
+		t.Errorf("Status = %q, want success", att.Status)
+	}
+}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -199,6 +199,21 @@ func (d *DB) migrate() error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_speedtest_ts ON speedtest_history(timestamp DESC)`,
 
+		// --- Last speed-test attempt (single-row table, see issue #210) ---
+		// Records the outcome of the most recent speed-test run — success,
+		// failure, pending, or disabled. Consumed by the scheduled
+		// type=speed service check (option B, reads attempt state + latest
+		// speedtest_history row instead of running Ookla per-check) and by
+		// the dashboard widget to render "Running initial speed test…"
+		// when no history has been produced yet. id=1 is enforced so the
+		// table never grows beyond a single row.
+		`CREATE TABLE IF NOT EXISTS speedtest_attempt (
+			id INTEGER PRIMARY KEY,
+			timestamp DATETIME NOT NULL,
+			status TEXT NOT NULL,
+			error_msg TEXT
+		)`,
+
 		// --- Notification log ---
 		`CREATE TABLE IF NOT EXISTS notification_log (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -865,6 +880,58 @@ func (d *DB) GetSpeedTestHistory(hours int) ([]SpeedTestHistoryPoint, error) {
 		points = append(points, p)
 	}
 	return points, rows.Err()
+}
+
+// LastSpeedTestAttempt records the outcome of the most recent speed-test
+// run. The scheduled type=speed service check reads this (plus the latest
+// speedtest_history row) to determine health, and the dashboard widget
+// reads it to render "Running initial speed test…" on fresh installs. See
+// issue #210.
+type LastSpeedTestAttempt struct {
+	Timestamp time.Time `json:"timestamp"`
+	// Status values: "success", "failed", "pending", "disabled".
+	// "success" — the run produced a speedtest_history row.
+	// "failed" — Ookla errored or returned zero throughput.
+	// "pending" — scheduler set this before invoking the runner;
+	//             cleared on outcome. Used by the widget to render
+	//             "Running initial speed test…" pre-first-result.
+	// "disabled" — the speed-test interval is the disabled sentinel (#180).
+	Status   string `json:"status"`
+	ErrorMsg string `json:"error_msg,omitempty"`
+}
+
+// SaveSpeedTestAttempt upserts the current speed-test attempt state into
+// the single-row speedtest_attempt table (id=1).
+func (d *DB) SaveSpeedTestAttempt(att LastSpeedTestAttempt) error {
+	_, err := d.db.Exec(
+		`INSERT INTO speedtest_attempt (id, timestamp, status, error_msg)
+		 VALUES (1, ?, ?, ?)
+		 ON CONFLICT(id) DO UPDATE SET
+		   timestamp = excluded.timestamp,
+		   status = excluded.status,
+		   error_msg = excluded.error_msg`,
+		att.Timestamp.UTC(), att.Status, att.ErrorMsg,
+	)
+	return err
+}
+
+// GetLastSpeedTestAttempt returns the current speed-test attempt state
+// or (nil, nil) if nothing has been recorded yet (fresh install pre-first
+// scheduler tick).
+func (d *DB) GetLastSpeedTestAttempt() (*LastSpeedTestAttempt, error) {
+	row := d.db.QueryRow(
+		`SELECT timestamp, status, COALESCE(error_msg, '')
+		 FROM speedtest_attempt
+		 WHERE id = 1`,
+	)
+	var att LastSpeedTestAttempt
+	if err := row.Scan(&att.Timestamp, &att.Status, &att.ErrorMsg); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &att, nil
 }
 
 // GPUHistoryPoint represents a single time-series data point for a GPU.

--- a/internal/storage/db_speedtest_attempt_test.go
+++ b/internal/storage/db_speedtest_attempt_test.go
@@ -1,0 +1,72 @@
+package storage
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSpeedTestAttempt_RoundTrip verifies that a saved LastSpeedTestAttempt
+// can be read back with identical status + timestamp + error_msg.
+// Covers the single-row upsert semantics: repeated Save calls should
+// overwrite, not append (the column surface is a single current value).
+func TestSpeedTestAttempt_RoundTrip(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	// No attempt yet → Get returns (nil, nil).
+	got, err := db.GetLastSpeedTestAttempt()
+	if err != nil {
+		t.Fatalf("GetLastSpeedTestAttempt on empty DB: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil on empty DB, got %+v", got)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	att := LastSpeedTestAttempt{
+		Timestamp: now,
+		Status:    "success",
+		ErrorMsg:  "",
+	}
+	if err := db.SaveSpeedTestAttempt(att); err != nil {
+		t.Fatalf("SaveSpeedTestAttempt: %v", err)
+	}
+
+	got, err = db.GetLastSpeedTestAttempt()
+	if err != nil {
+		t.Fatalf("GetLastSpeedTestAttempt after save: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected non-nil after save")
+	}
+	if got.Status != "success" {
+		t.Errorf("Status = %q, want success", got.Status)
+	}
+	if !got.Timestamp.Equal(now) {
+		t.Errorf("Timestamp = %v, want %v", got.Timestamp, now)
+	}
+
+	// Second save overwrites the first (single-row table).
+	later := now.Add(5 * time.Minute)
+	att2 := LastSpeedTestAttempt{
+		Timestamp: later,
+		Status:    "failed",
+		ErrorMsg:  "ookla binary not found",
+	}
+	if err := db.SaveSpeedTestAttempt(att2); err != nil {
+		t.Fatalf("second SaveSpeedTestAttempt: %v", err)
+	}
+	got, err = db.GetLastSpeedTestAttempt()
+	if err != nil {
+		t.Fatalf("Get after overwrite: %v", err)
+	}
+	if got.Status != "failed" {
+		t.Errorf("expected overwrite status=failed, got %q", got.Status)
+	}
+	if got.ErrorMsg != "ookla binary not found" {
+		t.Errorf("ErrorMsg = %q, want ookla binary not found", got.ErrorMsg)
+	}
+	if !got.Timestamp.Equal(later) {
+		t.Errorf("Timestamp = %v, want %v", got.Timestamp, later)
+	}
+}

--- a/internal/storage/fake.go
+++ b/internal/storage/fake.go
@@ -58,6 +58,14 @@ type FakeStore struct {
 	// Disk usage history rows (snapshot-independent; keyed by timestamp).
 	// Seeded via AddDiskUsageHistoryEntry() and pruned by PruneDiskUsageHistory().
 	diskUsageHistory []diskUsageRow
+
+	// Speed-test history (issue #210 — consumed by type=speed service
+	// check via option B read-from-history dispatch).
+	speedTestHistory []SpeedTestHistoryPoint
+
+	// LastSpeedTestAttempt state (single-row, issue #210). nil until
+	// the scheduler writes the first attempt outcome.
+	speedTestAttempt *LastSpeedTestAttempt
 }
 
 // diskUsageRow is the minimal fake representation of a disk_usage_history row.
@@ -524,14 +532,69 @@ func extractProcessName(command string) string {
 	return exe
 }
 
-func (f *FakeStore) SaveSpeedTest(_ string, _ *internal.SpeedTestResult) error {
-	// TODO: implement for testing
+func (f *FakeStore) SaveSpeedTest(_ string, result *internal.SpeedTestResult) error {
+	if result == nil {
+		return nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ts := result.Timestamp
+	if ts.IsZero() {
+		ts = time.Now()
+	}
+	f.speedTestHistory = append(f.speedTestHistory, SpeedTestHistoryPoint{
+		Timestamp:    ts,
+		DownloadMbps: result.DownloadMbps,
+		UploadMbps:   result.UploadMbps,
+		LatencyMs:    result.LatencyMs,
+		JitterMs:     result.JitterMs,
+		ServerName:   result.ServerName,
+		ISP:          result.ISP,
+	})
 	return nil
 }
 
-func (f *FakeStore) GetSpeedTestHistory(_ int) ([]SpeedTestHistoryPoint, error) {
-	// TODO: implement for testing
-	return nil, nil
+func (f *FakeStore) GetSpeedTestHistory(hours int) ([]SpeedTestHistoryPoint, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if len(f.speedTestHistory) == 0 {
+		return nil, nil
+	}
+	cutoff := time.Now().Add(-time.Duration(hours) * time.Hour)
+	out := make([]SpeedTestHistoryPoint, 0, len(f.speedTestHistory))
+	for _, p := range f.speedTestHistory {
+		if p.Timestamp.Before(cutoff) {
+			continue
+		}
+		out = append(out, p)
+	}
+	// Ascending order matches the DB query.
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Timestamp.Before(out[j].Timestamp)
+	})
+	return out, nil
+}
+
+// SaveSpeedTestAttempt records the current speed-test attempt state.
+// Single-row semantics — the existing attempt is replaced.
+func (f *FakeStore) SaveSpeedTestAttempt(att LastSpeedTestAttempt) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp := att
+	f.speedTestAttempt = &cp
+	return nil
+}
+
+// GetLastSpeedTestAttempt returns the current attempt state or (nil, nil)
+// if none has been recorded (fresh install pre-first scheduler tick).
+func (f *FakeStore) GetLastSpeedTestAttempt() (*LastSpeedTestAttempt, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if f.speedTestAttempt == nil {
+		return nil, nil
+	}
+	cp := *f.speedTestAttempt
+	return &cp, nil
 }
 
 // ── ConfigStore ──

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -36,6 +36,12 @@ type AlertStore interface {
 }
 
 // ServiceCheckStore handles service check results and history.
+//
+// As of issue #210 the scheduled type=speed service check dispatch reads
+// the shared LastSpeedTestAttempt + latest speedtest_history row rather
+// than running Ookla per-check, so the ServiceChecker needs access to
+// those two methods as well. They live on the broader HistoryStore but
+// are surfaced here so the narrow dependency remains a single interface.
 type ServiceCheckStore interface {
 	SaveServiceCheckResults(results []internal.ServiceCheckResult) error
 	GetLatestServiceCheckState(checkKey string) (ServiceCheckState, bool, error)
@@ -47,6 +53,10 @@ type ServiceCheckStore interface {
 	// whose check_key is NOT in keepKeys. Passing nil or an empty slice
 	// deletes all rows. Returns the number of rows deleted.
 	DeleteServiceChecksNotIn(keepKeys []string) (int, error)
+
+	// Speed-check dispatch (issue #210) reads attempt state + history.
+	GetLastSpeedTestAttempt() (*LastSpeedTestAttempt, error)
+	GetSpeedTestHistory(hours int) ([]SpeedTestHistoryPoint, error)
 }
 
 // HistoryStore handles time-series history for disks, system, GPU, containers, and speed tests.

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -69,6 +69,9 @@ type HistoryStore interface {
 	GetProcessHistory(hours int) ([]ProcessHistoryPoint, error)
 	SaveSpeedTest(snapshotID string, result *internal.SpeedTestResult) error
 	GetSpeedTestHistory(hours int) ([]SpeedTestHistoryPoint, error)
+	// Issue #210 — last attempt state (single-row table).
+	SaveSpeedTestAttempt(att LastSpeedTestAttempt) error
+	GetLastSpeedTestAttempt() (*LastSpeedTestAttempt, error)
 }
 
 // ConfigStore handles key/value configuration persistence.


### PR DESCRIPTION
Closes #210

## All 6 scope items complete

| # | Scope item | Commit |
|---|---|---|
| 1 | `LastSpeedTestAttempt` single-row table + Store methods (DB + FakeStore) | `d573039` |
| 2 | Scheduler writes attempt state (disabled/pending/success/failed, idempotent) | `86b2049` |
| 3 | `runSpeedCheck` reads from history (7 status branches, blank-threshold heartbeat, 30d stale guard) | `731fe9e` |
| 4 | Fresh-install seed of default "Internet Speed" service check (blank thresholds) | `29ddc91` |
| 5 | Default global cadence changed from 4h to 24h at 03:00 | `29ddc91` |
| 6 | Widget "Running initial speed test\u2026" state for first-boot + LastAttempt mirrored onto s.latest.SpeedTest | `5aee308` |

## Design summary (option B)

The service check stops running its own Ookla test. Instead it reads `LastSpeedTestAttempt` (this PR's new state) + the latest `speedtest_history` row (the existing global loop's output) and applies contracted thresholds. Zero extra bandwidth, one Ookla loop globally, many "readers" consuming it. Failures are recorded concretely (the scheduler marks each attempt as success/failed/pending/disabled) rather than inferred from stale timestamps \u2014 a dead-ISP moment shows DOWN within one scan cycle, not 48 hours later.

## Behavioral matrix

| Attempt status | Service check reports | Widget renders |
|---|---|---|
| `success` + fresh history + thresholds set | up/degraded/down based on margin | Download / Upload / Latency chart (happy path) |
| `success` + fresh history + blank thresholds | **up** (heartbeat) | Download / Upload / Latency chart |
| `success` + zero-throughput history row | down ("corrupt row" guard) | (widget unchanged \u2014 happy path still renders Latest) |
| `pending` + no Latest yet | up (heartbeat; "in progress") | **"Running initial speed test\u2026"** (new) |
| `failed` | down with the recorded Ookla error | (blank tile; service check surfaces the error) |
| `disabled` (#180) | down ("speed test disabled in settings") | (blank tile) |
| missing or >30d stale | down ("stale state" safety net) | (blank tile) |

## Release note

**Contracted-speed alerts start firing for the first time.** Any user who has ever set `ContractedDownMbps` / `ContractedUpMbps` on a service check has had zero signal from those thresholds because of the scheduler-wiring bug this PR fixes. Review your Notification rules if you have speed-check alerts configured \u2014 they'll start working on the next speed-test run after this ships.

**Default service check on fresh install**: new installs ship with one "Internet Speed" check (blank thresholds, heartbeat mode). Existing users are untouched; the seed only applies when no settings have been persisted.

**Default cadence changed from 4h to 24h at 03:00**. Fresh installs only \u2014 existing user settings preserved. Previous default produced ~10 GB/month of Ookla bandwidth; new default runs once a day during a low-usage window. Users who want the old cadence or a different one can tune in Settings \u2192 Speed Test. Combines cleanly with #180's "Disabled" option for metered connections.

**Widget shows "Running initial speed test\u2026"** instead of empty tile during the first-boot gap (after first scan, before first Ookla completion).

## Test coverage

17 new tests added across 5 test files:
- Storage: fake + real DB round-trip for LastSpeedTestAttempt
- Scheduler (attempt state): success / failed / pending-before-run / disabled-idempotent
- Scheduler (mirror on s.latest): 4 branches + nil-latest guard
- Service check (option B): 7 status branches + blank-thresholds + stale-state
- Settings defaults: 24h@3am + shipped seed + persisted-overrides-seed invariants (fresh vs existing user)
- Dashboard JS: pending branch present + happy-path regression guard

`go test ./...` green across all packages; `go vet ./...` clean; `go build ./...` clean.

## Known merge order with PR #213

PR #213 (#180 "Disabled" option) independently introduces `SpeedTestIntervalDisabled = -1` and a scheduler runner-injection hook (`SetSpeedTestRunner`). This PR introduces the same const + a similarly-shaped hook (`SetSpeedTestRunnerFn`). Merge conflict will be trivial \u2014 delete whichever is the second-lander's duplicate and standardize on the first-lander's naming. **Recommend merging #213 first**, then rebasing this branch.

## Not in scope (tracked separately)

- `handleTestServiceCheck` stays on direct Ookla call (per #170, PR #211). Test button meaning is preserved: "Test" = "test now".
- Fleet-instance targeting reads local `speedtest_history` only. Code comment flags this; follow-up tracked in #215.
- #170's zero-throughput guard (PR #211 \u2014 complementary fix at the collector + service-check layers).
- `execCmdTimeout` "timeout in name only" \u2014 pre-existing concern, out of scope.