### PR TITLE
fix(ui): inline service-check pill CSS in dashboard theme templates (#189 rc6)

### DIFF
--- a/internal/api/styles_pill_palette_test.go
+++ b/internal/api/styles_pill_palette_test.go
@@ -42,11 +42,11 @@ func TestStyles_ServiceCheckPillPalette(t *testing.T) {
 		"trace": "#2dd4bf", // teal-400
 	}
 
-	t.Run("each_pill_has_pinned_color", func(t *testing.T) {
+	t.Run("shared_css_has_pinned_colors", func(t *testing.T) {
 		for pillType, wantColor := range want {
-			got := extractPillColor(t, SharedCSS, pillType)
+			got := extractPillColor(t, SharedCSS, "SharedCSS", pillType)
 			if got != wantColor {
-				t.Errorf(".pill-%s: got colour %q, want %q — update this test AND styles.go together, and verify the new colour is perceptually distinct from neighbours at 14%% background opacity", pillType, got, wantColor)
+				t.Errorf(".pill-%s in SharedCSS: got %q, want %q — update this test AND styles.go together, and verify the new colour is perceptually distinct from neighbours at 14%% background opacity", pillType, got, wantColor)
 			}
 		}
 	})
@@ -54,7 +54,7 @@ func TestStyles_ServiceCheckPillPalette(t *testing.T) {
 	t.Run("all_pills_have_distinct_colors", func(t *testing.T) {
 		seen := map[string]string{} // color -> pill type that claimed it first
 		for pillType := range want {
-			got := extractPillColor(t, SharedCSS, pillType)
+			got := extractPillColor(t, SharedCSS, "SharedCSS", pillType)
 			if got == "" {
 				continue // pinned-color subtest will have reported this
 			}
@@ -64,19 +64,51 @@ func TestStyles_ServiceCheckPillPalette(t *testing.T) {
 			seen[got] = pillType
 		}
 	})
+
+	// Dashboard theme templates (midnight.html, clean.html) have their
+	// own inline <style> blocks and do NOT link /css/shared.css. So the
+	// .pill-<type> rules must exist inline in each theme, with the SAME
+	// approved colours as SharedCSS.
+	//
+	// Caught during v0.9.7 rc5 UAT: midnight theme rendered every
+	// service-check type as plain text in the Service Checks widget.
+	// Root cause: midnight.html had no .pill or .pill-<type> rules at
+	// all. The JS was rendering <span class="pill pill-http">PING</span>
+	// correctly, but with no CSS rules matching, the browser rendered
+	// it as plain inline text. Clean theme had .pill base + 5 unrelated
+	// .pill-healthy/warning/critical/info/neutral rules but none for
+	// the 8 service-check types.
+	//
+	// This subtest pins every theme template to the canonical palette.
+	themeSources := map[string]string{
+		"midnight.html": DashboardMidnight,
+		"clean.html":    DashboardClean,
+	}
+	t.Run("theme_templates_have_same_palette", func(t *testing.T) {
+		for themeName, css := range themeSources {
+			for pillType, wantColor := range want {
+				got := extractPillColor(t, css, themeName, pillType)
+				if got != wantColor {
+					t.Errorf("%s .pill-%s: got %q, want %q — dashboard theme templates must include every service-check pill rule inline (they don't link shared.css)", themeName, pillType, got, wantColor)
+				}
+			}
+		}
+	})
 }
 
 // extractPillColor returns the #RRGGBB value on the .pill-<type> rule
 // from css. Returns "" and fails the test if the rule is missing or
-// the colour can't be parsed. Multi-selector rules like
-// ".pill-x,.pill-y { ... }" match for either x or y and return the
-// same colour for both — which the distinctness subtest then catches.
-func extractPillColor(t *testing.T, css, pillType string) string {
+// the colour can't be parsed. sourceLabel is used in error messages
+// to identify which CSS source failed (e.g. "SharedCSS",
+// "midnight.html"). Multi-selector rules like ".pill-x,.pill-y {...}"
+// match for either x or y and return the same colour for both —
+// which the distinctness subtest then catches.
+func extractPillColor(t *testing.T, css, sourceLabel, pillType string) string {
 	t.Helper()
 	re := regexp.MustCompile(`\.pill-` + regexp.QuoteMeta(pillType) + `\b[^{]*\{[^}]*color:\s*(#[0-9a-fA-F]{6})`)
 	m := re.FindStringSubmatch(css)
 	if len(m) < 2 {
-		t.Errorf(".pill-%s: rule or colour not found in SharedCSS", pillType)
+		t.Errorf(".pill-%s: rule or colour not found in %s", pillType, sourceLabel)
 		return ""
 	}
 	return strings.ToLower(m[1])

--- a/internal/api/templates/clean.html
+++ b/internal/api/templates/clean.html
@@ -55,6 +55,16 @@ body{min-height:100vh;background:#fff}
 .pill-critical{background:#fef2f2;color:#dc2626}
 .pill-info{background:#ebf5ff;color:#0068d6}
 .pill-neutral{background:#fafafa;color:#4d4d4d}
+/* Service-check type pills — palette mirrored from SharedCSS. Locked
+   by TestStyles_ServiceCheckPillPalette/theme_templates_have_same_palette. */
+.pill-http  { background:rgba( 59,130,246,0.14); color:#60a5fa }
+.pill-tcp   { background:rgba( 16,185,129,0.14); color:#34d399 }
+.pill-dns   { background:rgba(236, 72,153,0.14); color:#f472b6 }
+.pill-smb   { background:rgba(245,158, 11,0.14); color:#fbbf24 }
+.pill-nfs   { background:rgba(251,146, 60,0.14); color:#fb923c }
+.pill-ping  { background:rgba(139, 92,246,0.14); color:#a78bfa }
+.pill-speed { background:rgba( 34,211,238,0.14); color:#22d3ee }
+.pill-trace { background:rgba( 45,212,191,0.14); color:#2dd4bf }
 .scan-bar{display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap;margin-top:16px;padding:8px 0}
 .scan-info{font-size:13px;color:#808080;font-weight:400}
 

--- a/internal/api/templates/midnight.html
+++ b/internal/api/templates/midnight.html
@@ -61,6 +61,17 @@ a:hover{color:var(--hover)}
 .health-badge.badge-red{color:var(--red);background:var(--red-bg)}
 .health-badge.badge-amber{color:var(--amber);background:var(--amber-bg)}
 .health-badge.badge-brand{color:var(--accent);background:rgba(94,106,210,0.1)}
+/* Service-check type pills — palette mirrored from SharedCSS. Locked
+   by TestStyles_ServiceCheckPillPalette/theme_templates_have_same_palette. */
+.pill{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;padding:2px 8px;border-radius:999px}
+.pill-http  { background:rgba( 59,130,246,0.14); color:#60a5fa }
+.pill-tcp   { background:rgba( 16,185,129,0.14); color:#34d399 }
+.pill-dns   { background:rgba(236, 72,153,0.14); color:#f472b6 }
+.pill-smb   { background:rgba(245,158, 11,0.14); color:#fbbf24 }
+.pill-nfs   { background:rgba(251,146, 60,0.14); color:#fb923c }
+.pill-ping  { background:rgba(139, 92,246,0.14); color:#a78bfa }
+.pill-speed { background:rgba( 34,211,238,0.14); color:#22d3ee }
+.pill-trace { background:rgba( 45,212,191,0.14); color:#2dd4bf }
 .top-bar-stats{display:flex;align-items:center;gap:calc(var(--sp)*3)}
 .stat-item{display:flex;align-items:baseline;gap:6px;font-size:13px;white-space:nowrap}
 .stat-item-label{color:var(--text-quaternary);font-weight:500;font-size:12px}


### PR DESCRIPTION
## Root cause of rc5 failure

User reported the dashboard Service Checks widget STILL rendered plain
uppercase text after swapping to rc5, confirmed in two different browsers
(ruling out client cache).

Investigation found that `midnight.html` and `clean.html` — the two
dashboard theme templates — do **not** link `/css/shared.css`. They
maintain their own inline `<style>` blocks to stay self-contained and
avoid cascading with the shared design system's comprehensive base
tokens (body padding, html background, reset, header styles, etc.).

The rc5 JS was correctly rendering:
```html
<span class="pill pill-http">PING</span>
```

But:
- `midnight.html` had **zero** `.pill*` rules → span rendered as plain inline text
- `clean.html` had `.pill` base + 5 unrelated `.pill-healthy/warning/critical/info/neutral` rules but **none** for the 8 service-check types (`.pill-http`, `.pill-tcp`, etc.)

The pills on `/service-checks` and `/settings` rendered correctly because
those pages DO link `shared.css` — different HTML page, different CSS
scope.

## Fix

Add the 8 `.pill-<type>` rules inline to both theme templates, matching
the approved palette from `styles.go` byte-for-byte:

| Type  | Hex        | Hue         |
| ----- | ---------- | ----------- |
| http  | `#60a5fa`  | blue-400    |
| tcp   | `#34d399`  | emerald-400 |
| dns   | `#f472b6`  | pink-400    |
| smb   | `#fbbf24`  | amber-400   |
| nfs   | `#fb923c`  | orange-400  |
| ping  | `#a78bfa`  | violet-400  |
| speed | `#22d3ee`  | cyan-400    |
| trace | `#2dd4bf`  | teal-400    |

`midnight.html` also gets a `.pill` base rule (clean.html already has one).

## Why not link shared.css?

Safer and wrong-vs-better trade-off:

- **Link shared.css from themes** — cleaner consolidation, BUT shared.css
  defines body padding, html background, fonts, reset, comprehensive
  header/layout tokens that may conflict with the theme templates'
  carefully-tuned inline styles. Risk of visual regressions across the
  whole dashboard. Too large a surface for a patch release.
- **Inline just the 8 pill rules** — minimal scope, zero cascade risk,
  palette now lives in three places (SharedCSS + 2 templates) but the
  regression test pins all three.

Consolidation into `shared.css` + audit of cascade safety is a v0.9.8
refactor candidate, not an rc6 move.

## Regression guard

Extended `TestStyles_ServiceCheckPillPalette` with a third subtest:

```
--- PASS: TestStyles_ServiceCheckPillPalette
    --- PASS: shared_css_has_pinned_colors      (unchanged)
    --- PASS: all_pills_have_distinct_colors    (unchanged)
    --- PASS: theme_templates_have_same_palette (NEW)
```

The new subtest iterates both `DashboardMidnight` and `DashboardClean`
string constants and asserts every canonical type's pill rule exists
with the correct hex color. If any of the three sources (SharedCSS,
midnight.html, clean.html) drifts, the test fails with a message
pointing at the divergent source.

Also extended `extractPillColor` helper to take a `sourceLabel`
parameter for clearer error messages across multiple CSS sources.

## Diff

- `internal/api/templates/midnight.html` — +11 lines (.pill base + 8 type rules)
- `internal/api/templates/clean.html` — +10 lines (8 type rules)
- `internal/api/styles_pill_palette_test.go` — extended with theme-template subtest

## Ship path

Merges into `release/v0.9.7-stage`, then tagged as `v0.9.7-rc6` for UAT.
This is the actual fix the user was flagging in rc5.

Closes #189 rc6.