### PR TITLE
docs(readme): reconcile Prometheus metric count (README + unraid-template) (#252)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Monitor all your NAS Doctor instances from a visual topology view at `/fleet`:
 
 | Integration | How |
 |---|---|
-| **Prometheus** | Scrape `/metrics` — 90+ gauges for system, disk, SMART, Docker, UPS, ZFS, services, tunnels, Proxmox, Kubernetes, findings |
+| **Prometheus** | Scrape `/metrics` — 110+ gauges for system, disk, SMART, Docker, network, UPS, ZFS, GPU, services, parity, tunnels, Proxmox, Kubernetes, backup, speed test, findings |
 | **Grafana** | Connect via Prometheus data source |
 | **Discord** | Webhook with rich embeds, severity colors, finding details |
 | **Slack** | Webhook with blocks, severity counts, top findings |
@@ -569,7 +569,7 @@ All configurable from the web UI at `/settings`, organized with a sticky section
 All metrics prefixed with `nasdoctor_`. Full list:
 
 <details>
-<summary>Expand metric list (80+ metrics)</summary>
+<summary>Expand metric list (110+ metrics)</summary>
 
 ```
 # System (12 gauges)
@@ -619,6 +619,27 @@ nasdoctor_parity_speed_mb_per_sec / _duration_seconds / _errors / _running
 # Tunnels
 nasdoctor_tunnel_cloudflared_up / _connections (labels: name)
 nasdoctor_tunnel_tailscale_node_online / _tx_bytes / _rx_bytes (labels: name, ip)
+
+# Proxmox (labels: node / vmid+name+type+node / storage+node+type)
+nasdoctor_proxmox_node_cpu_usage / _memory_used_bytes / _memory_total_bytes / _node_online
+nasdoctor_proxmox_guest_cpu_usage / _memory_used_bytes / _memory_max_bytes / _guest_running
+nasdoctor_proxmox_storage_used_bytes / _storage_total_bytes
+
+# Kubernetes (labels: node / pod+namespace / deployment+namespace)
+nasdoctor_k8s_node_ready / _node_pod_count
+nasdoctor_k8s_pod_running / _pod_restarts
+nasdoctor_k8s_deployment_ready_replicas / _deployment_desired_replicas
+
+# GPU (labels: index, name, vendor) — 10 gauges per GPU
+nasdoctor_gpu_usage_percent / _mem_used_mb / _mem_total_mb / _mem_percent
+nasdoctor_gpu_temperature_celsius / _power_watts / _power_max_watts / _fan_percent
+nasdoctor_gpu_encoder_percent / _decoder_percent
+
+# Backup (labels: provider, name)
+nasdoctor_backup_last_success_timestamp / _size_bytes / _status
+
+# Speed Test
+nasdoctor_speedtest_download_mbps / _upload_mbps / _latency_ms
 
 # Findings
 nasdoctor_findings_critical_count / _warning_count

--- a/internal/notifier/prometheus_docs_test.go
+++ b/internal/notifier/prometheus_docs_test.go
@@ -1,0 +1,125 @@
+package notifier
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+// repoRoot returns the absolute path to the repository root.
+// Tests in this file live at <root>/internal/notifier, so we walk up two levels.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	return filepath.Clean(filepath.Join(wd, "..", ".."))
+}
+
+// TestReadme_PrometheusCountConsistent guards against the v0.9.7-era drift where
+// README.md, the metric-list collapsible, and unraid-template.xml each advertised
+// a different metric count ("90+ gauges", "80+ metrics", "30+ gauges"). All three
+// sources MUST agree on the same round-down threshold so users (and downstream
+// app stores like Unraid CA / TrueNAS) see a single consistent number.
+//
+// The canonical phrasing is "<N>+ gauges" / "<N>+ metrics" where N is the
+// nearest round-down to the ACTUAL exported metric count (see
+// TestPrometheus_ActualMetricCount below).
+//
+// If you add new metrics and bump the threshold, update ALL three sources in
+// lockstep:
+//   - README.md line ~205 (Integrations table)
+//   - README.md line ~572 (collapsible metric list <summary>)
+//   - unraid-template.xml line ~29 (Overview field)
+//   - the companion mcdays94/docker-templates/nas-doctor/nas-doctor.xml
+func TestReadme_PrometheusCountConsistent(t *testing.T) {
+	root := repoRoot(t)
+
+	readmeBytes, err := os.ReadFile(filepath.Join(root, "README.md"))
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	readme := string(readmeBytes)
+
+	xmlBytes, err := os.ReadFile(filepath.Join(root, "unraid-template.xml"))
+	if err != nil {
+		t.Fatalf("read unraid-template.xml: %v", err)
+	}
+	xml := string(xmlBytes)
+
+	// Integrations-table phrasing: "Scrape `/metrics` — <N>+ gauges for ..."
+	integRe := regexp.MustCompile(`Scrape ` + "`/metrics`" + ` — (\d+)\+\s*gauges`)
+	integMatch := integRe.FindStringSubmatch(readme)
+	if integMatch == nil {
+		t.Fatalf("integrations-table Prometheus row not found in README.md (looking for `Scrape /metrics — N+ gauges`)")
+	}
+	integN, _ := strconv.Atoi(integMatch[1])
+
+	// Collapsible-list phrasing: "<summary>Expand metric list (<N>+ metrics)</summary>"
+	listRe := regexp.MustCompile(`Expand metric list \((\d+)\+\s*metrics\)`)
+	listMatch := listRe.FindStringSubmatch(readme)
+	if listMatch == nil {
+		t.Fatalf("collapsible metric-list summary not found in README.md (looking for `Expand metric list (N+ metrics)`)")
+	}
+	listN, _ := strconv.Atoi(listMatch[1])
+
+	// Unraid-template Overview phrasing: "Prometheus /metrics endpoint (<N>+ gauges)"
+	xmlRe := regexp.MustCompile(`Prometheus /metrics endpoint \((\d+)\+\s*gauges\)`)
+	xmlMatch := xmlRe.FindStringSubmatch(xml)
+	if xmlMatch == nil {
+		t.Fatalf("Overview field Prometheus line not found in unraid-template.xml (looking for `Prometheus /metrics endpoint (N+ gauges)`)")
+	}
+	xmlN, _ := strconv.Atoi(xmlMatch[1])
+
+	if integN != listN || listN != xmlN {
+		t.Errorf("Prometheus metric count drift detected — README integrations table says %d+, README metric list says %d+, unraid-template.xml says %d+. All three MUST match.",
+			integN, listN, xmlN)
+	}
+}
+
+// TestPrometheus_ActualMetricCount counts the actual metric registrations in
+// prometheus.go and asserts the documented threshold is a sensible round-down.
+//
+// "Sensible" means: the documented N must satisfy N <= actual < N + 50, i.e.
+// the README claim is honest (we have at least N) but not stale by more than
+// half a hundred (catches "we added 30 metrics and forgot to bump the docs").
+func TestPrometheus_ActualMetricCount(t *testing.T) {
+	root := repoRoot(t)
+
+	src, err := os.ReadFile(filepath.Join(root, "internal/notifier/prometheus.go"))
+	if err != nil {
+		t.Fatalf("read prometheus.go: %v", err)
+	}
+
+	// Each metric is registered as `m.<field> = gauge(ns, ...)` or `gaugeVec(ns, ...)`.
+	// Counting these gives us 1 distinct exported metric NAME per match (subsystem+name
+	// pairs are unique across the file — verified by hand at audit time).
+	registrationRe := regexp.MustCompile(`(?m)^\s*m\.[A-Za-z0-9_]+ = (gauge|gaugeVec)\(ns,`)
+	actual := len(registrationRe.FindAll(src, -1))
+	if actual == 0 {
+		t.Fatal("found 0 metric registrations — regex is broken or prometheus.go was restructured")
+	}
+
+	// Pull the documented threshold from README's integrations-table phrasing.
+	readmeBytes, err := os.ReadFile(filepath.Join(root, "README.md"))
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	integRe := regexp.MustCompile(`Scrape ` + "`/metrics`" + ` — (\d+)\+\s*gauges`)
+	m := integRe.FindStringSubmatch(string(readmeBytes))
+	if m == nil {
+		t.Fatal("integrations-table Prometheus row not found in README.md")
+	}
+	documented, _ := strconv.Atoi(m[1])
+
+	if actual < documented {
+		t.Errorf("README claims %d+ gauges but only %d are registered in prometheus.go — docs overstate reality", documented, actual)
+	}
+	if actual >= documented+50 {
+		t.Errorf("README claims %d+ gauges but %d are registered — docs are stale by 50+, bump the threshold to the next round-down (e.g. %d)",
+			documented, actual, (actual/10)*10)
+	}
+}

--- a/unraid-template.xml
+++ b/unraid-template.xml
@@ -26,7 +26,7 @@ Features:
 - 2 dashboard themes (Midnight and Clean)
 - Export professional PDF diagnostic reports
 - Multi-server fleet monitoring (monitor all your NAS instances)
-- Prometheus /metrics endpoint (30+ gauges)
+- Prometheus /metrics endpoint (110+ gauges)
 - Webhook alerts: Discord, Slack, Gotify, Ntfy, generic HTTP
 - Automatic backups with configurable schedule and location
 - Data lifecycle management (retention policies, DB size cap)


### PR DESCRIPTION
Closes #252

## Summary

Three documentation surfaces advertised three different Prometheus metric counts:

| Source | Was | Now |
|---|---|---|
| `README.md` integrations table (line 205) | `90+ gauges` | `110+ gauges` |
| `README.md` collapsible metric list (line 572) | `80+ metrics` | `110+ metrics` |
| `unraid-template.xml` Overview (line 29) | `30+ gauges` | `110+ gauges` |
| `mcdays94/docker-templates/nas-doctor/nas-doctor.xml` Overview | `30+ gauges` | `110+ gauges` (companion PR mcdays94/docker-templates#3) |

## Actual metric count (static analysis)

Counted via:
```
grep -cE '^\s*m\.[A-Za-z0-9_]+ = (gauge|gaugeVec)\(ns,' internal/notifier/prometheus.go
```

**Result: 117 metric registrations.** Each `m.<field> = gauge(...)` or `m.<field> = gaugeVec(...)` line in `internal/notifier/prometheus.go` produces one distinct exported metric name (subsystem/name pairs are unique across the file). Tally by subsystem:

| Subsystem | Count |
|---|---|
| zfs | 20 |
| system | 12 |
| smart | 11 |
| ups | 10 |
| proxmox | 10 |
| gpu | 10 |
| docker | 9 |
| k8s | 6 |
| tunnel | 5 |
| parity | 4 |
| service | 3 |
| disk | 3 |
| findings | 3 |
| backup | 3 |
| speedtest | 3 |
| network | 2 |
| (collection) | 2 |
| update | 1 |
| **Total** | **117** |

## Canonical phrase

**`110+ gauges` / `110+ metrics`** — round-down of 117 to the nearest 10, matching the existing README precedent of using tens (the prior `80+` and `90+` were also tens). Leaves enough headroom that the next 1-2 metric additions don't immediately invalidate the docs.

## Category audit (line 205)

The integrations-table category list previously read:
> system, disk, SMART, Docker, UPS, ZFS, services, tunnels, Proxmox, Kubernetes, findings

**Categories present in code but missing from the list:**
- `network` (2 metrics — interface_up, interface_mtu)
- `gpu` (10 metrics)
- `parity` (4 metrics)
- `backup` (3 metrics)
- `speedtest` (3 metrics)

Updated the list to:
> system, disk, SMART, Docker, network, UPS, ZFS, GPU, services, parity, tunnels, Proxmox, Kubernetes, backup, speed test, findings

**Categories listed but missing from code:** none. (Every advertised category had at least one metric.)

## Expandable metric list (line 572)

The expandable list under "Expand metric list" enumerated System, Disks, SMART, Docker, Network, UPS, ZFS, Service Checks, Parity, Tunnels, Findings, and Other — but had no entries for Proxmox, Kubernetes, GPU, Backup, or Speed Test. Added all five missing sections so the inventory matches the registration code.

## Regression guards

Added in `internal/notifier/prometheus_docs_test.go`:
- `TestReadme_PrometheusCountConsistent` — grep-asserts that all three documented counts (README integrations table, README metric list, `unraid-template.xml` Overview) agree on the same `N+` threshold.
- `TestPrometheus_ActualMetricCount` — counts actual `gauge(ns,...)` / `gaugeVec(ns,...)` registrations in `prometheus.go` and asserts `documented <= actual < documented + 50`. This catches both directions of drift: docs overstating reality, and docs going stale by 50+ behind.

## Companion PR

`mcdays94/docker-templates#3` updates the Unraid CA template's Overview field in lockstep, per AGENTS.md template-propagation protocol. The CA listing pulls from `mcdays94/docker-templates`; existing installs pull `TemplateURL` updates from this repo's `unraid-template.xml`. Both must move together.

## Pre-push gates

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` all green
- `xmllint --noout unraid-template.xml` clean