### PR TITLE
feat(scheduler): INFO + ERROR logs on container-stats 5min loop (#226)

### DIFF
--- a/internal/scheduler/container_stats_observability_test.go
+++ b/internal/scheduler/container_stats_observability_test.go
@@ -1,0 +1,160 @@
+package scheduler
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/collector"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// newObservabilityScheduler builds a scheduler whose log output is captured
+// in the returned buffer so tests can assert log lines produced by
+// collectContainerStats (issue #226).
+//
+// The scheduler is constructed with a real Collector (same as
+// newTestScheduler) but a text-handler logger writing to a bytes.Buffer
+// at Info level so Warn / Error / Info / Debug are all observable.
+func newObservabilityScheduler(t *testing.T) (*Scheduler, *storage.FakeStore, *syncBuffer) {
+	t.Helper()
+	store := storage.NewFakeStore()
+	buf := &syncBuffer{}
+	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	col := collector.New(internal.HostPaths{}, logger)
+	s := New(col, store, nil, nil, logger, 0)
+	return s, store, buf
+}
+
+// syncBuffer is a goroutine-safe bytes.Buffer wrapper. slog handlers
+// can write from any goroutine; tests read the accumulated output.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// TestCollectContainerStats_LogsErrorOnCollectorFailure verifies issue
+// #226's primary observability gap: when CollectDockerStats returns an
+// error, the 5-minute loop must emit a WARN/ERROR line so operators can
+// see why container_stats_history stopped advancing. Previously the
+// error was silently swallowed across 36+ hours of real-world data loss.
+func TestCollectContainerStats_LogsErrorOnCollectorFailure(t *testing.T) {
+	s, _, buf := newObservabilityScheduler(t)
+
+	wantErr := errors.New("docker ps: connection refused")
+	s.SetDockerStatsFn(func() (*internal.DockerInfo, error) {
+		return nil, wantErr
+	})
+
+	s.collectContainerStats()
+
+	out := buf.String()
+	if !strings.Contains(out, "container stats") {
+		t.Fatalf("expected log line mentioning 'container stats', got:\n%s", out)
+	}
+	// Must be at WARN or ERROR level (not DEBUG/INFO) so it surfaces in
+	// default operator log views.
+	if !strings.Contains(out, "level=WARN") && !strings.Contains(out, "level=ERROR") {
+		t.Errorf("expected WARN or ERROR level log for collector failure, got:\n%s", out)
+	}
+	if !strings.Contains(out, "connection refused") {
+		t.Errorf("expected log to include the error message 'connection refused', got:\n%s", out)
+	}
+}
+
+// TestCollectContainerStats_LogsInfoOnSuccess verifies the positive-path
+// observability: on each successful cycle, an INFO log line with the
+// container count confirms the loop is still firing. Without this an
+// operator cannot distinguish "loop running but zero containers" from
+// "loop dead".
+func TestCollectContainerStats_LogsInfoOnSuccess(t *testing.T) {
+	s, _, buf := newObservabilityScheduler(t)
+
+	s.SetDockerStatsFn(func() (*internal.DockerInfo, error) {
+		return &internal.DockerInfo{
+			Available: true,
+			Containers: []internal.ContainerInfo{
+				{ID: "abc123", Name: "test-one"},
+				{ID: "def456", Name: "test-two"},
+				{ID: "ghi789", Name: "test-three"},
+			},
+		}, nil
+	})
+
+	s.collectContainerStats()
+
+	out := buf.String()
+	if !strings.Contains(out, "level=INFO") {
+		t.Errorf("expected INFO-level log on successful cycle, got:\n%s", out)
+	}
+	if !strings.Contains(out, "container stats") {
+		t.Errorf("expected log line mentioning 'container stats', got:\n%s", out)
+	}
+	// Container count must be present so operators can spot a sudden
+	// drop from "27 containers" to "0 containers" at a glance.
+	if !strings.Contains(out, "containers=3") {
+		t.Errorf("expected log to include containers=3, got:\n%s", out)
+	}
+}
+
+// TestCollectContainerStats_LogsWarnOnDockerUnavailable verifies we
+// distinguish "docker daemon not reachable" from both the error case
+// (which is a code/permission failure) and the success case. Users on
+// non-Docker platforms will hit this branch every 5 minutes, so it
+// must be at WARN level (visible) but a concise one-liner.
+func TestCollectContainerStats_LogsWarnOnDockerUnavailable(t *testing.T) {
+	s, _, buf := newObservabilityScheduler(t)
+
+	s.SetDockerStatsFn(func() (*internal.DockerInfo, error) {
+		return &internal.DockerInfo{Available: false}, nil
+	})
+
+	s.collectContainerStats()
+
+	out := buf.String()
+	if !strings.Contains(out, "container stats") {
+		t.Fatalf("expected log line mentioning 'container stats', got:\n%s", out)
+	}
+	if !strings.Contains(out, "docker unavailable") {
+		t.Errorf("expected log to mention 'docker unavailable', got:\n%s", out)
+	}
+	// Must NOT claim success: info-level "saved" messages would mislead.
+	if strings.Contains(out, "containers=") {
+		t.Errorf("unavailable branch must not log a container count (would mimic success path), got:\n%s", out)
+	}
+}
+
+// TestCollectContainerStats_LogsOnNilDocker covers the defensive nil
+// branch. Today the production code collapses nil + error + unavailable
+// into a single silent return; after the fix, nil must at minimum log
+// a warning so the branch isn't invisible if it ever does fire.
+func TestCollectContainerStats_LogsOnNilDocker(t *testing.T) {
+	s, _, buf := newObservabilityScheduler(t)
+
+	s.SetDockerStatsFn(func() (*internal.DockerInfo, error) {
+		return nil, nil
+	})
+
+	s.collectContainerStats()
+
+	out := buf.String()
+	if !strings.Contains(out, "container stats") {
+		t.Fatalf("expected log line mentioning 'container stats' for nil docker, got:\n%s", out)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -105,6 +105,12 @@ type Scheduler struct {
 	// Matches the existing ServiceChecker.speedTestRunFn naming for
 	// consistency across the scheduler package.
 	speedTestRunFn SpeedTestRunner
+	// dockerStatsFn is the injectable seam for the 5-minute container
+	// stats loop. Production wires collector.CollectDockerStats via
+	// New(); tests swap it for a deterministic stub to exercise the
+	// three logging branches (error / unavailable / success) added in
+	// issue #226. Read under s.mu.
+	dockerStatsFn  func() (*internal.DockerInfo, error)
 	retention      RetentionConfig
 	alerting       AlertingConfig
 	serviceChecks  []internal.ServiceCheckConfig
@@ -145,6 +151,7 @@ func New(
 		interval:          interval,
 		speedTestInterval: 4 * time.Hour,
 		speedTestRunFn:    collector.RunSpeedTest,
+		dockerStatsFn:     col.CollectDockerStats,
 		retention: RetentionConfig{
 			SnapshotDays:  90,
 			MaxDBSizeMB:   500,
@@ -328,6 +335,17 @@ func (s *Scheduler) SetSpeedTestRunner(fn SpeedTestRunner) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.speedTestRunFn = fn
+}
+
+// SetDockerStatsFn injects the function used by collectContainerStats
+// to collect the 5-minute Docker stats snapshot. Production wires the
+// default to collector.CollectDockerStats via the constructor; tests
+// swap it for a stub so they can exercise the error / unavailable /
+// success logging branches without a live Docker daemon (issue #226).
+func (s *Scheduler) SetDockerStatsFn(fn func() (*internal.DockerInfo, error)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.dockerStatsFn = fn
 }
 
 // SetSMARTMaxAgeDays updates the max-age threshold driving the
@@ -922,15 +940,43 @@ func (s *Scheduler) runServiceChecks(now time.Time) ([]internal.ServiceCheckResu
 // collectContainerStats runs a lightweight Docker stats collection and saves to DB.
 // This runs every 5 minutes independently of the main scan (which runs every 6h)
 // to provide enough data points for the container metrics charts.
+//
+// Logging semantics (issue #226): every cycle emits exactly one log line so
+// operators can tell from grep alone whether the loop is still firing and
+// why it degraded when container_stats_history stops advancing.
+//
+//   - Collector error          -> WARN  "container stats: collector returned error"
+//   - Docker unavailable / nil -> WARN  "container stats: docker unavailable"
+//   - Save error               -> WARN  "container stats: failed to save"
+//   - Success                  -> INFO  "container stats: saved" with containers=N
+//
+// Previously all three failure modes collapsed into a silent return which
+// masked 36+ hours of real-world data loss on a UAT host.
 func (s *Scheduler) collectContainerStats() {
-	docker, err := s.collector.CollectDockerStats()
-	if err != nil || docker == nil || !docker.Available {
+	s.mu.RLock()
+	fn := s.dockerStatsFn
+	s.mu.RUnlock()
+	if fn == nil {
+		fn = s.collector.CollectDockerStats
+	}
+	docker, err := fn()
+	if err != nil {
+		s.logger.Warn("container stats: collector returned error", "error", err)
+		return
+	}
+	if docker == nil {
+		s.logger.Warn("container stats: collector returned nil docker info")
+		return
+	}
+	if !docker.Available {
+		s.logger.Warn("container stats: docker unavailable")
 		return
 	}
 	if err := s.store.SaveContainerStats(docker); err != nil {
-		s.logger.Warn("failed to save container stats", "error", err)
+		s.logger.Warn("container stats: failed to save", "error", err)
 		return
 	}
+	s.logger.Info("container stats: saved", "containers", len(docker.Containers))
 	// Update the cached snapshot's Docker data so the dashboard shows fresh values
 	s.mu.Lock()
 	if s.latest != nil {


### PR DESCRIPTION
Closes #226

## Problem

The independent 5-minute `collectContainerStats` loop in `internal/scheduler/scheduler.go` silently collapsed three distinct failure modes into a single bare `return`:

```go
docker, err := s.collector.CollectDockerStats()
if err != nil || docker == nil || !docker.Available {
    return  // SILENT — no log, no metric, no breadcrumb
}
```

On the reporter's UAT host this masked **36+ hours** of `container_stats_history` data loss across multiple container recycles. The dashboard widget still showed current values (the main scan's Docker collection populates `s.latest.Docker` separately) so there was no visible UI symptom — only `SELECT MAX(ts) FROM container_stats_history` revealed the problem.

## Fix

Per-cycle logging so grep alone answers "is the loop firing? why did it stop?":

| Branch | Level | Message |
|---|---|---|
| Collector returned error | `WARN` | `container stats: collector returned error` (+ `error=...`) |
| `DockerInfo` is nil | `WARN` | `container stats: collector returned nil docker info` |
| `docker.Available == false` | `WARN` | `container stats: docker unavailable` |
| `SaveContainerStats` error | `WARN` | `container stats: failed to save` (+ `error=...`) |
| Success | `INFO` | `container stats: saved` (+ `containers=N`) |

Example output:

```
time=2026-04-23T14:28:37Z level=WARN msg="container stats: collector returned error" error="docker ps: connection refused"
time=2026-04-23T14:28:37Z level=WARN msg="container stats: docker unavailable"
time=2026-04-23T14:28:37Z level=INFO msg="container stats: saved" containers=7
```

## Implementation

- New `dockerStatsFn` field on `Scheduler` + `SetDockerStatsFn` setter. Mirrors the existing `speedTestRunFn` / `SetSpeedTestRunner` seam pattern introduced in #180 / #210.
- `New()` wires `dockerStatsFn = col.CollectDockerStats` so production behaviour is unchanged.
- `collectContainerStats` now takes the snapshot of `fn` under `s.mu`, invokes it, and branches with an explicit log per outcome. Save path and cache-update path are unchanged.

## Tests

Four new tests in `internal/scheduler/container_stats_observability_test.go`, each capturing slog output into a goroutine-safe `syncBuffer` via a text handler and asserting the expected log level + substring for each branch:

- `TestCollectContainerStats_LogsErrorOnCollectorFailure`
- `TestCollectContainerStats_LogsInfoOnSuccess` (asserts `containers=3`)
- `TestCollectContainerStats_LogsWarnOnDockerUnavailable` (and confirms no spurious `containers=` token)
- `TestCollectContainerStats_LogsOnNilDocker`

## Scope

Purely additive observability. No change to:
- Public API
- Stored data / DB schema
- Cache-update behaviour on success
- Collector layer

Out of scope (filed for future work):
- Startup self-diagnostic one-shot docker readiness check (issue mentioned it as a "layer 2" follow-up)
- Collector-layer retry / goroutine restart-on-panic wrapper

## Pre-push checks

- `go build ./...` — clean
- `go test ./...` — all green (scheduler pkg runs new tests + existing suite)
- `go vet ./...` — clean
- `docker build .` — not run locally (no functional/build-surface change; `Dockerfile` untouched)