### PR TITLE
docs(readme): qualify Cloudflared host-binary detection + optional collector hint (#251)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Born from an [OpenCode diagnostic skill](https://github.com/mcdays94/opencode-se
 - **Network**: Interface speed negotiation, state, MTU
 - **Logs**: Filtered dmesg and syslog errors (ATA errors, I/O errors, medium errors)
 - **Parity** (Unraid): Historical parity check speed trend analysis, error tracking
-- **Tunnels**: Cloudflared tunnel status (connections, routes) and Tailscale peer graph (IPs, online/offline, relay, exit nodes) — detects host binaries and Docker containers
+- **Tunnels**: Cloudflared tunnel status (connections, routes) and Tailscale peer graph (IPs, online/offline, relay, exit nodes) — Tailscale detects both host binary (bundled in the image) and Docker containers; Cloudflared detects Docker containers, with host-binary detection requiring a custom image that bundles the `cloudflared` CLI
 - **Proxmox VE**: Cluster status, nodes (CPU/mem/uptime), VMs + LXCs (status, resources), storage pools, HA services, recent tasks/backups — via PVE REST API with test connection
 - **Kubernetes**: Cluster monitoring for k8s, k3s, EKS, GKE, AKS — nodes (status, disk usage, pod capacity), pods grouped by node with namespace breakdown, deployments, services, PVCs, warning events. In-cluster auto-detection + external token auth. *Tailscale detection in Kubernetes requires a sidecar pod sharing `/var/run/tailscale` via emptyDir — see [docs/tailscale-install-methods.md](docs/tailscale-install-methods.md).*
 - **OS Update Check**: Compares installed version against latest GitHub release for Unraid and TrueNAS
@@ -139,7 +139,7 @@ is reachable from the NAS Doctor container:
 ### Tunnel Monitoring
 
 Automatic detection and monitoring of remote access tunnels:
-- **Cloudflared**: Tunnel status, connection count, ingress routes — detects both host binary and Docker containers
+- **Cloudflared**: Tunnel status, connection count, ingress routes — detects Docker containers out of the box. Host-binary detection requires a custom image that bundles the `cloudflared` CLI (the default image bundles `tailscale` but not `cloudflared`).
 - **Tailscale**: Full peer graph (online status, IPs, OS, relay regions, TX/RX bytes, exit node status) **when the host daemon socket `/var/run/tailscale` is accessible via bind-mount**. A plain-text `tailscale status` fallback captures a reduced subset (IPs, hostnames, OS, online state) when JSON output is unavailable due to CLI-daemon version skew. When the daemon is unreachable the dashboard surfaces an actionable hint explaining what to mount.
 - Docker-container detection matches `tailscale` by default; opt-in env var `NAS_DOCTOR_TAILSCALE_CONTAINER_NAMES=ts-sidecar,mullvad-ts,vpn` (comma-separated, case-insensitive substring match) extends detection to custom-named sidecars.
 - Dashboard section in all themes with status dots per tunnel/peer

--- a/internal/collector/tunnels.go
+++ b/internal/collector/tunnels.go
@@ -12,6 +12,10 @@ import (
 // Package-level indirections so tests can stub out exec / filesystem access.
 // They default to the real implementations; tests swap them with t.Cleanup.
 var (
+	cloudflaredLookPath   = exec.LookPath
+	cloudflaredRunCommand = func(name string, args ...string) ([]byte, error) {
+		return exec.Command(name, args...).CombinedOutput()
+	}
 	tailscaleLookPath   = exec.LookPath
 	tailscaleRunCommand = func(name string, args ...string) ([]byte, error) {
 		return exec.Command(name, args...).CombinedOutput()
@@ -76,25 +80,35 @@ func collectTunnels(docker internal.DockerInfo) *internal.TunnelInfo {
 func collectCloudflared(docker internal.DockerInfo) *internal.CloudflaredInfo {
 	info := &internal.CloudflaredInfo{}
 
-	// 1. Check host binary
-	if path, err := exec.LookPath("cloudflared"); err == nil && path != "" {
+	// 1. Check host binary. Note: the default NAS Doctor Docker image does
+	// NOT bundle the `cloudflared` CLI (Dockerfile bundles `tailscale` but
+	// not cloudflared) — see issue #251. So this LookPath fails for almost
+	// every default install; the Docker-container detection below is the
+	// path that actually works. If we end up populating Installed=true via
+	// Docker fallback only, we add a Hint explaining why so API consumers
+	// understand the situation.
+	binaryFound := false
+	if path, err := cloudflaredLookPath("cloudflared"); err == nil && path != "" {
+		binaryFound = true
 		info.Installed = true
-		if out, err := exec.Command("cloudflared", "--version").CombinedOutput(); err == nil {
+		if out, err := cloudflaredRunCommand("cloudflared", "--version"); err == nil {
 			info.Version = parseCloudflaredVersion(string(out))
 		}
 		// Try to list tunnels via CLI (requires login)
-		if out, err := exec.Command("cloudflared", "tunnel", "list", "--output", "json").CombinedOutput(); err == nil {
+		if out, err := cloudflaredRunCommand("cloudflared", "tunnel", "list", "--output", "json"); err == nil {
 			info.Tunnels = parseCloudflaredTunnelList(out)
 		}
 	}
 
 	// 2. Check Docker containers (image contains "cloudflare" or "cloudflared")
+	dockerMatched := false
 	for _, c := range docker.Containers {
 		img := strings.ToLower(c.Image)
 		name := strings.ToLower(c.Name)
 		if !strings.Contains(img, "cloudflare") && !strings.Contains(name, "cloudflare") {
 			continue
 		}
+		dockerMatched = true
 		info.Installed = true
 		if info.Version == "" {
 			info.Version = "(docker: " + c.Image + ")"
@@ -123,6 +137,15 @@ func collectCloudflared(docker internal.DockerInfo) *internal.CloudflaredInfo {
 
 	if !info.Installed {
 		return nil
+	}
+	// Docker fallback fired but the host binary didn't — explain why so the
+	// "I thought my host cloudflared install was monitored" question never
+	// reaches the issue tracker. Quiet hint, only set when relevant.
+	if dockerMatched && !binaryFound {
+		info.Hint = "cloudflared CLI not bundled in the default NAS Doctor image; " +
+			"detection is operating from Docker containers only. To monitor a " +
+			"host-installed cloudflared, build a custom image that bundles the " +
+			"`cloudflared` binary (or bind-mount it into the container)."
 	}
 	return info
 }

--- a/internal/collector/tunnels_test.go
+++ b/internal/collector/tunnels_test.go
@@ -4,10 +4,54 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mcdays94/nas-doctor/internal"
 )
+
+// ── README claim audit (#251 / parent #244) ──
+
+// TestReadme_CloudflaredClaimQualified guards against the historical README
+// overstatement that NAS Doctor "detects both host binary and Docker
+// containers" for cloudflared. The default Docker image (Dockerfile line
+// ~34) bundles `tailscale` but NOT `cloudflared`, so host-binary detection
+// only fires on custom images. The README must reflect that reality.
+//
+// If a future edit reintroduces the misleading phrase, this test fails so
+// the docs and the shipped image stay in sync.
+func TestReadme_CloudflaredClaimQualified(t *testing.T) {
+	// README is at the repo root; this test file lives at
+	// internal/collector/tunnels_test.go — go up two levels.
+	data, err := os.ReadFile(filepath.Join("..", "..", "README.md"))
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	readme := string(data)
+
+	// Specific phrasing that the audit found misleading. The exact strings
+	// originally appeared on README lines 68 and 142. Both must be gone.
+	bannedPhrases := []string{
+		"detects both host binary and Docker containers",
+		"detects host binaries and Docker containers",
+	}
+	for _, phrase := range bannedPhrases {
+		if strings.Contains(readme, phrase) {
+			t.Errorf("README still contains misleading phrase %q — cloudflared binary is NOT bundled in the default image; only Docker-container detection works out of the box. See issue #251.", phrase)
+		}
+	}
+
+	// Positive assertion: the README should explain that host-binary
+	// detection for cloudflared requires a custom image. This keeps a
+	// future edit from removing the qualifier without re-adding the
+	// banned phrase.
+	if !strings.Contains(strings.ToLower(readme), "cloudflared") {
+		t.Fatal("README missing any cloudflared mention; sanity check failed")
+	}
+	if !strings.Contains(readme, "custom image") {
+		t.Errorf("README cloudflared section should explain that host-binary detection requires a custom image bundling the cloudflared CLI; see issue #251")
+	}
+}
 
 // ── Tailscale status --json parser ──
 

--- a/internal/collector/tunnels_test.go
+++ b/internal/collector/tunnels_test.go
@@ -125,6 +125,112 @@ func TestParseTailscaleStatusJSON(t *testing.T) {
 	}
 }
 
+// ── collectCloudflared (binary detection + Docker fallback hint) ──
+
+// withCloudflaredStubs swaps the package-level lookPath/run vars used by
+// collectCloudflared so tests stay hermetic (no real `cloudflared` invocation).
+func withCloudflaredStubs(
+	t *testing.T,
+	lookPath func(string) (string, error),
+	run func(name string, args ...string) ([]byte, error),
+) {
+	t.Helper()
+	origLook := cloudflaredLookPath
+	origRun := cloudflaredRunCommand
+	cloudflaredLookPath = lookPath
+	cloudflaredRunCommand = run
+	t.Cleanup(func() {
+		cloudflaredLookPath = origLook
+		cloudflaredRunCommand = origRun
+	})
+}
+
+// TestCollectCloudflared_EmitsHintWhenBinaryNotFound (issue #251):
+// the default Docker image does NOT bundle the cloudflared CLI, so
+// `exec.LookPath("cloudflared")` fails for almost every install. When
+// Docker-container detection still surfaces a tunnel (the common case),
+// CloudflaredInfo.Hint should explain the situation so API consumers
+// understand why host-binary detection didn't fire — instead of silent
+// fallback that looks like missing functionality.
+func TestCollectCloudflared_EmitsHintWhenBinaryNotFound(t *testing.T) {
+	withCloudflaredStubs(t,
+		func(string) (string, error) { return "", errors.New("not found") },
+		func(string, ...string) ([]byte, error) { return nil, errors.New("unused") },
+	)
+
+	docker := internal.DockerInfo{
+		Containers: []internal.ContainerInfo{
+			{ID: "abc", Name: "cloudflared", Image: "cloudflare/cloudflared:latest", State: "running"},
+		},
+	}
+	got := collectCloudflared(docker)
+	if got == nil {
+		t.Fatal("expected non-nil CloudflaredInfo from docker fallback")
+	}
+	if !got.Installed {
+		t.Error("expected Installed=true via docker fallback")
+	}
+	if got.Hint == "" {
+		t.Fatal("expected non-empty Hint explaining binary not bundled in default image")
+	}
+	if !containsCI(got.Hint, "cloudflared") {
+		t.Errorf("hint should mention cloudflared by name, got %q", got.Hint)
+	}
+	if !containsCI(got.Hint, "bundled") && !containsCI(got.Hint, "custom image") {
+		t.Errorf("hint should explain the binary is not bundled / requires a custom image, got %q", got.Hint)
+	}
+}
+
+// TestCollectCloudflared_NoHintWhenBinaryFound: if the host binary IS
+// available (custom image, or someone bind-mounted it), don't add the hint
+// — it would just be noise.
+func TestCollectCloudflared_NoHintWhenBinaryFound(t *testing.T) {
+	withCloudflaredStubs(t,
+		func(bin string) (string, error) {
+			if bin == "cloudflared" {
+				return "/usr/local/bin/cloudflared", nil
+			}
+			return "", errors.New("not found")
+		},
+		func(name string, args ...string) ([]byte, error) {
+			if len(args) >= 1 && args[0] == "--version" {
+				return []byte("cloudflared version 2024.6.1 (built 2024-06-15-...)"), nil
+			}
+			// `tunnel list` requires login; return error so .Tunnels stays empty.
+			return nil, errors.New("not logged in")
+		},
+	)
+
+	got := collectCloudflared(internal.DockerInfo{})
+	if got == nil {
+		t.Fatal("expected non-nil CloudflaredInfo when host binary exists")
+	}
+	if !got.Installed {
+		t.Error("expected Installed=true")
+	}
+	if got.Hint != "" {
+		t.Errorf("expected empty Hint when binary is found, got %q", got.Hint)
+	}
+	if got.Version != "2024.6.1" {
+		t.Errorf("expected parsed version 2024.6.1, got %q", got.Version)
+	}
+}
+
+// TestCollectCloudflared_ReturnsNilWhenNothingDetected: no host binary, no
+// matching Docker container — collectCloudflared must return nil so the
+// dashboard hides the section entirely (rather than rendering a hint with
+// no tunnels).
+func TestCollectCloudflared_ReturnsNilWhenNothingDetected(t *testing.T) {
+	withCloudflaredStubs(t,
+		func(string) (string, error) { return "", errors.New("not found") },
+		func(string, ...string) ([]byte, error) { return nil, errors.New("unused") },
+	)
+	got := collectCloudflared(internal.DockerInfo{})
+	if got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}
+
 // ── collectTailscale orchestration (binary + socket + docker) ──
 
 // withTailscaleStubs swaps the package-level runner vars for the duration of

--- a/internal/models.go
+++ b/internal/models.go
@@ -160,6 +160,7 @@ type CloudflaredInfo struct {
 	Installed bool                `json:"installed"`
 	Version   string              `json:"version,omitempty"`
 	Tunnels   []CloudflaredTunnel `json:"tunnels,omitempty"`
+	Hint      string              `json:"hint,omitempty"` // Operator hint when detection is partial (e.g. cloudflared CLI not bundled in default image)
 }
 
 type CloudflaredTunnel struct {


### PR DESCRIPTION
Closes #251
Refs #244 (parent README-audit tracker)

## Summary

Two-part fix for the README-claim audit gap on cloudflared detection:

### 1. README correction (commit `e774a5c`)

The README claimed NAS Doctor *"detects both host binary and Docker containers"* for cloudflared, but the default Docker image bundles `tailscale` without `cloudflared` (Dockerfile line 34: `apk add ... tailscale mtr` — no cloudflared). So `exec.LookPath("cloudflared")` silently fails for almost every default install; only Docker-container detection actually works out of the box.

Lines 68 and 142 of README.md now reflect that reality:

- Tailscale detects both host binary (bundled) and Docker containers — unchanged claim, still true.
- Cloudflared detects Docker containers out of the box; host-binary detection requires a custom image bundling the `cloudflared` CLI.

Guarded by `TestReadme_CloudflaredClaimQualified` so a future regression on the README phrasing fails CI.

### 2. Optional collector hint (commit `23c8f39`)

Added `Hint string` field to `CloudflaredInfo` (mirroring the existing `TailscaleInfo.Hint` pattern from #243). Populated **only** when Docker-container detection fired but the host binary was not found — i.e. the common default-install path. Hint message names the gap and points users at the workaround.

Quiet on the happy paths:
- Host binary found (custom image / bind-mount): no hint.
- Nothing detected at all: collector returns nil, dashboard hides the section.
- Only fires when Docker matched but binary did not.

Also seamed `exec.LookPath` and `exec.Command` for cloudflared behind package-level vars so the new tests stay hermetic (no real `cloudflared` invocation on the runner).

## Why both changes

The optional hint was implemented because it costs ~30 LOC, has no behaviour change for the dashboard (no UI rendering yet), and gives API consumers (`/api/v1/snapshot/latest`, Prometheus scrapers, fleet aggregators) a programmatic way to understand why host-binary detection didn't fire — the same observability win we got for tailscale via #243. Cheap.

## Tests added

- `TestReadme_CloudflaredClaimQualified` — README phrasing regression guard.
- `TestCollectCloudflared_EmitsHintWhenBinaryNotFound` — default-install path.
- `TestCollectCloudflared_NoHintWhenBinaryFound` — custom-image path: don't add noise.
- `TestCollectCloudflared_ReturnsNilWhenNothingDetected` — section-hidden regression guard.

## Out of scope (intentionally)

- Container-name substring matching at `tunnels.go:95` is still narrow (only `"cloudflare"` substring). A user running a container named `cf-tunnel` or image `mirror/cloudflared-custom` is still missed. Same shape as the Tailscale issue solved by #243's `NAS_DOCTOR_TAILSCALE_CONTAINER_NAMES` env var. Worth filing as a follow-up if anyone hits it; not done in this PR to stay scoped to the README-claim audit.
- Bundling the `cloudflared` CLI in the default image. Would inflate the image and requires a network-tool bundling discussion. The README now points users at the custom-image workaround.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` all green (whole repo)
- `docker build .` skipped (no Dockerfile changes; the package list is unmodified)

## Other cloudflared mentions audited

`grep -rn cloudflare README.md` surfaces these other mentions; reviewed each and none needed tightening:
- Line 20: live-demo badge logo (cosmetic).
- Line 620: Prometheus metric name listing (factual).
- Line 721: demo-data composition (factual).