### PR TITLE
fix(smart): detect USB-bridge errors in smartctl JSON envelope (#206 rc2)

### DIFF
--- a/internal/collector/smart.go
+++ b/internal/collector/smart.go
@@ -280,6 +280,18 @@ func looksLikeStandbyOutput(out string) bool {
 }
 
 type smartctlJSON struct {
+	// Smartctl envelope carries invocation metadata and error messages.
+	// Present on every smartctl 7.x JSON response, even on error outputs
+	// (smartctl --json=c emits the envelope before any device-specific
+	// data, so we can reliably check it to distinguish a "valid JSON but
+	// the drive doesn't expose SMART" case from a genuine read).
+	Smartctl struct {
+		ExitStatus int `json:"exit_status"`
+		Messages   []struct {
+			String   string `json:"string"`
+			Severity string `json:"severity"`
+		} `json:"messages"`
+	} `json:"smartctl"`
 	ModelName    string `json:"model_name"`
 	SerialNumber string `json:"serial_number"`
 	FirmwareVer  string `json:"firmware_version"`
@@ -344,6 +356,23 @@ func parseSMARTJSON(device, out string) (internal.SMARTInfo, error) {
 	var data smartctlJSON
 	if err := json.Unmarshal([]byte(jsonStr), &data); err != nil {
 		return info, fmt.Errorf("JSON parse error for %s: %w", device, err)
+	}
+
+	// Classic cause (issue #206): on Unraid, /dev/sda is the boot flash
+	// and smartctl --json=c returns a JSON envelope whose smartctl.messages
+	// array carries the "Unknown USB bridge" error — NOT a text-mode error
+	// we'd catch in readSMARTDevice's fallback paths. Without this check,
+	// we'd parse the JSON successfully but get an empty info{} struct
+	// (ModelName=="" && SerialNumber==""), which collectSMART then
+	// categorises as `failed` via the empty-model short-circuit. The rc1
+	// of v0.9.7 added the collector-layer errDriveUnsupported branch but
+	// missed THIS path, so /dev/sda still landed in `failed`. Return
+	// errDriveUnsupported here so the caller routes this through the
+	// unsupported counter and emits the per-drive INFO log.
+	for _, msg := range data.Smartctl.Messages {
+		if strings.Contains(msg.String, "Unknown USB bridge") || strings.Contains(msg.String, "Please specify device type") {
+			return info, fmt.Errorf("%w: %s (smartctl.messages: %s)", errDriveUnsupported, device, msg.String)
+		}
 	}
 
 	info.Model = data.ModelName

--- a/internal/collector/smart_unsupported_test.go
+++ b/internal/collector/smart_unsupported_test.go
@@ -171,3 +171,81 @@ func TestCollectSMART_UnsupportedDrive_EmitsPerDriveLog(t *testing.T) {
 		t.Errorf("per-drive log reason is empty; expected a human-readable explanation")
 	}
 }
+
+// TestCollectSMART_USBBridge_JSONWrapped_AlsoCountedAsUnsupported covers
+// the follow-up #206 fix: smartctl 7.x ALWAYS emits a JSON envelope
+// when invoked with --json=c, including on error outputs. The envelope's
+// smartctl.messages[] array carries the "Unknown USB bridge" / "Please
+// specify device type" strings that the rc1 fix relied on seeing in
+// text-mode fallback output.
+//
+// When the initial --json=c call returns JSON (which it does for
+// every smartctl 7.x invocation), readSMARTDevice immediately hands
+// off to parseSMARTJSON at line 188 and NEVER reaches the text-mode
+// fallback at line 220 where the rc1 check lives. Result on the
+// reporter's Tower: /dev/sda (Unraid boot flash) lands in `failed`
+// not `unsupported` because parseSMARTJSON returns an empty info
+// struct that collectSMART then trips on via the empty-model guard.
+//
+// This test feeds the real shape of smartctl 7.4's JSON output for
+// a USB-bridge device (taken from the reporter's actual /dev/sda
+// response) and asserts the drive is categorised correctly.
+func TestCollectSMART_USBBridge_JSONWrapped_AlsoCountedAsUnsupported(t *testing.T) {
+	if len(discoverDrives()) > 0 {
+		t.Skip("host has real drives discoverable via /dev/sd*; cannot run deterministic fake-execCmd test")
+	}
+
+	// Shape of smartctl 7.x --json=c output on an Unraid boot flash.
+	// Critical fields: json_format_version (so readSMARTDevice routes
+	// to parseSMARTJSON), and smartctl.messages[] carrying the error
+	// strings. ModelName / SerialNumber are absent because smartctl
+	// couldn't read the device.
+	usbBridgeJSON := `{
+		"json_format_version": [1, 0],
+		"smartctl": {
+			"version": [7, 4],
+			"pre_release": false,
+			"svn_revision": "5530",
+			"platform_info": "x86_64-linux-6.12.24-Unraid",
+			"build_info": "(local build)",
+			"argv": ["smartctl", "--json=c", "-a", "/dev/fake-usb"],
+			"exit_status": 4,
+			"messages": [
+				{"string": "/dev/fake-usb: Unknown USB bridge [0x0951:0x1666 (0x001)]", "severity": "error"},
+				{"string": "Please specify device type with the -d option.", "severity": "error"}
+			]
+		}
+	}`
+
+	fakeActiveJSON := `{"json_format_version":[1,0,0],"model_name":"FakeDrive 1TB","serial_number":"SN-ACTIVE","user_capacity":{"bytes":1000000000000},"temperature":{"current":30},"power_on_time":{"hours":100}}`
+
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		if len(args) == 1 && args[0] == "--scan" {
+			return "/dev/fake-usb -d sat # /dev/fake-usb, SAT\n" +
+				"/dev/fake-active -d sat # /dev/fake-active, SAT\n", nil
+		}
+		argv := strings.Join(args, " ")
+		switch {
+		case strings.Contains(argv, "/dev/fake-usb"):
+			// Every fallback also returns the JSON-wrapped USB bridge
+			// error — mirrors smartctl 7.x's actual behaviour where
+			// --json output is emitted regardless of -d option.
+			return usbBridgeJSON, nil
+		case strings.Contains(argv, "/dev/fake-active"):
+			return fakeActiveJSON, nil
+		}
+		return "", nil
+	})()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	_, _ = collectSMART(SMARTConfig{WakeDrives: false}, logger)
+
+	summary := scanSMARTSummary(t, buf.String())
+
+	assertCounter(t, summary, "total", 2)
+	assertCounter(t, summary, "active", 1)
+	assertCounter(t, summary, "standby", 0)
+	assertCounter(t, summary, "unsupported", 1)
+	assertCounter(t, summary, "failed", 0)
+}


### PR DESCRIPTION
## rc1 UAT finding

On real hardware, the reporter's v0.9.7-rc1 summary log was:

```
SMART collection complete total=13 active=12 standby=0 unsupported=0 failed=1
```

`failed=1` = still the Unraid boot flash at /dev/sda. rc1's fix was incomplete.

## Root cause

smartctl 7.x ALWAYS emits a JSON envelope when invoked with `--json=c`, including on error outputs. The initial `--json=c -a /dev/sda` call returns:

```json
{
  "json_format_version": [1, 0],
  "smartctl": {
    "exit_status": 4,
    "messages": [
      {"string": "/dev/sda: Unknown USB bridge [...]", "severity": "error"},
      {"string": "Please specify device type with the -d option.", "severity": "error"}
    ]
  }
}
```

`readSMARTDevice` sees `json_format_version`, hands off to `parseSMARTJSON` at line 188, and NEVER reaches the text-mode fallback at line 220 where rc1's `errDriveUnsupported` check lives. `parseSMARTJSON` unmarshals cleanly but gets an empty `info{}` struct (no model/serial in the error response), which `collectSMART` then catches via the empty-model guard at line 87 and classifies as `failed`.

## Fix

Extend `smartctlJSON` with the `Smartctl` envelope field (`exit_status` + `messages[]`). In `parseSMARTJSON`, after unmarshal succeeds, scan `data.Smartctl.Messages` for `Unknown USB bridge` or `Please specify device type` markers. If found, return `errDriveUnsupported` wrapping the first matched message.

Defense in depth: the existing text-mode check at line 220 stays in place for smartctl 6.x and any path where the JSON envelope is absent.

## Verification

- New test: `TestCollectSMART_USBBridge_JSONWrapped_AlsoCountedAsUnsupported` feeds the real shape of smartctl 7.4 JSON output and asserts `unsupported=1, failed=0`.
- All 7 existing SMART tests still pass.
- Full `go test ./...` green across all packages; `go vet ./...` clean.

## Target

Base: `release/v0.9.7-stage`. This is the rc2 fix for the v0.9.7 pack. Once merged + other rc2 items (if any), cut `v0.9.7-rc2` tag for UAT.

Refs #206 (issue stays open until this lands on main via v0.9.7 squash).