### PR TITLE
docs(#215): clarify that check.Instance is currently decorative UI metadata

### DIFF
--- a/internal/models.go
+++ b/internal/models.go
@@ -202,11 +202,28 @@ const (
 )
 
 type ServiceCheckConfig struct {
-	Name             string            `json:"name"`
-	Type             string            `json:"type"`
-	Target           string            `json:"target"`
-	Enabled          bool              `json:"enabled"`
-	Instance         string            `json:"instance,omitempty"`     // fleet server ID; empty = local
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Target  string `json:"target"`
+	Enabled bool   `json:"enabled"`
+	// Instance is the fleet server ID this check is "associated with"
+	// (empty = local instance). Currently decorative UI metadata ONLY —
+	// the scheduler's RunDueChecks / RunCheck dispatch does not filter
+	// on Instance, so every check runs on whichever NAS Doctor instance
+	// owns the configuration (the one whose scheduler picked it up).
+	//
+	// Fleet aggregation works by each peer independently running its
+	// own checks and the hub reading pre-computed results from peer
+	// snapshots (see internal/fleet/fleet.go) — NOT by remote
+	// dispatch. A check marked Instance=X running on the local
+	// instance therefore still reads local state (speedtest_history,
+	// DNS resolvers, TCP routes, etc.) rather than exercising X.
+	//
+	// This is a known limitation tracked in #215. Proper fleet-aware
+	// dispatch would require a real fleet-target API call on the
+	// owning scheduler and is worth doing alongside #205 (Uptime
+	// Kuma federation) — both need the same primitive.
+	Instance         string            `json:"instance,omitempty"`
 	IntervalSec      int               `json:"interval_sec,omitempty"` // Per-check interval in seconds (default 300 = 5min)
 	TimeoutSec       int               `json:"timeout_sec,omitempty"`
 	Port             int               `json:"port,omitempty"`

--- a/internal/scheduler/checks.go
+++ b/internal/scheduler/checks.go
@@ -546,9 +546,14 @@ func extractPacketLossPercent(out string) float64 {
 // This is the shape of the default shipped "Internet Speed" check —
 // a heartbeat that fires only when the speed test itself fails.
 //
-// TODO(#215): fleet-instance targeting reads local speedtest_history only.
-// A fleet-targeted speed check should read the remote peer's history via
-// the fleet API. Tracked separately.
+// Fleet-instance targeting (check.Instance) is not honoured by any
+// service-check type — the field is currently decorative UI metadata
+// only. The "read local history" behaviour here is therefore
+// consistent with every other check type, not unique to speed. See
+// ServiceCheckConfig.Instance docs in internal/models.go and #215
+// for the broader story (proper fleet-aware dispatch is worth doing
+// alongside #205 — Uptime Kuma federation — which needs the same
+// primitives).
 //
 // Test-button carve-out: the /api/v1/service-checks/test endpoint
 // (handleTestServiceCheck) builds a fresh ServiceChecker and injects


### PR DESCRIPTION
Refs #215 (doesn't close it — the proper fix is the fleet-aware dispatch that #215 tracks; this PR just makes the current state honest).

## Summary

Investigation for #215 during the v0.9.7 cycle revealed the fleet-targeting situation is **broader** than the `TODO(#215)` comment in `runSpeedCheck` described. `Instance` is a field on every check type (http / tcp / dns / smb / nfs / ping / speed), but no scheduler dispatch code reads it. Fleet aggregation works by peers running their own local checks and the hub reading pre-computed results via snapshots \u2014 no remote-dispatch path exists.

## What this PR does

Two doc updates, zero behavior change:

1. **`internal/models.go`** \u2014 fleshed out the `ServiceCheckConfig.Instance` field doc comment from "fleet server ID; empty = local" into the full story (it's decorative UI metadata today; fleet aggregation works via result-reading not remote dispatch; proper fix belongs alongside #205 Uptime Kuma federation).
2. **`internal/scheduler/checks.go`** \u2014 replaced the narrower `TODO(#215)` in `runSpeedCheck` with a shorter pointer comment that references the `models.go` docs + #215 rather than restating.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` green across all packages

No behavior change \u2014 pure documentation.