### PR TITLE
fix(ui): dashboard Service Checks widget renders type as pill + nfs helper fix (#189 rc5)

### DIFF
--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -86,6 +86,24 @@ util.severityClass = function(sev) {
   return "td-healthy";
 };
 
+/* Maps a service-check type string (http / tcp / dns / ping / smb /
+   nfs / speed / traceroute) to its CSS pill class. Must stay in sync
+   with serviceTypePillClass in settings.html and pillClass in
+   service_checks.html. The cross-file agreement is enforced by
+   TestServiceCheckPillHelpers_AgreeAcrossTemplates. */
+util.pillClass = function(t) {
+  var type = (t || "").toLowerCase();
+  if (type === "http") return "pill-http";
+  if (type === "tcp") return "pill-tcp";
+  if (type === "dns") return "pill-dns";
+  if (type === "ping") return "pill-ping";
+  if (type === "smb") return "pill-smb";
+  if (type === "nfs") return "pill-nfs";
+  if (type === "speed") return "pill-speed";
+  if (type === "traceroute") return "pill-trace";
+  return "pill-http";
+};
+
 /* ── Polling ───────────────────────────────────────────────────── */
 var polling = {};
 var _pollTimer = null;
@@ -782,7 +800,7 @@ sections.serviceChecks = function(sn) {
       h += '<tr style="cursor:pointer" data-sc-filter="' + esc(sc.name || '') + '">';
       h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border)"><div style="font-weight:500">' + esc(sc.name || 'Service') + '</div><div style="font-size:11px;color:var(--text-quaternary)">' + esc(sc.target || '') + '</div></td>';
       h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border);text-align:center"><div style="display:inline-flex;align-items:center;gap:0">' + dots + '</div></td>';
-      h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border)">' + esc((sc.type || '').toUpperCase()) + '</td>';
+      h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border)"><span class="pill ' + util.pillClass(sc.type) + '">' + esc((sc.type || '').toUpperCase()) + '</span></td>';
       h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border)" class="' + scClass + '">' + esc(sc.status || 'unknown') + '</td>';
       h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border)">' + ((sc.response_ms != null) ? (sc.response_ms + ' ms') : '\u2014') + '</td>';
       h += '<td style="padding:5px 8px;border-bottom:1px solid var(--border)">' + (sc.consecutive_failures || 0) + ' / ' + (sc.failure_threshold || 1) + '</td>';

--- a/internal/api/dashboard_service_check_pill_test.go
+++ b/internal/api/dashboard_service_check_pill_test.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// canonicalPillMapping is the single source of truth for how every
+// service-check type maps to its CSS pill class. Every place in the
+// codebase that renders a type-pill (settings.html, service_checks.html,
+// dashboard.go's DashboardJS) must agree on this mapping.
+//
+// Adding a new check type? Add it here and all three helpers become
+// testable against it in one go.
+type canonicalPillMapping struct {
+	typeName  string
+	pillClass string
+}
+
+var canonicalPillMap = []canonicalPillMapping{
+	{"http", "pill-http"},
+	{"tcp", "pill-tcp"},
+	{"dns", "pill-dns"},
+	{"ping", "pill-ping"},
+	{"smb", "pill-smb"},
+	{"nfs", "pill-nfs"},
+	{"speed", "pill-speed"},
+	{"traceroute", "pill-trace"},
+}
+
+// TestServiceCheckPillHelpers_AgreeAcrossTemplates catches the
+// "N independent copies of the same mapping, one of them drifts" bug.
+//
+// Background: before v0.9.7 rc4, three separate pill-class helpers
+// lived in the codebase:
+//
+//	1. settings.html serviceTypePillClass(t)        — correct
+//	2. service_checks.html pillClass(t)              — wrong: nfs→pill-smb
+//	3. (none for dashboard widget — rendered plain text)
+//
+// This test asserts that every known type maps to its approved class
+// in every file that contains a helper. If a new type is added to
+// canonicalPillMap above, every helper must be updated or this test
+// fails. If a future refactor consolidates the three helpers into
+// one, this test still passes (it just becomes tautological).
+//
+// #189 rc4 / v0.9.7.
+func TestServiceCheckPillHelpers_AgreeAcrossTemplates(t *testing.T) {
+	sources := map[string]string{
+		"settings.html (serviceTypePillClass)": loadSettingsHTML(t),
+		"service_checks.html (pillClass)":      loadServiceChecksHTML(t),
+		"dashboard.go (util.pillClass)":        DashboardJS,
+	}
+
+	for source, content := range sources {
+		for _, m := range canonicalPillMap {
+			// A helper mapping type -> class will have both literals
+			// close together (e.g. `if(t==="nfs")return"pill-nfs"`).
+			// Anchor on the type string, allow up to 80 chars of
+			// intervening syntax, then assert the class literal.
+			pattern := `"` + m.typeName + `"[^}]{0,80}"` + m.pillClass + `"`
+			matched, err := regexp.MatchString(pattern, content)
+			if err != nil {
+				t.Fatalf("regex error for %s[%s]: %v", source, m.typeName, err)
+			}
+			if !matched {
+				t.Errorf("%s: missing or wrong mapping for type %q — expected class %q", source, m.typeName, m.pillClass)
+			}
+		}
+	}
+}
+
+// TestDashboardJS_ServiceCheckTypePill asserts the Services section of
+// the dashboard widget renders the TYPE column as a coloured pill span
+// (matching /service-checks and /settings) rather than plain uppercase
+// text. Caught during v0.9.7 rc4 UAT: the dashboard Service Checks
+// widget rendered PING / HTTP / DNS / TCP / TRACEROUTE as grey plain
+// text in the TYPE column while the same data on /service-checks
+// rendered coloured pills.
+//
+// #189 rc4 / v0.9.7.
+func TestDashboardJS_ServiceCheckTypePill(t *testing.T) {
+	t.Run("pill_class_helper_is_defined", func(t *testing.T) {
+		// The helper must exist as util.pillClass so downstream
+		// code can call it without re-implementing the mapping.
+		if !strings.Contains(DashboardJS, "util.pillClass = function") {
+			t.Fatal("util.pillClass helper missing from DashboardJS — every other type-pill renderer has an equivalent helper")
+		}
+	})
+
+	t.Run("old_plain_text_rendering_removed", func(t *testing.T) {
+		// The rc3 rendering was:
+		//   h += '<td ...>' + esc((sc.type || '').toUpperCase()) + '</td>';
+		// — grey plain text. The fix replaces it with a pill span.
+		if strings.Contains(DashboardJS, `esc((sc.type || '').toUpperCase()) + '</td>'`) {
+			t.Error("dashboard services section still renders type as plain toUpperCase() text; expected coloured pill span via util.pillClass")
+		}
+	})
+
+	t.Run("services_section_uses_pill_helper", func(t *testing.T) {
+		// Anchor on the section header so we're certain we're
+		// asserting against the right block (DashboardJS has many
+		// section renderers).
+		idx := strings.Index(DashboardJS, "Service Checks (")
+		if idx < 0 {
+			t.Fatal("'Service Checks (' header anchor not found in DashboardJS — test can't locate the right section")
+		}
+		// Scan a generous window after the anchor; the current
+		// services renderer is under 2kB.
+		end := idx + 3000
+		if end > len(DashboardJS) {
+			end = len(DashboardJS)
+		}
+		section := DashboardJS[idx:end]
+
+		if !strings.Contains(section, "util.pillClass") {
+			t.Error("services section doesn't reference util.pillClass — the TYPE column probably still renders as plain text")
+		}
+		if !strings.Contains(section, `class="pill `) {
+			t.Error("services section missing 'class=\"pill ...\"' span wrapper around the type")
+		}
+	})
+}

--- a/internal/api/templates/service_checks.html
+++ b/internal/api/templates/service_checks.html
@@ -304,7 +304,7 @@
     }
     return out;
   }
-  function pillClass(t){t=(t||"").toLowerCase();if(t==="http")return"pill-http";if(t==="tcp")return"pill-tcp";if(t==="dns")return"pill-dns";if(t==="ping")return"pill-ping";if(t==="smb"||t==="nfs")return"pill-smb";if(t==="speed")return"pill-speed";if(t==="traceroute")return"pill-trace";return"pill-http";}
+  function pillClass(t){t=(t||"").toLowerCase();if(t==="http")return"pill-http";if(t==="tcp")return"pill-tcp";if(t==="dns")return"pill-dns";if(t==="ping")return"pill-ping";if(t==="smb")return"pill-smb";if(t==="nfs")return"pill-nfs";if(t==="speed")return"pill-speed";if(t==="traceroute")return"pill-trace";return"pill-http";}
   function fmtInterval(sec){if(sec<60)return sec+"s";if(sec<3600)return Math.floor(sec/60)+"m";return Math.floor(sec/3600)+"h";}
   function faviconHTML(type,target){
     if((type||"").toLowerCase()!=="http")return"";


### PR DESCRIPTION
## What

Two related consistency fixes for the type-pill rendering, surfaced
during v0.9.7 rc4 UAT on real hardware.

### 1. Dashboard Service Checks widget renders TYPE as a coloured pill

**Before:** Dashboard rendered the TYPE column as plain grey uppercase
text (`PING`, `HTTP`, `DNS`, `TCP`, `TRACEROUTE`) while `/service-checks`
and `/settings` rendered coloured pills for the same data.

**After:** Dashboard matches the other two pages — every TYPE cell is
a coloured pill span using `util.pillClass(sc.type)`.

### 2. `service_checks.html` `pillClass` helper — split nfs from smb

**Before:** `pillClass` used a multi-selector: `t==="smb"||t==="nfs"` →
`pill-smb`. That was fine when smb+nfs shared amber, but rc4's palette
split moved nfs onto its own orange rule. Result: nfs rows on the
`/service-checks` log page were rendering amber (stale) while nfs
appeared orange in `/settings`.

**After:** `pillClass` returns `pill-nfs` for nfs and `pill-smb` for
smb — matching the other two helpers.

### Hidden 3rd finding

There are now **three independent pill-class helpers** in the codebase
(settings.html `serviceTypePillClass`, service_checks.html `pillClass`,
dashboard.go `util.pillClass`). Every new check type has to be added in
three places. Same AGENTS.md-documented pattern as the N-column fallback
duplication.

This PR adds the dashboard helper (required for the pill rendering)
AND a cross-file agreement test (`TestServiceCheckPillHelpers_AgreeAcrossTemplates`)
that locks the mapping so future drift fails CI. A proper consolidation
(extract into DashboardJS or a shared template include) is tracked
separately — v0.9.8 candidate.

## Regression guards

**`TestServiceCheckPillHelpers_AgreeAcrossTemplates`** — for every
canonical check type in `canonicalPillMap`, asserts every helper file
contains the approved `type → class` mapping (anchored regex). Catches
accidental drift between the three copies. This is the key test —
adding a new check type in the future forces all three helpers to be
updated or this test fails.

**`TestDashboardJS_ServiceCheckTypePill`** (3 subtests):
1. `pill_class_helper_is_defined` — `util.pillClass` exists in DashboardJS
2. `old_plain_text_rendering_removed` — `esc((sc.type || '').toUpperCase())` is gone
3. `services_section_uses_pill_helper` — the Services section invokes `util.pillClass` and wraps in `class="pill ..."`

## Test

```
$ go test ./internal/api/ -run "TestServiceCheckPillHelpers_AgreeAcrossTemplates|TestDashboardJS_ServiceCheckTypePill" -v
=== RUN   TestServiceCheckPillHelpers_AgreeAcrossTemplates
--- PASS (0.00s)
=== RUN   TestDashboardJS_ServiceCheckTypePill
--- PASS (0.00s)
    --- PASS: pill_class_helper_is_defined
    --- PASS: old_plain_text_rendering_removed
    --- PASS: services_section_uses_pill_helper
PASS
```

Full suite green. Build clean.

## Diff size

- `internal/api/dashboard.go` — +19 lines (util.pillClass helper) + 1 line changed (services TYPE cell)
- `internal/api/templates/service_checks.html` — 1 line changed (pillClass helper)
- `internal/api/dashboard_service_check_pill_test.go` — new test file

## Ship path

Merges into `release/v0.9.7-stage`, then tagged as `v0.9.7-rc5` for
final UAT on `nas-doctor-uat`.

Closes #189 rc5.