### PR TITLE
feat(ui): cache-bust /css/shared.css via ?v=VERSION query-string across all templates (#229)

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -498,6 +498,17 @@ func (s *Server) serveDashboard(w http.ResponseWriter, theme string) {
 	w.Write([]byte(html))
 }
 
+// servePage writes a template body with __VERSION__ substituted to the
+// current server version. Page templates use this placeholder to
+// cache-bust /css/shared.css (and /js/*.js) on every release, so the
+// URL in the rendered HTML changes whenever the binary version changes.
+// See issue #229 for the v0.9.7-rc3 UAT incident that motivated this.
+func (s *Server) servePage(w http.ResponseWriter, body string) {
+	body = strings.Replace(body, "__VERSION__", s.version, -1)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write([]byte(body))
+}
+
 // ---------- Helpers ----------
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -2483,15 +2483,13 @@ func (s *Server) handleUnsnoozeAlert(w http.ResponseWriter, r *http.Request) {
 // handleSettingsPage serves the settings HTML page.
 // GET /settings
 func (s *Server) handleSettingsPage(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write([]byte(SettingsPage))
+	s.servePage(w, SettingsPage)
 }
 
 // handleAlertsPage serves the alerts HTML page.
 // GET /alerts
 func (s *Server) handleAlertsPage(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write([]byte(alertsPageHTML))
+	s.servePage(w, alertsPageHTML)
 }
 
 // handleTestFleetServer tests connectivity to a remote NAS Doctor instance.
@@ -2664,22 +2662,19 @@ func (s *Server) handleTestProxmox(w http.ResponseWriter, r *http.Request) {
 // handleServiceChecksPage serves the service checks HTML page.
 // GET /service-checks
 func (s *Server) handleServiceChecksPage(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write([]byte(serviceChecksPageHTML))
+	s.servePage(w, serviceChecksPageHTML)
 }
 
 // handleParityPage serves the parity history HTML page.
 // GET /parity
 func (s *Server) handleParityPage(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write([]byte(parityPageHTML))
+	s.servePage(w, parityPageHTML)
 }
 
 // handleDiskPage serves the disk detail HTML page.
 // GET /disk/{serial}
 func (s *Server) handleDiskPage(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write([]byte(DiskDetailPage))
+	s.servePage(w, DiskDetailPage)
 }
 
 // ---------- Internal helpers ----------

--- a/internal/api/css_cache_bust_test.go
+++ b/internal/api/css_cache_bust_test.go
@@ -1,0 +1,149 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// Issue #229 — cache-bust /css/shared.css via a ?v=<version> query string
+// so every release (and every rc/nightly rev) forces CF edge + browser
+// caches to re-fetch. Surfaced during v0.9.7-rc3 UAT when CF served a
+// 12+h stale copy of shared.css and hid the new .pill-trace styling.
+//
+// Two axes of coverage:
+//
+//  1. Template source: every template file under internal/api/templates/
+//     that contains a `/css/shared.css` link MUST have `?v=__VERSION__`
+//     appended. The `__VERSION__` token is the project-wide placeholder
+//     (same one already used for /js/dashboard.js?v=__VERSION__).
+//
+//  2. Serve-handler: every page handler that writes one of those
+//     templates MUST substitute `__VERSION__` with s.version before
+//     writing the body. Otherwise the raw placeholder ships to the
+//     browser and the query-string is meaningless.
+//
+// If a future PR adds a new page template that links shared.css, the
+// template-source test below will flag it — but the author will also
+// need to wire the substitution into that template's handler (the
+// per-handler integration tests are the template for that).
+
+// stylesheetLinkRE matches: <link rel="stylesheet" href="/css/shared.css...">
+// where ... is anything up to the closing quote.
+var stylesheetLinkRE = regexp.MustCompile(`<link[^>]+href="(/css/shared\.css[^"]*)"`)
+
+// TestTemplates_SharedCSSLink_UsesVersionCacheBust scans every HTML
+// template in internal/api/templates/ and, for each template that
+// links /css/shared.css, asserts the href ends with `?v=__VERSION__`.
+// The __VERSION__ placeholder is substituted at request time by the
+// corresponding page handler.
+func TestTemplates_SharedCSSLink_UsesVersionCacheBust(t *testing.T) {
+	templates := map[string]string{
+		"alerts.html":              alertsPageHTML,
+		"fleet.html":               fleetPageHTML,
+		"parity.html":              parityPageHTML,
+		"replacement_planner.html": replacementPlannerHTML,
+		"service_checks.html":      serviceChecksPageHTML,
+		"settings.html":            SettingsPage,
+		"stats.html":               statsPageHTML,
+	}
+
+	const wantSuffix = "?v=__VERSION__"
+
+	for name, body := range templates {
+		matches := stylesheetLinkRE.FindAllStringSubmatch(body, -1)
+		if len(matches) == 0 {
+			// Template doesn't link shared.css — nothing to assert.
+			// (midnight.html and clean.html fall into this bucket
+			// because the dashboard themes are self-contained.)
+			continue
+		}
+		for _, m := range matches {
+			href := m[1]
+			if !strings.HasSuffix(href, wantSuffix) {
+				t.Errorf("%s: /css/shared.css link missing cache-bust suffix %q; got href=%q (issue #229)",
+					name, wantSuffix, href)
+			}
+		}
+	}
+}
+
+// newTestServerForPageHandlers builds a minimal Server with a known
+// version string so we can assert __VERSION__ substitution against a
+// concrete value rather than the placeholder. The routes mirror the
+// real registration in api_extended.go.
+func newTestServerForPageHandlers(t *testing.T, version string) http.Handler {
+	t.Helper()
+	srv := &Server{
+		store:     storage.NewFakeStore(),
+		logger:    slog.Default(),
+		version:   version,
+		startTime: time.Now(),
+	}
+	r := chi.NewRouter()
+	r.Get("/alerts", srv.handleAlertsPage)
+	r.Get("/fleet", srv.handleFleetPage)
+	r.Get("/parity", srv.handleParityPage)
+	r.Get("/replacement-planner", srv.handleReplacementPlannerPage)
+	r.Get("/service-checks", srv.handleServiceChecksPage)
+	r.Get("/settings", srv.handleSettingsPage)
+	r.Get("/stats", srv.handleStatsPage)
+	return r
+}
+
+// TestPageHandlers_SubstituteVersionInSharedCSSLink is the integration
+// half of the fix: ensures that the rendered HTML response, as a
+// browser would see it, contains the concrete version in the
+// shared.css href — NOT the raw __VERSION__ placeholder.
+func TestPageHandlers_SubstituteVersionInSharedCSSLink(t *testing.T) {
+	const testVersion = "9.9.9-test"
+
+	pages := []struct {
+		name string
+		path string
+	}{
+		{"alerts", "/alerts"},
+		{"fleet", "/fleet"},
+		{"parity", "/parity"},
+		{"replacement_planner", "/replacement-planner"},
+		{"service_checks", "/service-checks"},
+		{"settings", "/settings"},
+		{"stats", "/stats"},
+	}
+
+	handler := newTestServerForPageHandlers(t, testVersion)
+
+	wantHref := "/css/shared.css?v=" + testVersion
+	badHref := "/css/shared.css?v=__VERSION__"
+
+	for _, p := range pages {
+		t.Run(p.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", p.path, nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("GET %s: status=%d, want 200", p.path, w.Code)
+			}
+			body := w.Body.String()
+
+			// Must contain the substituted href.
+			if !strings.Contains(body, wantHref) {
+				t.Errorf("GET %s: response missing substituted CSS link %q (issue #229)", p.path, wantHref)
+			}
+			// Must NOT contain the raw placeholder — that would mean
+			// the handler is writing the template bytes without running
+			// the substitution.
+			if strings.Contains(body, badHref) {
+				t.Errorf("GET %s: response still contains raw placeholder %q — handler is not substituting __VERSION__ (issue #229)", p.path, badHref)
+			}
+		})
+	}
+}

--- a/internal/api/fleet_page.go
+++ b/internal/api/fleet_page.go
@@ -3,6 +3,5 @@ package api
 import "net/http"
 
 func (s *Server) handleFleetPage(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write([]byte(fleetPageHTML))
+	s.servePage(w, fleetPageHTML)
 }

--- a/internal/api/replacement_page.go
+++ b/internal/api/replacement_page.go
@@ -32,8 +32,7 @@ func (s *Server) handleReplacementPlan(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleReplacementPlannerPage(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write([]byte(replacementPlannerHTML))
+	s.servePage(w, replacementPlannerHTML)
 }
 
 func (s *Server) handleCapacityForecast(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/stats_page.go
+++ b/internal/api/stats_page.go
@@ -3,6 +3,5 @@ package api
 import "net/http"
 
 func (s *Server) handleStatsPage(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write([]byte(statsPageHTML))
+	s.servePage(w, statsPageHTML)
 }

--- a/internal/api/templates/alerts.html
+++ b/internal/api/templates/alerts.html
@@ -7,7 +7,7 @@
 <link rel="icon" type="image/png" href="/icon.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="stylesheet" href="/css/shared.css">
+<link rel="stylesheet" href="/css/shared.css?v=__VERSION__">
 </head>
 <body>
 <div class="toast-container" id="toasts"></div>

--- a/internal/api/templates/fleet.html
+++ b/internal/api/templates/fleet.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>NAS Doctor</title>
 <link rel="icon" href="/icon.png">
-<link rel="stylesheet" href="/css/shared.css">
+<link rel="stylesheet" href="/css/shared.css?v=__VERSION__">
 <style>
 body{padding:0}
 .fleet-container{max-width:1200px;margin:0 auto;padding:24px}

--- a/internal/api/templates/parity.html
+++ b/internal/api/templates/parity.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>NAS Doctor</title>
 <link rel="icon" type="image/png" href="/icon.png">
-<link rel="stylesheet" href="/css/shared.css">
+<link rel="stylesheet" href="/css/shared.css?v=__VERSION__">
 <style>
 .summary-bar{display:flex;gap:12px;margin-bottom:20px;flex-wrap:wrap}
 .summary-stat{padding:12px 20px;border-radius:var(--radius);background:var(--surface);border:1px solid var(--border);font-size:13px;display:flex;align-items:center;gap:8px;flex:1;min-width:120px}

--- a/internal/api/templates/replacement_planner.html
+++ b/internal/api/templates/replacement_planner.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>NAS Doctor</title>
 <link rel="icon" href="/icon.png">
-<link rel="stylesheet" href="/css/shared.css">
+<link rel="stylesheet" href="/css/shared.css?v=__VERSION__">
 <style>
 body{padding:0}
 .rp-container{max-width:1200px;margin:0 auto;padding:24px}

--- a/internal/api/templates/service_checks.html
+++ b/internal/api/templates/service_checks.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>NAS Doctor</title>
 <link rel="icon" type="image/png" href="/icon.png">
-<link rel="stylesheet" href="/css/shared.css">
+<link rel="stylesheet" href="/css/shared.css?v=__VERSION__">
 <style>
 /* Summary counters */
 .summary-bar{display:flex;gap:12px;margin-bottom:20px;flex-wrap:wrap}

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -7,7 +7,7 @@
 <link rel="icon" type="image/png" href="/icon.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="stylesheet" href="/css/shared.css">
+<link rel="stylesheet" href="/css/shared.css?v=__VERSION__">
 <style>
 /* Settings-specific styles only */
 

--- a/internal/api/templates/stats.html
+++ b/internal/api/templates/stats.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>NAS Doctor</title>
 <link rel="icon" href="/icon.png">
-<link rel="stylesheet" href="/css/shared.css">
+<link rel="stylesheet" href="/css/shared.css?v=__VERSION__">
 <style>
 /* Stats-specific: drives, charts, SMART tables */
 body{padding:0}


### PR DESCRIPTION
Closes #229

## Summary

Append `?v=__VERSION__` to every `<link rel="stylesheet" href="/css/shared.css">` in the 7 page templates that link it, mirroring the existing pattern used for `/js/dashboard.js` in the dashboard theme templates. `__VERSION__` is substituted at request time so every release (including rcNN and nightly builds) forces CF edge + browser caches to re-fetch shared.css.

## Background

Surfaced during v0.9.7-rc3 UAT: the new `.pill-trace` CSS rule (from #228) was baked into the rc3 binary and served correctly by the origin, but CF edge + browser caches had a 12+ hour stale copy of the rc2 CSS — so UAT browsers rendered the service-checks page without the new pill styling. 2 days of rc-cycle friction, ultimately required a manual CF purge.

`serveSharedCSS` in `styles.go` sets `Cache-Control: public, max-age=86400`, which is the right policy for performance — but only if the URL changes when the content changes. This PR makes the URL change on every release.

## Files touched

**Templates (added `?v=__VERSION__`):**
- `internal/api/templates/alerts.html`
- `internal/api/templates/fleet.html`
- `internal/api/templates/parity.html`
- `internal/api/templates/replacement_planner.html`
- `internal/api/templates/service_checks.html`
- `internal/api/templates/settings.html`
- `internal/api/templates/stats.html`

`midnight.html`, `clean.html`, and `disk_detail.html` do not link `/css/shared.css` (dashboard themes are self-contained inline `<style>` blocks per AGENTS.md — see v0.9.7 rc5→rc6 postmortem) so they are not touched here.

**Handlers (wired through new `servePage` helper for `__VERSION__` substitution):**
- `Server.handleSettingsPage` / `handleAlertsPage` / `handleServiceChecksPage` / `handleParityPage` / `handleDiskPage` (api_extended.go)
- `Server.handleStatsPage` (stats_page.go)
- `Server.handleFleetPage` (fleet_page.go)
- `Server.handleReplacementPlannerPage` (replacement_page.go)

**New helper:**
- `Server.servePage(w, body)` in `api.go` — wraps the `Content-Type` header + `strings.Replace(__VERSION__)` + `w.Write` boilerplate. Factored out so it stays consistent with the pre-existing `serveDashboard` substitution.

## Two-axis test coverage

Following the rc5→rc6 lesson from v0.9.7 (assertion that JS renders a class is NOT the same as assertion that the class is styled / substitution actually happens), the new tests cover both axes:

1. **`TestTemplates_SharedCSSLink_UsesVersionCacheBust`** — scans all seven embedded templates and asserts every `/css/shared.css` link ends with `?v=__VERSION__`. If a future PR adds a new page template without the cache-bust suffix, this fails.
2. **`TestPageHandlers_SubstituteVersionInSharedCSSLink`** — hits each page route via `httptest` with `version="9.9.9-test"` and asserts the rendered response contains `/css/shared.css?v=9.9.9-test` (substituted) and NOT `/css/shared.css?v=__VERSION__` (raw placeholder). If a future handler is added that writes a template body directly (bypassing `servePage`), this fails.

## Verification

- `go build ./...` — clean
- `go test ./...` — all green (including the new tests)
- `go vet ./...` — clean
- `docker build` — not run locally; relying on CI + the fact that this is a Go-only change with no Dockerfile / CI workflow edits

## Sibling issue

Complements #234 (parallel `Cache-Control: no-cache` fix for the dashboard HTML path). Both issues surfaced from the same class of cache-invalidation pain during v0.9.7. This PR handles shared.css specifically; #234 handles the HTML body.