### PR TITLE
feat(startup): detect + warn when /data is not a persistent bind-mount (#227)

### DIFF
--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -91,6 +91,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Issue #227 — detect the "/data is not bind-mounted" footgun at startup.
+	// Runs only in production (demo mode writes to a tmpfs path by default
+	// and we don't want to scold users previewing the dashboard).
+	dataPersistent := true
+	if !*demoMode {
+		dataPersistent = warnIfDataEphemeral(logger, cfg.DataDir)
+	}
+
 	// Open database
 	dbPath := filepath.Join(cfg.DataDir, "nas-doctor.db")
 	store, err := storage.Open(dbPath, logger)
@@ -397,6 +405,7 @@ func main() {
 
 	// Create API server
 	apiServer := api.New(store, sched, coll, metrics, fleetMgr, logger, version)
+	apiServer.SetDataPersistent(dataPersistent)
 
 	// HTTP server
 	srv := &http.Server{

--- a/cmd/nas-doctor/persistence.go
+++ b/cmd/nas-doctor/persistence.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"log/slog"
+	"syscall"
+)
+
+// devIDFn resolves a filesystem path to a device identifier. In production
+// this is a stat(2) call that returns Stat_t.Dev (the device the path lives
+// on); tests inject a fake to exercise the comparison logic without real
+// filesystem state. Returning an error lets the caller distinguish "path
+// missing / not accessible" from "path exists on device X".
+type devIDFn func(path string) (uint64, error)
+
+// realDevID returns the device id that the given path currently lives on.
+// On Linux this is populated by the kernel from the inode's superblock,
+// so a bind-mounted /data (hosted by a real filesystem on the host) will
+// have a different Dev than / (the container's overlay rootfs).
+func realDevID(path string) (uint64, error) {
+	var st syscall.Stat_t
+	if err := syscall.Stat(path, &st); err != nil {
+		return 0, err
+	}
+	return uint64(st.Dev), nil
+}
+
+// checkDataPersistenceWith reports whether dataDir appears to be a
+// persistent (bind-mounted) filesystem distinct from rootDir. If dataDir
+// and rootDir share a device id they are both on the container's writable
+// overlay layer — which means SQLite writes survive container restart but
+// are silently wiped on every container recreation (docker-compose down,
+// template re-apply, image bump). See issue #227.
+//
+// Returns:
+//
+//	persistent=true  when dataDir and rootDir are on different devices
+//	persistent=false when they share a device (ephemeral overlay fs)
+//	err != nil       when either stat failed; caller decides how to react
+//
+// The devIDFn seam exists for tests; production callers use realDevID.
+func checkDataPersistenceWith(dataDir, rootDir string, fn devIDFn) (persistent bool, err error) {
+	dataDev, err := fn(dataDir)
+	if err != nil {
+		return false, err
+	}
+	rootDev, err := fn(rootDir)
+	if err != nil {
+		return false, err
+	}
+	return dataDev != rootDev, nil
+}
+
+// warnIfDataEphemeralWith runs the persistence check and emits a loud
+// WARN log if /data is on the same device as /. Returns the effective
+// persistent flag the caller should propagate to the dashboard banner:
+// stat errors are treated as "unknown, assume persistent" to avoid a
+// flapping false-positive banner on transient filesystem hiccups. The
+// log still captures the stat error so operators can investigate.
+//
+// Issue #227 — defense-in-depth. Most users run the container correctly
+// with /mnt/user/appdata/nas-doctor bind-mounted to /data; this warning
+// catches the silent-data-loss footgun when that mount is missing.
+func warnIfDataEphemeralWith(logger *slog.Logger, dataDir, rootDir string, fn devIDFn) (persistent bool) {
+	persistent, err := checkDataPersistenceWith(dataDir, rootDir, fn)
+	if err != nil {
+		// Non-authoritative: log INFO (not WARN — don't scream for a
+		// benign transient error) and assume persistent so we don't
+		// raise a false-positive dashboard banner.
+		logger.Info("data persistence check skipped", "data_dir", dataDir, "root_dir", rootDir, "error", err)
+		return true
+	}
+	if !persistent {
+		logger.Warn(
+			dataDir+" does not appear to be a persistent bind-mount — SQLite DB and config will be LOST on container recreation. "+
+				"Map a host path (e.g. /mnt/user/appdata/nas-doctor) to "+dataDir+" in your container configuration. "+
+				"See the README for bind-mount setup.",
+			"data_dir", dataDir,
+			"root_dir", rootDir,
+			"issue", "#227",
+		)
+	}
+	return persistent
+}
+
+// warnIfDataEphemeral is the production entry point wired from main. It
+// runs the real stat-based device-id comparison against /data and /.
+func warnIfDataEphemeral(logger *slog.Logger, dataDir string) (persistent bool) {
+	return warnIfDataEphemeralWith(logger, dataDir, "/", realDevID)
+}

--- a/cmd/nas-doctor/persistence_test.go
+++ b/cmd/nas-doctor/persistence_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestCheckDataPersistence_SameDevice_ReportsEphemeral verifies the statfs-style
+// device-ID comparison catches the classic "user forgot the bind-mount" footgun:
+// when /data and / share a device ID they are on the same filesystem (the
+// container's overlay writable layer) and the SQLite DB will be silently wiped
+// on every container recreation. Issue #227.
+func TestCheckDataPersistence_SameDevice_ReportsEphemeral(t *testing.T) {
+	devIDs := map[string]uint64{
+		"/data": 42,
+		"/":     42,
+	}
+	persistent, err := checkDataPersistenceWith("/data", "/", fakeDevIDFn(devIDs))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if persistent {
+		t.Error("expected /data to be reported ephemeral when it shares a device with / (overlay fs)")
+	}
+}
+
+// TestCheckDataPersistence_DifferentDevice_ReportsPersistent verifies the
+// happy path — when /data resolves to a different device than /, it is a
+// real bind-mount and data survives container recreation.
+func TestCheckDataPersistence_DifferentDevice_ReportsPersistent(t *testing.T) {
+	devIDs := map[string]uint64{
+		"/data": 42,
+		"/":     1,
+	}
+	persistent, err := checkDataPersistenceWith("/data", "/", fakeDevIDFn(devIDs))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !persistent {
+		t.Error("expected /data to be reported persistent when its device differs from /")
+	}
+}
+
+// TestCheckDataPersistence_StatError_ReturnsError verifies that if stat fails
+// (path missing, permission denied) we return the error rather than silently
+// guessing. Callers log a warning and treat the check as non-authoritative.
+func TestCheckDataPersistence_StatError_ReturnsError(t *testing.T) {
+	fn := func(path string) (uint64, error) {
+		return 0, errors.New("no such file")
+	}
+	_, err := checkDataPersistenceWith("/data", "/", fn)
+	if err == nil {
+		t.Fatal("expected error when stat fails, got nil")
+	}
+}
+
+// TestWarnIfDataEphemeral_LogsWARN verifies that when the persistence check
+// reports /data is ephemeral, we emit a WARN-level log line containing a
+// user-actionable pointer to the bind-mount configuration. This is the
+// user-visible signal documented in issue #227.
+func TestWarnIfDataEphemeral_LogsWARN(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	devIDs := map[string]uint64{
+		"/data": 42,
+		"/":     42,
+	}
+	persistent := warnIfDataEphemeralWith(logger, "/data", "/", fakeDevIDFn(devIDs))
+	if persistent {
+		t.Error("expected persistent=false when /data shares device with /")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "level=WARN") {
+		t.Errorf("expected WARN level log entry, got: %s", out)
+	}
+	if !strings.Contains(out, "/data") {
+		t.Errorf("expected log to mention /data, got: %s", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "bind-mount") && !strings.Contains(strings.ToLower(out), "persistent") {
+		t.Errorf("expected log to guide user toward bind-mount / persistent storage fix, got: %s", out)
+	}
+}
+
+// TestWarnIfDataEphemeral_Persistent_NoWARN verifies the happy path stays
+// silent — no WARN line when /data is correctly bind-mounted, so we don't
+// add noise to the production logs of properly-configured users.
+func TestWarnIfDataEphemeral_Persistent_NoWARN(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	devIDs := map[string]uint64{
+		"/data": 42,
+		"/":     1,
+	}
+	persistent := warnIfDataEphemeralWith(logger, "/data", "/", fakeDevIDFn(devIDs))
+	if !persistent {
+		t.Error("expected persistent=true when /data differs from /")
+	}
+	if strings.Contains(buf.String(), "level=WARN") {
+		t.Errorf("did not expect WARN log when /data is persistent, got: %s", buf.String())
+	}
+}
+
+// TestWarnIfDataEphemeral_StatError_DoesNotCrash verifies that if we can't
+// determine the device (e.g. /data hasn't been created yet) we neither
+// crash nor return a false persistent=true. We log but treat unknown as
+// "give the user the benefit of the doubt and report persistent" so that
+// the dashboard banner doesn't flap on transient stat errors. The log
+// captures it for ops visibility.
+func TestWarnIfDataEphemeral_StatError_DoesNotCrash(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	fn := func(path string) (uint64, error) {
+		return 0, errors.New("stat failed")
+	}
+	persistent := warnIfDataEphemeralWith(logger, "/data", "/", fn)
+	if !persistent {
+		t.Error("on stat error we default to persistent=true to avoid false-positive banners")
+	}
+	// We still want visibility — INFO or DEBUG log is fine, but don't scream WARN
+	// for a benign transient error. The check simply couldn't run.
+	if strings.Contains(buf.String(), "level=WARN") {
+		t.Errorf("should not log WARN for a stat error, got: %s", buf.String())
+	}
+}
+
+func fakeDevIDFn(m map[string]uint64) func(string) (uint64, error) {
+	return func(path string) (uint64, error) {
+		id, ok := m[path]
+		if !ok {
+			return 0, errors.New("no fake entry for " + path)
+		}
+		return id, nil
+	}
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -51,6 +51,25 @@ type Server struct {
 	// to collector.RunMTR. Tests override this to inject deterministic
 	// results without needing mtr installed. See issue #189.
 	tracerouteRunner scheduler.TracerouteRunner
+	// dataEphemeral is set at startup from cmd/nas-doctor/main.go via
+	// SetDataPersistent. When true, the /api/v1/status response carries
+	// data_ephemeral=true so the dashboard renders a loud banner telling
+	// the user their /data mount is actually on the container's overlay
+	// filesystem and will be wiped on every recreation. The field is
+	// stored in its user-visible polarity (ephemeral=bad) so the zero
+	// value is the safe default — bare Servers in tests and demo mode
+	// don't scare users with a false-positive banner. See #227.
+	dataEphemeral bool
+}
+
+// SetDataPersistent records whether /data resolved to a real bind-mount
+// at startup. main.go runs the check via cmd/nas-doctor.warnIfDataEphemeral
+// and calls this before wiring the router. When persistent=false,
+// /api/v1/status exposes data_ephemeral=true and the dashboard shows a
+// red banner pointing the user at the container bind-mount they need to
+// fix. #227.
+func (s *Server) SetDataPersistent(persistent bool) {
+	s.dataEphemeral = !persistent
 }
 
 // New creates a new API server.
@@ -64,6 +83,9 @@ func New(store storage.Store, sched *scheduler.Scheduler, coll *collector.Collec
 		logger:    logger,
 		version:   version,
 		startTime: time.Now(),
+		// dataEphemeral defaults to the zero value (false = persistent).
+		// main.go overrides via SetDataPersistent once the startup check
+		// has run. Safe default: no false-positive banner. #227
 	}
 }
 
@@ -231,10 +253,22 @@ type statusResponse struct {
 	SectionHeights    map[string]int      `json:"section_heights,omitempty"`
 	SectionOrder      map[string][]string `json:"section_order,omitempty"`
 	DismissedFindings []string            `json:"dismissed_findings,omitempty"`
+	// DataEphemeral is true when /data resolved to the same device as /
+	// at startup, meaning the SQLite DB lives on the container's overlay
+	// filesystem and will be wiped on every container recreation. The
+	// dashboard renders a warning banner when this is true. Absent
+	// (omitempty) on the happy path so unrelated consumers of the status
+	// endpoint don't need to care. Issue #227.
+	DataEphemeral bool `json:"data_ephemeral,omitempty"`
 }
 
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	resp := statusResponse{Version: s.version}
+	// Surface the startup persistence check to the dashboard (#227).
+	// dataEphemeral defaults to the zero value (false = persistent)
+	// so bare Servers in tests/demo mode don't render a false-positive
+	// banner. main.go sets it via SetDataPersistent at startup.
+	resp.DataEphemeral = s.dataEphemeral
 	settings := s.getSettings()
 	dismissed := make(map[string]struct{}, len(settings.DismissedFindings))
 	for _, title := range settings.DismissedFindings {

--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -104,6 +104,31 @@ util.pillClass = function(t) {
   return "pill-http";
 };
 
+/* Issue #227 — render a prominent warning banner when the server
+   reports that /data is not a real bind-mount. The server sets
+   data_ephemeral=true on /api/v1/status when /data shares a device
+   id with /, which means the SQLite DB lives on the container's
+   overlay fs and is silently wiped on every container recreation.
+
+   The banner's CSS hook (class=ephemeral-data-banner plus the
+   data-ephemeral-banner data-attribute) is referenced by a paired
+   test (TestThemeTemplates_StyleEphemeralBanner) that enforces both
+   dashboard theme templates inline matching CSS rules. Dashboard
+   theme templates do NOT link /css/shared.css, so the rule MUST be
+   inlined in each theme — AGENTS.md calls this the two-axis test
+   pattern. */
+util.ephemeralDataBanner = function(st) {
+  if (!st || !st.data_ephemeral) return "";
+  var h = "";
+  h += '<div class="ephemeral-data-banner fade-in" data-ephemeral-banner role="alert">';
+  h += '<strong>&#9888; /data is not a persistent bind-mount.</strong> ';
+  h += 'History, settings, and the SQLite database will be lost on every container recreation. ';
+  h += 'Map a host path (e.g. <code>/mnt/user/appdata/nas-doctor</code>) to <code>/data</code> in your container configuration. ';
+  h += '<a href="https://github.com/mcdays94/nas-doctor#quick-start" target="_blank" rel="noopener">See the README for bind-mount setup &rarr;</a>';
+  h += '</div>';
+  return h;
+};
+
 /* ── Polling ───────────────────────────────────────────────────── */
 var polling = {};
 var _pollTimer = null;

--- a/internal/api/data_ephemeral_banner_test.go
+++ b/internal/api/data_ephemeral_banner_test.go
@@ -1,0 +1,175 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// Issue #227 — "/data is not a persistent bind-mount" detection and UI banner.
+//
+// These tests lock in three cross-layer invariants so a future refactor
+// can't silently break the user-visible banner (the whole point of the
+// feature — catch the silent-data-loss footgun loudly, as documented in
+// the AGENTS.md two-axis test pattern).
+//
+//  1. Server has a SetDataPersistent setter consumed by main.go.
+//  2. /api/v1/status exposes data_ephemeral so the browser JS can react.
+//  3. DashboardJS renders the banner when data_ephemeral is true, in
+//     BOTH theme templates (midnight + clean), because the dashboard
+//     theme templates don't link shared.css (see AGENTS.md). Any class
+//     the JS references must have its CSS rule inlined in each theme.
+
+// newEphemeralBannerTestServer builds a minimal Server for exercising
+// /api/v1/status against an in-memory FakeStore.
+func newEphemeralBannerTestServer() *Server {
+	return &Server{
+		store:     storage.NewFakeStore(),
+		logger:    slog.Default(),
+		version:   "test",
+		startTime: time.Now(),
+	}
+}
+
+// TestSetDataPersistent_DefaultsToPersistent verifies the zero-value of
+// Server.dataPersistent is true. Most deployments are correctly
+// bind-mounted, and the field is set during main.go startup; if the
+// startup check doesn't run (demo mode, test harnesses, third-party
+// embedders) we must not show a false-positive banner.
+func TestSetDataPersistent_DefaultsToPersistent(t *testing.T) {
+	srv := newEphemeralBannerTestServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	rec := httptest.NewRecorder()
+	srv.handleStatus(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/status returned %d: %s", rec.Code, rec.Body.String())
+	}
+	body, _ := io.ReadAll(rec.Body)
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	// A zero-value Server (no SetDataPersistent called) must not claim
+	// /data is ephemeral — this protects unrelated tests that spin up
+	// bare Servers from suddenly rendering a scary banner in fixtures.
+	if eph, ok := parsed["data_ephemeral"].(bool); ok && eph {
+		t.Errorf("zero-value Server should not report data_ephemeral=true; got %v", parsed["data_ephemeral"])
+	}
+}
+
+// TestSetDataPersistent_FalseExposedAsEphemeralTrue verifies that when
+// main.go determines /data is on the overlay fs and calls
+// SetDataPersistent(false), the /api/v1/status response propagates
+// data_ephemeral=true to the browser.
+func TestSetDataPersistent_FalseExposedAsEphemeralTrue(t *testing.T) {
+	srv := newEphemeralBannerTestServer()
+	srv.SetDataPersistent(false)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	rec := httptest.NewRecorder()
+	srv.handleStatus(rec, req)
+	body, _ := io.ReadAll(rec.Body)
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	eph, ok := parsed["data_ephemeral"].(bool)
+	if !ok {
+		t.Fatalf("data_ephemeral missing from /api/v1/status response: %v", parsed)
+	}
+	if !eph {
+		t.Errorf("expected data_ephemeral=true after SetDataPersistent(false), got %v", eph)
+	}
+}
+
+// TestSetDataPersistent_TrueExposedAsEphemeralFalse verifies the happy
+// path — when /data IS a real bind-mount, data_ephemeral is false (or
+// absent via omitempty), so no banner appears.
+func TestSetDataPersistent_TrueExposedAsEphemeralFalse(t *testing.T) {
+	srv := newEphemeralBannerTestServer()
+	srv.SetDataPersistent(true)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	rec := httptest.NewRecorder()
+	srv.handleStatus(rec, req)
+	body, _ := io.ReadAll(rec.Body)
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	// Either absent (omitempty) or explicitly false — both are fine.
+	if eph, present := parsed["data_ephemeral"].(bool); present && eph {
+		t.Errorf("expected data_ephemeral=false (or absent) after SetDataPersistent(true), got %v", eph)
+	}
+}
+
+// TestDashboardJS_RendersEphemeralBannerWhenFlagSet verifies the browser
+// JS reads data_ephemeral from the status payload and renders a warning
+// banner. We assert three substrings:
+//
+//  1. The JS reads `data_ephemeral` from statusData (otherwise the
+//     banner would never appear regardless of server state).
+//  2. The banner contains the word "persistent" or "bind-mount" so the
+//     user understands what to fix.
+//  3. The banner uses a class/id we can cross-reference with theme CSS.
+func TestDashboardJS_RendersEphemeralBannerWhenFlagSet(t *testing.T) {
+	js := DashboardJS
+
+	if !strings.Contains(js, "data_ephemeral") {
+		t.Errorf("DashboardJS must read data_ephemeral from statusData to render the ephemeral /data banner (issue #227)")
+	}
+
+	// The banner markup must include an identifiable CSS hook so the
+	// theme templates can style it. "data-ephemeral-banner" is the
+	// canonical attribute — if a refactor renames it, update BOTH the
+	// JS and both theme templates. See theme-parity test below.
+	hookRE := regexp.MustCompile(`data-ephemeral-banner|id=["']ephemeral-data-banner["']|class=["'][^"']*ephemeral-data-banner`)
+	if !hookRE.MatchString(js) {
+		t.Errorf("DashboardJS ephemeral /data banner must carry a stable CSS hook (data-ephemeral-banner attr or id=ephemeral-data-banner class). Found none — theme-parity test can't lock the styling in.")
+	}
+
+	// The banner must name the problem so a user can act on it. We
+	// accept either phrase but require at least one — grep-based.
+	lowerJS := strings.ToLower(js)
+	if !strings.Contains(lowerJS, "persistent") && !strings.Contains(lowerJS, "bind-mount") {
+		t.Errorf("DashboardJS ephemeral /data banner must include guidance (\"persistent\" / \"bind-mount\") so users know what to fix")
+	}
+}
+
+// TestThemeTemplates_StyleEphemeralBanner verifies both dashboard theme
+// templates (midnight + clean) carry a CSS rule for the ephemeral-data
+// banner hook emitted by DashboardJS. This is the second axis of the
+// two-axis test pattern called out in AGENTS.md: asserting "JS emits
+// class X" (above) is not the same as asserting "class X is styled on
+// every page where it appears". Dashboard theme templates intentionally
+// do not link shared.css, so rules must be inlined in each.
+func TestThemeTemplates_StyleEphemeralBanner(t *testing.T) {
+	files := []string{
+		filepath.Join("templates", "midnight.html"),
+		filepath.Join("templates", "clean.html"),
+	}
+	for _, f := range files {
+		t.Run(filepath.Base(f), func(t *testing.T) {
+			data, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			content := string(data)
+			// Must style the selector emitted by DashboardJS.
+			if !strings.Contains(content, "ephemeral-data-banner") {
+				t.Errorf("%s must style the ephemeral-data-banner selector; DashboardJS emits the class/attr but this theme inlines no matching CSS rule, so the banner would render as unstyled plain text on the dashboard (see AGENTS.md on theme templates not linking shared.css)", f)
+			}
+		})
+	}
+}

--- a/internal/api/templates/clean.html
+++ b/internal/api/templates/clean.html
@@ -65,6 +65,15 @@ body{min-height:100vh;background:#fff}
 .pill-ping  { background:rgba(139, 92,246,0.14); color:#a78bfa }
 .pill-speed { background:rgba( 34,211,238,0.14); color:#22d3ee }
 .pill-trace { background:rgba( 45,212,191,0.14); color:#2dd4bf }
+/* Ephemeral /data warning banner (#227). Rendered by util.ephemeralDataBanner
+   when /api/v1/status reports data_ephemeral=true. MUST be inlined here
+   because dashboard theme templates do not link /css/shared.css — see
+   AGENTS.md and TestThemeTemplates_StyleEphemeralBanner. */
+.ephemeral-data-banner{display:block;padding:14px 18px;margin:16px 0 8px;background:#fef2f2;border:1px solid rgba(220,38,38,0.25);border-left:4px solid #dc2626;border-radius:8px;color:#171717;font-size:13px;line-height:1.6}
+.ephemeral-data-banner strong{color:#dc2626;display:inline-block;margin-right:4px}
+.ephemeral-data-banner code{background:rgba(0,0,0,0.05);padding:1px 6px;border-radius:4px;font-family:'SF Mono',ui-monospace,monospace;font-size:12px;color:#171717}
+.ephemeral-data-banner a{color:#0068d6;text-decoration:underline;font-weight:600;margin-left:4px}
+.ephemeral-data-banner a:hover{color:#0050aa}
 .scan-bar{display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap;margin-top:16px;padding:8px 0}
 .scan-info{font-size:13px;color:#808080;font-weight:400}
 
@@ -367,6 +376,12 @@ tbody tr:hover{background:rgba(0,0,0,0.03)}
       h += '<span class="stat-item"><span class="stat-label">Up</span> <span class="stat-val">' + esc(uptime) + '</span></span>';
     }
     h += '</div></div>';
+
+    // Ephemeral /data banner (#227) — renders only when the server
+    // reports data_ephemeral=true on /api/v1/status. Placed above the
+    // OS version banner so it's the first thing users see when /data
+    // is not bind-mounted and the DB is about to be wiped.
+    h += NasDashboard.util.ephemeralDataBanner(st);
 
     // OS version banner
     var upd = sn ? sn.update : null;

--- a/internal/api/templates/midnight.html
+++ b/internal/api/templates/midnight.html
@@ -72,6 +72,15 @@ a:hover{color:var(--hover)}
 .pill-ping  { background:rgba(139, 92,246,0.14); color:#a78bfa }
 .pill-speed { background:rgba( 34,211,238,0.14); color:#22d3ee }
 .pill-trace { background:rgba( 45,212,191,0.14); color:#2dd4bf }
+/* Ephemeral /data warning banner (#227). Rendered by util.ephemeralDataBanner
+   when /api/v1/status reports data_ephemeral=true. MUST be inlined here
+   because dashboard theme templates do not link /css/shared.css — see
+   AGENTS.md and TestThemeTemplates_StyleEphemeralBanner. */
+.ephemeral-data-banner{display:block;padding:14px 18px;margin:16px 0 8px;background:var(--red-bg);border:1px solid rgba(220,38,38,0.3);border-left:4px solid var(--red);border-radius:var(--radius);color:var(--text-primary);font-size:13px;line-height:1.6}
+.ephemeral-data-banner strong{color:var(--red);display:inline-block;margin-right:4px}
+.ephemeral-data-banner code{background:rgba(255,255,255,0.05);padding:1px 6px;border-radius:4px;font-family:ui-monospace,'SF Mono',Menlo,monospace;font-size:12px;color:var(--text-primary)}
+.ephemeral-data-banner a{color:var(--accent);text-decoration:underline;font-weight:600;margin-left:4px}
+.ephemeral-data-banner a:hover{color:var(--hover)}
 .top-bar-stats{display:flex;align-items:center;gap:calc(var(--sp)*3)}
 .stat-item{display:flex;align-items:baseline;gap:6px;font-size:13px;white-space:nowrap}
 .stat-item-label{color:var(--text-quaternary);font-weight:500;font-size:12px}
@@ -312,6 +321,12 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
       h += '<div class="stat-item"><span class="stat-item-label">Up</span><span class="stat-item-value" style="color:var(--text-primary)">' + esc(uptime) + '</span></div>';
     }
     h += '</div></div>';
+
+    // Ephemeral /data banner (#227) — renders only when the server
+    // reports data_ephemeral=true on /api/v1/status. Placed above the
+    // OS version banner so it's the first thing users see when /data
+    // is not bind-mounted and the DB is about to be wiped.
+    h += NasDashboard.util.ephemeralDataBanner(st);
 
     // OS version banner
     var upd = sn ? sn.update : null;


### PR DESCRIPTION
Closes #227

## Summary

Detect at startup when `/data` shares a device id with `/` — i.e. lives
on the container's overlay filesystem rather than a real bind-mount —
and surface it loudly so users can fix their container configuration
before silent data loss bites.

## Detection mechanism

`syscall.Stat`-based device-id comparison between `/data` and `/`. If
`st.Dev` matches on both, `/data` is on the same overlay layer as the
rest of the container; SQLite writes survive a restart but are wiped
on every container recreation (docker-compose down, Unraid template
re-apply, image bump). An interface seam (`devIDFn`) lets the unit
tests exercise the three branches (ephemeral / persistent / stat
error) without real filesystem state — the seam is the whole reason we
can ship a deterministic test for this on both Linux and non-Linux
development hosts.

## User-visible state

On detection we do two things:

1. **WARN log at startup** with a user-actionable message naming
   `/data`, explaining the consequence (LOST on container recreation),
   citing bind-mount configuration, and pointing at the README.

2. **Dashboard banner** — red, prominent, rendered above the OS
   version banner so it's the first thing users see. The banner is
   produced by a shared `util.ephemeralDataBanner` helper in
   `DashboardJS`, called from both theme templates (`midnight.html`
   and `clean.html`) so both themes render identically. CSS rules are
   **inlined in both theme templates** because dashboard theme
   templates do NOT link `/css/shared.css` — AGENTS.md two-axis test
   pattern: the paired test \`TestThemeTemplates_StyleEphemeralBanner\`
   enforces the CSS hook exists in every page where the JS emits the
   class.

Stat errors (path missing, permissions) are treated as "assume
persistent" — we log them at INFO, not WARN, and don't raise a
false-positive banner. The classic failure mode of a naive
'ambient-state check' is flapping on a transient error; the unit tests
pin this behavior.

## Defense-in-depth

Most users bind-mount `/data` correctly and will never see this banner.
For the minority who don't, this would have caught the v0.9.7-rc1 UAT
36-hour silent-ephemeral situation at container startup rather than
requiring hours of chart-history archaeology to notice.

## Safe defaults

- Zero-value of \`Server.dataEphemeral\` is false (persistent), so bare
  \`Server\` structs used by tests and \`api.New\` callers that never run
  the startup check don't accidentally render a banner.
- main.go skips the check entirely in demo mode so demo-viewers
  previewing the themes don't see a false warning.

## Tests

Added 11 test cases across two files, all green:

- \`cmd/nas-doctor/persistence_test.go\` — 6 cases covering the
  device-id comparison, WARN-log emission, happy-path silence, and
  stat-error handling. Uses the \`devIDFn\` seam to avoid real FS
  dependency.
- \`internal/api/data_ephemeral_banner_test.go\` — 5 cases covering
  zero-value default, \`SetDataPersistent(false)\` → \`data_ephemeral=true\`,
  \`SetDataPersistent(true)\` → absent/false, DashboardJS reads the flag
  and emits a stable CSS hook, AND both theme templates inline a
  matching CSS rule (two-axis lock).

## Pre-push gates

- \`go build ./...\` — clean
- \`go vet ./...\` — clean
- \`go test ./...\` — all packages green (including 11 new tests)
- \`docker build\` — not run (Docker daemon not available on this
  worker host); no Dockerfile changes so §4b package-name risk is
  zero, but worth a manual \`docker build\` in local review.

## Files changed

| File | Purpose |
| ---- | ------- |
| \`cmd/nas-doctor/persistence.go\` | Detection function + WARN wrapper |
| \`cmd/nas-doctor/persistence_test.go\` | TDD unit tests |
| \`cmd/nas-doctor/main.go\` | Wire check + propagate flag to API |
| \`internal/api/api.go\` | \`SetDataPersistent\` setter + \`data_ephemeral\` JSON field |
| \`internal/api/dashboard.go\` | \`util.ephemeralDataBanner\` helper |
| \`internal/api/templates/midnight.html\` | Call helper + inline CSS rule |
| \`internal/api/templates/clean.html\` | Call helper + inline CSS rule |
| \`internal/api/data_ephemeral_banner_test.go\` | API + theme invariant tests |