### PR TITLE
feat(api): Cache-Control no-cache on dashboard HTML so ?v=VERSION cache-bust actually works (#234)

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -494,6 +494,13 @@ func (s *Server) serveDashboard(w http.ResponseWriter, theme string) {
 		html = DashboardMidnight
 	}
 	html = strings.Replace(html, "__VERSION__", s.version, -1)
+	// Force the browser to revalidate the dashboard HTML on every load.
+	// The HTML embeds `<script src="/js/dashboard.js?v=<VERSION>">` with
+	// VERSION baked at render time; if the HTML itself is cached, the
+	// `?v=` cache-bust points at a stale URL after an upgrade and the
+	// browser keeps serving the old bundle. Matches the pattern already
+	// used for /js/dashboard.js and /js/charts.js (see #234).
+	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write([]byte(html))
 }

--- a/internal/api/dashboard_cache_control_test.go
+++ b/internal/api/dashboard_cache_control_test.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestServeDashboard_SetsNoCacheHeader locks in the fix for issue #234.
+//
+// Before the fix, serveDashboard wrote the HTML with zero cache headers.
+// Browsers then applied heuristic freshness and could serve stale HTML.
+// Because the HTML embeds `<script src="/js/dashboard.js?v=<VERSION>">`
+// with VERSION baked at render time, stale HTML means the browser keeps
+// requesting the previous version's JS URL and never revalidates against
+// the newly-upgraded binary. The `?v=VERSION` cache-bust only works when
+// the HTML itself is fresh.
+//
+// The fix mirrors the pattern already used for /js/dashboard.js and
+// /js/charts.js (see api.go:125 and :132): explicitly set
+// "Cache-Control: no-cache" so the browser revalidates the dashboard
+// HTML on every load.
+func TestServeDashboard_SetsNoCacheHeader(t *testing.T) {
+	srv := &Server{version: "test"}
+	w := httptest.NewRecorder()
+
+	srv.serveDashboard(w, ThemeMidnight)
+
+	got := w.Header().Get("Cache-Control")
+	if got != "no-cache" {
+		t.Errorf("serveDashboard must set Cache-Control: no-cache so the dashboard HTML revalidates on every load (otherwise the `?v=VERSION` cache-bust on /js/dashboard.js points at a stale URL after an upgrade); got Cache-Control=%q", got)
+	}
+}
+
+// TestServeDashboard_SetsNoCacheHeader_CleanTheme is the parallel
+// assertion for the clean theme. Both theme branches must set the
+// header — the fix must not regress one while covering the other.
+func TestServeDashboard_SetsNoCacheHeader_CleanTheme(t *testing.T) {
+	srv := &Server{version: "test"}
+	w := httptest.NewRecorder()
+
+	srv.serveDashboard(w, ThemeClean)
+
+	got := w.Header().Get("Cache-Control")
+	if got != "no-cache" {
+		t.Errorf("serveDashboard (clean theme) must also set Cache-Control: no-cache; got %q", got)
+	}
+}
+
+// TestServeDashboard_PreservesExistingBehavior is a regression guard.
+// Adding the new header must not displace the pre-existing
+// Content-Type header or corrupt the HTML body. If a future refactor
+// reorders header writes after a w.Write (which would silently drop
+// them), this test catches it.
+func TestServeDashboard_PreservesExistingBehavior(t *testing.T) {
+	srv := &Server{version: "test-version-xyz"}
+	w := httptest.NewRecorder()
+
+	srv.serveDashboard(w, ThemeMidnight)
+
+	if ct := w.Header().Get("Content-Type"); ct != "text/html; charset=utf-8" {
+		t.Errorf("Content-Type header must remain text/html; charset=utf-8; got %q", ct)
+	}
+
+	body := w.Body.String()
+	if len(body) == 0 {
+		t.Fatalf("serveDashboard wrote an empty body")
+	}
+	// The body must have had the __VERSION__ placeholder substituted.
+	if strings.Contains(body, "__VERSION__") {
+		t.Errorf("serveDashboard did not substitute __VERSION__ placeholder in the HTML body")
+	}
+	if !strings.Contains(body, "test-version-xyz") {
+		t.Errorf("serveDashboard body must contain the substituted version string %q", "test-version-xyz")
+	}
+}


### PR DESCRIPTION
Closes #234

## Problem

`serveDashboard` in `internal/api/api.go` wrote the dashboard HTML with **zero** cache headers. Browsers then applied heuristic freshness and could serve stale HTML for an unspecified window.

The HTML embeds `<script src="/js/dashboard.js?v=<VERSION>">` with VERSION baked at render time — that's the cache-bust for the JS bundle. But if the HTML itself is stale, the `?v=` still points at the PREVIOUS version's URL and the browser serves the cached JS for that URL without revalidating. Result: "after upgrade, dashboard JS stays on the old version until hard-refresh."

## Fix

Add `w.Header().Set("Cache-Control", "no-cache")` just before the `Content-Type` write in `serveDashboard`. Matches the pattern already used for `/js/dashboard.js` (api.go:132) and `/js/charts.js` (api.go:125).

## Related

Sibling to #229 (parallel cache-bust fix for `/css/shared.css` via version query-string). Together they address the "cache-invalidation hygiene" cluster tracked in AGENTS.md for v0.9.8.

## Tests

Three new tests in `internal/api/dashboard_cache_control_test.go`:

- `TestServeDashboard_SetsNoCacheHeader` — midnight theme asserts `Cache-Control: no-cache`
- `TestServeDashboard_SetsNoCacheHeader_CleanTheme` — clean theme parallel (guards against regressing one branch)
- `TestServeDashboard_PreservesExistingBehavior` — regression guard that the new header doesn't displace `Content-Type: text/html; charset=utf-8` and that the HTML body + `__VERSION__` substitution still work

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` all green (full suite)
- `docker build` not run locally — pure Go one-liner addition, Dockerfile unaffected