### PR TITLE
feat: drive maintenance log with manual notes + auto-detected replacements (#130)

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -436,6 +436,25 @@ func (s *Server) handleReport(w http.ResponseWriter, r *http.Request) {
 		if diskH, err := s.store.GetAllDiskSparklines(60); err == nil {
 			sparks.Disks = diskH
 		}
+		// Pre-load per-drive maintenance events keyed by slot_key
+		// (issue #130). Resolves the same way the API and UI do:
+		// ArraySlot on Unraid, Serial otherwise. One query per drive
+		// is acceptable here — reports are generated on-demand and
+		// bounded by the drive count (typically < 30).
+		if len(snap.SMART) > 0 {
+			sparks.DriveEventsBySlot = make(map[string][]storage.DriveEvent, len(snap.SMART))
+			seen := make(map[string]bool, len(snap.SMART))
+			for _, sm := range snap.SMART {
+				slotKey := resolveReportSlotKey(sm)
+				if slotKey == "" || seen[slotKey] {
+					continue
+				}
+				seen[slotKey] = true
+				if events, err := s.store.ListDriveEvents(slotKey); err == nil && len(events) > 0 {
+					sparks.DriveEventsBySlot[slotKey] = events
+				}
+			}
+		}
 	}
 	html := GenerateReport(snap, sparks)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -358,6 +358,9 @@ func (s *Server) RegisterExtendedRoutes(r chi.Router) {
 	r.Get("/api/v1/capacity-forecast", s.handleCapacityForecast)
 	r.Get("/api/v1/disk-usage-history", s.handleDiskUsageHistory)
 
+	// Drive maintenance log endpoints (issue #130)
+	s.registerDriveEventRoutes(r)
+
 	// Pages
 	r.Get("/settings", s.handleSettingsPage)
 	r.Get("/disk/{serial}", s.handleDiskPage)

--- a/internal/api/disk_detail_maintenance_log_test.go
+++ b/internal/api/disk_detail_maintenance_log_test.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDiskDetailTemplate_HasMaintenanceLogSection is a cross-reference
+// check (per AGENTS.md §4b): the disk_detail.html template must contain
+// the Maintenance Log section markup that the Phase 3 API endpoints
+// feed into. It also validates the JavaScript glue that fetches from
+// /api/v1/drives/{slot_key}/events and wires the Add/Edit/Delete flow.
+//
+// If someone deletes or renames any of these anchors, the UI will
+// silently render blank even though the API responds correctly — this
+// test catches that class of regression.
+func TestDiskDetailTemplate_HasMaintenanceLogSection(t *testing.T) {
+	path := filepath.Join("templates", "disk_detail.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read disk_detail.html: %v", err)
+	}
+	src := string(data)
+
+	// IDs live inside JS string literals with escaped quotes, so we
+	// search by the unique identifier value (stripped of quotes).
+	// If any of these anchors drifts the UI silently renders blank.
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		{"section heading", "Maintenance Log"},
+		{"list container id", "maintenanceLogList"},
+		{"add-entry form id", "maintenanceLogForm"},
+		{"content textarea id", "maintenanceLogContent"},
+		{"event_time input id", "maintenanceLogTime"},
+		{"save button id", "maintenanceLogSave"},
+		{"fetch endpoint", "/api/v1/drives/"},
+		{"events path fragment", "/events"},
+		{"render function", "renderMaintenanceLog"},
+		{"create handler", "createMaintenanceEntry"},
+		{"edit action", "editMaintenanceEntry"},
+		{"delete action", "deleteMaintenanceEntry"},
+		{"system badge label", "System"},
+	}
+	for _, c := range checks {
+		if !strings.Contains(src, c.substr) {
+			t.Errorf("disk_detail.html missing %s (%q)", c.name, c.substr)
+		}
+	}
+
+	// The UI must resolve the slot_key from the current disk payload:
+	// prefer array_slot when populated, fall back to serial. Guard
+	// against a regression where someone hard-codes serial as slot_key
+	// and silently breaks Unraid where slot_key is the ArraySlot.
+	if !strings.Contains(src, "disk.array_slot") {
+		t.Errorf("template does not reference disk.array_slot when computing slot_key")
+	}
+	if !strings.Contains(src, "maintenance-log-entry") {
+		t.Errorf("template missing per-entry CSS class .maintenance-log-entry — row styling hook must exist")
+	}
+}
+
+// TestDiskDetailTemplate_MaintenanceLog_SystemBadgeOnly_ForAuto ensures
+// the UI distinguishes auto events (no edit/delete controls) from manual
+// ones. The only reliable signal in the template is that the is_auto
+// branch renders a "System" badge and does NOT render the edit/delete
+// buttons, keyed off ev.is_auto.
+func TestDiskDetailTemplate_MaintenanceLog_SystemBadgeOnly_ForAuto(t *testing.T) {
+	path := filepath.Join("templates", "disk_detail.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	src := string(data)
+
+	// The template must branch on is_auto when deciding whether to
+	// render edit/delete buttons. Look for the idiomatic check.
+	if !strings.Contains(src, "ev.is_auto") && !strings.Contains(src, "entry.is_auto") {
+		t.Errorf("template does not branch on is_auto — auto events may render edit/delete buttons")
+	}
+}

--- a/internal/api/drive_events.go
+++ b/internal/api/drive_events.go
@@ -1,0 +1,219 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// registerDriveEventRoutes wires the four CRUD endpoints for the
+// per-drive maintenance log (issue #130) onto the given router. The
+// {slot_key} param is URL-path-encoded by the client; chi handles the
+// decode automatically via URLParam.
+func (s *Server) registerDriveEventRoutes(r chi.Router) {
+	r.Get("/api/v1/drives/{slot_key}/events", s.handleListDriveEvents)
+	r.Post("/api/v1/drives/{slot_key}/events", s.handleCreateDriveEvent)
+	r.Put("/api/v1/drives/{slot_key}/events/{id}", s.handleUpdateDriveEvent)
+	r.Delete("/api/v1/drives/{slot_key}/events/{id}", s.handleDeleteDriveEvent)
+}
+
+// handleListDriveEvents returns all events for the given slot_key,
+// newest first.
+func (s *Server) handleListDriveEvents(w http.ResponseWriter, r *http.Request) {
+	slotKey := chi.URLParam(r, "slot_key")
+	if strings.TrimSpace(slotKey) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "slot_key required"})
+		return
+	}
+	events, err := s.store.ListDriveEvents(slotKey)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if events == nil {
+		events = []storage.DriveEvent{}
+	}
+	writeJSON(w, http.StatusOK, events)
+}
+
+// createDriveEventReq is the POST request body.
+//
+// event_time is optional; if omitted the server uses time.Now().UTC().
+// content is required and must be non-empty.
+type createDriveEventReq struct {
+	EventTime string `json:"event_time,omitempty"`
+	Content   string `json:"content"`
+}
+
+// handleCreateDriveEvent inserts a new manual (is_auto=0) event.
+// The content is the freeform text the user typed in the Add Entry form.
+func (s *Server) handleCreateDriveEvent(w http.ResponseWriter, r *http.Request) {
+	slotKey := chi.URLParam(r, "slot_key")
+	if strings.TrimSpace(slotKey) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "slot_key required"})
+		return
+	}
+
+	var req createDriveEventReq
+	raw, err := io.ReadAll(io.LimitReader(r.Body, 64*1024))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to read body"})
+		return
+	}
+	defer r.Body.Close()
+	if err := json.Unmarshal(raw, &req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		return
+	}
+	if strings.TrimSpace(req.Content) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "content is required"})
+		return
+	}
+
+	evTime := time.Now().UTC()
+	if strings.TrimSpace(req.EventTime) != "" {
+		parsed, err := time.Parse(time.RFC3339, req.EventTime)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid event_time; expected RFC3339"})
+			return
+		}
+		evTime = parsed.UTC()
+	}
+
+	platform := s.currentPlatform()
+	id, err := s.store.SaveDriveEvent(storage.DriveEvent{
+		SlotKey:   slotKey,
+		Platform:  platform,
+		EventType: "note",
+		EventTime: evTime,
+		Content:   req.Content,
+		IsAuto:    false,
+	})
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	ev, err := s.store.GetDriveEvent(id)
+	if err != nil || ev == nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to re-read created event"})
+		return
+	}
+	writeJSON(w, http.StatusCreated, ev)
+}
+
+// updateDriveEventReq is the PUT request body. Both fields are optional
+// but at least one must be set; an empty body is a no-op 200.
+type updateDriveEventReq struct {
+	EventTime *string `json:"event_time,omitempty"`
+	Content   *string `json:"content,omitempty"`
+}
+
+// handleUpdateDriveEvent modifies a manual event. Auto events (is_auto=1)
+// return 403.
+func (s *Server) handleUpdateDriveEvent(w http.ResponseWriter, r *http.Request) {
+	slotKey := chi.URLParam(r, "slot_key")
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil || id <= 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+		return
+	}
+	if strings.TrimSpace(slotKey) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "slot_key required"})
+		return
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(r.Body, 64*1024))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to read body"})
+		return
+	}
+	defer r.Body.Close()
+
+	var req updateDriveEventReq
+	if err := json.Unmarshal(raw, &req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		return
+	}
+
+	var evTime *time.Time
+	if req.EventTime != nil && strings.TrimSpace(*req.EventTime) != "" {
+		parsed, err := time.Parse(time.RFC3339, *req.EventTime)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid event_time; expected RFC3339"})
+			return
+		}
+		u := parsed.UTC()
+		evTime = &u
+	}
+
+	if err := s.store.UpdateDriveEvent(slotKey, id, evTime, req.Content); err != nil {
+		switch {
+		case storage.IsDriveEventImmutableErr(err):
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		case storage.IsDriveEventNotFoundErr(err):
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		default:
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		}
+		return
+	}
+	ev, err := s.store.GetDriveEvent(id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if ev == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "event disappeared"})
+		return
+	}
+	writeJSON(w, http.StatusOK, ev)
+}
+
+// handleDeleteDriveEvent removes a manual event. Auto events return 403.
+func (s *Server) handleDeleteDriveEvent(w http.ResponseWriter, r *http.Request) {
+	slotKey := chi.URLParam(r, "slot_key")
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil || id <= 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+		return
+	}
+	if strings.TrimSpace(slotKey) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "slot_key required"})
+		return
+	}
+	if err := s.store.DeleteDriveEvent(slotKey, id); err != nil {
+		switch {
+		case storage.IsDriveEventImmutableErr(err):
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		case storage.IsDriveEventNotFoundErr(err):
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		default:
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		}
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// currentPlatform returns the platform string captured by the latest
+// snapshot, or "" if unknown. Used to stamp drive_events rows at
+// creation time; downstream readers can filter or enrich by platform.
+func (s *Server) currentPlatform() string {
+	if s.scheduler != nil {
+		if snap := s.scheduler.Latest(); snap != nil {
+			return snap.System.Platform
+		}
+	}
+	snap, _ := s.store.GetLatestSnapshot()
+	if snap == nil {
+		return ""
+	}
+	return snap.System.Platform
+}

--- a/internal/api/drive_events_test.go
+++ b/internal/api/drive_events_test.go
@@ -1,0 +1,224 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// driveEventsTestServer wires RegisterExtendedRoutes onto a chi router so
+// {slot_key} and {id} URL params are extracted the same way they are in
+// production. Returns the router + underlying FakeStore so tests can seed
+// or inspect events directly.
+func driveEventsTestServer(t *testing.T) (http.Handler, *storage.FakeStore) {
+	t.Helper()
+	fs := storage.NewFakeStore()
+	srv := newSettingsTestServer()
+	srv.store = fs
+	r := chi.NewRouter()
+	srv.RegisterExtendedRoutes(r)
+	return r, fs
+}
+
+// TestHandleDriveEvents_CRUD exercises the four endpoints end-to-end:
+//
+//	GET    /api/v1/drives/{slot_key}/events           → list
+//	POST   /api/v1/drives/{slot_key}/events           → create (manual note)
+//	PUT    /api/v1/drives/{slot_key}/events/{id}      → update note
+//	DELETE /api/v1/drives/{slot_key}/events/{id}      → delete note
+//
+// Plus the 403 contract for auto events (Update/Delete forbidden).
+func TestHandleDriveEvents_CRUD(t *testing.T) {
+	handler, fs := driveEventsTestServer(t)
+
+	// Pre-seed an auto (replacement) event that should NOT be
+	// mutable via PUT/DELETE.
+	autoID, err := fs.SaveDriveEvent(storage.DriveEvent{
+		SlotKey:   "disk1",
+		Platform:  "unraid",
+		EventType: "replacement",
+		EventTime: time.Now().UTC(),
+		Content:   `{"old_serial":"A","new_serial":"B"}`,
+		IsAuto:    true,
+	})
+	if err != nil {
+		t.Fatalf("seed auto event: %v", err)
+	}
+
+	// --- POST: create manual note ---
+	body := strings.NewReader(`{"content":"SATA cable replaced"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/drives/disk1/events", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var created struct {
+		ID      int64  `json:"id"`
+		SlotKey string `json:"slot_key"`
+		IsAuto  bool   `json:"is_auto"`
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode POST response: %v (body=%s)", err, rec.Body.String())
+	}
+	if created.ID <= 0 {
+		t.Errorf("POST id = %d, want >0", created.ID)
+	}
+	if created.IsAuto {
+		t.Errorf("POST created event is_auto=true, want false")
+	}
+	if created.SlotKey != "disk1" {
+		t.Errorf("POST slot_key = %q, want disk1", created.SlotKey)
+	}
+	if created.Content != "SATA cable replaced" {
+		t.Errorf("POST content = %q, want SATA cable replaced", created.Content)
+	}
+	manualID := created.ID
+
+	// --- POST: reject empty content ---
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/drives/disk1/events", strings.NewReader(`{"content":""}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("POST empty content expected 400, got %d", rec.Code)
+	}
+
+	// --- GET: list returns both events, newest first ---
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/drives/disk1/events", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET list expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var list []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decode GET: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("GET expected 2 events, got %d", len(list))
+	}
+
+	// --- PUT: update manual note ---
+	putBody := strings.NewReader(`{"content":"SATA cable replaced and tested"}`)
+	req = httptest.NewRequest(http.MethodPut, "/api/v1/drives/disk1/events/"+itoaInt64(manualID), putBody)
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT manual expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	ev, err := fs.GetDriveEvent(manualID)
+	if err != nil || ev == nil {
+		t.Fatalf("GetDriveEvent: %v, ev=%v", err, ev)
+	}
+	if ev.Content != "SATA cable replaced and tested" {
+		t.Errorf("after PUT, content = %q", ev.Content)
+	}
+	if ev.UpdatedAt == nil {
+		t.Errorf("after PUT, updated_at is nil")
+	}
+
+	// --- PUT: auto event → 403 ---
+	req = httptest.NewRequest(http.MethodPut, "/api/v1/drives/disk1/events/"+itoaInt64(autoID),
+		strings.NewReader(`{"content":"cannot change"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("PUT auto expected 403, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	// --- DELETE: auto event → 403 ---
+	req = httptest.NewRequest(http.MethodDelete, "/api/v1/drives/disk1/events/"+itoaInt64(autoID), nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("DELETE auto expected 403, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	// --- DELETE: manual event → 204 ---
+	req = httptest.NewRequest(http.MethodDelete, "/api/v1/drives/disk1/events/"+itoaInt64(manualID), nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("DELETE manual expected 204, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	// Confirm gone from store.
+	if ev, _ := fs.GetDriveEvent(manualID); ev != nil {
+		t.Errorf("manual event still present after DELETE")
+	}
+
+	// --- DELETE: nonexistent → 404 ---
+	req = httptest.NewRequest(http.MethodDelete, "/api/v1/drives/disk1/events/99999", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("DELETE missing expected 404, got %d", rec.Code)
+	}
+}
+
+// TestHandleDriveEvents_URLEncodedSlotKey verifies slot keys containing
+// a space (like "Disk 1") round-trip correctly through URL path encoding.
+func TestHandleDriveEvents_URLEncodedSlotKey(t *testing.T) {
+	handler, fs := driveEventsTestServer(t)
+	// Slot key "Disk 1" → "/api/v1/drives/Disk%201/events"
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/drives/Disk%201/events",
+		strings.NewReader(`{"content":"note with spaces"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	events, err := fs.ListDriveEvents("Disk 1")
+	if err != nil {
+		t.Fatalf("ListDriveEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event for Disk 1, got %d", len(events))
+	}
+	if events[0].SlotKey != "Disk 1" {
+		t.Errorf("slot_key stored as %q, want %q", events[0].SlotKey, "Disk 1")
+	}
+}
+
+// TestHandleDriveEvents_POST_ValidatesEventTime ensures a bad event_time
+// timestamp is rejected with 400, and a valid RFC3339 value is accepted.
+func TestHandleDriveEvents_POST_ValidatesEventTime(t *testing.T) {
+	handler, _ := driveEventsTestServer(t)
+
+	// Invalid event_time.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/drives/disk1/events",
+		strings.NewReader(`{"content":"x","event_time":"not-a-date"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for bad event_time, got %d", rec.Code)
+	}
+
+	// Valid event_time.
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/drives/disk1/events",
+		strings.NewReader(`{"content":"x","event_time":"2026-04-15T10:00:00Z"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Errorf("expected 201 for valid event_time, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+}
+
+func itoaInt64(i int64) string {
+	return strconv.FormatInt(i, 10)
+}

--- a/internal/api/report.go
+++ b/internal/api/report.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"html"
 	"sort"
@@ -15,6 +16,13 @@ import (
 type ReportSparklines struct {
 	System []storage.SystemHistoryPoint
 	Disks  []storage.DiskSparklines
+
+	// DriveEventsBySlot maps a resolved slot_key (ArraySlot on Unraid,
+	// Serial elsewhere) to the full event timeline for that slot.
+	// Populated by handleReport so the Drive Health & SMART Analysis
+	// section can render a per-drive Maintenance Log without the
+	// report logic needing a storage.Store reference. Issue #130.
+	DriveEventsBySlot map[string][]storage.DriveEvent
 }
 
 // svgSparkline generates an inline SVG sparkline from float64 values.
@@ -1185,7 +1193,114 @@ func writeSMART(b *strings.Builder, snap *internal.Snapshot, sparks ReportSparkl
 
 	b.WriteString("    </tbody>\n")
 	b.WriteString("  </table></div>\n")
+
+	// ── Maintenance Log (issue #130) ────────────────────────────────
+	// For each drive that has maintenance events, render a compact
+	// chronological list so the exported report captures the full
+	// per-slot history (manual notes + auto-detected replacements).
+	// Skip drives with no events to keep the report tight.
+	writeDriveMaintenanceLogs(b, snap, sparks)
+
 	b.WriteString("</div>\n")
+}
+
+// writeDriveMaintenanceLogs appends a per-drive Maintenance Log
+// sub-section to the SMART page, one block per drive that has events.
+// Keyed by resolveReportSlotKey — matches the UI slot_key policy so
+// what operators see on /disk/{serial} is what they get in the report.
+func writeDriveMaintenanceLogs(b *strings.Builder, snap *internal.Snapshot, sparks ReportSparklines) {
+	if len(sparks.DriveEventsBySlot) == 0 {
+		return
+	}
+	// Collect drives that have at least one event, preserving SMART
+	// ordering so the report reads in the same sequence as the table.
+	type logBlock struct {
+		title  string
+		events []storage.DriveEvent
+	}
+	var blocks []logBlock
+	for _, s := range snap.SMART {
+		slotKey := resolveReportSlotKey(s)
+		if slotKey == "" {
+			continue
+		}
+		events := sparks.DriveEventsBySlot[slotKey]
+		if len(events) == 0 {
+			continue
+		}
+		title := s.Model
+		if s.ArraySlot != "" {
+			title = s.ArraySlot + " — " + s.Model
+		} else if s.Serial != "" {
+			title = s.Model + " (" + s.Serial + ")"
+		}
+		blocks = append(blocks, logBlock{title: title, events: events})
+	}
+	if len(blocks) == 0 {
+		return
+	}
+
+	b.WriteString("  <h3 class=\"sub-heading\" style=\"margin-top:24px\">Maintenance Log</h3>\n")
+	for _, blk := range blocks {
+		b.WriteString("  <div style=\"margin-bottom:12px\">\n")
+		b.WriteString(fmt.Sprintf("    <div style=\"font-weight:600;font-size:13px;margin-bottom:4px\">%s</div>\n", escHTML(blk.title)))
+		b.WriteString("    <ul style=\"margin:0;padding-left:18px;font-size:12px;line-height:1.5\">\n")
+		for _, ev := range blk.events {
+			ts := ev.EventTime.Format("2006-01-02 15:04")
+			var line string
+			if ev.EventType == "replacement" && ev.IsAuto {
+				line = ts + " — " + formatReplacementLine(ev.Content)
+				line += "  [system]"
+			} else {
+				line = ts + " — " + ev.Content
+			}
+			b.WriteString(fmt.Sprintf("      <li>%s</li>\n", escHTML(line)))
+		}
+		b.WriteString("    </ul>\n")
+		b.WriteString("  </div>\n")
+	}
+}
+
+// resolveReportSlotKey mirrors the API/UI slot_key policy so a drive's
+// event timeline is reachable from both surfaces with the same key.
+func resolveReportSlotKey(s internal.SMARTInfo) string {
+	if s.ArraySlot != "" {
+		return s.ArraySlot
+	}
+	return s.Serial
+}
+
+// formatReplacementLine unmarshals a replacement event's JSON content
+// into a human-readable one-liner. Falls back to raw content on parse
+// failure so we never drop a row from the report.
+func formatReplacementLine(raw string) string {
+	if raw == "" {
+		return "Drive replaced"
+	}
+	var p struct {
+		OldSerial string `json:"old_serial"`
+		OldModel  string `json:"old_model"`
+		NewSerial string `json:"new_serial"`
+		NewModel  string `json:"new_model"`
+	}
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		return raw
+	}
+	old := p.OldSerial
+	if p.OldModel != "" {
+		old += " (" + p.OldModel + ")"
+	}
+	if old == "" {
+		old = "?"
+	}
+	fresh := p.NewSerial
+	if p.NewModel != "" {
+		fresh += " (" + p.NewModel + ")"
+	}
+	if fresh == "" {
+		fresh = "?"
+	}
+	return "Drive replaced: " + old + " \u2192 " + fresh
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/internal/api/report_maintenance_log_test.go
+++ b/internal/api/report_maintenance_log_test.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// TestReportExport_IncludesMaintenanceLog verifies the Diagnostic Report
+// includes per-drive maintenance log sections when events exist, and
+// that replacement events are expanded into a human-readable one-liner
+// rather than raw JSON.
+func TestReportExport_IncludesMaintenanceLog(t *testing.T) {
+	ts := time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC)
+	snap := &internal.Snapshot{
+		ID:        "snap-1",
+		Timestamp: ts,
+		System:    internal.SystemInfo{Hostname: "testhost", Platform: "unraid"},
+		SMART: []internal.SMARTInfo{
+			{Device: "/dev/sdb", Model: "WDC 4TB", Serial: "WD-NEW", ArraySlot: "disk1", HealthPassed: true, SizeGB: 4000},
+			{Device: "/dev/sdc", Model: "Seagate 6TB", Serial: "ST-1", ArraySlot: "disk2", HealthPassed: true, SizeGB: 6000},
+		},
+	}
+	sparks := ReportSparklines{
+		DriveEventsBySlot: map[string][]storage.DriveEvent{
+			"disk1": {
+				{
+					ID:        2,
+					SlotKey:   "disk1",
+					Platform:  "unraid",
+					EventType: "note",
+					EventTime: ts,
+					Content:   "SATA cable replaced",
+					IsAuto:    false,
+				},
+				{
+					ID:        1,
+					SlotKey:   "disk1",
+					Platform:  "unraid",
+					EventType: "replacement",
+					EventTime: ts.Add(-24 * time.Hour),
+					Content:   `{"old_serial":"WD-OLD","old_model":"WDC 2TB","new_serial":"WD-NEW","new_model":"WDC 4TB"}`,
+					IsAuto:    true,
+				},
+			},
+			// disk2 deliberately has no events — should NOT appear in the log section.
+		},
+	}
+
+	htmlOut := GenerateReport(snap, sparks)
+
+	// Section heading.
+	if !strings.Contains(htmlOut, "Maintenance Log") {
+		t.Errorf("report missing 'Maintenance Log' heading")
+	}
+	// disk1 title + manual note content present.
+	if !strings.Contains(htmlOut, "disk1") || !strings.Contains(htmlOut, "WDC 4TB") {
+		t.Errorf("report missing disk1/WDC 4TB title block")
+	}
+	if !strings.Contains(htmlOut, "SATA cable replaced") {
+		t.Errorf("report missing manual note content")
+	}
+	// Replacement event rendered as human-readable line, NOT raw JSON.
+	if strings.Contains(htmlOut, `"old_serial"`) {
+		t.Errorf("report shows raw JSON for replacement event; should parse to human-readable line")
+	}
+	if !strings.Contains(htmlOut, "Drive replaced") {
+		t.Errorf("report missing 'Drive replaced' summary for replacement event")
+	}
+	if !strings.Contains(htmlOut, "WD-OLD") || !strings.Contains(htmlOut, "WD-NEW") {
+		t.Errorf("report missing old/new serial in replacement summary")
+	}
+	// [system] marker on auto events.
+	if !strings.Contains(htmlOut, "[system]") {
+		t.Errorf("report missing [system] marker on auto replacement event")
+	}
+	// Timestamps formatted (not zero).
+	if !strings.Contains(htmlOut, "2026-04-15 10:00") {
+		t.Errorf("report missing formatted timestamp; got: want substring 2026-04-15 10:00")
+	}
+	// disk2 should not appear in a Maintenance Log entry — it has no events.
+	// We verify this by splitting the HTML at the Maintenance Log heading.
+	idx := strings.Index(htmlOut, "Maintenance Log")
+	if idx < 0 {
+		t.Fatal("Maintenance Log heading missing")
+	}
+	afterHeading := htmlOut[idx:]
+	// Cut off after the next </div> … </div> closing the SMART section,
+	// to avoid false positives from disk2 being mentioned in the main
+	// SMART table above OR in the Docker/other sections below.
+	if end := strings.Index(afterHeading, "</div>\n</div>\n"); end > 0 {
+		afterHeading = afterHeading[:end]
+	}
+	if strings.Contains(afterHeading, "disk2") {
+		t.Errorf("report Maintenance Log unexpectedly includes disk2 (which has no events)")
+	}
+}
+
+// TestReportExport_NoMaintenanceLog_WhenNoEvents ensures the section is
+// omitted entirely if no drives have events. The report should not
+// render an empty heading.
+func TestReportExport_NoMaintenanceLog_WhenNoEvents(t *testing.T) {
+	snap := &internal.Snapshot{
+		ID:        "snap-1",
+		Timestamp: time.Now(),
+		System:    internal.SystemInfo{Hostname: "testhost", Platform: "unraid"},
+		SMART: []internal.SMARTInfo{
+			{Device: "/dev/sdb", Model: "WDC", Serial: "S1", ArraySlot: "disk1"},
+		},
+	}
+	sparks := ReportSparklines{}
+	htmlOut := GenerateReport(snap, sparks)
+	// Drive Health & SMART Analysis section should still render its heading.
+	if !strings.Contains(htmlOut, "SMART Analysis") {
+		t.Errorf("report missing SMART Analysis section")
+	}
+	// But no Maintenance Log heading when no events.
+	if strings.Contains(htmlOut, "Maintenance Log") {
+		t.Errorf("report contains empty Maintenance Log section when no events exist")
+	}
+}

--- a/internal/api/templates/disk_detail.html
+++ b/internal/api/templates/disk_detail.html
@@ -124,6 +124,31 @@ a:hover{color:var(--accent-hover)}
 .info-table .label-cell{color:var(--text-tertiary);font-weight:500;width:200px}
 .info-table .value-cell{color:var(--text-primary);font-variant-numeric:tabular-nums}
 
+/* ── Maintenance Log (issue #130) ────────── */
+.maintenance-log-card{background:var(--bg-surface);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:20px;margin-bottom:calc(var(--sp)*4)}
+.maintenance-log-entry{display:flex;align-items:flex-start;gap:12px;padding:12px 0;border-bottom:1px solid var(--border)}
+.maintenance-log-entry:last-child{border-bottom:none}
+.maintenance-log-entry .ml-time{flex-shrink:0;color:var(--text-tertiary);font-size:12px;font-variant-numeric:tabular-nums;width:140px;white-space:nowrap}
+.maintenance-log-entry .ml-body{flex:1;min-width:0;word-break:break-word;font-size:13px;color:var(--text-primary);line-height:1.5}
+.maintenance-log-entry .ml-badge{display:inline-block;margin-left:8px;padding:1px 7px;font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;border-radius:4px;color:var(--text-tertiary);background:var(--bg-elevated);vertical-align:middle}
+.maintenance-log-entry .ml-actions{flex-shrink:0;display:flex;gap:6px;opacity:0;transition:opacity 150ms ease}
+.maintenance-log-entry:hover .ml-actions{opacity:1}
+.maintenance-log-entry .ml-actions button{background:transparent;border:1px solid var(--border);color:var(--text-tertiary);font-size:11px;padding:3px 8px;border-radius:4px;cursor:pointer;transition:all 150ms ease}
+.maintenance-log-entry .ml-actions button:hover{color:var(--text-primary);border-color:var(--accent)}
+.maintenance-log-entry .ml-updated{display:inline-block;margin-left:6px;color:var(--text-tertiary);font-size:11px;font-style:italic}
+.maintenance-log-empty{text-align:center;color:var(--text-tertiary);padding:24px 0;font-size:13px}
+.maintenance-log-form{margin-top:16px;padding-top:16px;border-top:1px solid var(--border);display:flex;flex-direction:column;gap:8px}
+.maintenance-log-form label{font-size:11px;font-weight:600;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:0.4px}
+.maintenance-log-form input[type="datetime-local"],
+.maintenance-log-form textarea{background:var(--bg-elevated);color:var(--text-primary);border:1px solid var(--border);border-radius:var(--radius);padding:8px 10px;font-family:inherit;font-size:13px;width:100%}
+.maintenance-log-form textarea{min-height:60px;resize:vertical}
+.maintenance-log-form-row{display:flex;gap:12px;align-items:flex-end;flex-wrap:wrap}
+.maintenance-log-form-row > div{flex:1;min-width:200px}
+.maintenance-log-form button{align-self:flex-end;background:var(--accent);color:#fff;border:none;border-radius:var(--radius);padding:8px 16px;font-size:13px;font-weight:500;cursor:pointer;transition:background 150ms ease}
+.maintenance-log-form button:hover{background:var(--accent-hover)}
+.maintenance-log-form button:disabled{opacity:0.5;cursor:not-allowed}
+.maintenance-log-error{color:var(--red);font-size:12px;padding:6px 0}
+
 /* ── Empty states ────────────────────────── */
 .no-data{text-align:center;color:var(--text-tertiary);padding:40px;font-size:13px}
 
@@ -516,6 +541,24 @@ fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d
       html += "</div>";
     }
 
+    /* ── Maintenance Log (issue #130) ──────────────────────────── */
+    html += "<div class=\"section-heading\">Maintenance Log</div>";
+    html += "<div class=\"maintenance-log-card\">";
+    html += "  <div id=\"maintenanceLogList\"><div class=\"maintenance-log-empty\">Loading\u2026</div></div>";
+    html += "  <form class=\"maintenance-log-form\" id=\"maintenanceLogForm\" autocomplete=\"off\" onsubmit=\"return false\">";
+    html += "    <div class=\"maintenance-log-form-row\">";
+    html += "      <div><label for=\"maintenanceLogTime\">When</label>";
+    html += "        <input type=\"datetime-local\" id=\"maintenanceLogTime\">";
+    html += "      </div>";
+    html += "      <div><label for=\"maintenanceLogContent\">What happened</label>";
+    html += "        <textarea id=\"maintenanceLogContent\" placeholder=\"e.g. SATA cable replaced, drive moved to new bay\u2026\"></textarea>";
+    html += "      </div>";
+    html += "    </div>";
+    html += "    <div class=\"maintenance-log-error\" id=\"maintenanceLogError\" style=\"display:none\"></div>";
+    html += "    <button type=\"submit\" id=\"maintenanceLogSave\">Add Entry</button>";
+    html += "  </form>";
+    html += "</div>";
+
     /* ── Drive Identification ──────────────────────────────────── */
     html += "<div class=\"section-heading\">Drive Identification</div>";
     html += "<div class=\"info-table-wrap\"><table class=\"info-table\">";
@@ -544,7 +587,197 @@ fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d
 
     /* ── Render charts after DOM update ────────────────────────── */
     setTimeout(function() { renderCharts(disk, history); }, 50);
+
+    /* ── Wire up Maintenance Log (issue #130) ──────────────────── */
+    setTimeout(function() { initMaintenanceLog(disk); }, 50);
   }
+
+  /* ── Maintenance Log ───────────────────────────────────────────
+     Per-slot chronological timeline. Manual notes (is_auto=false)
+     render with edit/delete controls; auto "replacement" events
+     (is_auto=true) render read-only with a "System" badge and
+     parsed JSON content. slot_key prefers disk.array_slot (stable
+     across replacements on Unraid) and falls back to serial. */
+  var _currentSlotKey = "";
+
+  function resolveSlotKey(disk) {
+    if (disk && disk.array_slot) return disk.array_slot;
+    return (disk && disk.serial) || serial;
+  }
+
+  function initMaintenanceLog(disk) {
+    _currentSlotKey = resolveSlotKey(disk);
+    // Prefill the "When" field with now-local so submitting without
+    // touching it produces a sensible timestamp.
+    var inp = document.getElementById("maintenanceLogTime");
+    if (inp) {
+      var d = new Date();
+      // datetime-local expects YYYY-MM-DDTHH:MM with no timezone suffix.
+      var pad = function(n){return (n<10?"0":"")+n};
+      inp.value = d.getFullYear()+"-"+pad(d.getMonth()+1)+"-"+pad(d.getDate())+"T"+pad(d.getHours())+":"+pad(d.getMinutes());
+    }
+    var form = document.getElementById("maintenanceLogForm");
+    if (form && !form._mlBound) {
+      form._mlBound = true;
+      form.addEventListener("submit", function(e){ e.preventDefault(); createMaintenanceEntry(); });
+    }
+    renderMaintenanceLog();
+  }
+
+  function renderMaintenanceLog() {
+    var listEl = document.getElementById("maintenanceLogList");
+    if (!listEl || !_currentSlotKey) return;
+    fetch("/api/v1/drives/" + encodeURIComponent(_currentSlotKey) + "/events")
+      .then(function(r){ if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
+      .then(function(events){
+        if (!events || events.length === 0) {
+          listEl.innerHTML = "<div class=\"maintenance-log-empty\">No entries yet. Add one below to start the log.</div>";
+          return;
+        }
+        var html = "";
+        for (var i = 0; i < events.length; i++) {
+          html += renderMaintenanceEntryRow(events[i]);
+        }
+        listEl.innerHTML = html;
+      })
+      .catch(function(err){
+        listEl.innerHTML = "<div class=\"maintenance-log-empty\">Failed to load entries: " + escHtml(err.message) + "</div>";
+      });
+  }
+
+  function renderMaintenanceEntryRow(ev) {
+    var when = formatEntryTime(ev.event_time);
+    var body;
+    if (ev.event_type === "replacement" && ev.is_auto) {
+      body = formatReplacementContent(ev.content);
+    } else {
+      body = escHtml(ev.content);
+    }
+    var out = "<div class=\"maintenance-log-entry\" data-id=\"" + ev.id + "\">";
+    out += "<div class=\"ml-time\">" + escHtml(when) + "</div>";
+    out += "<div class=\"ml-body\">" + body;
+    if (ev.is_auto) {
+      out += "<span class=\"ml-badge\">System</span>";
+    }
+    if (ev.updated_at) {
+      out += "<span class=\"ml-updated\">(edited)</span>";
+    }
+    out += "</div>";
+    if (!ev.is_auto) {
+      out += "<div class=\"ml-actions\">";
+      out += "<button type=\"button\" onclick=\"editMaintenanceEntry(" + ev.id + ")\">Edit</button>";
+      out += "<button type=\"button\" onclick=\"deleteMaintenanceEntry(" + ev.id + ")\">Delete</button>";
+      out += "</div>";
+    }
+    out += "</div>";
+    return out;
+  }
+
+  function formatEntryTime(iso) {
+    if (!iso) return "";
+    var d = new Date(iso);
+    if (isNaN(d.getTime())) return iso;
+    // Mirror the rest of the page's timestamp style but include year
+    // (users will often scan across releases over multiple years).
+    var y = d.getFullYear();
+    var mo = d.getMonth() + 1;
+    var dy = d.getDate();
+    var hr = d.getHours();
+    var mn = d.getMinutes();
+    return y + "-" + (mo<10?"0":"") + mo + "-" + (dy<10?"0":"") + dy + " " +
+      (hr<10?"0":"") + hr + ":" + (mn<10?"0":"") + mn;
+  }
+
+  function formatReplacementContent(raw) {
+    if (!raw) return escHtml("Drive replaced");
+    try {
+      var p = JSON.parse(raw);
+      var oldSide = escHtml((p.old_serial || "?")) + (p.old_model ? " (" + escHtml(p.old_model) + ")" : "");
+      var newSide = escHtml((p.new_serial || "?")) + (p.new_model ? " (" + escHtml(p.new_model) + ")" : "");
+      return "Drive replaced: " + oldSide + " \u2192 " + newSide;
+    } catch (e) {
+      return escHtml(raw);
+    }
+  }
+
+  function createMaintenanceEntry() {
+    var contentEl = document.getElementById("maintenanceLogContent");
+    var timeEl = document.getElementById("maintenanceLogTime");
+    var errEl = document.getElementById("maintenanceLogError");
+    var btn = document.getElementById("maintenanceLogSave");
+    if (!contentEl) return;
+    var content = (contentEl.value || "").trim();
+    if (!content) {
+      if (errEl) { errEl.textContent = "Please enter what happened."; errEl.style.display = "block"; }
+      return;
+    }
+    var body = { content: content };
+    if (timeEl && timeEl.value) {
+      // datetime-local is local time; convert to RFC3339 in UTC.
+      var parsed = new Date(timeEl.value);
+      if (!isNaN(parsed.getTime())) {
+        body.event_time = parsed.toISOString();
+      }
+    }
+    if (btn) btn.disabled = true;
+    if (errEl) { errEl.style.display = "none"; errEl.textContent = ""; }
+    fetch("/api/v1/drives/" + encodeURIComponent(_currentSlotKey) + "/events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body)
+    }).then(function(r){
+      if (!r.ok) return r.text().then(function(t){ throw new Error("HTTP " + r.status + ": " + t); });
+      return r.json();
+    }).then(function(){
+      contentEl.value = "";
+      renderMaintenanceLog();
+    }).catch(function(err){
+      if (errEl) { errEl.textContent = err.message; errEl.style.display = "block"; }
+    }).finally(function(){
+      if (btn) btn.disabled = false;
+    });
+  }
+
+  function editMaintenanceEntry(id) {
+    // Minimal inline edit via prompt() to avoid a second modal layer.
+    // Users who want richer editing can delete and re-add.
+    var row = document.querySelector('.maintenance-log-entry[data-id="'+id+'"]');
+    var current = "";
+    if (row) {
+      var bodyEl = row.querySelector(".ml-body");
+      if (bodyEl) current = (bodyEl.textContent || "").replace(/\s*System\s*$/, "").replace(/\s*\(edited\)\s*$/, "").trim();
+    }
+    var next = window.prompt("Edit maintenance note:", current);
+    if (next === null) return; // cancelled
+    next = next.trim();
+    if (!next) return;
+    fetch("/api/v1/drives/" + encodeURIComponent(_currentSlotKey) + "/events/" + id, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: next })
+    }).then(function(r){
+      if (!r.ok) return r.text().then(function(t){ throw new Error("HTTP " + r.status + ": " + t); });
+      renderMaintenanceLog();
+    }).catch(function(err){
+      window.alert("Update failed: " + err.message);
+    });
+  }
+
+  function deleteMaintenanceEntry(id) {
+    if (!window.confirm("Delete this maintenance log entry?")) return;
+    fetch("/api/v1/drives/" + encodeURIComponent(_currentSlotKey) + "/events/" + id, {
+      method: "DELETE"
+    }).then(function(r){
+      if (!r.ok && r.status !== 204) return r.text().then(function(t){ throw new Error("HTTP " + r.status + ": " + t); });
+      renderMaintenanceLog();
+    }).catch(function(err){
+      window.alert("Delete failed: " + err.message);
+    });
+  }
+
+  // Expose edit/delete onto window so inline onclick handlers resolve.
+  window.editMaintenanceEntry = editMaintenanceEntry;
+  window.deleteMaintenanceEntry = deleteMaintenanceEntry;
 
   /* ── Render all charts ────────────────────────────────────────── */
   function renderCharts(disk, history) {

--- a/internal/scheduler/drive_events.go
+++ b/internal/scheduler/drive_events.go
@@ -1,0 +1,142 @@
+package scheduler
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// resolveSlotKey returns the stable identifier for a drive. On Unraid the
+// ArraySlot is preferred because it persists across drive replacements
+// within the same bay (e.g., "disk1" maps to whatever physical drive the
+// user has pushed into that slot). On other platforms the serial number
+// is used; this is less stable (it changes every time the drive does)
+// but it's the best identifier available.
+//
+// Returns the empty string when neither is populated — callers must skip
+// events for empty slot keys.
+func resolveSlotKey(d internal.SMARTInfo) string {
+	if d.ArraySlot != "" {
+		return d.ArraySlot
+	}
+	return d.Serial
+}
+
+// detectDriveReplacements compares the current SMART scan against the
+// last-observed per-slot state and emits a "replacement" drive_event when
+// a slot's serial number has changed. Also UPSERTs the per-slot state so
+// the next scan has fresh baseline data.
+//
+// Behaviour contract (issue #130):
+//   - Only runs on Unraid. Other platforms lack stable slot identity
+//     (slot_key == serial), so detection would be meaningless.
+//   - First-ever observation of a slot (no prior state row) establishes
+//     baseline and emits no event. This avoids a flood of spurious
+//     "replacement" events on fresh install.
+//   - If a slot was populated in the prior scan but is absent from the
+//     current scan (drive physically pulled), no event is emitted — we
+//     wait for the replacement to arrive. State is left unchanged.
+//   - If a slot's serial differs from the stored value, one event is
+//     emitted and the state row is updated.
+//
+// `platform` is stamped onto new drive_events rows for filtering in
+// cross-platform deployments.
+func detectDriveReplacements(store storage.DriveEventStore, platform string, scan []internal.SMARTInfo, at time.Time) error {
+	// Phase 2 only supports Unraid — see doc comment above.
+	if platform != "unraid" {
+		return nil
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+
+	for _, d := range scan {
+		slotKey := resolveSlotKey(d)
+		if slotKey == "" || d.Serial == "" {
+			// Can't track a slot we can't identify. Skip.
+			continue
+		}
+		// Only track ArraySlot-based keys for detection. If the drive
+		// has no array slot (e.g., a standalone drive on Unraid that
+		// isn't array-assigned) we can't meaningfully compare against
+		// "this slot's previous occupant".
+		if d.ArraySlot == "" {
+			continue
+		}
+
+		prev, err := store.GetDriveSlotState(slotKey)
+		if err != nil {
+			return fmt.Errorf("load slot state for %s: %w", slotKey, err)
+		}
+
+		if prev == nil {
+			// First observation — establish baseline, no event.
+			if err := store.SaveDriveSlotState(storage.DriveSlotState{
+				SlotKey:    slotKey,
+				Serial:     d.Serial,
+				Model:      d.Model,
+				Platform:   platform,
+				ObservedAt: at,
+			}); err != nil {
+				return fmt.Errorf("save slot state for %s: %w", slotKey, err)
+			}
+			continue
+		}
+
+		if prev.Serial == d.Serial {
+			// Same drive — just freshen observed_at.
+			if err := store.SaveDriveSlotState(storage.DriveSlotState{
+				SlotKey:    slotKey,
+				Serial:     d.Serial,
+				Model:      d.Model,
+				Platform:   platform,
+				ObservedAt: at,
+			}); err != nil {
+				return fmt.Errorf("refresh slot state for %s: %w", slotKey, err)
+			}
+			continue
+		}
+
+		// Serial changed → emit replacement event.
+		payload := map[string]string{
+			"old_serial": prev.Serial,
+			"old_model":  prev.Model,
+			"new_serial": d.Serial,
+			"new_model":  d.Model,
+		}
+		raw, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("marshal replacement payload: %w", err)
+		}
+		if _, err := store.SaveDriveEvent(storage.DriveEvent{
+			SlotKey:   slotKey,
+			Platform:  platform,
+			EventType: "replacement",
+			EventTime: at,
+			Content:   string(raw),
+			IsAuto:    true,
+		}); err != nil {
+			return fmt.Errorf("save replacement event for %s: %w", slotKey, err)
+		}
+		// Update baseline to the new serial so the next scan sees a
+		// steady state rather than repeatedly emitting the same event.
+		if err := store.SaveDriveSlotState(storage.DriveSlotState{
+			SlotKey:    slotKey,
+			Serial:     d.Serial,
+			Model:      d.Model,
+			Platform:   platform,
+			ObservedAt: at,
+		}); err != nil {
+			return fmt.Errorf("update slot state after replacement for %s: %w", slotKey, err)
+		}
+	}
+
+	// Note: if a slot was present previously and is now absent from the
+	// scan, we intentionally do NOT touch its state row. The user pulled
+	// the drive; when a replacement arrives, the next scan will see a
+	// serial mismatch and emit the event at the correct moment.
+	return nil
+}

--- a/internal/scheduler/drive_events_test.go
+++ b/internal/scheduler/drive_events_test.go
@@ -1,0 +1,206 @@
+package scheduler
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// TestDetectDriveReplacements_DetectsReplacement_OnSerialChange simulates
+// two consecutive SMART scans where slot "disk1" changes serial number
+// between them. The second scan should produce exactly one "replacement"
+// drive_event row with the old and new serial/model in its content JSON.
+//
+// Core detection contract for issue #130.
+func TestDetectDriveReplacements_DetectsReplacement_OnSerialChange(t *testing.T) {
+	store := storage.NewFakeStore()
+
+	// First scan — fresh install, no prior state exists.
+	scan1 := []internal.SMARTInfo{
+		{Device: "/dev/sdb", Serial: "OLDSERIAL", Model: "OLDMODEL", ArraySlot: "disk1"},
+	}
+	if err := detectDriveReplacements(store, "unraid", scan1, time.Now().UTC()); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	// No events should have been emitted on fresh install.
+	events, err := store.ListDriveEvents("disk1")
+	if err != nil {
+		t.Fatalf("ListDriveEvents: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected 0 events after fresh-install scan, got %d", len(events))
+	}
+
+	// Second scan — same slot, DIFFERENT serial → replacement.
+	replacedAt := time.Now().UTC().Add(time.Hour)
+	scan2 := []internal.SMARTInfo{
+		{Device: "/dev/sdb", Serial: "NEWSERIAL", Model: "NEWMODEL", ArraySlot: "disk1"},
+	}
+	if err := detectDriveReplacements(store, "unraid", scan2, replacedAt); err != nil {
+		t.Fatalf("second scan: %v", err)
+	}
+
+	events, err = store.ListDriveEvents("disk1")
+	if err != nil {
+		t.Fatalf("ListDriveEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 replacement event, got %d: %+v", len(events), events)
+	}
+	ev := events[0]
+	if ev.EventType != "replacement" {
+		t.Errorf("event_type = %q, want replacement", ev.EventType)
+	}
+	if !ev.IsAuto {
+		t.Errorf("replacement event is_auto = false, want true")
+	}
+	if ev.SlotKey != "disk1" {
+		t.Errorf("slot_key = %q, want disk1", ev.SlotKey)
+	}
+	if !ev.EventTime.Equal(replacedAt) {
+		t.Errorf("event_time = %v, want %v", ev.EventTime, replacedAt)
+	}
+
+	var content struct {
+		OldSerial string `json:"old_serial"`
+		NewSerial string `json:"new_serial"`
+		OldModel  string `json:"old_model"`
+		NewModel  string `json:"new_model"`
+	}
+	if err := json.Unmarshal([]byte(ev.Content), &content); err != nil {
+		t.Fatalf("parse content JSON %q: %v", ev.Content, err)
+	}
+	if content.OldSerial != "OLDSERIAL" {
+		t.Errorf("old_serial = %q, want OLDSERIAL", content.OldSerial)
+	}
+	if content.NewSerial != "NEWSERIAL" {
+		t.Errorf("new_serial = %q, want NEWSERIAL", content.NewSerial)
+	}
+	if content.OldModel != "OLDMODEL" {
+		t.Errorf("old_model = %q, want OLDMODEL", content.OldModel)
+	}
+	if content.NewModel != "NEWMODEL" {
+		t.Errorf("new_model = %q, want NEWMODEL", content.NewModel)
+	}
+}
+
+// TestDetectDriveReplacements_NoReplacementEventOnFirstScan — the very
+// first scan establishes baseline state but must not emit any events.
+func TestDetectDriveReplacements_NoReplacementEventOnFirstScan(t *testing.T) {
+	store := storage.NewFakeStore()
+	scan := []internal.SMARTInfo{
+		{Device: "/dev/sdb", Serial: "S1", Model: "M1", ArraySlot: "disk1"},
+		{Device: "/dev/sdc", Serial: "S2", Model: "M2", ArraySlot: "parity"},
+	}
+	if err := detectDriveReplacements(store, "unraid", scan, time.Now().UTC()); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	for _, slot := range []string{"disk1", "parity"} {
+		events, err := store.ListDriveEvents(slot)
+		if err != nil {
+			t.Fatalf("ListDriveEvents %s: %v", slot, err)
+		}
+		if len(events) != 0 {
+			t.Errorf("slot %s: expected 0 events, got %d", slot, len(events))
+		}
+	}
+}
+
+// TestDetectDriveReplacements_NoReplacementEventWhenSlotGoesEmpty — if a
+// slot had a drive in the previous scan and is now missing, do NOT emit
+// an event; wait for the replacement drive to show up.
+func TestDetectDriveReplacements_NoReplacementEventWhenSlotGoesEmpty(t *testing.T) {
+	store := storage.NewFakeStore()
+	scan1 := []internal.SMARTInfo{
+		{Device: "/dev/sdb", Serial: "S1", Model: "M1", ArraySlot: "disk1"},
+	}
+	if err := detectDriveReplacements(store, "unraid", scan1, time.Now().UTC()); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	// Second scan — slot is missing (drive pulled out, not yet replaced).
+	scan2 := []internal.SMARTInfo{}
+	if err := detectDriveReplacements(store, "unraid", scan2, time.Now().UTC().Add(time.Hour)); err != nil {
+		t.Fatalf("second scan: %v", err)
+	}
+	events, err := store.ListDriveEvents("disk1")
+	if err != nil {
+		t.Fatalf("ListDriveEvents: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("expected 0 events when slot goes empty, got %d", len(events))
+	}
+
+	// Third scan — same slot, same serial as before. This should NOT
+	// trigger an event either (the stored state still matches).
+	scan3 := []internal.SMARTInfo{
+		{Device: "/dev/sdb", Serial: "S1", Model: "M1", ArraySlot: "disk1"},
+	}
+	if err := detectDriveReplacements(store, "unraid", scan3, time.Now().UTC().Add(2*time.Hour)); err != nil {
+		t.Fatalf("third scan: %v", err)
+	}
+	events, err = store.ListDriveEvents("disk1")
+	if err != nil {
+		t.Fatalf("ListDriveEvents after reinsert: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("expected 0 events when drive returns with same serial, got %d", len(events))
+	}
+}
+
+// TestDetectDriveReplacements_SkipsNonUnraid — on platforms without
+// stable slot identity, skip detection entirely to avoid false positives.
+// (Serial-as-slot-key can't meaningfully detect "drive replaced in slot"
+// because the slot_key IS the serial.)
+func TestDetectDriveReplacements_SkipsNonUnraid(t *testing.T) {
+	store := storage.NewFakeStore()
+	scan := []internal.SMARTInfo{
+		{Device: "/dev/sdb", Serial: "S1", Model: "M1", ArraySlot: ""},
+	}
+	// First scan on a non-Unraid platform — no state should be written.
+	if err := detectDriveReplacements(store, "synology", scan, time.Now().UTC()); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	// Serial change wouldn't make sense here either; verify no state row.
+	if state, _ := store.GetDriveSlotState("S1"); state != nil {
+		t.Errorf("non-Unraid platform unexpectedly wrote drive_slot_state for serial %q", state.SlotKey)
+	}
+	// No events regardless.
+	if evs, _ := store.ListDriveEvents("S1"); len(evs) != 0 {
+		t.Errorf("expected 0 events on non-Unraid platform, got %d", len(evs))
+	}
+}
+
+// TestDetectDriveReplacements_MultipleSlotsIndependent ensures events
+// for one slot don't leak into another, and that one replacement doesn't
+// block another slot's detection in the same scan.
+func TestDetectDriveReplacements_MultipleSlotsIndependent(t *testing.T) {
+	store := storage.NewFakeStore()
+	// Seed state for two slots.
+	scan1 := []internal.SMARTInfo{
+		{Device: "/dev/sdb", Serial: "S1", Model: "M1", ArraySlot: "disk1"},
+		{Device: "/dev/sdc", Serial: "S2", Model: "M2", ArraySlot: "disk2"},
+	}
+	if err := detectDriveReplacements(store, "unraid", scan1, time.Now().UTC()); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	// Replace both.
+	scan2 := []internal.SMARTInfo{
+		{Device: "/dev/sdb", Serial: "S1-NEW", Model: "M1", ArraySlot: "disk1"},
+		{Device: "/dev/sdc", Serial: "S2-NEW", Model: "M2", ArraySlot: "disk2"},
+	}
+	if err := detectDriveReplacements(store, "unraid", scan2, time.Now().UTC().Add(time.Hour)); err != nil {
+		t.Fatalf("second scan: %v", err)
+	}
+	for _, slot := range []string{"disk1", "disk2"} {
+		evs, err := store.ListDriveEvents(slot)
+		if err != nil {
+			t.Fatalf("ListDriveEvents %s: %v", slot, err)
+		}
+		if len(evs) != 1 {
+			t.Errorf("slot %s: expected 1 replacement event, got %d", slot, len(evs))
+		}
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -370,6 +370,13 @@ func (s *Scheduler) RunOnce() {
 		return
 	}
 
+	// Drive replacement detection (issue #130). Runs on every scan but
+	// only actually does work on Unraid, where ArraySlot gives us a
+	// stable per-bay identifier that outlives individual drives.
+	if err := detectDriveReplacements(s.store, snap.System.Platform, snap.SMART, snap.Timestamp); err != nil {
+		s.logger.Warn("drive replacement detection failed", "error", err)
+	}
+
 	serviceResults, err := s.runServiceChecks(snap.Timestamp)
 	if err != nil {
 		s.logger.Warn("service checks partial failure", "error", err)

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -298,6 +298,43 @@ func (d *DB) migrate() error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_disk_usage_mount_ts ON disk_usage_history(mount_point, timestamp DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_disk_usage_ts ON disk_usage_history(timestamp DESC)`,
+
+		// --- Drive maintenance events (issue #130) ---
+		// Per-slot chronological timeline of events for a drive. Two types:
+		//   "note"        — user-entered freeform content. is_auto=0, mutable.
+		//   "replacement" — system-detected when a slot's serial changes
+		//                   between scans. Content is JSON {old_serial,
+		//                   old_model, new_serial, new_model}. is_auto=1,
+		//                   immutable (Update/Delete return 403).
+		// slot_key is the ArraySlot on Unraid (stable across replacements)
+		// or the Serial on platforms without physical-slot identity.
+		`CREATE TABLE IF NOT EXISTS drive_events (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			slot_key TEXT NOT NULL,
+			platform TEXT NOT NULL DEFAULT '',
+			event_type TEXT NOT NULL,
+			event_time DATETIME NOT NULL,
+			content TEXT NOT NULL DEFAULT '',
+			is_auto INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_drive_events_slot_ts ON drive_events(slot_key, event_time DESC)`,
+
+		// --- Drive slot state (issue #130, replacement detection) ---
+		// Tracks the last-observed serial+model per slot_key so the SMART
+		// collector can detect when a slot's physical drive changes.
+		// Separate from smart_history because the detection logic should
+		// be snapshot-agnostic (it compares the current cycle against the
+		// persisted last-observed state, not against an arbitrary slice
+		// of history rows). A single row per slot; UPSERT semantics.
+		`CREATE TABLE IF NOT EXISTS drive_slot_state (
+			slot_key TEXT PRIMARY KEY,
+			serial TEXT NOT NULL,
+			model TEXT NOT NULL DEFAULT '',
+			platform TEXT NOT NULL DEFAULT '',
+			observed_at DATETIME NOT NULL
+		)`,
 	}
 
 	for _, m := range migrations {

--- a/internal/storage/db_drive_events.go
+++ b/internal/storage/db_drive_events.go
@@ -1,0 +1,293 @@
+package storage
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// DriveEvent is a single entry in the per-slot maintenance log for a drive.
+//
+// Two event types are supported:
+//
+//   - "note"        — user-entered freeform text. Content is plain string.
+//     IsAuto=false, mutable via Update/Delete.
+//   - "replacement" — system-detected when a slot's serial number changes
+//     between SMART scans. Content is a JSON blob containing
+//     the old/new serial and model. IsAuto=true, immutable.
+//
+// SlotKey semantics (issue #130):
+//   - On Unraid: ArraySlot (e.g., "disk1", "parity", "cache"), which is stable
+//     across drive replacements.
+//   - On non-Unraid platforms: the drive serial number. Less stable but the
+//     best identifier available where the OS doesn't map physical bays.
+type DriveEvent struct {
+	ID        int64      `json:"id"`
+	SlotKey   string     `json:"slot_key"`
+	Platform  string     `json:"platform"`
+	EventType string     `json:"event_type"`
+	EventTime time.Time  `json:"event_time"`
+	Content   string     `json:"content"`
+	IsAuto    bool       `json:"is_auto"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+}
+
+// DriveEventImmutableError is returned by UpdateDriveEvent / DeleteDriveEvent
+// when the target row has is_auto=1. API callers translate this to HTTP 403.
+type DriveEventImmutableError struct {
+	ID int64
+}
+
+func (e *DriveEventImmutableError) Error() string {
+	return fmt.Sprintf("drive event %d is system-generated and cannot be modified", e.ID)
+}
+
+// IsDriveEventImmutableErr reports whether err is a DriveEventImmutableError.
+func IsDriveEventImmutableErr(err error) bool {
+	var e *DriveEventImmutableError
+	return errors.As(err, &e)
+}
+
+// DriveEventNotFoundError is returned when an Update/Delete targets an ID
+// that does not exist (or belongs to a different slot_key).
+type DriveEventNotFoundError struct {
+	SlotKey string
+	ID      int64
+}
+
+func (e *DriveEventNotFoundError) Error() string {
+	return fmt.Sprintf("drive event %d not found for slot %q", e.ID, e.SlotKey)
+}
+
+// IsDriveEventNotFoundErr reports whether err is a DriveEventNotFoundError.
+func IsDriveEventNotFoundErr(err error) bool {
+	var e *DriveEventNotFoundError
+	return errors.As(err, &e)
+}
+
+// SaveDriveEvent inserts a new row into drive_events and returns the new id.
+// created_at is set to the current UTC time on insert.
+func (d *DB) SaveDriveEvent(ev DriveEvent) (int64, error) {
+	if ev.SlotKey == "" {
+		return 0, fmt.Errorf("slot_key is required")
+	}
+	if ev.EventType == "" {
+		return 0, fmt.Errorf("event_type is required")
+	}
+	if ev.EventTime.IsZero() {
+		ev.EventTime = time.Now().UTC()
+	}
+	res, err := d.db.Exec(
+		`INSERT INTO drive_events (slot_key, platform, event_type, event_time, content, is_auto, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		ev.SlotKey, ev.Platform, ev.EventType, ev.EventTime, ev.Content, boolToInt(ev.IsAuto), time.Now().UTC(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("insert drive_event: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("drive_event last insert id: %w", err)
+	}
+	return id, nil
+}
+
+// ListDriveEvents returns every event for slotKey, newest first.
+func (d *DB) ListDriveEvents(slotKey string) ([]DriveEvent, error) {
+	rows, err := d.db.Query(
+		`SELECT id, slot_key, platform, event_type, event_time, content, is_auto, created_at, updated_at
+		 FROM drive_events
+		 WHERE slot_key = ?
+		 ORDER BY event_time DESC, id DESC`,
+		slotKey,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query drive_events: %w", err)
+	}
+	defer rows.Close()
+
+	var out []DriveEvent
+	for rows.Next() {
+		var ev DriveEvent
+		var isAuto int
+		var updatedAt sql.NullTime
+		if err := rows.Scan(&ev.ID, &ev.SlotKey, &ev.Platform, &ev.EventType, &ev.EventTime, &ev.Content, &isAuto, &ev.CreatedAt, &updatedAt); err != nil {
+			return nil, fmt.Errorf("scan drive_event: %w", err)
+		}
+		ev.IsAuto = isAuto != 0
+		if updatedAt.Valid {
+			t := updatedAt.Time
+			ev.UpdatedAt = &t
+		}
+		out = append(out, ev)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows.Err: %w", err)
+	}
+	return out, nil
+}
+
+// UpdateDriveEvent modifies a manual (is_auto=0) drive event.
+// If eventTime or content is nil the corresponding field is left unchanged.
+// Auto events (is_auto=1) are immutable and cause DriveEventImmutableError.
+// Missing IDs or mismatched slot_key cause DriveEventNotFoundError.
+func (d *DB) UpdateDriveEvent(slotKey string, id int64, eventTime *time.Time, content *string) error {
+	var (
+		isAuto int
+		stored string
+	)
+	err := d.db.QueryRow(
+		`SELECT is_auto, slot_key FROM drive_events WHERE id = ?`,
+		id,
+	).Scan(&isAuto, &stored)
+	if errors.Is(err, sql.ErrNoRows) || (err == nil && stored != slotKey) {
+		return &DriveEventNotFoundError{SlotKey: slotKey, ID: id}
+	}
+	if err != nil {
+		return fmt.Errorf("lookup drive_event: %w", err)
+	}
+	if isAuto != 0 {
+		return &DriveEventImmutableError{ID: id}
+	}
+
+	// Build an UPDATE that only changes the fields the caller provided.
+	// Always bump updated_at when any change is applied.
+	now := time.Now().UTC()
+	switch {
+	case eventTime != nil && content != nil:
+		_, err = d.db.Exec(
+			`UPDATE drive_events SET event_time = ?, content = ?, updated_at = ? WHERE id = ?`,
+			*eventTime, *content, now, id,
+		)
+	case eventTime != nil:
+		_, err = d.db.Exec(
+			`UPDATE drive_events SET event_time = ?, updated_at = ? WHERE id = ?`,
+			*eventTime, now, id,
+		)
+	case content != nil:
+		_, err = d.db.Exec(
+			`UPDATE drive_events SET content = ?, updated_at = ? WHERE id = ?`,
+			*content, now, id,
+		)
+	default:
+		// No-op — nothing to update.
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("update drive_event: %w", err)
+	}
+	return nil
+}
+
+// DeleteDriveEvent removes a manual (is_auto=0) drive event.
+// Auto events are immutable. Missing rows return DriveEventNotFoundError.
+func (d *DB) DeleteDriveEvent(slotKey string, id int64) error {
+	var (
+		isAuto int
+		stored string
+	)
+	err := d.db.QueryRow(
+		`SELECT is_auto, slot_key FROM drive_events WHERE id = ?`,
+		id,
+	).Scan(&isAuto, &stored)
+	if errors.Is(err, sql.ErrNoRows) || (err == nil && stored != slotKey) {
+		return &DriveEventNotFoundError{SlotKey: slotKey, ID: id}
+	}
+	if err != nil {
+		return fmt.Errorf("lookup drive_event: %w", err)
+	}
+	if isAuto != 0 {
+		return &DriveEventImmutableError{ID: id}
+	}
+
+	if _, err := d.db.Exec(`DELETE FROM drive_events WHERE id = ?`, id); err != nil {
+		return fmt.Errorf("delete drive_event: %w", err)
+	}
+	return nil
+}
+
+// GetDriveEvent fetches a single event by id, or nil if not found.
+func (d *DB) GetDriveEvent(id int64) (*DriveEvent, error) {
+	var ev DriveEvent
+	var isAuto int
+	var updatedAt sql.NullTime
+	err := d.db.QueryRow(
+		`SELECT id, slot_key, platform, event_type, event_time, content, is_auto, created_at, updated_at
+		 FROM drive_events WHERE id = ?`,
+		id,
+	).Scan(&ev.ID, &ev.SlotKey, &ev.Platform, &ev.EventType, &ev.EventTime, &ev.Content, &isAuto, &ev.CreatedAt, &updatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query drive_event: %w", err)
+	}
+	ev.IsAuto = isAuto != 0
+	if updatedAt.Valid {
+		t := updatedAt.Time
+		ev.UpdatedAt = &t
+	}
+	return &ev, nil
+}
+
+// DriveSlotState records the last-observed serial+model for a given
+// slot_key, used by the SMART collector to detect drive replacements
+// across scans (issue #130).
+type DriveSlotState struct {
+	SlotKey    string
+	Serial     string
+	Model      string
+	Platform   string
+	ObservedAt time.Time
+}
+
+// GetDriveSlotState returns the last-known state for slotKey, or (nil, nil)
+// if no state has been recorded yet (fresh install, or brand-new slot).
+func (d *DB) GetDriveSlotState(slotKey string) (*DriveSlotState, error) {
+	var state DriveSlotState
+	err := d.db.QueryRow(
+		`SELECT slot_key, serial, model, platform, observed_at
+		 FROM drive_slot_state WHERE slot_key = ?`,
+		slotKey,
+	).Scan(&state.SlotKey, &state.Serial, &state.Model, &state.Platform, &state.ObservedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query drive_slot_state: %w", err)
+	}
+	return &state, nil
+}
+
+// SaveDriveSlotState UPSERTs the last-observed state for a slot.
+func (d *DB) SaveDriveSlotState(state DriveSlotState) error {
+	if state.SlotKey == "" {
+		return fmt.Errorf("slot_key is required")
+	}
+	if state.ObservedAt.IsZero() {
+		state.ObservedAt = time.Now().UTC()
+	}
+	_, err := d.db.Exec(
+		`INSERT INTO drive_slot_state (slot_key, serial, model, platform, observed_at)
+		 VALUES (?, ?, ?, ?, ?)
+		 ON CONFLICT(slot_key) DO UPDATE SET
+		   serial = excluded.serial,
+		   model = excluded.model,
+		   platform = excluded.platform,
+		   observed_at = excluded.observed_at`,
+		state.SlotKey, state.Serial, state.Model, state.Platform, state.ObservedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert drive_slot_state: %w", err)
+	}
+	return nil
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/storage/db_drive_events_test.go
+++ b/internal/storage/db_drive_events_test.go
@@ -1,0 +1,236 @@
+package storage
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestStore_DriveEvents_SaveAndList verifies that a manual note can be
+// saved and read back by slot_key, ordered newest-first. This is the
+// minimum contract for issue #130 Phase 1.
+func TestStore_DriveEvents_SaveAndList(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	db, err := Open(dbPath, logger)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC()
+	older := now.Add(-2 * time.Hour)
+
+	id1, err := db.SaveDriveEvent(DriveEvent{
+		SlotKey:   "disk1",
+		Platform:  "unraid",
+		EventType: "note",
+		EventTime: older,
+		Content:   "SATA cable replaced",
+		IsAuto:    false,
+	})
+	if err != nil {
+		t.Fatalf("SaveDriveEvent older: %v", err)
+	}
+	if id1 <= 0 {
+		t.Errorf("expected positive id, got %d", id1)
+	}
+
+	id2, err := db.SaveDriveEvent(DriveEvent{
+		SlotKey:   "disk1",
+		Platform:  "unraid",
+		EventType: "note",
+		EventTime: now,
+		Content:   "Second note",
+		IsAuto:    false,
+	})
+	if err != nil {
+		t.Fatalf("SaveDriveEvent newer: %v", err)
+	}
+	if id2 == id1 || id2 <= 0 {
+		t.Errorf("expected distinct positive id, got %d vs %d", id2, id1)
+	}
+
+	// An event on a different slot must not come back.
+	if _, err := db.SaveDriveEvent(DriveEvent{
+		SlotKey:   "disk2",
+		Platform:  "unraid",
+		EventType: "note",
+		EventTime: now,
+		Content:   "Other slot",
+		IsAuto:    false,
+	}); err != nil {
+		t.Fatalf("SaveDriveEvent other slot: %v", err)
+	}
+
+	events, err := db.ListDriveEvents("disk1")
+	if err != nil {
+		t.Fatalf("ListDriveEvents: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events for disk1, got %d", len(events))
+	}
+	// newest first
+	if !events[0].EventTime.After(events[1].EventTime) {
+		t.Errorf("events not ordered newest-first: %v vs %v", events[0].EventTime, events[1].EventTime)
+	}
+	if events[0].Content != "Second note" {
+		t.Errorf("first event content = %q, want Second note", events[0].Content)
+	}
+	if events[1].Content != "SATA cable replaced" {
+		t.Errorf("second event content = %q, want SATA cable replaced", events[1].Content)
+	}
+	for _, ev := range events {
+		if ev.SlotKey != "disk1" {
+			t.Errorf("event leaked from other slot: slot_key=%q", ev.SlotKey)
+		}
+		if ev.IsAuto {
+			t.Errorf("note event unexpectedly is_auto=true")
+		}
+		if ev.CreatedAt.IsZero() {
+			t.Errorf("created_at not populated")
+		}
+	}
+}
+
+// TestStore_DriveEvents_UpdateAndDelete_ManualOnly verifies that
+// is_auto=1 events are immutable: both UpdateDriveEvent and
+// DeleteDriveEvent return a "forbidden" error for auto events.
+func TestStore_DriveEvents_UpdateAndDelete_ManualOnly(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	db, err := Open(dbPath, logger)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC()
+
+	manualID, err := db.SaveDriveEvent(DriveEvent{
+		SlotKey:   "disk1",
+		Platform:  "unraid",
+		EventType: "note",
+		EventTime: now,
+		Content:   "initial",
+		IsAuto:    false,
+	})
+	if err != nil {
+		t.Fatalf("save manual: %v", err)
+	}
+	autoID, err := db.SaveDriveEvent(DriveEvent{
+		SlotKey:   "disk1",
+		Platform:  "unraid",
+		EventType: "replacement",
+		EventTime: now,
+		Content:   `{"old_serial":"OLD","new_serial":"NEW"}`,
+		IsAuto:    true,
+	})
+	if err != nil {
+		t.Fatalf("save auto: %v", err)
+	}
+
+	// Manual event: Update allowed.
+	newTime := now.Add(-1 * time.Hour)
+	newContent := "updated"
+	if err := db.UpdateDriveEvent("disk1", manualID, &newTime, &newContent); err != nil {
+		t.Fatalf("UpdateDriveEvent manual: %v", err)
+	}
+
+	events, err := db.ListDriveEvents("disk1")
+	if err != nil {
+		t.Fatalf("ListDriveEvents: %v", err)
+	}
+	var found *DriveEvent
+	for i := range events {
+		if events[i].ID == manualID {
+			found = &events[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("manual event %d not found after update", manualID)
+	}
+	if found.Content != "updated" {
+		t.Errorf("update did not persist content: got %q", found.Content)
+	}
+	if found.UpdatedAt == nil {
+		t.Errorf("updated_at not populated after manual update")
+	}
+
+	// Auto event: Update rejected.
+	contentChange := "should fail"
+	err = db.UpdateDriveEvent("disk1", autoID, nil, &contentChange)
+	if err == nil {
+		t.Errorf("expected error when updating auto event, got nil")
+	} else if !IsDriveEventImmutableErr(err) {
+		t.Errorf("expected immutable-error sentinel, got %v", err)
+	}
+
+	// Auto event: Delete rejected.
+	err = db.DeleteDriveEvent("disk1", autoID)
+	if err == nil {
+		t.Errorf("expected error when deleting auto event, got nil")
+	} else if !IsDriveEventImmutableErr(err) {
+		t.Errorf("expected immutable-error sentinel, got %v", err)
+	}
+
+	// Manual event: Delete allowed.
+	if err := db.DeleteDriveEvent("disk1", manualID); err != nil {
+		t.Fatalf("DeleteDriveEvent manual: %v", err)
+	}
+	events, err = db.ListDriveEvents("disk1")
+	if err != nil {
+		t.Fatalf("ListDriveEvents after delete: %v", err)
+	}
+	for _, ev := range events {
+		if ev.ID == manualID {
+			t.Errorf("manual event not deleted")
+		}
+	}
+	// Auto event still there.
+	found = nil
+	for i := range events {
+		if events[i].ID == autoID {
+			found = &events[i]
+		}
+	}
+	if found == nil {
+		t.Errorf("auto event gone after failed delete attempt — should still exist")
+	}
+}
+
+// TestStore_DriveEvents_MissingSlotOrID returns zero events / clear errors
+// for bogus lookups.
+func TestStore_DriveEvents_MissingSlotOrID(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	db, err := Open(dbPath, logger)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	events, err := db.ListDriveEvents("nonexistent")
+	if err != nil {
+		t.Fatalf("ListDriveEvents: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("expected empty, got %d events", len(events))
+	}
+
+	// Update/Delete on missing ID surfaces a not-found error.
+	content := "x"
+	err = db.UpdateDriveEvent("nope", 9999, nil, &content)
+	if err == nil {
+		t.Errorf("expected error updating nonexistent event")
+	}
+	err = db.DeleteDriveEvent("nope", 9999)
+	if err == nil {
+		t.Errorf("expected error deleting nonexistent event")
+	}
+}

--- a/internal/storage/fake.go
+++ b/internal/storage/fake.go
@@ -66,6 +66,11 @@ type FakeStore struct {
 	// LastSpeedTestAttempt state (single-row, issue #210). nil until
 	// the scheduler writes the first attempt outcome.
 	speedTestAttempt *LastSpeedTestAttempt
+
+	// Drive maintenance events (issue #130).
+	driveEvents     []DriveEvent
+	driveEventSeq   int64
+	driveSlotStates map[string]DriveSlotState
 }
 
 // diskUsageRow is the minimal fake representation of a disk_usage_history row.
@@ -851,6 +856,139 @@ func (f *FakeStore) Close() error {
 
 func (f *FakeStore) DataDir() string {
 	return "/tmp/fake-store"
+}
+
+// ── DriveEventStore ──
+
+// SaveDriveEvent stores a new drive event and returns its assigned id.
+func (f *FakeStore) SaveDriveEvent(ev DriveEvent) (int64, error) {
+	if ev.SlotKey == "" {
+		return 0, fmt.Errorf("slot_key is required")
+	}
+	if ev.EventType == "" {
+		return 0, fmt.Errorf("event_type is required")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.driveEventSeq++
+	ev.ID = f.driveEventSeq
+	if ev.EventTime.IsZero() {
+		ev.EventTime = time.Now().UTC()
+	}
+	ev.CreatedAt = time.Now().UTC()
+	ev.UpdatedAt = nil
+	f.driveEvents = append(f.driveEvents, ev)
+	return ev.ID, nil
+}
+
+// ListDriveEvents returns events for slotKey, newest first.
+func (f *FakeStore) ListDriveEvents(slotKey string) ([]DriveEvent, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	var out []DriveEvent
+	for _, ev := range f.driveEvents {
+		if ev.SlotKey == slotKey {
+			out = append(out, ev)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].EventTime.Equal(out[j].EventTime) {
+			return out[i].ID > out[j].ID
+		}
+		return out[i].EventTime.After(out[j].EventTime)
+	})
+	return out, nil
+}
+
+// UpdateDriveEvent mutates a manual event's time and/or content.
+func (f *FakeStore) UpdateDriveEvent(slotKey string, id int64, eventTime *time.Time, content *string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i := range f.driveEvents {
+		if f.driveEvents[i].ID != id {
+			continue
+		}
+		if f.driveEvents[i].SlotKey != slotKey {
+			return &DriveEventNotFoundError{SlotKey: slotKey, ID: id}
+		}
+		if f.driveEvents[i].IsAuto {
+			return &DriveEventImmutableError{ID: id}
+		}
+		if eventTime != nil {
+			f.driveEvents[i].EventTime = *eventTime
+		}
+		if content != nil {
+			f.driveEvents[i].Content = *content
+		}
+		if eventTime != nil || content != nil {
+			now := time.Now().UTC()
+			f.driveEvents[i].UpdatedAt = &now
+		}
+		return nil
+	}
+	return &DriveEventNotFoundError{SlotKey: slotKey, ID: id}
+}
+
+// DeleteDriveEvent removes a manual event.
+func (f *FakeStore) DeleteDriveEvent(slotKey string, id int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i := range f.driveEvents {
+		if f.driveEvents[i].ID != id {
+			continue
+		}
+		if f.driveEvents[i].SlotKey != slotKey {
+			return &DriveEventNotFoundError{SlotKey: slotKey, ID: id}
+		}
+		if f.driveEvents[i].IsAuto {
+			return &DriveEventImmutableError{ID: id}
+		}
+		f.driveEvents = append(f.driveEvents[:i], f.driveEvents[i+1:]...)
+		return nil
+	}
+	return &DriveEventNotFoundError{SlotKey: slotKey, ID: id}
+}
+
+// GetDriveEvent returns a single event or nil if not found.
+func (f *FakeStore) GetDriveEvent(id int64) (*DriveEvent, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	for i := range f.driveEvents {
+		if f.driveEvents[i].ID == id {
+			cp := f.driveEvents[i]
+			return &cp, nil
+		}
+	}
+	return nil, nil
+}
+
+// GetDriveSlotState returns the last-observed state for slotKey, or
+// (nil, nil) if no state has been recorded.
+func (f *FakeStore) GetDriveSlotState(slotKey string) (*DriveSlotState, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if state, ok := f.driveSlotStates[slotKey]; ok {
+		cp := state
+		return &cp, nil
+	}
+	return nil, nil
+}
+
+// SaveDriveSlotState UPSERTs the last-observed state for a slot.
+func (f *FakeStore) SaveDriveSlotState(state DriveSlotState) error {
+	if state.SlotKey == "" {
+		return fmt.Errorf("slot_key is required")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.driveSlotStates == nil {
+		f.driveSlotStates = make(map[string]DriveSlotState)
+	}
+	if state.ObservedAt.IsZero() {
+		state.ObservedAt = time.Now().UTC()
+	}
+	f.driveSlotStates[state.SlotKey] = state
+	return nil
 }
 
 // ── Test helpers (not part of Store interface) ──

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -119,6 +119,24 @@ type LifecycleStore interface {
 	DataDir() string
 }
 
+// DriveEventStore handles per-drive maintenance log events (issue #130).
+// Events come in two flavours:
+//   - manual "note" (user-entered; mutable)
+//   - auto   "replacement" (system-detected on serial change; immutable)
+//
+// The SlotKey is the Unraid ArraySlot when available, else the drive serial.
+type DriveEventStore interface {
+	SaveDriveEvent(ev DriveEvent) (int64, error)
+	ListDriveEvents(slotKey string) ([]DriveEvent, error)
+	UpdateDriveEvent(slotKey string, id int64, eventTime *time.Time, content *string) error
+	DeleteDriveEvent(slotKey string, id int64) error
+	GetDriveEvent(id int64) (*DriveEvent, error)
+
+	// Slot state tracking for replacement detection (issue #130).
+	GetDriveSlotState(slotKey string) (*DriveSlotState, error)
+	SaveDriveSlotState(state DriveSlotState) error
+}
+
 // Store composes all domain-specific interfaces into a single aggregate.
 // Use the narrower interfaces when possible; use Store when a consumer
 // genuinely needs access to multiple domains.
@@ -131,6 +149,7 @@ type Store interface {
 	NotificationStore
 	FindingStore
 	LifecycleStore
+	DriveEventStore
 }
 
 // Compile-time checks: *DB must satisfy Store.


### PR DESCRIPTION
Refs #130

## Base branch
`release/v0.9.7-stage` — do **not** merge to main.

## Summary

Implements a per-drive chronological maintenance log (issue #130). Two event types:

- **Manual notes** (`event_type=note`, `is_auto=0`) — user-entered, mutable. Example: "SATA cable replaced 2026-04-15".
- **Auto-detected replacements** (`event_type=replacement`, `is_auto=1`) — system-generated when a slot's serial number changes between SMART scans. Content is JSON `{old_serial, old_model, new_serial, new_model}`. Immutable.

Log is reachable from three surfaces, all sharing the same `slot_key` policy (ArraySlot on Unraid, Serial elsewhere):

1. `/disk/{serial}` detail page — new "Maintenance Log" section with inline Add/Edit/Delete controls.
2. REST API at `/api/v1/drives/{slot_key}/events` (GET/POST/PUT/DELETE).
3. Diagnostic Report export — per-drive subsection with parsed replacement lines (no raw JSON).

## What's in scope

- New tables: `drive_events` (timeline) and `drive_slot_state` (per-slot last-observed serial for replacement detection).
- Replacement detector in the scheduler, wired into `Scheduler.Run` after `Collect()`. Unraid-only in this phase (other platforms lack stable slot identity).
- 403 enforcement on auto events via `DriveEventImmutableError`; 404 via `DriveEventNotFoundError`.
- First-observation suppression (no event on fresh install) and empty-slot suppression (no event when a drive is pulled — wait for the replacement to arrive).
- UI's slot_key resolves from `disk.array_slot` first, with fallback to serial, so the same key round-trips through URL path encoding into the API.

## What's NOT in scope (deferred)

- Replacement detection on non-Unraid platforms. On Synology/TrueNAS/generic Linux, `slot_key == serial`, so "same slot, different serial" is a tautology. Implementing per-platform physical-bay mapping (Synology `/proc/scsi`, etc.) is a separate feature.
- Bulk operations (e.g., "delete all notes for a slot"). Low demand so far.
- Rich text / markdown in notes — plain text only.
- Per-event email notifications on auto replacement.

## Test coverage

| Package | Test | What it pins |
|---|---|---|
| storage | `TestStore_DriveEvents_SaveAndList` | Insert + ordering (newest-first by event_time) |
| storage | `TestStore_DriveEvents_UpdateAndDelete_ManualOnly` | 403 contract on auto events, 200 path on manual |
| storage | `TestStore_DriveEvents_MissingSlotOrID` | not-found error on bogus lookups |
| scheduler | `TestDetectDriveReplacements_DetectsReplacement_OnSerialChange` | Core detection + JSON content shape |
| scheduler | `TestDetectDriveReplacements_NoReplacementEventOnFirstScan` | Fresh-install suppression |
| scheduler | `TestDetectDriveReplacements_NoReplacementEventWhenSlotGoesEmpty` | Pulled-drive suppression |
| scheduler | `TestDetectDriveReplacements_SkipsNonUnraid` | Platform guard |
| scheduler | `TestDetectDriveReplacements_MultipleSlotsIndependent` | Cross-slot isolation |
| api | `TestHandleDriveEvents_CRUD` | All four endpoints + 403/404/204 wire |
| api | `TestHandleDriveEvents_URLEncodedSlotKey` | Spaces in slot keys round-trip |
| api | `TestHandleDriveEvents_POST_ValidatesEventTime` | RFC3339 validation |
| api | `TestDiskDetailTemplate_HasMaintenanceLogSection` | Cross-reference on DOM ids, fetch endpoint, JS glue |
| api | `TestDiskDetailTemplate_MaintenanceLog_SystemBadgeOnly_ForAuto` | Template branches on `is_auto` so auto events don't render edit/delete |
| api | `TestReportExport_IncludesMaintenanceLog` | Report expands replacement JSON into human-readable line |
| api | `TestReportExport_NoMaintenanceLog_WhenNoEvents` | No empty section when nothing to show |

Full `go build ./...`, `go vet ./...`, and `go test ./...` all green on the stage branch base.

## Design surprises

- **Two tables, not one.** The detection logic needed a stable "what did I observe last time?" record that's snapshot-agnostic. Reusing `smart_history` would have tied detection semantics to arbitrary slices of history and made first-observation detection brittle. `drive_slot_state` is a single row per slot with UPSERT semantics — trivially correct.
- **Report pre-loading, not injection.** The report layer had no `store.Store` reference, and adding one would have rippled through `ReportSparklines` callers. Instead, `handleReport` pre-loads per-drive events into a new `ReportSparklines.DriveEventsBySlot` map (one `ListDriveEvents` per unique slot_key, bounded by the drive count). Keeps the report layer dependency-free.
- **`slot_key` resolver is duplicated once** — lives as `resolveSlotKey` in `internal/scheduler`, `resolveReportSlotKey` in `internal/api`, and inline JS `resolveSlotKey(disk)` in the template. Three identical implementations of `prefer ArraySlot, fall back to Serial`. Keeping them separate was cheaper than introducing an exported `internal.SlotKey` helper that would force import changes across three packages for what is a four-line policy. If a future session needs to change the policy they'll need to touch all three — noted in per-commit body.
- **Inline edit uses `window.prompt`** rather than a second modal layer. Minimal footprint, no CSS churn, and matches the "low-ceremony journal" nature of manual notes. Users who want richer editing can delete + re-add.

## Follow-up

- v0.9.7 UAT should exercise this on the Tower: add a manual note, verify it shows on the disk page, diag-report it, then swap an actual drive (or manually mutate `drive_slot_state` to simulate) and confirm a replacement event lands.
- Non-Unraid replacement detection is worth filing separately once someone has a Synology/TrueNAS bay-to-device mapping approach.