### PR TITLE
fix(ui): split pill palette so every service-check type has a distinct colour (#189 rc4)

### DIFF
--- a/internal/api/styles.go
+++ b/internal/api/styles.go
@@ -238,13 +238,18 @@ body.theme-clean .badge-generic { background:rgba(0,0,0,0.06) }
   text-transform:uppercase; letter-spacing:0.5px;
   padding:2px 8px; border-radius:999px;
 }
-.pill-http { background:rgba(59,130,246,0.14); color:#60a5fa }
-.pill-tcp  { background:rgba(16,185,129,0.14); color:#34d399 }
-.pill-dns  { background:rgba(236,72,153,0.14); color:#f472b6 }
-.pill-smb,.pill-nfs { background:rgba(245,158,11,0.14); color:#fbbf24 }
-.pill-ping { background:rgba(139,92,246,0.14); color:#a78bfa }
-.pill-speed { background:rgba(14,165,233,0.14); color:#38bdf8 }
-.pill-trace { background:rgba(99,102,241,0.14); color:#818cf8 }
+/* Each service-check type gets a perceptually-distinct hue so users
+   can tell them apart at a glance in the list. Red is reserved for
+   .pill-critical. Palette locked by TestStyles_ServiceCheckPillPalette
+   — update the test AND this rule together. */
+.pill-http  { background:rgba( 59,130,246,0.14); color:#60a5fa } /* blue-400    */
+.pill-tcp   { background:rgba( 16,185,129,0.14); color:#34d399 } /* emerald-400 */
+.pill-dns   { background:rgba(236, 72,153,0.14); color:#f472b6 } /* pink-400    */
+.pill-smb   { background:rgba(245,158, 11,0.14); color:#fbbf24 } /* amber-400   */
+.pill-nfs   { background:rgba(251,146, 60,0.14); color:#fb923c } /* orange-400  */
+.pill-ping  { background:rgba(139, 92,246,0.14); color:#a78bfa } /* violet-400  */
+.pill-speed { background:rgba( 34,211,238,0.14); color:#22d3ee } /* cyan-400    */
+.pill-trace { background:rgba( 45,212,191,0.14); color:#2dd4bf } /* teal-400    */
 
 /* ── Status Dots ────────────────────────────────────────────── */
 .status-dot.degraded { background:#f59e0b }

--- a/internal/api/styles_pill_palette_test.go
+++ b/internal/api/styles_pill_palette_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestStyles_ServiceCheckPillPalette pins the pill colour palette for
+// all service-check types and asserts no two types share a colour.
+//
+// Why this test exists: v0.9.7 rc4 UAT caught that .pill-http
+// (#60a5fa), .pill-speed (#38bdf8) and .pill-trace (#818cf8) were
+// all technically-distinct hex values but perceptually all in the
+// "blue" family at 14% background opacity — users couldn't tell them
+// apart in the service-checks list. Likewise .pill-smb and .pill-nfs
+// explicitly shared amber via a multi-selector rule.
+//
+// This test locks the approved palette per type so:
+//
+//	(a) Accidental regressions (copy-paste duplicates, or re-adding a
+//	    multi-selector that groups two types under one colour) fail
+//	    loudly.
+//	(b) Intentional palette changes require updating this test,
+//	    forcing the conversation about whether the new colour is
+//	    perceptually distinct from its neighbours.
+//
+// #189 rc4.
+func TestStyles_ServiceCheckPillPalette(t *testing.T) {
+	// Approved palette — each type has a perceptually-distinct hue.
+	// Red is reserved for .pill-critical, so not used here.
+	// Tailwind 400-weight shades for consistency with the rest of the
+	// design system.
+	want := map[string]string{
+		"http":  "#60a5fa", // blue-400
+		"tcp":   "#34d399", // emerald-400
+		"dns":   "#f472b6", // pink-400
+		"smb":   "#fbbf24", // amber-400
+		"nfs":   "#fb923c", // orange-400
+		"ping":  "#a78bfa", // violet-400
+		"speed": "#22d3ee", // cyan-400
+		"trace": "#2dd4bf", // teal-400
+	}
+
+	t.Run("each_pill_has_pinned_color", func(t *testing.T) {
+		for pillType, wantColor := range want {
+			got := extractPillColor(t, SharedCSS, pillType)
+			if got != wantColor {
+				t.Errorf(".pill-%s: got colour %q, want %q — update this test AND styles.go together, and verify the new colour is perceptually distinct from neighbours at 14%% background opacity", pillType, got, wantColor)
+			}
+		}
+	})
+
+	t.Run("all_pills_have_distinct_colors", func(t *testing.T) {
+		seen := map[string]string{} // color -> pill type that claimed it first
+		for pillType := range want {
+			got := extractPillColor(t, SharedCSS, pillType)
+			if got == "" {
+				continue // pinned-color subtest will have reported this
+			}
+			if prev, dup := seen[got]; dup {
+				t.Errorf(".pill-%s and .pill-%s both resolve to %s — every service-check type must have a unique pill colour", pillType, prev, got)
+			}
+			seen[got] = pillType
+		}
+	})
+}
+
+// extractPillColor returns the #RRGGBB value on the .pill-<type> rule
+// from css. Returns "" and fails the test if the rule is missing or
+// the colour can't be parsed. Multi-selector rules like
+// ".pill-x,.pill-y { ... }" match for either x or y and return the
+// same colour for both — which the distinctness subtest then catches.
+func extractPillColor(t *testing.T, css, pillType string) string {
+	t.Helper()
+	re := regexp.MustCompile(`\.pill-` + regexp.QuoteMeta(pillType) + `\b[^{]*\{[^}]*color:\s*(#[0-9a-fA-F]{6})`)
+	m := re.FindStringSubmatch(css)
+	if len(m) < 2 {
+		t.Errorf(".pill-%s: rule or colour not found in SharedCSS", pillType)
+		return ""
+	}
+	return strings.ToLower(m[1])
+}


### PR DESCRIPTION
## What

Split the service-check type pill colour palette so every type has a
perceptually-distinct hue.

| Type  | Before                    | After                     |
|-------|---------------------------|---------------------------|
| http  | `#60a5fa` blue-400        | `#60a5fa` blue-400 *(unchanged)* |
| tcp   | `#34d399` emerald-400     | `#34d399` emerald-400 *(unchanged)* |
| dns   | `#f472b6` pink-400        | `#f472b6` pink-400 *(unchanged)* |
| smb   | `#fbbf24` amber-400 *(shared with nfs)* | `#fbbf24` amber-400 *(own rule)* |
| nfs   | `#fbbf24` amber-400 *(shared with smb)* | **`#fb923c` orange-400 (split)** |
| ping  | `#a78bfa` violet-400      | `#a78bfa` violet-400 *(unchanged)* |
| speed | `#38bdf8` sky-400         | **`#22d3ee` cyan-400**    |
| trace | `#818cf8` indigo-400      | **`#2dd4bf` teal-400**    |

## Why

Caught during v0.9.7 rc3 UAT on real Unraid hardware:
`http` / `speed` / `trace` were all technically-distinct hex values
but perceptually all in the blue family at 14% background opacity —
users couldn't tell them apart in the service-checks list. The
`.pill-trace` class was added in #228 (rc3) to fix the styling-missing
symptom, but the colour choice (indigo) landed too close to existing
blues. `smb` and `nfs` were also explicitly sharing amber via a
multi-selector rule.

Red is deliberately skipped because `.pill-critical` claims that
hue semantically.

## Regression guard

New `TestStyles_ServiceCheckPillPalette` test with two subtests:

1. **`each_pill_has_pinned_color`** — pins every type → approved hex.
   Accidental or intentional colour changes fail loudly until both
   the test and `styles.go` are updated together.
2. **`all_pills_have_distinct_colors`** — asserts no two types share a
   colour (catches accidental multi-selector rules and copy-paste
   duplicates).

Together these catch the next 'add a pill' session's palette
collisions at test time instead of during UAT.

## Test

```
$ go test ./internal/api/ -run TestStyles_ServiceCheckPillPalette -v
=== RUN   TestStyles_ServiceCheckPillPalette
=== RUN   TestStyles_ServiceCheckPillPalette/each_pill_has_pinned_color
=== RUN   TestStyles_ServiceCheckPillPalette/all_pills_have_distinct_colors
--- PASS: TestStyles_ServiceCheckPillPalette (0.00s)
PASS
```

Full suite green. Build clean.

## Ship path

Merges into `release/v0.9.7-stage`, then tagged as `v0.9.7-rc4` for
UAT on `nas-doctor-uat` before v0.9.7 final.

Closes #189 rc4.