### PR TITLE
fix(ui): add .pill-trace CSS rule for traceroute service-check pill (#189 rc3 polish)

### DIFF
--- a/internal/api/styles.go
+++ b/internal/api/styles.go
@@ -244,6 +244,7 @@ body.theme-clean .badge-generic { background:rgba(0,0,0,0.06) }
 .pill-smb,.pill-nfs { background:rgba(245,158,11,0.14); color:#fbbf24 }
 .pill-ping { background:rgba(139,92,246,0.14); color:#a78bfa }
 .pill-speed { background:rgba(14,165,233,0.14); color:#38bdf8 }
+.pill-trace { background:rgba(99,102,241,0.14); color:#818cf8 }
 
 /* ── Status Dots ────────────────────────────────────────────── */
 .status-dot.degraded { background:#f59e0b }

--- a/internal/api/styles_pill_trace_test.go
+++ b/internal/api/styles_pill_trace_test.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStyles_PillTrace_HasCSSRule pins the CSS rule for the
+// traceroute service-check pill. #189 (v0.9.7) added the pill-trace
+// class to both service_checks.html and settings.html via pillClass
+// / serviceTypePillClass helpers, but the initial implementation
+// forgot to add a matching .pill-trace rule to the shared styles.go.
+// Result: the Traceroute label in the service-checks list rendered
+// without the colored background that every other check type has
+// (TCP green, HTTP blue, DNS pink, etc). Caught during rc2 UAT.
+//
+// This test guards against a regression where the CSS class gets
+// renamed / removed on one side but not the other.
+func TestStyles_PillTrace_HasCSSRule(t *testing.T) {
+	if !strings.Contains(SharedCSS, ".pill-trace") {
+		t.Error("styles.go: missing .pill-trace CSS rule — traceroute type pill in service-checks list will render without colored background (other .pill-* rules exist for http/tcp/dns/smb/nfs/ping/speed)")
+	}
+	// The rule must define both background and color so the pill
+	// matches the visual pattern of the other check types.
+	lines := strings.Split(SharedCSS, "\n")
+	var rule string
+	for _, line := range lines {
+		if strings.Contains(line, ".pill-trace") {
+			rule = line
+			break
+		}
+	}
+	if rule == "" {
+		t.Fatal("unreachable: first assertion passed but line scan failed")
+	}
+	if !strings.Contains(rule, "background:") {
+		t.Errorf(".pill-trace rule missing background property: %q", rule)
+	}
+	if !strings.Contains(rule, "color:") {
+		t.Errorf(".pill-trace rule missing color property: %q", rule)
+	}
+}


### PR DESCRIPTION
rc2 UAT finding: the TRACEROUTE label in the service-checks list renders without the colored background every other check type has.

## Root cause

PR #223 (v0.9.7 traceroute feature) added the `pill-trace` class to both `service_checks.html` and `settings.html` via the `pillClass` / `serviceTypePillClass` helpers, AND added cross-reference tests that verified the class string was in the HTML — but forgot to add a matching `.pill-trace` rule to `internal/api/styles.go`'s `SharedCSS`. The HTML gets the class applied but with no CSS behind it, the label falls back to the plain container text look.

## Fix

One-line addition to `SharedCSS`:

```css
.pill-trace { background:rgba(99,102,241,0.14); color:#818cf8 }
```

Indigo-500/400 — the only major color in the palette not already taken by an existing pill type (visually fills the gap between http's blue-500 and ping's violet-500).

## Regression guard

New test `TestStyles_PillTrace_HasCSSRule` scans `SharedCSS` for the `.pill-trace` selector and requires both `background:` and `color:` properties. Pairs with the existing `TestSettingsHTML_TracerouteTypePillClass` (which only checks the class is APPLIED in the HTML) so a future refactor that removes one side without the other fails loudly.

## Target

Base: `release/v0.9.7-stage`. Potential rc3 candidate for v0.9.7 (depending on whether you think this visual nit warrants another RC cycle vs shipping as-is with the pill rendering unstyled).

Refs #189.