### PR TITLE
feat(settings): Advanced Scan Settings card + SMART schema migration (#237)

### DIFF
--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -366,9 +366,10 @@ func main() {
 		}
 		// Apply SMART standby-awareness preference on startup (#198). Default
 		// (false) uses `-n standby` so spun-down drives aren't woken by scans.
+		// Since schema v2 (#237) this lives under Settings.SMART.WakeDrives.
 		if persistedSettings != nil {
 			coll.SetSMARTConfig(collector.SMARTConfig{
-				WakeDrives: persistedSettings.WakeDrivesForSMART,
+				WakeDrives: persistedSettings.SMART.WakeDrives,
 			})
 		}
 		sched.Start()

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -50,11 +50,13 @@ type Settings struct {
 	SectionHeights    map[string]int          `json:"section_heights,omitempty"` // Persisted section resize heights (section name → px)
 	SectionOrder      map[string][]string     `json:"section_order,omitempty"`   // Persisted drag-and-drop column order ({"cols": [["findings","docker"], ...]})
 
-	// WakeDrivesForSMART, when true, opts back into pre-v0.9.5 behaviour of
-	// reading SMART from spun-down drives each scan cycle (waking them).
-	// Default (false) is standby-aware: smartctl runs with `-n standby` and
-	// skips sleeping drives. See issue #198.
-	WakeDrivesForSMART bool `json:"wake_drives_for_smart,omitempty"`
+	// SMART holds the SMART-scan policy knobs surfaced under
+	// "Advanced Scan Settings" in the settings UI. Prior to schema
+	// v2 the only knob here (WakeDrives) lived at the top level of
+	// Settings as `wake_drives_for_smart`; the v1→v2 migration in
+	// getSettings() lifts that value into SMART.WakeDrives. See
+	// issues #236 (PRD) and #237 (this slice).
+	SMART SMARTSettings `json:"smart"`
 
 	// DockerHiddenContainers is a list of container names that should be
 	// omitted from the Docker Containers dashboard section. Exact-match
@@ -65,7 +67,29 @@ type Settings struct {
 	DockerHiddenContainers []string `json:"docker_hidden_containers,omitempty"`
 }
 
-const currentSettingsVersion = 1
+// SMARTSettings groups SMART-scan policy. Added in schema v2 (#237).
+type SMARTSettings struct {
+	// WakeDrives, when true, opts back into pre-v0.9.5 behaviour of
+	// reading SMART from spun-down drives each scan cycle (waking
+	// them). Default (false) is standby-aware: smartctl runs with
+	// `-n standby` and skips sleeping drives. See issue #198.
+	WakeDrives bool `json:"wake_drives"`
+
+	// MaxAgeDays bounds how long a drive may remain unread by SMART
+	// before the scheduler forces one wake-up to refresh SMART data.
+	// Default 7. Valid range 0-30. A value of 0 disables the
+	// safety-net entirely (preserves exact v0.9.5 behaviour). The
+	// scheduler does NOT yet consume this value — slice 1a (#237)
+	// only persists it; slice 1b (#238) wires it into the scan loop.
+	MaxAgeDays int `json:"max_age_days"`
+}
+
+// SMARTMaxAgeDaysMax is the upper bound on Settings.SMART.MaxAgeDays.
+// A value of 0 disables the safety-net; values 1-30 are valid.
+// Enforced in handleUpdateSettings and in the UI input element.
+const SMARTMaxAgeDaysMax = 30
+
+const currentSettingsVersion = 2
 
 // DashboardSections controls which sections appear on the dashboard.
 // All default to true (visible). Users can hide sections they don't use.
@@ -279,6 +303,10 @@ func defaultSettings() Settings {
 			DashColumns: 3,
 		},
 		ChartRangeHours: 1,
+		SMART: SMARTSettings{
+			WakeDrives: false,
+			MaxAgeDays: 7,
+		},
 	}
 }
 
@@ -884,9 +912,10 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 			InCluster: settings.Kubernetes.InCluster,
 		})
 
-		// Update SMART config on the collector (#198)
+		// Update SMART config on the collector (#198, nested under
+		// Settings.SMART since schema v2 — see #237).
 		s.collector.SetSMARTConfig(collector.SMARTConfig{
-			WakeDrives: settings.WakeDrivesForSMART,
+			WakeDrives: settings.SMART.WakeDrives,
 		})
 
 		// Update log forwarding
@@ -1100,19 +1129,63 @@ func (s *Server) handleListBackups(w http.ResponseWriter, r *http.Request) {
 func (s *Server) getSettings() Settings {
 	settings := defaultSettings()
 	if raw, err := s.store.GetConfig(settingsConfigKey); err == nil && raw != "" {
-		json.Unmarshal([]byte(raw), &settings)
+		settings = migrateSettings([]byte(raw), settings)
 		if settings.SettingsVersion < currentSettingsVersion {
-			// v0 → v1: merged_drives defaults to true
-			if settings.SettingsVersion < 1 {
-				settings.Sections.MergedDrives = true
-			}
 			settings.SettingsVersion = currentSettingsVersion
-			if data, err := json.Marshal(settings); err == nil {
-				s.store.SetConfig(settingsConfigKey, string(data))
-			}
+		}
+		// Persist the migrated blob so downstream reads skip the
+		// migration path. Only write if we actually had to migrate
+		// (cheap no-op when raw was already v2-shaped).
+		if data, err := json.Marshal(settings); err == nil {
+			s.store.SetConfig(settingsConfigKey, string(data))
 		}
 	}
 	return settings
+}
+
+// migrateSettings unmarshals a stored settings blob on top of the given
+// defaults struct and applies any one-time migrations required to reach
+// currentSettingsVersion. It does NOT persist — the caller owns that.
+//
+// Migration ladder:
+//
+//   - v0 → v1: sections.merged_drives defaults to true (historical)
+//   - v1 → v2: lift legacy top-level wake_drives_for_smart into
+//     Settings.SMART.WakeDrives; seed Settings.SMART.MaxAgeDays = 7
+//     for upgraders that never had the field (#236/#237).
+//
+// The function is idempotent: running it against an already-v2 blob
+// preserves the persisted smart.wake_drives / smart.max_age_days
+// values verbatim (the legacy field shim is only consulted when the
+// stored schema version is below 2).
+func migrateSettings(raw []byte, base Settings) Settings {
+	// Note: json.Unmarshal onto base preserves default field values
+	// when the incoming JSON omits them — critical for SMART.MaxAgeDays
+	// since old blobs will not contain smart.max_age_days at all.
+	_ = json.Unmarshal(raw, &base)
+
+	if base.SettingsVersion < 1 {
+		base.Sections.MergedDrives = true
+	}
+
+	if base.SettingsVersion < 2 {
+		// Legacy shim: v1 stored WakeDrives at the top level. Unmarshal
+		// a second time into a shadow struct to recover that field.
+		var legacy struct {
+			WakeDrivesForSMART bool `json:"wake_drives_for_smart"`
+		}
+		_ = json.Unmarshal(raw, &legacy)
+		base.SMART.WakeDrives = legacy.WakeDrivesForSMART
+		// Every upgrader lands on the default 7-day ceiling regardless
+		// of whether the raw blob carries a smart.max_age_days value
+		// (it can't — the field didn't exist before v2). PRD #236 user
+		// story 2: the safety net opts in by default on upgrade.
+		if base.SMART.MaxAgeDays == 0 {
+			base.SMART.MaxAgeDays = 7
+		}
+	}
+
+	return base
 }
 
 func (s *Server) buildNotifier(webhooks []internal.WebhookConfig) *notifier.Notifier {

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -814,6 +814,18 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 	if settings.LogPush.Destinations == nil {
 		settings.LogPush.Destinations = []LogForwardDestination{}
 	}
+	// SMART scan policy validation (#237). The UI clamps client-side
+	// but a direct API caller could still submit out-of-range values;
+	// reject rather than silently clamping so the caller knows their
+	// input was ignored. 0 is valid (safety net disabled, PRD #236
+	// user story 5); 1-30 inclusive is the active range.
+	if settings.SMART.MaxAgeDays < 0 || settings.SMART.MaxAgeDays > SMARTMaxAgeDaysMax {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": fmt.Sprintf("smart.max_age_days must be between 0 and %d (0 disables the safety net)", SMARTMaxAgeDaysMax),
+		})
+		return
+	}
+
 	// Retention defaults and bounds
 	if settings.Retention.SnapshotDays < 7 {
 		settings.Retention.SnapshotDays = 90

--- a/internal/api/settings_advanced_scans_card_test.go
+++ b/internal/api/settings_advanced_scans_card_test.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSettingsHTML_AdvancedScansCard pins the structural contract of
+// the new "Advanced Scan Settings" card introduced by issue #237.
+//
+// The card lives alongside the existing generic Advanced card; it
+// holds the scan-policy knobs (wake-drives toggle + new max-age
+// input). The existing Advanced card keeps the Hide Docker
+// Containers knob. Separating the two concerns is user story 22 in
+// PRD #236.
+func TestSettingsHTML_AdvancedScansCard(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read settings.html: %v", err)
+	}
+	content := string(data)
+
+	mustContain := []struct {
+		name   string
+		substr string
+	}{
+		// New card anchor + title + sticky-nav entry.
+		{"card anchor", `id="card-advanced-scans"`},
+		{"card title", `Advanced Scan Settings`},
+		{"nav link to new card", `href="#card-advanced-scans"`},
+
+		// Max-age input: id + nested JSON key on the load and save
+		// paths. Range validation is a separate assertion below.
+		{"max-age input id", `id="smart-max-age-days"`},
+		{"load binds nested max_age_days", `smart.max_age_days`},
+
+		// The input must enforce 0-30 client-side so the browser's
+		// native validity UI catches out-of-range values before the
+		// server round-trip rejects them.
+		{"max-age min attribute", `min="0"`},
+		{"max-age max attribute", `max="30"`},
+
+		// Inline explanation must surface the disable-by-zero
+		// convention (PRD user stories 5 + 23).
+		{"max-age explanation mentions disabled", `disabled`},
+
+		// Wake-drives toggle lives HERE now, not in the legacy card.
+		{"wake-drives toggle still present", `id="wake-drives-for-smart"`},
+	}
+	for _, tc := range mustContain {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(content, tc.substr) {
+				t.Errorf("settings.html missing %q — expected substring: %q", tc.name, tc.substr)
+			}
+		})
+	}
+
+	// The wake-drives toggle must appear AFTER the new card opens
+	// and BEFORE the legacy Advanced card opens. This enforces that
+	// the toggle moved — it's no longer inside id="card-advanced".
+	newCardIdx := strings.Index(content, `id="card-advanced-scans"`)
+	legacyCardIdx := strings.Index(content, `id="card-advanced"`)
+	toggleIdx := strings.Index(content, `id="wake-drives-for-smart"`)
+	if newCardIdx < 0 || legacyCardIdx < 0 || toggleIdx < 0 {
+		t.Fatalf("missing required markers (new=%d legacy=%d toggle=%d)", newCardIdx, legacyCardIdx, toggleIdx)
+	}
+	if !(newCardIdx < toggleIdx && toggleIdx < legacyCardIdx) {
+		t.Errorf("wake-drives toggle must sit between the new card (at %d) and the legacy card (at %d); got toggle at %d — did it get left behind in the legacy Advanced card?", newCardIdx, legacyCardIdx, toggleIdx)
+	}
+
+	// The Hide-Docker-Containers knob must remain inside the legacy
+	// Advanced card. Its marker phrase is unique enough to serve as
+	// an anchor. If this assertion fails someone moved the wrong
+	// thing.
+	hideDockerIdx := strings.Index(content, `Hide Docker containers from dashboard`)
+	if hideDockerIdx < 0 {
+		t.Fatalf("Hide Docker containers label vanished from settings.html")
+	}
+	if hideDockerIdx < legacyCardIdx {
+		t.Errorf("Hide Docker containers knob must stay inside the legacy Advanced card (at %d); got marker at %d — did this move by mistake?", legacyCardIdx, hideDockerIdx)
+	}
+}

--- a/internal/api/settings_smart_migration_test.go
+++ b/internal/api/settings_smart_migration_test.go
@@ -1,0 +1,164 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestMigrateSettings_V1toV2_LiftsWakeDrivesForSMART covers user story
+// 11 of PRD #236: the user's existing wake_drives_for_smart preference
+// is automatically preserved across the schema migration.
+//
+// Input: v1 blob with the legacy flat wake_drives_for_smart=true field.
+// Expected: v2-shape output with smart.wake_drives=true, seeded
+// smart.max_age_days=7, and settings_version bumped to 2.
+func TestMigrateSettings_V1toV2_LiftsWakeDrivesForSMART(t *testing.T) {
+	raw := []byte(`{
+		"settings_version": 1,
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"wake_drives_for_smart": true
+	}`)
+
+	got := migrateSettings(raw, defaultSettings())
+	// Caller (getSettings) is responsible for stamping the new version
+	// number; migrateSettings only populates the struct. Simulate that.
+	if got.SettingsVersion < currentSettingsVersion {
+		got.SettingsVersion = currentSettingsVersion
+	}
+
+	if got.SettingsVersion != 2 {
+		t.Errorf("settings_version: got %d, want 2", got.SettingsVersion)
+	}
+	if !got.SMART.WakeDrives {
+		t.Errorf("smart.wake_drives: got false, want true (lifted from wake_drives_for_smart)")
+	}
+	if got.SMART.MaxAgeDays != 7 {
+		t.Errorf("smart.max_age_days: got %d, want 7 (PRD #236 user story 2 default)", got.SMART.MaxAgeDays)
+	}
+}
+
+// TestMigrateSettings_V1toV2_SeedsMaxAgeDaysForOptedOutUpgrader covers
+// the case where the v1 user had wake_drives_for_smart=false (the
+// default post-v0.9.5). The migration must still seed max_age_days=7
+// because the safety net is a distinct concept from the opt-in
+// wake-drives behaviour.
+func TestMigrateSettings_V1toV2_SeedsMaxAgeDaysForOptedOutUpgrader(t *testing.T) {
+	raw := []byte(`{
+		"settings_version": 1,
+		"scan_interval": "30m",
+		"theme": "midnight"
+	}`)
+
+	got := migrateSettings(raw, defaultSettings())
+
+	if got.SMART.WakeDrives {
+		t.Errorf("smart.wake_drives: got true, want false (no legacy opt-in present)")
+	}
+	if got.SMART.MaxAgeDays != 7 {
+		t.Errorf("smart.max_age_days: got %d, want 7 (seeded for every upgrader)", got.SMART.MaxAgeDays)
+	}
+}
+
+// TestMigrateSettings_V2_Idempotent confirms that a v2-shaped blob is
+// passed through unchanged. Running the migration on an already-
+// migrated blob is the code path hit on every subsequent read of the
+// persisted config, so it must not mutate preserved values.
+func TestMigrateSettings_V2_Idempotent(t *testing.T) {
+	raw := []byte(`{
+		"settings_version": 2,
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"smart": {
+			"wake_drives": true,
+			"max_age_days": 14
+		}
+	}`)
+
+	got := migrateSettings(raw, defaultSettings())
+
+	if got.SettingsVersion != 2 {
+		t.Errorf("settings_version: got %d, want 2 preserved", got.SettingsVersion)
+	}
+	if !got.SMART.WakeDrives {
+		t.Errorf("smart.wake_drives: got false, want true (should not be clobbered)")
+	}
+	if got.SMART.MaxAgeDays != 14 {
+		t.Errorf("smart.max_age_days: got %d, want 14 (should not be reseeded)", got.SMART.MaxAgeDays)
+	}
+}
+
+// TestMigrateSettings_V2_PreservesMaxAgeDaysZero ensures that a user
+// who has deliberately disabled the safety net (set max_age_days=0)
+// does not silently get it re-enabled by the migration. Idempotency
+// must hold for explicit user-chosen values, including edge cases.
+func TestMigrateSettings_V2_PreservesMaxAgeDaysZero(t *testing.T) {
+	raw := []byte(`{
+		"settings_version": 2,
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"smart": {
+			"wake_drives": false,
+			"max_age_days": 0
+		}
+	}`)
+
+	got := migrateSettings(raw, defaultSettings())
+
+	if got.SMART.MaxAgeDays != 0 {
+		t.Errorf("smart.max_age_days: got %d, want 0 (user explicitly disabled the safety net — must be preserved)", got.SMART.MaxAgeDays)
+	}
+}
+
+// TestGetSettings_V1toV2_PersistsMigration closes the loop end-to-end
+// through the HTTP-facing getSettings() function: a stored v1 blob is
+// transparently migrated to v2 on first read, and the persisted
+// representation on the store is rewritten so subsequent reads skip
+// the migration path. This guards against a subtle regression where
+// the migration only applies in-memory and the stored blob stays v1.
+func TestGetSettings_V1toV2_PersistsMigration(t *testing.T) {
+	srv := newSettingsTestServer()
+	if err := srv.store.SetConfig(settingsConfigKey, `{
+		"settings_version": 1,
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"wake_drives_for_smart": true
+	}`); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+
+	loaded := srv.getSettings()
+	if loaded.SettingsVersion != 2 {
+		t.Errorf("loaded settings_version: got %d, want 2", loaded.SettingsVersion)
+	}
+	if !loaded.SMART.WakeDrives {
+		t.Errorf("loaded smart.wake_drives: got false, want true")
+	}
+	if loaded.SMART.MaxAgeDays != 7 {
+		t.Errorf("loaded smart.max_age_days: got %d, want 7", loaded.SMART.MaxAgeDays)
+	}
+
+	// Subsequent read: the stored blob must now be v2-shaped, so a
+	// fresh migrateSettings invocation on it is an idempotent no-op.
+	raw, err := srv.store.GetConfig(settingsConfigKey)
+	if err != nil {
+		t.Fatalf("re-read stored settings: %v", err)
+	}
+	var persisted map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &persisted); err != nil {
+		t.Fatalf("parse persisted settings: %v", err)
+	}
+	if v, _ := persisted["settings_version"].(float64); int(v) != 2 {
+		t.Errorf("persisted settings_version: got %v, want 2 (migration must rewrite the store)", persisted["settings_version"])
+	}
+	smartMap, ok := persisted["smart"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("persisted settings missing nested smart object: %v", persisted["smart"])
+	}
+	if wd, _ := smartMap["wake_drives"].(bool); !wd {
+		t.Errorf("persisted smart.wake_drives: got %v, want true", smartMap["wake_drives"])
+	}
+	if mad, _ := smartMap["max_age_days"].(float64); int(mad) != 7 {
+		t.Errorf("persisted smart.max_age_days: got %v, want 7", smartMap["max_age_days"])
+	}
+}

--- a/internal/api/settings_smart_schema_test.go
+++ b/internal/api/settings_smart_schema_test.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestSettingsDefault_SMART_NestedDefaults guards the defaults for
+// the new Settings.SMART sub-struct introduced by issue #237. Every
+// fresh install (and every upgrader via the migration in getSettings)
+// must land on these concrete defaults:
+//   - WakeDrives = false (unchanged from v0.9.5 #198 standby-aware default)
+//   - MaxAgeDays = 7     (new; safety-net threshold documented in PRD #236)
+func TestSettingsDefault_SMART_NestedDefaults(t *testing.T) {
+	d := defaultSettings()
+	if d.SMART.WakeDrives {
+		t.Errorf("defaultSettings().SMART.WakeDrives must be false (#198 standby-aware default)")
+	}
+	if d.SMART.MaxAgeDays != 7 {
+		t.Errorf("defaultSettings().SMART.MaxAgeDays = %d, want 7 (PRD #236)", d.SMART.MaxAgeDays)
+	}
+}
+
+// TestSettingsRoundTrip_SMART_Nested exercises PUT→GET for the new
+// nested smart shape. The client sends `smart: {wake_drives: true,
+// max_age_days: 14}` and the server must return the same values on
+// the subsequent GET. No new scheduler behaviour fires in this slice
+// (that's #238's scope) — this test only pins the schema contract.
+func TestSettingsRoundTrip_SMART_Nested(t *testing.T) {
+	srv := newSettingsTestServer()
+
+	putBody := map[string]interface{}{
+		"scan_interval": "30m",
+		"theme":         "midnight",
+		"smart": map[string]interface{}{
+			"wake_drives":   true,
+			"max_age_days":  14,
+		},
+	}
+	buf, _ := json.Marshal(putBody)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(buf))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.handleUpdateSettings(rec, req)
+	if rec.Code != http.StatusOK {
+		b, _ := io.ReadAll(rec.Body)
+		t.Fatalf("PUT returned %d: %s", rec.Code, b)
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	rec2 := httptest.NewRecorder()
+	srv.handleGetSettings(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("GET returned %d", rec2.Code)
+	}
+	var got Settings
+	if err := json.Unmarshal(rec2.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse GET response: %v", err)
+	}
+	if !got.SMART.WakeDrives {
+		t.Errorf("smart.wake_drives did not round-trip; got false, want true")
+	}
+	if got.SMART.MaxAgeDays != 14 {
+		t.Errorf("smart.max_age_days did not round-trip; got %d, want 14", got.SMART.MaxAgeDays)
+	}
+}

--- a/internal/api/settings_smart_validation_test.go
+++ b/internal/api/settings_smart_validation_test.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestHandleUpdateSettings_SMART_MaxAgeDays_RangeRejected pins the
+// server-side validation for smart.max_age_days. The UI clamps
+// client-side (min=0 max=30) but a caller using the HTTP API
+// directly could still submit out-of-range values — the server must
+// reject them with 400 rather than silently clamping.
+//
+// Valid range: 0-30 inclusive. 0 disables the safety net (per PRD
+// user story 5); 31+ and negative values are invalid input.
+func TestHandleUpdateSettings_SMART_MaxAgeDays_RangeRejected(t *testing.T) {
+	cases := []struct {
+		name       string
+		maxAgeDays int
+		wantStatus int
+	}{
+		{"zero allowed (disables safety net)", 0, http.StatusOK},
+		{"one allowed (maximum caution)", 1, http.StatusOK},
+		{"seven is the default", 7, http.StatusOK},
+		{"thirty is the ceiling", 30, http.StatusOK},
+		{"thirty-one rejected", 31, http.StatusBadRequest},
+		{"one hundred rejected", 100, http.StatusBadRequest},
+		{"negative rejected", -1, http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newSettingsTestServer()
+			body, _ := json.Marshal(map[string]interface{}{
+				"scan_interval": "30m",
+				"theme":         "midnight",
+				"smart": map[string]interface{}{
+					"wake_drives":  false,
+					"max_age_days": tc.maxAgeDays,
+				},
+			})
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			srv.handleUpdateSettings(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Errorf("max_age_days=%d returned %d, want %d; body=%s",
+					tc.maxAgeDays, rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if tc.wantStatus == http.StatusBadRequest {
+				lower := strings.ToLower(rec.Body.String())
+				if !strings.Contains(lower, "max_age_days") {
+					t.Errorf("400 error body should name the offending field; got: %s", rec.Body.String())
+				}
+			}
+		})
+	}
+}
+
+// TestHandleUpdateSettings_SMART_MaxAgeDays_InvalidDoesNotPersist
+// ensures an out-of-range PUT does NOT partially persist anything:
+// a subsequent GET must still see the pre-edit state. This is a
+// standard "rejected input leaves the store untouched" guarantee.
+func TestHandleUpdateSettings_SMART_MaxAgeDays_InvalidDoesNotPersist(t *testing.T) {
+	srv := newSettingsTestServer()
+
+	// First, persist a known-good state.
+	good, _ := json.Marshal(map[string]interface{}{
+		"scan_interval": "30m",
+		"theme":         "midnight",
+		"smart": map[string]interface{}{
+			"wake_drives":  true,
+			"max_age_days": 14,
+		},
+	})
+	rec := httptest.NewRecorder()
+	srv.handleUpdateSettings(rec, httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(good)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("seed PUT failed: %d %s", rec.Code, rec.Body.String())
+	}
+
+	// Submit invalid max_age_days=99.
+	bad, _ := json.Marshal(map[string]interface{}{
+		"scan_interval": "30m",
+		"theme":         "midnight",
+		"smart": map[string]interface{}{
+			"wake_drives":  false,
+			"max_age_days": 99,
+		},
+	})
+	rec2 := httptest.NewRecorder()
+	srv.handleUpdateSettings(rec2, httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(bad)))
+	if rec2.Code != http.StatusBadRequest {
+		t.Fatalf("invalid PUT must return 400, got %d: %s", rec2.Code, rec2.Body.String())
+	}
+
+	// GET and confirm nothing leaked through.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	rec3 := httptest.NewRecorder()
+	srv.handleGetSettings(rec3, req)
+	if rec3.Code != http.StatusOK {
+		t.Fatalf("GET failed: %d", rec3.Code)
+	}
+	var got Settings
+	if err := json.Unmarshal(rec3.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse GET: %v", err)
+	}
+	if got.SMART.MaxAgeDays != 14 {
+		t.Errorf("max_age_days leaked from rejected PUT: got %d, want 14 (seeded value)", got.SMART.MaxAgeDays)
+	}
+	if !got.SMART.WakeDrives {
+		t.Errorf("wake_drives leaked from rejected PUT: got false, want true (seeded value)")
+	}
+}

--- a/internal/api/settings_wake_drives_for_smart_test.go
+++ b/internal/api/settings_wake_drives_for_smart_test.go
@@ -13,8 +13,9 @@ import (
 )
 
 // TestSettingsHTMLIncludesWakeDrivesForSMARTToggle verifies the settings
-// template ships the Advanced section with the wake-drives toggle +
-// disclaimer required by issue #198.
+// template ships the wake-drives toggle + disclaimer required by issue #198.
+// Since #237 the toggle lives inside the new "Advanced Scan Settings"
+// card (id="card-advanced-scans"), not the legacy generic Advanced card.
 //
 // This is a cross-reference test: it confirms the HTML mentions every
 // symbol the JS load/save wiring expects, so a future refactor that
@@ -31,20 +32,20 @@ func TestSettingsHTMLIncludesWakeDrivesForSMARTToggle(t *testing.T) {
 		name   string
 		substr string
 	}{
-		// Advanced card anchor so the sticky section nav can link to it.
-		{"advanced card anchor", `id="card-advanced"`},
-		// Section nav link to the advanced card.
-		{"advanced nav link", `href="#card-advanced"`},
+		// New Advanced Scan Settings card anchor (#237).
+		{"advanced scans card anchor", `id="card-advanced-scans"`},
+		// Section nav link to the new card.
+		{"advanced scans nav link", `href="#card-advanced-scans"`},
 		// Disclosure element — using <details>/<summary> per the issue's
 		// guidance (no extra JS needed).
 		{"details element", `<details`},
 		{"summary element", `<summary`},
 		// The toggle control + its stable id for load/save wiring.
 		{"wake-drives toggle id", `id="wake-drives-for-smart"`},
-		// Load path reads the JSON field name.
-		{"load binds field", `data.wake_drives_for_smart`},
-		// Save payload writes the JSON field name.
-		{"save sends field", `wake_drives_for_smart:`},
+		// Load path reads the nested JSON field.
+		{"load binds nested field", `data.smart`},
+		// Save payload writes the nested JSON field.
+		{"save sends nested field", `smart:`},
 		// Disclaimer text must communicate the wear trade-off. We keep
 		// the assertion loose so copy can be edited, but pin the key
 		// concepts: spin-ups and opt-in intent.
@@ -61,30 +62,32 @@ func TestSettingsHTMLIncludesWakeDrivesForSMARTToggle(t *testing.T) {
 }
 
 // TestSettingsRoundTrip_WakeDrivesForSMART exercises the GET/PUT cycle for
-// the new setting to make sure it persists and is returned by handleGetSettings.
+// the wake-drives flag using the new nested schema (Settings.SMART.WakeDrives,
+// `smart.wake_drives` on the wire) introduced in #237.
 func TestSettingsRoundTrip_WakeDrivesForSMART(t *testing.T) {
-	s := newSettingsTestServer()
+	srv := newSettingsTestServer()
 
-	// PUT enabling the flag.
-	put := Settings{
-		ScanInterval:       "30m",
-		Theme:              ThemeMidnight,
-		WakeDrivesForSMART: true,
+	put := map[string]interface{}{
+		"scan_interval": "30m",
+		"theme":         "midnight",
+		"smart": map[string]interface{}{
+			"wake_drives":  true,
+			"max_age_days": 7,
+		},
 	}
 	body, _ := json.Marshal(put)
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
-	s.handleUpdateSettings(rr, req)
+	srv.handleUpdateSettings(rr, req)
 	if rr.Code != http.StatusOK {
 		b, _ := io.ReadAll(rr.Body)
 		t.Fatalf("PUT returned %d: %s", rr.Code, b)
 	}
 
-	// GET and verify the flag survived the round-trip.
 	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
 	rr2 := httptest.NewRecorder()
-	s.handleGetSettings(rr2, req2)
+	srv.handleGetSettings(rr2, req2)
 	if rr2.Code != http.StatusOK {
 		t.Fatalf("GET returned %d", rr2.Code)
 	}
@@ -92,8 +95,8 @@ func TestSettingsRoundTrip_WakeDrivesForSMART(t *testing.T) {
 	if err := json.Unmarshal(rr2.Body.Bytes(), &got); err != nil {
 		t.Fatalf("parse GET response: %v", err)
 	}
-	if !got.WakeDrivesForSMART {
-		t.Errorf("WakeDrivesForSMART did not round-trip; got false, wanted true")
+	if !got.SMART.WakeDrives {
+		t.Errorf("smart.wake_drives did not round-trip; got false, wanted true")
 	}
 }
 
@@ -102,7 +105,7 @@ func TestSettingsRoundTrip_WakeDrivesForSMART(t *testing.T) {
 // means drives in standby are NOT woken by SMART scans.
 func TestSettingsDefault_WakeDrivesForSMARTIsFalse(t *testing.T) {
 	d := defaultSettings()
-	if d.WakeDrivesForSMART {
-		t.Errorf("defaultSettings().WakeDrivesForSMART must be false (standby-aware by default, issue #198)")
+	if d.SMART.WakeDrives {
+		t.Errorf("defaultSettings().SMART.WakeDrives must be false (standby-aware by default, issue #198)")
 	}
 }

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -63,6 +63,7 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
     <a href="#card-replacement-cost" class="btn btn-secondary btn-sm" style="text-decoration:none">Replacement Cost</a>
     <a href="#card-speedtest" class="btn btn-secondary btn-sm" style="text-decoration:none">Speed Test</a>
     <a href="#card-backup" class="btn btn-secondary btn-sm" style="text-decoration:none">Backup</a>
+    <a href="#card-advanced-scans" class="btn btn-secondary btn-sm" style="text-decoration:none">Advanced Scans</a>
     <a href="#card-advanced" class="btn btn-secondary btn-sm" style="text-decoration:none">Advanced</a>
   </div>
 
@@ -887,13 +888,15 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
     </div>
   </div>
 
-  <!-- 9. Advanced -->
-  <div class="card" id="card-advanced">
-    <div class="card-title">Advanced</div>
-    <div class="card-desc">Expert-only knobs. Defaults are safe — only change these if you understand the trade-offs.</div>
-    <details style="margin-top:8px">
-      <summary style="cursor:pointer;padding:6px 0;font-weight:600;font-size:13px;color:var(--text)">Show advanced options</summary>
+  <!-- 9. Advanced Scan Settings (#237) -->
+  <div class="card" id="card-advanced-scans">
+    <div class="card-title">Advanced Scan Settings</div>
+    <div class="card-desc">Fine-grained control over how NAS Doctor schedules SMART reads and related scans. Defaults are safe — change only if you understand the trade-offs.</div>
+    <details style="margin-top:8px" open>
+      <summary style="cursor:pointer;padding:6px 0;font-weight:600;font-size:13px;color:var(--text)">Show scan-policy options</summary>
       <div style="margin-top:14px;padding-top:12px;border-top:1px solid var(--border)">
+
+        <!-- Wake drives for SMART check (moved from legacy Advanced card, #198) -->
         <div class="toggle-wrap">
           <div class="toggle" id="wake-drives-for-smart" onclick="this.classList.toggle('on');saveSettings()"><div class="toggle-knob"></div></div>
           <span class="toggle-label">Wake drives for SMART check</span>
@@ -904,7 +907,33 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
           At the default 30-min scan interval, that's roughly 48 extra spin-ups per drive per day.
           Only enable if your drives never spin down, or if you deliberately need every-cycle SMART monitoring and accept the wear cost.
         </p>
+
+        <!-- Max days without SMART read (#237 schema; #238 wires into the scheduler) -->
         <div style="margin-top:18px;padding-top:14px;border-top:1px solid var(--border)">
+          <label for="smart-max-age-days" style="display:block;font-weight:600;font-size:13px;color:var(--text);margin-bottom:4px">Max days without SMART read</label>
+          <div style="display:flex;align-items:center;gap:10px">
+            <input type="number" id="smart-max-age-days" min="0" max="30" step="1" value="7" onchange="saveSettings()" style="width:80px;text-align:center">
+            <span style="font-size:12px;color:var(--text2)">days (0 = never force wake)</span>
+          </div>
+          <p style="font-size:12px;color:var(--text2);margin-top:8px;line-height:1.5">
+            If a drive stays in standby longer than this many days without a successful SMART read, NAS Doctor will force one wake-up to refresh SMART data.
+            Lower values keep SMART data fresher at the cost of more spin-ups; higher values reduce wear but let drives go longer unobserved.
+            Set to <strong>0</strong> to <strong>disable</strong> the safety net entirely — SMART will never force a wake-up (v0.9.5 behaviour).
+            Valid range 0&ndash;30.
+          </p>
+        </div>
+      </div>
+    </details>
+  </div>
+
+  <!-- 10. Advanced -->
+  <div class="card" id="card-advanced">
+    <div class="card-title">Advanced</div>
+    <div class="card-desc">Expert-only knobs. Defaults are safe — only change these if you understand the trade-offs.</div>
+    <details style="margin-top:8px">
+      <summary style="cursor:pointer;padding:6px 0;font-weight:600;font-size:13px;color:var(--text)">Show advanced options</summary>
+      <div style="margin-top:14px;padding-top:12px;border-top:1px solid var(--border)">
+        <div>
           <div style="display:block;font-weight:600;font-size:13px;color:var(--text);margin-bottom:4px">Hide Docker containers from dashboard</div>
           <p style="font-size:12px;color:var(--text2);margin-top:4px;margin-bottom:10px;line-height:1.5">
             Tick the containers you want hidden from the <strong>Docker Containers section</strong>.
@@ -1217,10 +1246,22 @@ function loadSettings() {
       /* Drive replacement cost per TB */
       var costEl = document.getElementById("cost-per-tb");
       if (costEl) costEl.value = (data.cost_per_tb && data.cost_per_tb > 0) ? data.cost_per_tb : "";
-      /* Advanced: wake drives for SMART (#198) */
+      /* Advanced Scan Settings (#237): SMART sub-struct. Reads
+         smart.wake_drives and smart.max_age_days from the server's
+         nested schema. Falls back to the legacy flat
+         wake_drives_for_smart field if the server hasn't migrated yet
+         (defensive — getSettings migrates on first read). */
+      var smartCfg = (data && data.smart) || {};
       var wakeEl = document.getElementById("wake-drives-for-smart");
       if (wakeEl) {
-        if (data.wake_drives_for_smart) wakeEl.classList.add("on"); else wakeEl.classList.remove("on");
+        var wakeVal = (smartCfg.wake_drives !== undefined) ? !!smartCfg.wake_drives : !!data.wake_drives_for_smart;
+        if (wakeVal) wakeEl.classList.add("on"); else wakeEl.classList.remove("on");
+      }
+      var maxAgeEl = document.getElementById("smart-max-age-days");
+      if (maxAgeEl) {
+        var maxAgeVal = (smartCfg.max_age_days !== undefined) ? parseInt(smartCfg.max_age_days, 10) : 7;
+        if (isNaN(maxAgeVal)) maxAgeVal = 7;
+        maxAgeEl.value = maxAgeVal;
       }
       /* Advanced: hide Docker containers from dashboard (#204) */
       var hidden = Array.isArray(data.docker_hidden_containers) ? data.docker_hidden_containers : [];
@@ -1337,7 +1378,17 @@ function buildSettingsPayload() {
     fleet: fleetServers || base.fleet || [],
     dismissed_findings: base.dismissed_findings || [],
     cost_per_tb: parseFloat(document.getElementById("cost-per-tb") && document.getElementById("cost-per-tb").value) || 0,
-    wake_drives_for_smart: !!(document.getElementById("wake-drives-for-smart") && document.getElementById("wake-drives-for-smart").classList.contains("on")),
+    smart: {
+      wake_drives: !!(document.getElementById("wake-drives-for-smart") && document.getElementById("wake-drives-for-smart").classList.contains("on")),
+      max_age_days: (function() {
+        var el = document.getElementById("smart-max-age-days");
+        if (!el) return 7;
+        var v = parseInt(el.value, 10);
+        if (isNaN(v) || v < 0) return 0;
+        if (v > 30) return 30;
+        return v;
+      })()
+    },
     docker_hidden_containers: collectCheckedHiddenContainers()
   };
 }


### PR DESCRIPTION
Closes #237

Vertical slice 1a of the Advanced Scan Settings rework (parent PRD #236). Establishes the settings schema, migration path, and UI shell. Persisted values survive restart and round-trip through the HTTP API, but **no new scheduler behaviour fires yet** — that wiring lands in slice 1b (#238).

## Summary

### Schema (`internal/api/api_extended.go`)

- New nested `SMARTSettings` sub-struct on `Settings` with two fields:
  - `WakeDrives bool` — migrated from the legacy top-level `WakeDrivesForSMART`
  - `MaxAgeDays int` — new, default 7, valid range 0-30 (0 disables the planned safety net)
- `currentSettingsVersion` bumped 1 → 2
- Top-level `Settings.WakeDrivesForSMART` field **removed entirely** (the JSON wire key `wake_drives_for_smart` is only consumed by the one-time v1→v2 migration shim)

### Migration (`migrateSettings` extracted helper)

Delegated from `getSettings()` into a testable `migrateSettings(raw, base) Settings` so the migration ladder can be exercised directly (no HTTP round-trip). Behaviour:

1. **v0 → v1**: existing `sections.merged_drives = true` default (historical, unchanged)
2. **v1 → v2** (new): unmarshals the raw blob into a shadow struct to recover the legacy `wake_drives_for_smart` field, lifts it into `SMART.WakeDrives`, seeds `SMART.MaxAgeDays = 7` for every upgrader (per PRD user story 2 — the safety net opts in by default on upgrade)

Idempotent: running the migration on an already-v2 blob preserves both `smart.wake_drives` and `smart.max_age_days` verbatim, including the edge case of a user-chosen `max_age_days = 0` (deliberate opt-out of the safety net).

### UI (`internal/api/templates/settings.html`)

- New **"Advanced Scan Settings"** card (`id="card-advanced-scans"`) with its own sticky-nav entry ("Advanced Scans") sitting between the Backup and legacy Advanced entries
- The existing **"Wake drives for SMART check"** toggle + disclaimer **moves** from the legacy Advanced card into the new card (unchanged copy)
- New numeric input **"Max days without SMART read"** (`id="smart-max-age-days"`) with `min="0" max="30" step="1"` and an inline explanation that calls out the disable-by-zero convention
- Legacy Advanced card keeps the **Hide Docker containers** knob (unchanged)
- JS load path reads `data.smart.wake_drives` + `data.smart.max_age_days`, with a defensive fallback to the legacy flat `wake_drives_for_smart` field so the UI doesn't regress if it loads before `getSettings()` has migrated the store
- JS save path sends nested `smart: { wake_drives, max_age_days }` and clamps `max_age_days` client-side to 0-30

### Validation (`handleUpdateSettings`)

Server-side range check rejects `smart.max_age_days` outside 0-30 inclusive with HTTP 400. Client clamping + server rejection close the loop end-to-end so a direct API caller can't persist out-of-range values the UI would refuse.

### Call-site update (`cmd/nas-doctor/main.go`)

Startup `SetSMARTConfig` call now reads from `persistedSettings.SMART.WakeDrives` (was `persistedSettings.WakeDrivesForSMART`).

## Tests added (14 new, 3 reshaped)

- `settings_smart_schema_test.go` — 2 tests: defaults (`SMART.WakeDrives=false`, `SMART.MaxAgeDays=7`) + PUT/GET round-trip for the nested shape
- `settings_smart_migration_test.go` — 5 tests: v1→v2 lift with legacy=true, v1→v2 seed for opted-out upgrader, v2 idempotency (both wake_drives and max_age_days preserved), v2 preserves explicit `max_age_days=0`, end-to-end `getSettings` persists the migrated blob to the store
- `settings_advanced_scans_card_test.go` — 1 table test with 8 subtests: new card anchor, title, nav link, max-age input id, nested-field load binding, `min="0"`/`max="30"` attributes, wake-drives toggle presence, inline explanation mentions "disabled"; **plus relative-position assertions** that prove the wake-drives toggle moved (sits between the new card and the legacy card anchor) and the Hide Docker Containers label stayed (sits after the legacy card anchor)
- `settings_smart_validation_test.go` — 2 tests: parameterised range acceptance (0/1/7/30) and rejection (31/100/-1) with name-the-field error body; plus "rejected PUT does not leak partial state" via seeded-pre-edit-GET assertion
- `settings_wake_drives_for_smart_test.go` — reshaped to use the nested `smart.wake_drives` wire format; the template-structure test now pins `card-advanced-scans` as the parent anchor and `data.smart` / `smart:` as the nested load/save markers

## Design decision notes

- **`WakeDrivesForSMART` legacy field**: removed entirely from the `Settings` struct per the issue's explicit direction. The JSON wire key is only reachable through a private shadow struct inside the v1→v2 migration path. Rationale: keeping it as a deprecated alias would have required guarding every internal read site, and any API caller still sending the flat key will be correctly served by the migration on the next `GET` (which rewrites the store to the nested shape).
- **Migration rewrites the store**: the one-time `getSettings()` migration path now unconditionally persists the migrated blob. This guarantees that downstream reads (e.g. periodic reloads, the Dashboard API, the scheduler reconfig path) see a stable v2 shape. Test `TestGetSettings_V1toV2_PersistsMigration` pins this.
- **`max_age_days` UI default of 7 in the DOM**: the numeric input's `value="7"` is a belt-and-braces fallback for the `.catch()` branch in the settings-load flow. Production loads always populate via `settings.smart.max_age_days` from the server (which ships 7 for both fresh installs and upgraders).
- **`max_age_days` is persisted but unused**: deliberate per the issue — slice 1b (#238) wires this into `StaleSMARTChecker`. A grep for `MaxAgeDays` outside `internal/api/` returns zero hits, guarding against accidental premature wiring.

## Verified locally

- `go build ./...` ✅
- `go test ./...` ✅ (all packages green)
- `go vet ./...` ✅
- `docker build .` — **not run**: this PR touches no Dockerfile, CI workflow, `go.mod`, or DB migration files, so §4b doesn't apply. Docker Desktop is also currently requiring an org sign-in on this build host that isn't available in-session. If a reviewer wants a local image build, nothing in this diff should affect the build graph.

## What is explicitly NOT in this PR

- No scheduler behaviour change (no `StaleSMARTChecker`, no `CollectSMARTForced`, no force-wake loop) — that's #238
- No fleet federation of settings — explicitly out of scope per PRD
- No dashboard indicator / notification for future force-wake events — deferred to slice 1b follow-ups