### PR TITLE
docs(readme): link Agentic Setup section to blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,7 +739,7 @@ Click **Export Report** on the dashboard to generate a print-ready diagnostic re
 
 NAS Doctor is also an experiment in how far agentic coding can carry a production-shaped project. The whole thing is written through [opencode](https://opencode.ai), mostly by a mix of Claude Opus 4.7 / 4.6 and GPT Codex 5.3, directed by hand.
 
-In the same spirit, the issue tracker itself is partly automated — an opencode agent triages open issues, posts replies, and drafts PRs. The orchestration uses dedicated agents and sub-agents inspired by [Matt Pocock's](https://www.mattpocock.com/) workflow: a top-level orchestrator that breaks features into independently-shippable pieces and dispatches worker agents to execute them on isolated branches.
+In the same spirit, the issue tracker itself is partly automated — an opencode agent triages open issues, posts replies, and drafts PRs. The orchestration uses dedicated agents and sub-agents inspired by [Matt Pocock's](https://www.mattpocock.com/) workflow: a top-level orchestrator that breaks features into independently-shippable pieces and dispatches worker agents to execute them on isolated branches. I wrote up how the setup works in [Cloning Matt Pocock with opencode](https://mdias.info/posts/cloning-matt-pocock-opencode/).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a pointer from the README's existing Agentic Setup section to the [Cloning Matt Pocock with opencode](https://mdias.info/posts/cloning-matt-pocock-opencode/) blog post which documents how this workflow runs day-to-day.

One-line addition to an existing sentence. Docs-only change \u2014 no code, no workflows, no metadata touched.

## History

An earlier attempt at this PR (force-pushed away) had a pre-commit state-sync mistake that left conflict markers in the diff. Corrected \u2014 the current HEAD is a clean single-line addition.