### PR TITLE
fix(smart): USB bridges count as 'unsupported' not 'failed' in cycle summary (#206)

### DIFF
--- a/internal/collector/smart.go
+++ b/internal/collector/smart.go
@@ -32,6 +32,15 @@ type SMARTConfig struct {
 // that should create a history row or surface in logs.
 var errDriveInStandby = errors.New("drive in standby; skipped SMART read")
 
+// errDriveUnsupported is returned by readSMARTDevice when smartctl
+// reported the target device cannot be read over SMART — classic
+// example is an Unraid boot flash at /dev/sda presenting as
+// "Unknown USB bridge", but also applies to other SMART-incapable
+// devices. The collector distinguishes this from a real failure so
+// the cycle summary log doesn't categorise benign non-SMART devices
+// as failed drives (issue #206).
+var errDriveUnsupported = errors.New("device does not support SMART")
+
 func collectSMART(cfg SMARTConfig, logger *slog.Logger) ([]internal.SMARTInfo, error) {
 	startedAt := time.Now()
 	devices := discoverDrives()
@@ -64,7 +73,7 @@ func collectSMART(cfg SMARTConfig, logger *slog.Logger) ([]internal.SMARTInfo, e
 
 	var results []internal.SMARTInfo
 	var lastErr error
-	var skipped, standby int
+	var skipped, standby, unsupported int
 	for _, dev := range devices {
 		info, err := readSMARTDevice(dev, cfg.WakeDrives)
 		if err != nil {
@@ -79,6 +88,25 @@ func collectSMART(cfg SMARTConfig, logger *slog.Logger) ([]internal.SMARTInfo, e
 				standby++
 				continue
 			}
+			if errors.Is(err, errDriveUnsupported) {
+				// Classic cause: /dev/sda on Unraid is the boot flash
+				// and presents as "Unknown USB bridge". Not a failure
+				// — just a device that cannot expose SMART. Categorised
+				// separately from `failed` so the summary log doesn't
+				// alarm operators about a drive that isn't a drive
+				// (issue #206). Per-drive INFO log mirrors the standby
+				// pattern from #202 so operators can see which device
+				// was skipped and why without cross-referencing
+				// discoverDrives() output.
+				if logger != nil {
+					logger.Info("skipped SMART read: unsupported device",
+						"device", dev,
+						"reason", err.Error(),
+					)
+				}
+				unsupported++
+				continue
+			}
 			lastErr = err
 			skipped++
 			continue
@@ -91,28 +119,31 @@ func collectSMART(cfg SMARTConfig, logger *slog.Logger) ([]internal.SMARTInfo, e
 		results = append(results, info)
 	}
 
-	// Per-cycle INFO summary (issue #203). `standby` and `skipped` are
-	// disjoint counters (both branches use `continue` before incrementing
-	// either one), so total = active + standby + failed holds by
-	// construction, where active=len(results) and failed=skipped.
-	// Emit this before any error-return paths below so the summary fires
-	// even when the cycle ultimately fails.
+	// Per-cycle INFO summary (issue #203 + #206). `standby`, `unsupported`,
+	// and `skipped` are disjoint counters (each branch uses `continue`
+	// before incrementing exactly one), so the identity
+	//   total = active + standby + unsupported + failed
+	// holds by construction, where active=len(results) and
+	// failed=skipped. Emit this before any error-return paths below so
+	// the summary fires even when the cycle ultimately fails.
 	if logger != nil {
 		logger.Info("SMART collection complete",
 			"total", len(devices),
 			"active", len(results),
 			"standby", standby,
+			"unsupported", unsupported,
 			"failed", skipped,
 			"duration", time.Since(startedAt).Round(time.Millisecond).String(),
 		)
 	}
 
-	// If every discovered drive is in standby and nothing else failed,
-	// that's a legitimate outcome (all disks asleep); return no error and
-	// an empty slice so the caller can persist an empty SMART snapshot
-	// rather than treating it as a collection failure.
+	// If every discovered drive is in standby / unsupported and nothing
+	// else failed, that's a legitimate outcome (all disks asleep or the
+	// only thing discovered was an Unraid boot flash); return no error
+	// and an empty slice so the caller can persist an empty SMART
+	// snapshot rather than treating it as a collection failure.
 	if len(results) == 0 && lastErr != nil {
-		return nil, fmt.Errorf("all %d drives failed SMART read (%d skipped, %d standby), last error: %w", len(devices), skipped, standby, lastErr)
+		return nil, fmt.Errorf("all %d drives failed SMART read (%d failed, %d standby, %d unsupported), last error: %w", len(devices), skipped, standby, unsupported, lastErr)
 	}
 	return results, nil
 }
@@ -206,7 +237,7 @@ func readSMARTDevice(device string, wakeDrives bool) (internal.SMARTInfo, error)
 
 	// Check for USB bridge / unsupported device
 	if strings.Contains(out, "Unknown USB bridge") || strings.Contains(out, "Please specify device type") {
-		return info, fmt.Errorf("unsupported device (USB bridge): %s", device)
+		return info, fmt.Errorf("%w: %s (USB bridge / requires -d option)", errDriveUnsupported, device)
 	}
 
 	// Fallback to text parsing (also ignore exit code)
@@ -218,7 +249,7 @@ func readSMARTDevice(device string, wakeDrives bool) (internal.SMARTInfo, error)
 		return info, fmt.Errorf("smartctl returned no output for %s", device)
 	}
 	if strings.Contains(out, "Unknown USB bridge") || strings.Contains(out, "Please specify device type") {
-		return info, fmt.Errorf("unsupported device (USB bridge): %s", device)
+		return info, fmt.Errorf("%w: %s (USB bridge / requires -d option)", errDriveUnsupported, device)
 	}
 	return parseSMARTText(device, out), nil
 }

--- a/internal/collector/smart_summary_test.go
+++ b/internal/collector/smart_summary_test.go
@@ -10,10 +10,12 @@ import (
 )
 
 // TestCollectSMART_EmitsSummaryLogFormat is a grep-based cross-reference
-// that pins the summary log line's field names. The v0.9.5 UAT feedback
-// (issue #203) asked for a single per-cycle line with total/active/standby/
-// failed/duration, and operators' log pipelines depend on that format not
-// drifting. If someone renames a field, this test fails loudly.
+// that pins the summary log line's field names. v0.9.5 (#203) introduced
+// total/active/standby/failed/duration; v0.9.7 (#206) added `unsupported`
+// to separate SMART-incapable devices (USB bridges, boot flashes) from
+// real collection failures. Operators' log pipelines depend on this
+// format not drifting — if someone renames or drops a field, this test
+// fails loudly.
 func TestCollectSMART_EmitsSummaryLogFormat(t *testing.T) {
 	data, err := os.ReadFile("smart.go")
 	if err != nil {
@@ -24,7 +26,7 @@ func TestCollectSMART_EmitsSummaryLogFormat(t *testing.T) {
 	if !strings.Contains(src, `"SMART collection complete"`) {
 		t.Errorf("smart.go missing summary log message %q — if you renamed it, update the log pipeline docs too", "SMART collection complete")
 	}
-	for _, field := range []string{`"total"`, `"active"`, `"standby"`, `"failed"`, `"duration"`} {
+	for _, field := range []string{`"total"`, `"active"`, `"standby"`, `"unsupported"`, `"failed"`, `"duration"`} {
 		if !strings.Contains(src, field) {
 			t.Errorf("smart.go summary log missing required field %s", field)
 		}

--- a/internal/collector/smart_unsupported_test.go
+++ b/internal/collector/smart_unsupported_test.go
@@ -1,0 +1,173 @@
+package collector
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// Issue #206 — the v0.9.5 summary log counted USB bridges and other
+// unsupported devices as "failed", misleading users into thinking a
+// drive is failing when actually the device is just not SMART-capable
+// (classic example: an Unraid boot flash at /dev/sda presenting as
+// Unknown USB bridge). This file pins the new semantics:
+//
+//   - Unsupported devices increment a new `unsupported` counter, not
+//     `failed`. Real failures (smartctl returned no output, or some
+//     other non-unsupported error) continue to increment `failed`.
+//   - Each unsupported device emits a per-drive INFO log carrying the
+//     device name and the reason so operators can see which device
+//     was skipped without cross-referencing discovery output.
+
+// helper: grab the single "SMART collection complete" JSON summary log
+// line from the captured buffer. Used by several tests below.
+func scanSMARTSummary(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if msg, _ := rec["msg"].(string); msg == "SMART collection complete" {
+			return rec
+		}
+	}
+	t.Fatalf("no 'SMART collection complete' log line; raw:\n%s", raw)
+	return nil
+}
+
+// helper: asserts a specific numeric field exists on the summary and
+// equals want. JSON numbers decode as float64.
+func assertCounter(t *testing.T, summary map[string]any, field string, want int) {
+	t.Helper()
+	v, ok := summary[field]
+	if !ok {
+		t.Fatalf("summary missing %q field; got: %v", field, summary)
+	}
+	f, ok := v.(float64)
+	if !ok {
+		t.Fatalf("summary %q is not a number: %v (%T)", field, v, v)
+	}
+	if int(f) != want {
+		t.Errorf("summary %q = %d, want %d (full summary: %v)", field, int(f), want, summary)
+	}
+}
+
+// TestCollectSMART_USBBridge_CountedAsUnsupportedNotFailed is the #206
+// regression guard: a USB-bridge device must be categorised as
+// `unsupported` in the summary log, not `failed`. Shape of the fake
+// environment: three drives, one of them reporting "Unknown USB
+// bridge" across every fallback — exactly the shape of an Unraid
+// boot flash at /dev/sda.
+func TestCollectSMART_USBBridge_CountedAsUnsupportedNotFailed(t *testing.T) {
+	if len(discoverDrives()) > 0 {
+		t.Skip("host has real drives discoverable via /dev/sd*; cannot run deterministic fake-execCmd test")
+	}
+
+	fakeActiveJSON := `{"json_format_version":[1,0,0],"model_name":"FakeDrive 1TB","serial_number":"SN-ACTIVE","user_capacity":{"bytes":1000000000000},"temperature":{"current":30},"power_on_time":{"hours":100}}`
+	usbBridgeOut := `smartctl 7.4 2023-08-01 r5530 [x86_64-linux-6.12.24-Unraid] (local build)
+Copyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org
+
+/dev/fake-usb: Unknown USB bridge [0x0951:0x1666 (0x001)]
+Please specify device type with the -d option.
+
+Use smartctl -h to get a usage summary
+`
+
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		if len(args) == 1 && args[0] == "--scan" {
+			return "/dev/fake-usb -d sat # /dev/fake-usb, SAT\n" +
+				"/dev/fake-active -d sat # /dev/fake-active, SAT\n", nil
+		}
+		argv := strings.Join(args, " ")
+		switch {
+		case strings.Contains(argv, "/dev/fake-usb"):
+			// Every fallback returns the same USB bridge error — mirroring
+			// the smartctl behaviour on /dev/sda on the reporter's Tower.
+			return usbBridgeOut, nil
+		case strings.Contains(argv, "/dev/fake-active"):
+			return fakeActiveJSON, nil
+		}
+		return "", nil
+	})()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	_, _ = collectSMART(SMARTConfig{WakeDrives: false}, logger)
+
+	summary := scanSMARTSummary(t, buf.String())
+
+	assertCounter(t, summary, "total", 2)
+	assertCounter(t, summary, "active", 1)
+	assertCounter(t, summary, "standby", 0)
+	assertCounter(t, summary, "unsupported", 1) // USB bridge
+	assertCounter(t, summary, "failed", 0)      // NOT lumped into failed
+
+	// Conservation identity: total must equal active + standby +
+	// unsupported + failed. Catches future regressions that might add
+	// a fifth bucket without updating the summary math.
+	total := 2
+	sum := 1 + 0 + 1 + 0
+	if total != sum {
+		t.Errorf("counter math broken: active(1) + standby(0) + unsupported(1) + failed(0) = %d, total = %d", sum, total)
+	}
+}
+
+// TestCollectSMART_UnsupportedDrive_EmitsPerDriveLog pins the operator-
+// facing INFO log emitted for each unsupported device. Mirrors the
+// per-drive standby log introduced in #202 so operators can see
+// which device was skipped without cross-referencing discovery
+// output.
+func TestCollectSMART_UnsupportedDrive_EmitsPerDriveLog(t *testing.T) {
+	if len(discoverDrives()) > 0 {
+		t.Skip("host has real drives discoverable via /dev/sd*")
+	}
+
+	usbBridgeOut := "/dev/fake-usb: Unknown USB bridge [0x0951:0x1666]\nPlease specify device type with the -d option.\n"
+
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		if len(args) == 1 && args[0] == "--scan" {
+			return "/dev/fake-usb -d sat # /dev/fake-usb, SAT\n", nil
+		}
+		return usbBridgeOut, nil
+	})()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	_, _ = collectSMART(SMARTConfig{WakeDrives: false}, logger)
+
+	// Find the per-drive INFO log. Carries the exact device name so
+	// a user with multiple unsupported devices can tell them apart.
+	var perDrive map[string]any
+	for _, line := range strings.Split(buf.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if msg, _ := rec["msg"].(string); strings.Contains(strings.ToLower(msg), "unsupported") && strings.Contains(strings.ToLower(msg), "smart") {
+			perDrive = rec
+			break
+		}
+	}
+	if perDrive == nil {
+		t.Fatalf("no per-drive unsupported-device INFO log; raw:\n%s", buf.String())
+	}
+	if dev, _ := perDrive["device"].(string); dev != "/dev/fake-usb" {
+		t.Errorf("per-drive log device = %q, want /dev/fake-usb", dev)
+	}
+	// Reason field should exist and be non-empty so operators can
+	// actually see why the device was skipped.
+	if reason, _ := perDrive["reason"].(string); reason == "" {
+		t.Errorf("per-drive log reason is empty; expected a human-readable explanation")
+	}
+}


### PR DESCRIPTION
Closes #206.

Targets `release/v0.9.7-stage`, not main. No release action until you explicitly tag v0.9.7.

## TL;DR

Your Unraid Tower diagnostic showed all 12 data drives PASSED. The v0.9.5 summary log was reporting `failed=1` because `/dev/sda` (the Unraid boot flash, an `Unknown USB bridge`) was lumped in with real I/O errors under a single `failed` counter. Fix: distinguish unsupported from failed — new `unsupported` counter + per-drive INFO log so operators can see which device was skipped and why.

## Before

```
SMART collection complete total=13 active=12 standby=0 failed=1 duration=8s
```
\u2191 `failed=1` reads as 'a drive is failing'; it's actually the boot flash.

## After

```
skipped SMART read: unsupported device device=/dev/sda reason="device does not support SMART: /dev/sda (USB bridge / requires -d option)"
SMART collection complete total=13 active=12 standby=0 unsupported=1 failed=0 duration=8s
```
\u2191 `unsupported=1` is honest; `failed=0` matches your smartctl verdict on the data drives.

## Changes

| File | Change |
|---|---|
| `internal/collector/smart.go` | New `errDriveUnsupported` sentinel. `readSMARTDevice` returns it for USB-bridge detection points. `collectSMART` adds an `unsupported` branch + per-drive INFO log. Summary log adds `unsupported` field. |
| `internal/collector/smart_unsupported_test.go` | New \u2014 2 tests: the summary-counter invariant + the per-drive INFO log pinned. |
| `internal/collector/smart_summary_test.go` | Updated the cross-reference test to require the new `unsupported` field. |

## Non-scope

- `/dev/sdg` and `/dev/sdk` on your Tower have marginal `Airflow_Temperature_Cel` attributes (`WHEN_FAILED=In_the_past`) but both report SMART overall-health PASSED. Not implicated in the miscount; not touched here.
- No analyzer / Finding changes. The existing 'SMART data unavailable' Warning for USB bridges still fires correctly.

## Breaking: log pipelines

The summary log line carries a new `unsupported` field. External scrapers that parse the exact field set will need updating. Documented in the commit message and AGENTS.md changelog.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` green across all packages (5 modules, ~2min)
- New tests: `TestCollectSMART_USBBridge_CountedAsUnsupportedNotFailed`, `TestCollectSMART_UnsupportedDrive_EmitsPerDriveLog`
- Updated regression guard: `TestCollectSMART_EmitsSummaryLogFormat`