### PR TITLE
feat(scheduler): SMART max-age force-wake behaviour (#238)

### DIFF
--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -371,6 +371,9 @@ func main() {
 			coll.SetSMARTConfig(collector.SMARTConfig{
 				WakeDrives: persistedSettings.SMART.WakeDrives,
 			})
+			// Apply the max-age force-wake threshold on startup (#238).
+			// Scheduler owns this policy; 0 disables the safety net.
+			sched.SetSMARTMaxAgeDays(persistedSettings.SMART.MaxAgeDays)
 		}
 		sched.Start()
 		defer sched.Stop()

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -929,6 +929,10 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		s.collector.SetSMARTConfig(collector.SMARTConfig{
 			WakeDrives: settings.SMART.WakeDrives,
 		})
+		// Update the max-age safety-net threshold on the scheduler
+		// (#238). The scheduler owns this policy (the collector stays
+		// DB-unaware) and applies it after each scan's Collect().
+		s.scheduler.SetSMARTMaxAgeDays(settings.SMART.MaxAgeDays)
 
 		// Update log forwarding
 		if settings.LogPush.Enabled && len(settings.LogPush.Destinations) > 0 {

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -70,10 +70,13 @@ func (c *Collector) Collect() (*internal.Snapshot, error) {
 
 	// SMART data
 	c.logger.Info("collecting SMART data", "wake_drives", c.smartConfig.WakeDrives)
-	smart, err := collectSMART(c.smartConfig, c.logger)
+	smart, standbyDevices, err := collectSMART(c.smartConfig, c.logger)
 	if err != nil {
 		c.logger.Warn("SMART collection partial failure", "error", err)
 	}
+	// Issue #238: surface standby device list to the scheduler so the
+	// StaleSMARTChecker can evaluate max-age and force-wake if overdue.
+	snap.SMARTStandbyDevices = standbyDevices
 	// Enrich SMART data with Unraid array slot mapping (md -> physical device)
 	if smart != nil && sys.Platform == "unraid" {
 		mdMap := buildMDToPhysicalMap() // "sdb" -> "1" (for /mnt/disk1)
@@ -213,6 +216,15 @@ func (c *Collector) Collect() (*internal.Snapshot, error) {
 	snap.Duration = time.Since(start).Seconds()
 	c.logger.Info("collection complete", "duration", fmt.Sprintf("%.1fs", snap.Duration))
 	return snap, nil
+}
+
+// CollectSMARTForced reads SMART for the given devices without the
+// `-n standby` guard. Used by the scheduler's StaleSMARTChecker (issue
+// #238) as the seam for the force-wake path. Thin wrapper around the
+// package-level function so the scheduler doesn't need to import
+// collector internals directly.
+func (c *Collector) CollectSMARTForced(devices []string) ([]internal.SMARTInfo, error) {
+	return CollectSMARTForced(devices, c.logger)
 }
 
 // CollectDockerStats runs a lightweight Docker stats collection (no full scan).

--- a/internal/collector/smart.go
+++ b/internal/collector/smart.go
@@ -41,7 +41,7 @@ var errDriveInStandby = errors.New("drive in standby; skipped SMART read")
 // as failed drives (issue #206).
 var errDriveUnsupported = errors.New("device does not support SMART")
 
-func collectSMART(cfg SMARTConfig, logger *slog.Logger) ([]internal.SMARTInfo, error) {
+func collectSMART(cfg SMARTConfig, logger *slog.Logger) ([]internal.SMARTInfo, []string, error) {
 	startedAt := time.Now()
 	devices := discoverDrives()
 	if len(devices) == 0 {
@@ -68,10 +68,11 @@ func collectSMART(cfg SMARTConfig, logger *slog.Logger) ([]internal.SMARTInfo, e
 				"duration", time.Since(startedAt).Round(time.Millisecond).String(),
 			)
 		}
-		return nil, fmt.Errorf("no drives discovered")
+		return nil, nil, fmt.Errorf("no drives discovered")
 	}
 
 	var results []internal.SMARTInfo
+	var standbyDevices []string
 	var lastErr error
 	var skipped, standby, unsupported int
 	for _, dev := range devices {
@@ -86,6 +87,10 @@ func collectSMART(cfg SMARTConfig, logger *slog.Logger) ([]internal.SMARTInfo, e
 					logger.Info("skipped SMART read: drive in standby", "device", dev)
 				}
 				standby++
+				// Issue #238: surface the standby device to the caller
+				// so the scheduler's StaleSMARTChecker can evaluate its
+				// age against Settings.SMART.MaxAgeDays.
+				standbyDevices = append(standbyDevices, dev)
 				continue
 			}
 			if errors.Is(err, errDriveUnsupported) {
@@ -143,9 +148,50 @@ func collectSMART(cfg SMARTConfig, logger *slog.Logger) ([]internal.SMARTInfo, e
 	// and an empty slice so the caller can persist an empty SMART
 	// snapshot rather than treating it as a collection failure.
 	if len(results) == 0 && lastErr != nil {
-		return nil, fmt.Errorf("all %d drives failed SMART read (%d failed, %d standby, %d unsupported), last error: %w", len(devices), skipped, standby, unsupported, lastErr)
+		return nil, standbyDevices, fmt.Errorf("all %d drives failed SMART read (%d failed, %d standby, %d unsupported), last error: %w", len(devices), skipped, standby, unsupported, lastErr)
 	}
-	return results, nil
+	return results, standbyDevices, nil
+}
+
+// CollectSMARTForced reads SMART for exactly the supplied devices,
+// WITHOUT the `-n standby` guard. Returns results in the same shape
+// as collectSMART's normal path. Used by the scheduler's
+// StaleSMARTChecker (issue #238) to force-wake drives whose last
+// SMART read is older than Settings.SMART.MaxAgeDays.
+//
+// A per-device INFO log ("force-read SMART") fires on each invocation
+// so operators can distinguish these reads from normal scan-cycle
+// reads and from standby skips.
+//
+// Errors from individual devices are logged at WARN and collected into
+// the returned error chain via errors.Join. Successful devices are
+// always returned in the results slice regardless of peer failures —
+// this is the "one-drive failure doesn't block others" requirement.
+func CollectSMARTForced(devices []string, logger *slog.Logger) ([]internal.SMARTInfo, error) {
+	if len(devices) == 0 {
+		return nil, nil
+	}
+	var results []internal.SMARTInfo
+	var errs []error
+	for _, dev := range devices {
+		if logger != nil {
+			logger.Info("force-read SMART", "device", dev)
+		}
+		info, err := readSMARTDevice(dev, true /* wakeDrives: force read */)
+		if err != nil {
+			if logger != nil {
+				logger.Warn("force-read SMART failed", "device", dev, "error", err)
+			}
+			errs = append(errs, fmt.Errorf("%s: %w", dev, err))
+			continue
+		}
+		// Guard against empty reads the same way collectSMART does.
+		if info.Model == "" && info.Serial == "" {
+			continue
+		}
+		results = append(results, info)
+	}
+	return results, errors.Join(errs...)
 }
 
 func discoverDrives() []string {

--- a/internal/collector/smart_forced_test.go
+++ b/internal/collector/smart_forced_test.go
@@ -1,0 +1,146 @@
+package collector
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestCollectSMARTForced_OmitsStandbyFlag is the defining contract of
+// the new force-wake path (issue #238). Every smartctl invocation made
+// by CollectSMARTForced MUST NOT carry `-n standby` — the whole point
+// is to wake the drive and refresh SMART data even if it's spun down.
+//
+// If a future refactor accidentally pipes the default SMARTConfig
+// (WakeDrives=false) into the forced path, the max-age safety net
+// becomes a no-op. This test pins that contract.
+func TestCollectSMARTForced_OmitsStandbyFlag(t *testing.T) {
+	var calls [][]string
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		calls = append(calls, append([]string{name}, args...))
+		return `{"json_format_version":[1,0,0],"model_name":"Forced 4TB","serial_number":"SN-F1","user_capacity":{"bytes":4000000000000}}`, nil
+	})()
+
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	results, err := CollectSMARTForced([]string{"/dev/sda"}, logger)
+	if err != nil {
+		t.Fatalf("CollectSMARTForced: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	if results[0].Device != "/dev/sda" {
+		t.Errorf("result device = %q, want %q", results[0].Device, "/dev/sda")
+	}
+	if results[0].Serial != "SN-F1" {
+		t.Errorf("result serial = %q, want SN-F1", results[0].Serial)
+	}
+
+	if len(calls) == 0 {
+		t.Fatal("expected at least one smartctl call")
+	}
+	for i, call := range calls {
+		joined := strings.Join(call, " ")
+		if strings.Contains(joined, "-n standby") {
+			t.Errorf("call %d carries `-n standby` despite force-wake path: %s", i, joined)
+		}
+		if !strings.Contains(joined, "/dev/sda") {
+			t.Errorf("call %d missing target device /dev/sda: %s", i, joined)
+		}
+	}
+}
+
+// TestCollectSMARTForced_PartialFailureContinues verifies that when one
+// device in the list fails SMART read, the remaining devices are still
+// processed. Matches the graceful-degradation requirement in issue #238
+// ("one-drive failure doesn't block others").
+func TestCollectSMARTForced_PartialFailureContinues(t *testing.T) {
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		argv := strings.Join(args, " ")
+		switch {
+		case strings.Contains(argv, "/dev/sdgood"):
+			return `{"json_format_version":[1,0,0],"model_name":"Good 2TB","serial_number":"SN-GOOD","user_capacity":{"bytes":2000000000000}}`, nil
+		case strings.Contains(argv, "/dev/sdbad"):
+			// No parseable output at all — collectSMART's existing fall-through
+			// treats this as a failed read (not standby, not unsupported).
+			return "", errors.New("smartctl exploded")
+		}
+		return "", nil
+	})()
+
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	results, err := CollectSMARTForced([]string{"/dev/sdbad", "/dev/sdgood"}, logger)
+	// We tolerate a non-nil err (so the caller can log it), but the good
+	// device MUST be in the results regardless.
+	_ = err
+
+	foundGood := false
+	for _, r := range results {
+		if r.Device == "/dev/sdgood" {
+			foundGood = true
+		}
+	}
+	if !foundGood {
+		t.Errorf("expected /dev/sdgood in results despite /dev/sdbad failure; got %+v", results)
+	}
+}
+
+// TestCollectSMARTForced_EmptyListNoCalls — a CollectSMARTForced call
+// with no devices should be a fast no-op; it must not invoke smartctl
+// at all (important because the scheduler will call this on every scan
+// cycle, and on cycles with no stale drives the list is empty).
+func TestCollectSMARTForced_EmptyListNoCalls(t *testing.T) {
+	var calls int
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		calls++
+		return "", nil
+	})()
+
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	results, err := CollectSMARTForced(nil, logger)
+	if err != nil {
+		t.Errorf("empty list should not error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("empty list must produce empty results; got %d", len(results))
+	}
+	if calls != 0 {
+		t.Errorf("empty list must make 0 smartctl calls; got %d", calls)
+	}
+}
+
+// TestCollectSMARTForced_LogsPerDevice pins the INFO log emitted for
+// each successful force-wake. The scheduler's StaleSMARTChecker emits
+// the "forcing SMART wake on ..." line at the orchestration layer; the
+// collector emits a lower-level "force-read SMART" per device so
+// operators can distinguish force-reads from standby skips in logs.
+func TestCollectSMARTForced_LogsPerDevice(t *testing.T) {
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		return `{"json_format_version":[1,0,0],"model_name":"X","serial_number":"X","user_capacity":{"bytes":1000000000000}}`, nil
+	})()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	_, _ = CollectSMARTForced([]string{"/dev/sda", "/dev/sdb"}, logger)
+
+	var matches int
+	for _, line := range strings.Split(buf.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if msg, _ := rec["msg"].(string); strings.Contains(msg, "force-read SMART") {
+			matches++
+		}
+	}
+	if matches != 2 {
+		t.Errorf("expected 2 per-device force-read log lines, got %d; log:\n%s", matches, buf.String())
+	}
+}

--- a/internal/collector/smart_standby_list_test.go
+++ b/internal/collector/smart_standby_list_test.go
@@ -1,0 +1,52 @@
+package collector
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestCollectSMART_ReturnsStandbyDeviceList pins the signal that the
+// scheduler's StaleSMARTChecker (issue #238) depends on: when
+// `-n standby` skips a drive, its device path must be surfaced to the
+// caller so the scheduler can evaluate its age against MaxAgeDays.
+//
+// Prior to issue #238 the collector silently dropped standby drives
+// and the caller had no way to learn of them. The new contract is
+// that collectSMART's third return value is the list of device paths
+// that were skipped for standby this cycle.
+func TestCollectSMART_ReturnsStandbyDeviceList(t *testing.T) {
+	if len(discoverDrives()) > 0 {
+		t.Skip("host has real drives discoverable via /dev/sd*")
+	}
+
+	// Three fake devs: active, standby, active.
+	activeJSON := `{"json_format_version":[1,0,0],"model_name":"Active","serial_number":"SN-ACTIVE","user_capacity":{"bytes":1000000000000}}`
+	standbyOut := "smartctl 7.3\n\nDevice is in STANDBY mode, exit(2)\n"
+
+	defer swapExecCmd(func(name string, args ...string) (string, error) {
+		if len(args) == 1 && args[0] == "--scan" {
+			return "/dev/fakeA -d sat\n/dev/fakeStandby -d sat\n/dev/fakeB -d sat\n", nil
+		}
+		argv := strings.Join(args, " ")
+		switch {
+		case strings.Contains(argv, "/dev/fakeStandby"):
+			return standbyOut, nil
+		default:
+			return activeJSON, nil
+		}
+	})()
+
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	results, standby, err := collectSMART(SMARTConfig{WakeDrives: false}, logger)
+	if err != nil {
+		t.Fatalf("collectSMART: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("expected 2 active results, got %d", len(results))
+	}
+	if len(standby) != 1 || standby[0] != "/dev/fakeStandby" {
+		t.Errorf("expected standby=[/dev/fakeStandby], got %v", standby)
+	}
+}

--- a/internal/collector/smart_summary_test.go
+++ b/internal/collector/smart_summary_test.go
@@ -82,7 +82,7 @@ func TestCollectSMART_SummaryLogCounters(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
-	_, _ = collectSMART(SMARTConfig{WakeDrives: false}, logger)
+	_, _, _ = collectSMART(SMARTConfig{WakeDrives: false}, logger)
 
 	// Scan log lines for the summary.
 	var summary map[string]any
@@ -150,7 +150,7 @@ func TestCollectSMART_SummaryLogEmittedOnNoDrives(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
-	_, err := collectSMART(SMARTConfig{}, logger)
+	_, _, err := collectSMART(SMARTConfig{}, logger)
 	if err == nil {
 		t.Fatal("expected 'no drives discovered' error")
 	}
@@ -170,5 +170,5 @@ func TestCollectSMART_NilLoggerTolerated(t *testing.T) {
 	})()
 
 	// Should not panic despite logger=nil.
-	_, _ = collectSMART(SMARTConfig{}, nil)
+	_, _, _ = collectSMART(SMARTConfig{}, nil)
 }

--- a/internal/collector/smart_unsupported_test.go
+++ b/internal/collector/smart_unsupported_test.go
@@ -99,7 +99,7 @@ Use smartctl -h to get a usage summary
 
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	_, _ = collectSMART(SMARTConfig{WakeDrives: false}, logger)
+	_, _, _ = collectSMART(SMARTConfig{WakeDrives: false}, logger)
 
 	summary := scanSMARTSummary(t, buf.String())
 
@@ -140,7 +140,7 @@ func TestCollectSMART_UnsupportedDrive_EmitsPerDriveLog(t *testing.T) {
 
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	_, _ = collectSMART(SMARTConfig{WakeDrives: false}, logger)
+	_, _, _ = collectSMART(SMARTConfig{WakeDrives: false}, logger)
 
 	// Find the per-drive INFO log. Carries the exact device name so
 	// a user with multiple unsupported devices can tell them apart.
@@ -239,7 +239,7 @@ func TestCollectSMART_USBBridge_JSONWrapped_AlsoCountedAsUnsupported(t *testing.
 
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	_, _ = collectSMART(SMARTConfig{WakeDrives: false}, logger)
+	_, _, _ = collectSMART(SMARTConfig{WakeDrives: false}, logger)
 
 	summary := scanSMARTSummary(t, buf.String())
 

--- a/internal/models.go
+++ b/internal/models.go
@@ -59,6 +59,14 @@ type Snapshot struct {
 	SpeedTest  *SpeedTestInfo       `json:"speed_test,omitempty"`
 	Services   []ServiceCheckResult `json:"service_checks,omitempty"`
 	Findings   []Finding            `json:"findings"`
+
+	// SMARTStandbyDevices lists devices that were in standby during this
+	// scan's SMART collect pass (i.e. `-n standby` skipped them). The
+	// scheduler's StaleSMARTChecker (issue #238) uses this list to
+	// decide which drives to force-wake when Settings.SMART.MaxAgeDays
+	// has been exceeded. Persisted so historical snapshots retain an
+	// accurate "which drives were asleep at this point" audit trail.
+	SMARTStandbyDevices []string `json:"smart_standby_devices,omitempty"`
 }
 
 // ---------- Proxmox VE ----------

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -111,6 +111,12 @@ type Scheduler struct {
 	checker        *ServiceChecker
 	retentionMgr   *RetentionManager
 
+	// smartMaxAgeDays is the Settings.SMART.MaxAgeDays value driving
+	// the StaleSMARTChecker (issue #238). 0 disables the feature
+	// entirely. Mutated by SetSMARTMaxAgeDays from the API handler
+	// when the user changes the setting. Read under s.mu.
+	smartMaxAgeDays int
+
 	logForwarder *logfwd.Forwarder
 
 	mu      sync.RWMutex
@@ -152,6 +158,10 @@ func New(
 		serviceChecks: []internal.ServiceCheckConfig{},
 		stop:          make(chan struct{}),
 		restart:       make(chan time.Duration, 1),
+		// Default matches defaultSettings().SMART.MaxAgeDays (#237).
+		// Callers that want a different value (or zero to disable)
+		// should call SetSMARTMaxAgeDays after construction.
+		smartMaxAgeDays: 7,
 	}
 	s.checker = NewServiceChecker(store, logger)
 	// Opt into the per-type Details map on the scheduled path too —
@@ -320,6 +330,20 @@ func (s *Scheduler) SetSpeedTestRunner(fn SpeedTestRunner) {
 	s.speedTestRunFn = fn
 }
 
+// SetSMARTMaxAgeDays updates the max-age threshold driving the
+// StaleSMARTChecker (issue #238). 0 disables the feature entirely —
+// in which case RunOnce skips the Check+Apply pass completely and
+// the scheduler behaves exactly like v0.9.5 (user story 5).
+//
+// Called by the API handler when the user edits
+// Settings.SMART.MaxAgeDays; also by main.go on startup to apply the
+// persisted preference.
+func (s *Scheduler) SetSMARTMaxAgeDays(days int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.smartMaxAgeDays = days
+}
+
 // SetSpeedTestSchedule sets specific times of day to run speed tests.
 func (s *Scheduler) SetSpeedTestSchedule(times []string, day string, freq string) {
 	s.mu.Lock()
@@ -372,6 +396,26 @@ func (s *Scheduler) RunOnce() {
 	if err != nil {
 		s.logger.Error("collection failed", "error", err)
 		return
+	}
+
+	// Stale-SMART force-wake (issue #238). After the normal SMART
+	// collect pass, any drive reported as "standby" via `-n standby`
+	// whose last recorded read exceeds Settings.SMART.MaxAgeDays is
+	// force-woken for a single SMART read and merged back into the
+	// snapshot. MaxAgeDays=0 disables the feature entirely.
+	//
+	// Runs BEFORE detectDriveReplacements so the replacement logic
+	// sees fresh SMART for force-woken drives (avoids a spurious
+	// "drive missing" interpretation if a standby drive's last
+	// snapshot reported different ArraySlot metadata).
+	s.mu.RLock()
+	maxAgeDays := s.smartMaxAgeDays
+	s.mu.RUnlock()
+	if maxAgeDays > 0 {
+		staleChecker := NewStaleSMARTChecker(s.store, maxAgeDays, s.logger)
+		if stale := staleChecker.Check(snap); len(stale) > 0 {
+			staleChecker.Apply(snap, stale, s.collector.CollectSMARTForced)
+		}
 	}
 
 	// Drive replacement detection (issue #130). Runs on every scan but

--- a/internal/scheduler/stale_smart.go
+++ b/internal/scheduler/stale_smart.go
@@ -16,11 +16,18 @@
 package scheduler
 
 import (
+	"fmt"
 	"log/slog"
 	"time"
 
 	"github.com/mcdays94/nas-doctor/internal"
 )
+
+// ForcedSMARTCollectorFn is the seam StaleSMARTChecker.Apply invokes
+// to force-read SMART for a list of devices. In production the
+// scheduler wires this to collector.Collector.CollectSMARTForced; in
+// tests it's a stub that returns the desired shape.
+type ForcedSMARTCollectorFn func(devices []string) ([]internal.SMARTInfo, error)
 
 // staleSMARTStore is the narrow dependency StaleSMARTChecker needs
 // from the storage layer. Declared as its own interface here (rather
@@ -108,4 +115,100 @@ func (c *StaleSMARTChecker) Check(snap *internal.Snapshot) []string {
 		}
 	}
 	return stale
+}
+
+// Apply invokes the forced-collector callback for the given devices
+// and merges the fresh SMART results into the snapshot. For each
+// device the caller asked to wake, the canonical INFO log line is
+// emitted BEFORE the callback runs:
+//
+//	forcing SMART wake on <device>: last read <duration> ago exceeds max_age_days=<N>
+//
+// Merge semantics:
+//   - Any SMARTInfo the callback returns is appended to snap.SMART
+//     and the corresponding device is removed from
+//     snap.SMARTStandbyDevices (the drive is no longer asleep).
+//   - A callback error is logged at ERROR but does NOT abort. Devices
+//     whose force-read failed remain in snap.SMARTStandbyDevices
+//     (they're still considered asleep; we just don't have fresh data).
+//   - A nil callback is a no-op (defensive guard — the scheduler
+//     always wires a real callback in production, but a mis-wire
+//     shouldn't panic).
+func (c *StaleSMARTChecker) Apply(snap *internal.Snapshot, devices []string, fn ForcedSMARTCollectorFn) {
+	if snap == nil || len(devices) == 0 || fn == nil {
+		return
+	}
+
+	now := snap.Timestamp
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	// Emit the canonical per-device INFO log before the callback so
+	// operators can see intent even if the force-read itself fails.
+	for _, dev := range devices {
+		lastAt, found, err := c.store.GetLastSMARTCollectedAt(dev)
+		if err != nil || !found {
+			// Shouldn't happen (Check already filtered these out) but
+			// be defensive.
+			if c.logger != nil {
+				c.logger.Info(fmt.Sprintf("forcing SMART wake on %s: last read unknown ago exceeds max_age_days=%d", dev, c.maxAgeDays))
+			}
+			continue
+		}
+		age := now.Sub(lastAt)
+		if c.logger != nil {
+			c.logger.Info(fmt.Sprintf(
+				"forcing SMART wake on %s: last read %s ago exceeds max_age_days=%d",
+				dev,
+				age.Round(time.Minute).String(),
+				c.maxAgeDays,
+			))
+		}
+	}
+
+	results, err := fn(devices)
+	if err != nil {
+		if c.logger != nil {
+			c.logger.Error("force-wake SMART collector returned error (partial results may still be merged)",
+				"error", err,
+				"devices", devices,
+			)
+		}
+	}
+
+	if len(results) == 0 {
+		return
+	}
+
+	// Merge fresh entries into snap.SMART. Replace existing entries
+	// for the same device (defensive — snap.SMART shouldn't contain
+	// standby devices, but if a future change adds a "standby marker"
+	// entry we still want to overwrite cleanly).
+	freshByDevice := make(map[string]internal.SMARTInfo, len(results))
+	for _, r := range results {
+		freshByDevice[r.Device] = r
+	}
+	for i, existing := range snap.SMART {
+		if fresh, ok := freshByDevice[existing.Device]; ok {
+			snap.SMART[i] = fresh
+			delete(freshByDevice, existing.Device)
+		}
+	}
+	for _, fresh := range freshByDevice {
+		snap.SMART = append(snap.SMART, fresh)
+	}
+
+	// Remove force-woken devices from the standby list.
+	wokenSet := make(map[string]struct{}, len(results))
+	for _, r := range results {
+		wokenSet[r.Device] = struct{}{}
+	}
+	filtered := snap.SMARTStandbyDevices[:0]
+	for _, dev := range snap.SMARTStandbyDevices {
+		if _, woken := wokenSet[dev]; !woken {
+			filtered = append(filtered, dev)
+		}
+	}
+	snap.SMARTStandbyDevices = filtered
 }

--- a/internal/scheduler/stale_smart.go
+++ b/internal/scheduler/stale_smart.go
@@ -1,0 +1,111 @@
+// Package scheduler — stale_smart.go implements the max-age SMART
+// force-wake checker introduced in issue #238 (PRD #236 slice 1b).
+//
+// Design (agreed in the Apr 2026 grilling session):
+//   - The collector is DB-unaware. It simply reports which drives were
+//     in standby this cycle (snap.SMARTStandbyDevices) and otherwise
+//     behaves identically to the v0.9.5 `-n standby` flow.
+//   - The scheduler owns the max-age policy. After a normal scan,
+//     StaleSMARTChecker.Check queries smart_history for each standby
+//     device and returns the list whose last read has exceeded
+//     Settings.SMART.MaxAgeDays. StaleSMARTChecker.Apply then invokes
+//     the forced collector for that list and merges the fresh SMART
+//     rows into the snapshot.
+//   - MaxAgeDays==0 disables the feature entirely — no store queries,
+//     no force-wake invocations. Preserves exact v0.9.5 behaviour.
+package scheduler
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// staleSMARTStore is the narrow dependency StaleSMARTChecker needs
+// from the storage layer. Declared as its own interface here (rather
+// than reusing storage.HistoryStore) so tests can inject a tiny mock
+// without implementing the 20+ methods of the broader interface.
+type staleSMARTStore interface {
+	GetLastSMARTCollectedAt(device string) (time.Time, bool, error)
+}
+
+// StaleSMARTChecker is the deep module that implements the max-age
+// force-wake safety net (issue #238 / PRD #236).
+//
+// Check() is a pure policy decision — which of the standby drives in
+// the current snapshot have been unread for longer than MaxAgeDays?
+//
+// Apply() performs the side effect — invokes the forced collector for
+// the returned device list and merges the fresh results into the
+// snapshot. These are intentionally separate so the scheduler can
+// short-circuit the callback wiring when Check returns empty.
+type StaleSMARTChecker struct {
+	store      staleSMARTStore
+	maxAgeDays int
+	logger     *slog.Logger
+}
+
+// NewStaleSMARTChecker constructs the checker. maxAgeDays is the
+// number of days a drive may remain unread before force-wake; 0
+// disables the feature entirely.
+func NewStaleSMARTChecker(store staleSMARTStore, maxAgeDays int, logger *slog.Logger) *StaleSMARTChecker {
+	return &StaleSMARTChecker{
+		store:      store,
+		maxAgeDays: maxAgeDays,
+		logger:     logger,
+	}
+}
+
+// Check returns the subset of snapshot.SMARTStandbyDevices whose last
+// successful SMART read is older than MaxAgeDays.
+//
+// Returns empty (no store queries) when:
+//   - snapshot is nil
+//   - MaxAgeDays == 0 (feature disabled)
+//   - snapshot.SMARTStandbyDevices is empty
+//
+// Drives with no smart_history row are SKIPPED (PRD #236 user story 7:
+// new drives must not be force-woken). Drives whose store lookup
+// errors are SKIPPED and logged at WARN so a DB blip doesn't cause a
+// spurious force-wake.
+func (c *StaleSMARTChecker) Check(snap *internal.Snapshot) []string {
+	if snap == nil {
+		return nil
+	}
+	if c.maxAgeDays <= 0 {
+		return nil
+	}
+	if len(snap.SMARTStandbyDevices) == 0 {
+		return nil
+	}
+
+	now := snap.Timestamp
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	threshold := time.Duration(c.maxAgeDays) * 24 * time.Hour
+
+	var stale []string
+	for _, dev := range snap.SMARTStandbyDevices {
+		lastAt, found, err := c.store.GetLastSMARTCollectedAt(dev)
+		if err != nil {
+			if c.logger != nil {
+				c.logger.Warn("stale-SMART lookup failed; skipping device",
+					"device", dev,
+					"error", err,
+				)
+			}
+			continue
+		}
+		if !found {
+			// New drive — no history yet. Do not force-wake.
+			continue
+		}
+		age := now.Sub(lastAt)
+		if age > threshold {
+			stale = append(stale, dev)
+		}
+	}
+	return stale
+}

--- a/internal/scheduler/stale_smart_apply_test.go
+++ b/internal/scheduler/stale_smart_apply_test.go
@@ -1,0 +1,212 @@
+package scheduler
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// newApplyChecker builds a StaleSMARTChecker wired to a JSON-buffer
+// logger so tests can assert on the canonical INFO log format.
+func newApplyChecker(maxAgeDays int) (*StaleSMARTChecker, *mockLastCollectedStore, *bytes.Buffer) {
+	return newTestStaleChecker(maxAgeDays)
+}
+
+// TestStaleSMARTChecker_Apply_EmptyListSkipsCallback: with no stale
+// devices, the forced-collector callback must not fire, and the
+// snapshot must be untouched.
+func TestStaleSMARTChecker_Apply_EmptyListSkipsCallback(t *testing.T) {
+	chk, _, _ := newApplyChecker(7)
+	snap := &internal.Snapshot{SMARTStandbyDevices: []string{"/dev/sda"}}
+
+	var called bool
+	chk.Apply(snap, nil, func(devices []string) ([]internal.SMARTInfo, error) {
+		called = true
+		return nil, nil
+	})
+	if called {
+		t.Errorf("callback must not fire for empty stale list")
+	}
+}
+
+// TestStaleSMARTChecker_Apply_MergesResultsIntoSnapshot: when the
+// callback returns SMARTInfo for a previously-standby device, the
+// snapshot gains that entry and the device is removed from the
+// standby list.
+func TestStaleSMARTChecker_Apply_MergesResultsIntoSnapshot(t *testing.T) {
+	chk, store, _ := newApplyChecker(7)
+	now := time.Now().UTC()
+	// Seed so lastAt is 10 days old -> past threshold.
+	store.data["/dev/sda"] = now.Add(-10 * 24 * time.Hour)
+
+	snap := &internal.Snapshot{
+		Timestamp:           now,
+		SMARTStandbyDevices: []string{"/dev/sda"},
+	}
+	stale := chk.Check(snap)
+	if len(stale) != 1 {
+		t.Fatalf("precondition: expected 1 stale, got %v", stale)
+	}
+
+	fresh := internal.SMARTInfo{Device: "/dev/sda", Serial: "SN-FRESH", Model: "Freshly Woke 8TB"}
+	chk.Apply(snap, stale, func(devices []string) ([]internal.SMARTInfo, error) {
+		if len(devices) != 1 || devices[0] != "/dev/sda" {
+			t.Errorf("callback got %v, want [/dev/sda]", devices)
+		}
+		return []internal.SMARTInfo{fresh}, nil
+	})
+
+	if len(snap.SMART) != 1 || snap.SMART[0].Serial != "SN-FRESH" {
+		t.Errorf("expected snap.SMART to contain fresh /dev/sda entry, got %+v", snap.SMART)
+	}
+	// Device must be removed from the standby list — it is no longer
+	// in standby after a force-read.
+	for _, dev := range snap.SMARTStandbyDevices {
+		if dev == "/dev/sda" {
+			t.Errorf("expected /dev/sda removed from standby list after force-wake; got %v", snap.SMARTStandbyDevices)
+		}
+	}
+}
+
+// TestStaleSMARTChecker_Apply_EmitsCanonicalInfoLog pins the log
+// format specified in issue #238:
+//
+//	forcing SMART wake on <device>: last read <duration> ago exceeds max_age_days=<N>
+func TestStaleSMARTChecker_Apply_EmitsCanonicalInfoLog(t *testing.T) {
+	chk, store, buf := newApplyChecker(7)
+	now := time.Now().UTC()
+	store.data["/dev/sda"] = now.Add(-10 * 24 * time.Hour)
+
+	snap := &internal.Snapshot{
+		Timestamp:           now,
+		SMARTStandbyDevices: []string{"/dev/sda"},
+	}
+	stale := chk.Check(snap)
+	chk.Apply(snap, stale, func(devices []string) ([]internal.SMARTInfo, error) {
+		return []internal.SMARTInfo{{Device: "/dev/sda", Model: "X", Serial: "SN"}}, nil
+	})
+
+	// Scan the log lines for the canonical INFO entry.
+	var foundMsg string
+	re := regexp.MustCompile(`forcing SMART wake on \S+: last read .+ ago exceeds max_age_days=7`)
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if rec["level"] != "INFO" {
+			continue
+		}
+		msg, _ := rec["msg"].(string)
+		if re.MatchString(msg) {
+			foundMsg = msg
+			break
+		}
+	}
+	if foundMsg == "" {
+		t.Errorf("expected INFO log matching canonical format; got:\n%s", buf.String())
+	}
+}
+
+// TestStaleSMARTChecker_Apply_PartialFailureContinues: when the
+// forced collector returns partial results (one entry + one error),
+// the successful entry is merged and the error is logged at ERROR.
+// The failed device remains in the standby list (it's still
+// considered asleep because the force-read didn't produce data).
+func TestStaleSMARTChecker_Apply_PartialFailureContinues(t *testing.T) {
+	chk, store, buf := newApplyChecker(7)
+	now := time.Now().UTC()
+	store.data["/dev/sda"] = now.Add(-10 * 24 * time.Hour)
+	store.data["/dev/sdb"] = now.Add(-10 * 24 * time.Hour)
+
+	snap := &internal.Snapshot{
+		Timestamp:           now,
+		SMARTStandbyDevices: []string{"/dev/sda", "/dev/sdb"},
+	}
+	stale := chk.Check(snap)
+	if len(stale) != 2 {
+		t.Fatalf("precondition: expected 2 stale, got %v", stale)
+	}
+
+	chk.Apply(snap, stale, func(devices []string) ([]internal.SMARTInfo, error) {
+		return []internal.SMARTInfo{
+			{Device: "/dev/sdb", Serial: "SN-B", Model: "OK"},
+		}, errors.New("simulated force-read failure on /dev/sda")
+	})
+
+	// /dev/sdb's fresh entry merged.
+	foundSDB := false
+	for _, s := range snap.SMART {
+		if s.Device == "/dev/sdb" {
+			foundSDB = true
+		}
+	}
+	if !foundSDB {
+		t.Errorf("expected /dev/sdb merged into snap.SMART; got %+v", snap.SMART)
+	}
+
+	// /dev/sda must remain on the standby list (never force-read successfully).
+	foundSDA := false
+	for _, d := range snap.SMARTStandbyDevices {
+		if d == "/dev/sda" {
+			foundSDA = true
+		}
+	}
+	if !foundSDA {
+		t.Errorf("expected /dev/sda still in standby list, got %v", snap.SMARTStandbyDevices)
+	}
+
+	// Assert an ERROR log was emitted for the callback failure.
+	foundErrLog := false
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var rec map[string]any
+		if json.Unmarshal([]byte(line), &rec) != nil {
+			continue
+		}
+		if rec["level"] == "ERROR" {
+			foundErrLog = true
+		}
+	}
+	if !foundErrLog {
+		t.Errorf("expected ERROR log for force-read failure; got:\n%s", buf.String())
+	}
+}
+
+// TestStaleSMARTChecker_Apply_NilCallbackSafe ensures a nil callback
+// (e.g. scheduler mis-wire) doesn't panic.
+func TestStaleSMARTChecker_Apply_NilCallbackSafe(t *testing.T) {
+	chk, store, _ := newApplyChecker(7)
+	now := time.Now().UTC()
+	store.data["/dev/sda"] = now.Add(-10 * 24 * time.Hour)
+
+	snap := &internal.Snapshot{
+		Timestamp:           now,
+		SMARTStandbyDevices: []string{"/dev/sda"},
+	}
+	stale := chk.Check(snap)
+	chk.Apply(snap, stale, nil) // must not panic
+	// Nothing merged.
+	if len(snap.SMART) != 0 {
+		t.Errorf("nil callback should not mutate snapshot, got %+v", snap.SMART)
+	}
+}
+
+// Silence unused-import hint when the test file above doesn't use fmt.
+var _ = fmt.Sprintf
+
+// Reusing slog so the compiler keeps the import honest across files.
+var _ = slog.LevelInfo

--- a/internal/scheduler/stale_smart_integration_test.go
+++ b/internal/scheduler/stale_smart_integration_test.go
@@ -1,0 +1,214 @@
+package scheduler
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// TestStaleSMARTChecker_Integration_EndToEnd pins the end-to-end
+// contract from issue #238: given a real *storage.DB seeded with
+// smart_history rows at known ages, the Check+Apply flow must
+//
+//  1. identify exactly the drive(s) past the MaxAgeDays threshold
+//  2. invoke the forced-collector callback for those drive(s)
+//  3. merge the fresh results into the snapshot
+//  4. emit the canonical INFO log
+//
+// This is the "integration test with seeded DB" acceptance criterion
+// from the issue.
+func TestStaleSMARTChecker_Integration_EndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "integration.db")
+	silentLogger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	db, err := storage.Open(dbPath, silentLogger)
+	if err != nil {
+		t.Fatalf("Open DB: %v", err)
+	}
+	defer db.Close()
+
+	// Seed a snapshot row + three smart_history rows of varying ages.
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := db.SaveSnapshot(&internal.Snapshot{
+		ID:        "seed-snap",
+		Timestamp: now.Add(-30 * 24 * time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	// Directly seed smart_history with known-age rows.
+	type seed struct {
+		device string
+		age    time.Duration
+	}
+	for _, s := range []seed{
+		{"/dev/sda", 10 * 24 * time.Hour}, // 10d — stale at 7d threshold
+		{"/dev/sdb", 3 * 24 * time.Hour},  // 3d — fresh
+		// /dev/sdc: intentionally has NO history row → new drive
+	} {
+		if err := seedSmartHistoryRow(db, "seed-snap", s.device, now.Add(-s.age)); err != nil {
+			t.Fatalf("seed %s: %v", s.device, err)
+		}
+	}
+
+	// Build the snapshot the collector would have produced — with all
+	// three drives reported as standby (the `-n standby` skip path).
+	// /dev/sda and /dev/sdc are past-threshold candidates on paper;
+	// only /dev/sda should actually be flagged because /dev/sdc has
+	// no history and new drives are never force-woken (user story 7).
+	snap := &internal.Snapshot{
+		Timestamp:           now,
+		SMARTStandbyDevices: []string{"/dev/sda", "/dev/sdb", "/dev/sdc"},
+	}
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	chk := NewStaleSMARTChecker(db, 7 /* maxAgeDays */, logger)
+
+	stale := chk.Check(snap)
+	if len(stale) != 1 || stale[0] != "/dev/sda" {
+		t.Fatalf("expected Check to flag only /dev/sda, got %v", stale)
+	}
+
+	// Capture the callback argument list to confirm it's invoked with
+	// the exact stale list.
+	var gotDevices []string
+	forced := func(devices []string) ([]internal.SMARTInfo, error) {
+		gotDevices = append([]string{}, devices...)
+		return []internal.SMARTInfo{
+			{Device: "/dev/sda", Model: "Reawakened 8TB", Serial: "SN-SDA"},
+		}, nil
+	}
+	chk.Apply(snap, stale, forced)
+
+	if len(gotDevices) != 1 || gotDevices[0] != "/dev/sda" {
+		t.Errorf("callback devices = %v, want [/dev/sda]", gotDevices)
+	}
+	// Snapshot merge: /dev/sda appears with fresh serial, removed from standby list.
+	foundFresh := false
+	for _, s := range snap.SMART {
+		if s.Device == "/dev/sda" && s.Serial == "SN-SDA" {
+			foundFresh = true
+		}
+	}
+	if !foundFresh {
+		t.Errorf("expected fresh /dev/sda entry in snap.SMART; got %+v", snap.SMART)
+	}
+	stillStandby := false
+	for _, d := range snap.SMARTStandbyDevices {
+		if d == "/dev/sda" {
+			stillStandby = true
+		}
+	}
+	if stillStandby {
+		t.Errorf("/dev/sda should be removed from standby list after force-wake; got %v", snap.SMARTStandbyDevices)
+	}
+
+	// Assert the canonical INFO log fired for /dev/sda with a
+	// duration describing roughly 10 days.
+	foundLog := false
+	for _, line := range strings.Split(buf.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if json.Unmarshal([]byte(line), &rec) != nil {
+			continue
+		}
+		msg, _ := rec["msg"].(string)
+		if strings.HasPrefix(msg, "forcing SMART wake on /dev/sda") &&
+			strings.Contains(msg, "max_age_days=7") {
+			foundLog = true
+		}
+	}
+	if !foundLog {
+		t.Errorf("expected canonical INFO log for /dev/sda; got:\n%s", buf.String())
+	}
+}
+
+// TestStaleSMARTChecker_Integration_MaxAgeZeroNoForceWake is the
+// regression guard for user story 5 (MaxAgeDays=0 preserves v0.9.5
+// behaviour). Even with a drive 30 days stale, no force-wake happens.
+func TestStaleSMARTChecker_Integration_MaxAgeZeroNoForceWake(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "disabled.db")
+	silentLogger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	db, err := storage.Open(dbPath, silentLogger)
+	if err != nil {
+		t.Fatalf("Open DB: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := db.SaveSnapshot(&internal.Snapshot{ID: "s-off", Timestamp: now.Add(-60 * 24 * time.Hour)}); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+	if err := seedSmartHistoryRow(db, "s-off", "/dev/sda", now.Add(-30*24*time.Hour)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	snap := &internal.Snapshot{
+		Timestamp:           now,
+		SMARTStandbyDevices: []string{"/dev/sda"},
+	}
+
+	chk := NewStaleSMARTChecker(db, 0 /* disabled */, slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+
+	stale := chk.Check(snap)
+	if len(stale) != 0 {
+		t.Fatalf("MaxAgeDays=0 must disable force-wake; got stale=%v", stale)
+	}
+
+	var callbackFired bool
+	chk.Apply(snap, stale, func(devices []string) ([]internal.SMARTInfo, error) {
+		callbackFired = true
+		return nil, nil
+	})
+	if callbackFired {
+		t.Errorf("MaxAgeDays=0: force-wake callback must not fire")
+	}
+	// Snapshot shape preserved.
+	if len(snap.SMART) != 0 {
+		t.Errorf("snap.SMART should not be mutated; got %+v", snap.SMART)
+	}
+	if len(snap.SMARTStandbyDevices) != 1 || snap.SMARTStandbyDevices[0] != "/dev/sda" {
+		t.Errorf("standby list should be preserved, got %v", snap.SMARTStandbyDevices)
+	}
+}
+
+// seedSmartHistoryRow is a small test helper that inserts a
+// smart_history row directly. Uses db.Exec on the (unexported) *sql.DB
+// via a cast — that's why this helper lives in the scheduler package
+// and calls db methods that are exported for this purpose. If the
+// storage package stops exporting a raw Exec path we can switch to
+// constructing full Snapshots and calling SaveSnapshot.
+func seedSmartHistoryRow(db *storage.DB, snapshotID, device string, ts time.Time) error {
+	// Construct a real Snapshot and call SaveSnapshot — the only
+	// exported write path in storage.DB. Each call generates one row
+	// in smart_history with the specified timestamp (snapshot's
+	// Timestamp field is used for the row).
+	snap := &internal.Snapshot{
+		ID:        snapshotID + "-" + device,
+		Timestamp: ts,
+		SMART: []internal.SMARTInfo{
+			{
+				Device:       device,
+				Serial:       "SERIAL-" + device,
+				Model:        "MODEL",
+				Temperature:  30,
+				HealthPassed: true,
+				PowerOnHours: 1000,
+			},
+		},
+	}
+	return db.SaveSnapshot(snap)
+}

--- a/internal/scheduler/stale_smart_scheduler_wiring_test.go
+++ b/internal/scheduler/stale_smart_scheduler_wiring_test.go
@@ -1,0 +1,43 @@
+package scheduler
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/collector"
+	"github.com/mcdays94/nas-doctor/internal/notifier"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// TestScheduler_SetSMARTMaxAgeDays_RoundTrips confirms the setter
+// introduced for issue #238 actually mutates the field the
+// StaleSMARTChecker consumes. This is the seam the API settings
+// handler uses to push user changes through to the scheduler.
+func TestScheduler_SetSMARTMaxAgeDays_RoundTrips(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	col := collector.New(internal.HostPaths{}, logger)
+	fake := storage.NewFakeStore()
+	s := New(col, fake, &notifier.Notifier{}, nil, logger, 30*time.Minute)
+
+	// Default from constructor matches defaultSettings().SMART.MaxAgeDays.
+	if got := s.smartMaxAgeDays; got != 7 {
+		t.Errorf("default smartMaxAgeDays = %d, want 7 (matches defaultSettings)", got)
+	}
+
+	s.SetSMARTMaxAgeDays(14)
+	if got := s.smartMaxAgeDays; got != 14 {
+		t.Errorf("after SetSMARTMaxAgeDays(14), got %d", got)
+	}
+
+	// 0 is the disabled sentinel — RunOnce must skip the Check+Apply
+	// pass entirely when this is set (user story 5). We verify the
+	// field update here; end-to-end disabled behaviour is exercised
+	// by TestStaleSMARTChecker_Integration_MaxAgeZeroNoForceWake.
+	s.SetSMARTMaxAgeDays(0)
+	if got := s.smartMaxAgeDays; got != 0 {
+		t.Errorf("after SetSMARTMaxAgeDays(0), got %d", got)
+	}
+}

--- a/internal/scheduler/stale_smart_test.go
+++ b/internal/scheduler/stale_smart_test.go
@@ -1,0 +1,211 @@
+package scheduler
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// mockLastCollectedStore is a minimal stub that satisfies the
+// last-collected lookup surface StaleSMARTChecker needs, without
+// pulling in the full storage.HistoryStore machinery.
+type mockLastCollectedStore struct {
+	data map[string]time.Time // device -> last read
+	// forceErr, when non-nil, is returned instead of a lookup.
+	forceErr error
+	calls    []string // devices queried in order
+}
+
+func newMockStore() *mockLastCollectedStore {
+	return &mockLastCollectedStore{data: map[string]time.Time{}}
+}
+
+func (m *mockLastCollectedStore) GetLastSMARTCollectedAt(device string) (time.Time, bool, error) {
+	m.calls = append(m.calls, device)
+	if m.forceErr != nil {
+		return time.Time{}, false, m.forceErr
+	}
+	ts, ok := m.data[device]
+	return ts, ok, nil
+}
+
+// newTestStaleChecker constructs a StaleSMARTChecker with a mock store
+// and a buffer-backed logger so tests can assert on log output.
+func newTestStaleChecker(maxAgeDays int) (*StaleSMARTChecker, *mockLastCollectedStore, *bytes.Buffer) {
+	store := newMockStore()
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	chk := NewStaleSMARTChecker(store, maxAgeDays, logger)
+	return chk, store, buf
+}
+
+// TestStaleSMARTChecker_Check_PastThresholdReturnsDevice: a drive
+// that's been in standby and whose last successful SMART read is
+// 8 days old with MaxAgeDays=7 must be flagged for force-wake.
+func TestStaleSMARTChecker_Check_PastThresholdReturnsDevice(t *testing.T) {
+	chk, store, _ := newTestStaleChecker(7)
+	now := time.Now().UTC()
+	store.data["/dev/sda"] = now.Add(-8 * 24 * time.Hour)
+
+	snap := &internal.Snapshot{
+		Timestamp:           now,
+		SMARTStandbyDevices: []string{"/dev/sda"},
+	}
+	got := chk.Check(snap)
+	if len(got) != 1 || got[0] != "/dev/sda" {
+		t.Errorf("expected [/dev/sda], got %v", got)
+	}
+}
+
+// TestStaleSMARTChecker_Check_WithinThresholdSkipped: a drive whose
+// last SMART read is 5 days old with MaxAgeDays=7 must NOT be
+// flagged; the existing passive collection path already covers it.
+func TestStaleSMARTChecker_Check_WithinThresholdSkipped(t *testing.T) {
+	chk, store, _ := newTestStaleChecker(7)
+	now := time.Now().UTC()
+	store.data["/dev/sda"] = now.Add(-5 * 24 * time.Hour)
+
+	snap := &internal.Snapshot{
+		Timestamp:           now,
+		SMARTStandbyDevices: []string{"/dev/sda"},
+	}
+	got := chk.Check(snap)
+	if len(got) != 0 {
+		t.Errorf("expected no force-wake (5d < 7d), got %v", got)
+	}
+}
+
+// TestStaleSMARTChecker_Check_NoHistorySkipped: a drive in standby
+// with no smart_history rows is a new drive — never force-wake. This
+// is the user-story-7 contract.
+func TestStaleSMARTChecker_Check_NoHistorySkipped(t *testing.T) {
+	chk, _, _ := newTestStaleChecker(7)
+
+	snap := &internal.Snapshot{
+		Timestamp:           time.Now().UTC(),
+		SMARTStandbyDevices: []string{"/dev/brand-new"},
+	}
+	got := chk.Check(snap)
+	if len(got) != 0 {
+		t.Errorf("expected no force-wake for new drive, got %v", got)
+	}
+}
+
+// TestStaleSMARTChecker_Check_EmptyStandbyListSkipsStoreQueries: when
+// the snapshot reports no drives in standby, the checker must not
+// query the store at all (fast path).
+func TestStaleSMARTChecker_Check_EmptyStandbyListSkipsStoreQueries(t *testing.T) {
+	chk, store, _ := newTestStaleChecker(7)
+
+	snap := &internal.Snapshot{
+		Timestamp:           time.Now().UTC(),
+		SMARTStandbyDevices: nil,
+	}
+	got := chk.Check(snap)
+	if len(got) != 0 {
+		t.Errorf("expected empty result, got %v", got)
+	}
+	if len(store.calls) != 0 {
+		t.Errorf("expected 0 store queries, got %d (calls=%v)", len(store.calls), store.calls)
+	}
+}
+
+// TestStaleSMARTChecker_Check_MaxAgeZeroDisablesFeature: setting the
+// threshold to 0 means "never force wake" (PRD #236 user story 5 —
+// preserve exact v0.9.5 behaviour). No store queries, no devices
+// returned — regardless of how old the histories are.
+func TestStaleSMARTChecker_Check_MaxAgeZeroDisablesFeature(t *testing.T) {
+	chk, store, _ := newTestStaleChecker(0)
+	now := time.Now().UTC()
+	store.data["/dev/sda"] = now.Add(-365 * 24 * time.Hour) // a year ago — would be way stale
+
+	snap := &internal.Snapshot{
+		Timestamp:           now,
+		SMARTStandbyDevices: []string{"/dev/sda"},
+	}
+	got := chk.Check(snap)
+	if len(got) != 0 {
+		t.Errorf("MaxAgeDays=0 should disable force-wake, got %v", got)
+	}
+	if len(store.calls) != 0 {
+		t.Errorf("MaxAgeDays=0 must not issue store queries, got %d", len(store.calls))
+	}
+}
+
+// TestStaleSMARTChecker_Check_NilSnapshotSafe: a nil snapshot must not
+// panic (defensive, in case a collection failure upstream passes nil).
+func TestStaleSMARTChecker_Check_NilSnapshotSafe(t *testing.T) {
+	chk, _, _ := newTestStaleChecker(7)
+	got := chk.Check(nil)
+	if len(got) != 0 {
+		t.Errorf("nil snapshot must return empty, got %v", got)
+	}
+}
+
+// TestStaleSMARTChecker_Check_StoreErrorLoggedContinues: if the store
+// lookup fails for one device, the checker logs a WARN and continues
+// processing the rest of the standby list. The failed device is not
+// flagged for force-wake (we don't force-read without knowing when it
+// was last read).
+func TestStaleSMARTChecker_Check_StoreErrorLoggedContinues(t *testing.T) {
+	store := newMockStore()
+	store.data["/dev/sdb"] = time.Now().UTC().Add(-10 * 24 * time.Hour)
+	// /dev/sda would fail — but mockLastCollectedStore forceErr is
+	// global. Simulate per-device error by wrapping.
+	var perDeviceErr = func(dev string) bool { return dev == "/dev/sda" }
+	wrapper := &wrappedStore{inner: store, failIf: perDeviceErr}
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	chk := NewStaleSMARTChecker(wrapper, 7, logger)
+
+	snap := &internal.Snapshot{
+		Timestamp:           time.Now().UTC(),
+		SMARTStandbyDevices: []string{"/dev/sda", "/dev/sdb"},
+	}
+	got := chk.Check(snap)
+	if len(got) != 1 || got[0] != "/dev/sdb" {
+		t.Errorf("expected [/dev/sdb], got %v", got)
+	}
+
+	// Assert a warn log was emitted for /dev/sda.
+	foundWarn := false
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if rec["level"] == "WARN" && strings.Contains(rec["msg"].(string), "stale-SMART lookup failed") {
+			foundWarn = true
+		}
+	}
+	if !foundWarn {
+		t.Errorf("expected WARN log for /dev/sda store failure; got: %s", buf.String())
+	}
+}
+
+// wrappedStore injects a per-device error into the mock store.
+type wrappedStore struct {
+	inner  *mockLastCollectedStore
+	failIf func(string) bool
+}
+
+func (w *wrappedStore) GetLastSMARTCollectedAt(device string) (time.Time, bool, error) {
+	if w.failIf != nil && w.failIf(device) {
+		return time.Time{}, false, errFake
+	}
+	return w.inner.GetLastSMARTCollectedAt(device)
+}
+
+var errFake = &fakeErr{"simulated DB failure"}
+
+type fakeErr struct{ s string }
+
+func (e *fakeErr) Error() string { return e.s }

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -2193,6 +2193,39 @@ func (d *DB) GetDiskHistoryInRange(serial string, window time.Duration) ([]DiskH
 	return points, rows.Err()
 }
 
+// GetLastSMARTCollectedAt returns the most recent smart_history.timestamp
+// for the given device and a found flag. Used by the scheduler's
+// StaleSMARTChecker (issue #238) to decide whether a drive in standby is
+// overdue for a SMART read.
+//
+// Returns:
+//   - (ts, true, nil)          — device has at least one smart_history row
+//   - (time.Time{}, false, nil) — device has no smart_history rows (new drive)
+//   - (time.Time{}, false, err) — query failed
+//
+// Uses idx_smart_history_device (device, timestamp DESC) so the
+// ORDER BY ... LIMIT 1 form is an index seek, not a table scan. We
+// prefer that over MAX() because the modernc.org/sqlite driver only
+// applies timestamp affinity to bare column scans — MAX() returns a
+// string that would fail to scan into a time.Time.
+func (d *DB) GetLastSMARTCollectedAt(device string) (time.Time, bool, error) {
+	var ts time.Time
+	err := d.db.QueryRow(
+		`SELECT timestamp FROM smart_history
+		 WHERE device = ?
+		 ORDER BY timestamp DESC
+		 LIMIT 1`,
+		device,
+	).Scan(&ts)
+	if err == sql.ErrNoRows {
+		return time.Time{}, false, nil
+	}
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	return ts, true, nil
+}
+
 // ---------- System history ----------
 
 // SystemHistoryPoint represents a single system metrics data point.

--- a/internal/storage/db_smart_last_collected_test.go
+++ b/internal/storage/db_smart_last_collected_test.go
@@ -1,0 +1,99 @@
+package storage
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestDB_GetLastSMARTCollectedAt_ReturnsLatestTimestamp verifies the
+// scheduler-facing "when was this device last read" query. Used by the
+// StaleSMARTChecker (issue #238) to decide whether to force-wake a drive
+// that has been in standby longer than Settings.SMART.MaxAgeDays.
+//
+// Expected query: SELECT MAX(timestamp) FROM smart_history WHERE device = ?
+// backed by idx_smart_history_device.
+func TestDB_GetLastSMARTCollectedAt_ReturnsLatestTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	db, err := Open(dbPath, logger)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	// Seed a snapshot the smart_history rows can reference.
+	snapID := "snap-1"
+	now := time.Now().UTC().Truncate(time.Second)
+	if _, err := db.db.Exec(
+		`INSERT INTO snapshots (id, timestamp, duration_seconds, data) VALUES (?, ?, ?, ?)`,
+		snapID, now, 0.1, "{}",
+	); err != nil {
+		t.Fatalf("insert snapshot: %v", err)
+	}
+
+	// Two rows for /dev/sda (8h and 2h old), one row for /dev/sdb (1h old).
+	rows := []struct {
+		device string
+		age    time.Duration
+	}{
+		{"/dev/sda", 8 * time.Hour},
+		{"/dev/sda", 2 * time.Hour},
+		{"/dev/sdb", 1 * time.Hour},
+	}
+	for _, r := range rows {
+		ts := now.Add(-r.age)
+		if _, err := db.db.Exec(
+			`INSERT INTO smart_history (snapshot_id, device, serial, model, temperature, reallocated, pending, udma_crc, command_timeout, power_on_hours, health_passed, timestamp)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			snapID, r.device, "SER-"+r.device, "MODEL", 30, int64(0), int64(0), int64(0), int64(0), int64(1000), true, ts,
+		); err != nil {
+			t.Fatalf("insert smart_history: %v", err)
+		}
+	}
+
+	// /dev/sda: latest is 2h old.
+	got, found, err := db.GetLastSMARTCollectedAt("/dev/sda")
+	if err != nil {
+		t.Fatalf("GetLastSMARTCollectedAt(/dev/sda): %v", err)
+	}
+	if !found {
+		t.Fatalf("expected found=true for /dev/sda")
+	}
+	wantSDA := now.Add(-2 * time.Hour)
+	delta := got.Sub(wantSDA)
+	if delta < -2*time.Second || delta > 2*time.Second {
+		t.Errorf("/dev/sda: got %v, want ≈ %v (delta %v)", got, wantSDA, delta)
+	}
+}
+
+// TestDB_GetLastSMARTCollectedAt_MissingDeviceReturnsNotFound verifies the
+// "new drive" path: a device that has no smart_history rows yet must return
+// found=false without an error, so the StaleSMARTChecker can skip it (new
+// drives are not force-woken per PRD #236 user story 7).
+func TestDB_GetLastSMARTCollectedAt_MissingDeviceReturnsNotFound(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	db, err := Open(dbPath, logger)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	got, found, err := db.GetLastSMARTCollectedAt("/dev/never-seen")
+	if err != nil {
+		t.Fatalf("unexpected error for unknown device: %v", err)
+	}
+	if found {
+		t.Errorf("expected found=false for unknown device, got found=true with ts=%v", got)
+	}
+	if !got.IsZero() {
+		t.Errorf("expected zero timestamp for not-found, got %v", got)
+	}
+}

--- a/internal/storage/fake.go
+++ b/internal/storage/fake.go
@@ -418,6 +418,14 @@ func (f *FakeStore) GetDiskHistoryInRange(_ string, _ time.Duration) ([]DiskHist
 	return nil, nil
 }
 
+// GetLastSMARTCollectedAt satisfies HistoryStore so *FakeStore keeps
+// satisfying the Store composite. The real scheduler tests construct
+// dedicated mocks rather than poking at this FakeStore (see
+// internal/scheduler/stale_smart_test.go).
+func (f *FakeStore) GetLastSMARTCollectedAt(_ string) (time.Time, bool, error) {
+	return time.Time{}, false, nil
+}
+
 func (f *FakeStore) GetAvgTempDuringRange(_, _ time.Time) (float64, float64, error) {
 	// TODO: implement for testing
 	return 0, 0, nil

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -63,6 +63,11 @@ type ServiceCheckStore interface {
 type HistoryStore interface {
 	GetDiskHistory(serial string, limit int) ([]DiskHistoryPoint, error)
 	GetDiskHistoryInRange(serial string, window time.Duration) ([]DiskHistoryPoint, error)
+	// GetLastSMARTCollectedAt returns the latest smart_history.timestamp
+	// for the given device and a found flag. Used by the scheduler's
+	// StaleSMARTChecker (issue #238) to decide whether to force-wake a
+	// drive that has been in standby longer than Settings.SMART.MaxAgeDays.
+	GetLastSMARTCollectedAt(device string) (time.Time, bool, error)
 	GetAvgTempDuringRange(start, end time.Time) (float64, float64, error)
 	ListDisks() ([]DiskSummary, error)
 	GetAllDiskSparklines(pointsPerDisk int) ([]DiskSparklines, error)


### PR DESCRIPTION
Closes #238

## Summary

End-to-end wiring of PRD #236 slice 1b: when a drive has been in standby longer than `Settings.SMART.MaxAgeDays` (default 7), the scheduler force-wakes it for a single SMART read, merges the result into the snapshot, and emits a canonical INFO log. `MaxAgeDays=0` disables the feature entirely and preserves exact v0.9.5 behaviour (user story 5).

V1a (#237) laid the settings schema + UI + migration; this PR activates the behaviour those pieces persisted.

## Architecture (D2 from grilling)

Two-pass at the scheduler layer; the collector stays DB-unaware.

1. `Collect()` runs normally, including `-n standby`. Collector now surfaces standby devices via `snap.SMARTStandbyDevices` (previously dropped silently).
2. `StaleSMARTChecker.Check(snap)` queries `smart_history` for each standby device and returns the subset past the threshold.
3. `StaleSMARTChecker.Apply(snap, stale, collector.CollectSMARTForced)` force-reads those drives WITHOUT `-n standby`, merges fresh SMART entries into `snap.SMART`, and removes them from the standby list. Canonical INFO log fires per device: `forcing SMART wake on <device>: last read <duration> ago exceeds max_age_days=<N>`.

## Changes by layer

### Storage (`internal/storage/db.go`, `interfaces.go`, `fake.go`)
- New `HistoryStore.GetLastSMARTCollectedAt(device) (time.Time, bool, error)` backed by `idx_smart_history_device`. Uses `ORDER BY timestamp DESC LIMIT 1` (the modernc.org sqlite driver doesn't round-trip `MAX()` into `time.Time` cleanly).
- `(zero, false, nil)` for unknown device so the checker can skip new drives (user story 7).
- `FakeStore` gets a stub.

### Collector (`internal/collector/smart.go`, `collector.go`)
- New exported `CollectSMARTForced(devices, logger)` — reads SMART WITHOUT `-n standby`, logs `force-read SMART` per device, uses `errors.Join` for graceful multi-device degradation.
- `Collector.CollectSMARTForced` method wrapper (the scheduler seam).
- `collectSMART` signature extended to return `(results, standbyDevices, error)`. `Collector.Collect()` stamps `standbyDevices` onto `snap.SMARTStandbyDevices`.
- `Snapshot.SMARTStandbyDevices []string` added in `internal/models.go` (`omitempty`).

### Scheduler (`internal/scheduler/stale_smart.go` — new)
- `StaleSMARTChecker` deep module with narrow `staleSMARTStore` interface (testability).
- `Check(snap) []string`: pure policy. Nil snap / MaxAgeDays=0 / empty standby list all return empty without store queries. Per-device store error → WARN, skip. No history → skip (new-drive contract).
- `Apply(snap, devices, callback)`: invokes callback, merges returned SMARTInfo into `snap.SMART`, removes woken devices from standby list. Canonical INFO log per device fires BEFORE callback so operators see intent even on failure. Callback error → ERROR; partial results still merge.

### Scheduler wiring (`internal/scheduler/scheduler.go`)
- `Scheduler.smartMaxAgeDays` field (default 7, matches `defaultSettings().SMART.MaxAgeDays` from #237).
- `SetSMARTMaxAgeDays(n)` setter.
- `RunOnce`: after `Collect()`, before `detectDriveReplacements`, instantiate `StaleSMARTChecker`, call `Check`+`Apply` if enabled. `MaxAgeDays==0` short-circuits entirely.

### Settings wiring (`internal/api/api_extended.go`, `cmd/nas-doctor/main.go`)
- PUT /api/v1/settings calls `scheduler.SetSMARTMaxAgeDays` alongside existing `collector.SetSMARTConfig`.
- Startup applies persisted `Settings.SMART.MaxAgeDays` before the first scan.

## Tests added

| File | Tests | Coverage |
|---|---|---|
| `internal/storage/db_smart_last_collected_test.go` | 2 | latest timestamp returned, missing device → not-found |
| `internal/collector/smart_forced_test.go` | 4 | no `-n standby`, partial failure continues, empty list = 0 calls, per-device INFO log |
| `internal/collector/smart_standby_list_test.go` | 1 | `collectSMART` returns standby device list |
| `internal/scheduler/stale_smart_test.go` | 7 | `Check`: past threshold, within threshold, no history, empty list, MaxAgeDays=0, nil snap, store error |
| `internal/scheduler/stale_smart_apply_test.go` | 5 | `Apply`: empty skips callback, merges + removes from standby, canonical INFO log format, partial failure + ERROR log, nil callback safe |
| `internal/scheduler/stale_smart_integration_test.go` | 2 | end-to-end with real SQLite: flags only the stale drive (ignores fresh + new), merges result, logs canonically; MaxAgeDays=0 disables completely |
| `internal/scheduler/stale_smart_scheduler_wiring_test.go` | 1 | `SetSMARTMaxAgeDays` round-trip |

**Total: ~22 new tests** across storage, collector, and scheduler layers.

## Acceptance criteria checklist (from #238)

- [x] `GetLastSMARTCollectedAt` semantics (found / not-found / error)
- [x] `CollectSMARTForced` drops `-n standby`, same shape as `collectSMART`
- [x] `Check` flags stale-standby drives correctly
- [x] `Check` returns empty when `MaxAgeDays==0`
- [x] `Check` excludes drives with no history
- [x] `Apply` merges forced reads into snapshot
- [x] Canonical INFO log format
- [x] Scheduler wiring runs Check+Apply after Collect()
- [x] One-drive failure doesn't block others
- [x] Integration test with seeded DB proves end-to-end behaviour
- [x] No regression in `collectSMART` when max-age doesn't trigger (existing tests still green)
- [x] `MaxAgeDays=0` disables entirely

## Pre-push gates

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages green
- [ ] `docker build .` — NOT RUN locally. This environment's Docker Desktop is blocked by a Cloudflare org policy (`Sign in to continue... Membership in [cloudflare bastionzero] required`). CI will cover it on PR open. No Dockerfile changes in this PR — only Go sources under `internal/` and `cmd/` are touched.

## Out of scope (by design)

- No maintenance-log entries on force-wake (avoids spam on routinely-sleeping drives; decided in grilling).
- No dashboard indicators.
- Per-instance only — no fleet federation of max-age state.