### PR TITLE
fix(unraid-template): drop invalid 'Monitoring' token from Category (#214)

### DIFF
--- a/unraid-template.xml
+++ b/unraid-template.xml
@@ -32,7 +32,7 @@ Features:
 - Data lifecycle management (retention policies, DB size cap)
 - Dashboard section visibility toggles and multi-column layout
   </Overview>
-  <Category>Tools: Monitoring Status:Stable</Category>
+  <Category>Tools: Status:Stable</Category>
   <WebUI>http://[IP]:[PORT:8060]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/mcdays94/nas-doctor/main/unraid-template.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/mcdays94/nas-doctor/main/icons/icon3.png</Icon>


### PR DESCRIPTION
Closes #214.

Mirror of mcdays94/docker-templates#1 in the main repo's `unraid-template.xml`. Without this commit, the CA auto-refresh (which pulls from this file via `TemplateURL`) would keep serving the invalid category on any future template update.

### Scope

One line, no other template fields.

### Reported

@geransmith via Unraid CA listing: `Unknown category Monitoring:`.