### PR TITLE
feat(settings): merge Advanced Scan Settings back into Advanced card (#256)

### DIFF
--- a/internal/api/settings_advanced_card_scan_knobs_test.go
+++ b/internal/api/settings_advanced_card_scan_knobs_test.go
@@ -1,0 +1,186 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestSettingsHTML_NoOrphanAdvancedScansCardReference is a regression guard
+// introduced by issue #256. The V1a design from #237 created a dedicated
+// "Advanced Scan Settings" card (id="card-advanced-scans") and moved the
+// wake-drives toggle into it. UAT on v0.9.8-rc1 showed that two
+// "Advanced"-prefixed cards on the same page added clutter without clarity,
+// so #256 reverses that split: every scan-policy knob moves BACK into the
+// single existing generic Advanced card (id="card-advanced").
+//
+// This test grep-checks the whole repo for any lingering reference to the
+// defunct "card-advanced-scans" anchor — template, nav, tests, comments.
+// A non-zero count means something was missed during the reversal.
+func TestSettingsHTML_NoOrphanAdvancedScansCardReference(t *testing.T) {
+	// Start at the repo root (two levels up from internal/api).
+	root := filepath.Join("..", "..")
+
+	var offenders []string
+
+	walkErr := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // skip unreadable paths, don't fail the walk
+		}
+		if info.IsDir() {
+			// Skip VCS + build artefact dirs.
+			name := info.Name()
+			if name == ".git" || name == "node_modules" || name == "vendor" || name == "dist" || name == "build" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// Only scan source-ish files.
+		ext := strings.ToLower(filepath.Ext(path))
+		switch ext {
+		case ".go", ".html", ".js", ".css", ".md", ".yaml", ".yml", ".json":
+			// ok
+		default:
+			return nil
+		}
+		// Skip this test file itself — it legitimately mentions the string.
+		if strings.HasSuffix(path, "settings_advanced_card_scan_knobs_test.go") {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		if strings.Contains(string(data), "card-advanced-scans") {
+			offenders = append(offenders, path)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk failed: %v", walkErr)
+	}
+	if len(offenders) > 0 {
+		t.Errorf("orphan references to the retired 'card-advanced-scans' anchor found in %d file(s) — issue #256 merged this card back into card-advanced, every mention should be gone:\n  %s",
+			len(offenders), strings.Join(offenders, "\n  "))
+	}
+}
+
+// TestSettingsHTML_AdvancedCardDescriptorMentionsScanKeywords pins the
+// descriptor-cue enhancement from #256. The Advanced card's descriptor
+// (the <div class="card-desc"> line right below the card title) must
+// surface the SMART scan + max-age keywords so users can gauge what's
+// inside without expanding the <details> block.
+//
+// Exact phrasing is the worker's choice; this test only asserts the
+// keywords are present (case-insensitive).
+func TestSettingsHTML_AdvancedCardDescriptorMentionsScanKeywords(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read settings.html: %v", err)
+	}
+	content := string(data)
+
+	cardIdx := strings.Index(content, `id="card-advanced"`)
+	if cardIdx < 0 {
+		t.Fatalf("card-advanced block not found in settings.html")
+	}
+	// The descriptor is the first card-desc after the card anchor, but
+	// before the next card opens. Slice the card body and regex-match
+	// within it.
+	nextCardIdx := strings.Index(content[cardIdx+1:], `<div class="card"`)
+	var cardBody string
+	if nextCardIdx < 0 {
+		cardBody = content[cardIdx:]
+	} else {
+		cardBody = content[cardIdx : cardIdx+1+nextCardIdx]
+	}
+
+	descRE := regexp.MustCompile(`(?s)<div class="card-desc">(.*?)</div>`)
+	m := descRE.FindStringSubmatch(cardBody)
+	if m == nil {
+		t.Fatalf("no <div class=\"card-desc\"> found inside card-advanced block")
+	}
+	desc := strings.ToLower(m[1])
+
+	for _, kw := range []string{"smart scan controls", "max-age"} {
+		if !strings.Contains(desc, kw) {
+			t.Errorf("Advanced card descriptor missing keyword %q (case-insensitive); got: %q", kw, strings.TrimSpace(m[1]))
+		}
+	}
+}
+
+// TestSettingsHTML_ScanKnobsLiveInsideAdvancedCard pins the structural
+// reshape done by #256. The wake-drives toggle and the max-age input
+// (both originally introduced in #237 inside a dedicated card) must now
+// live INSIDE the generic Advanced card (id="card-advanced"), specifically
+// inside its <details> disclosure block.
+//
+// We assert position via byte-offset ordering: the card anchor must
+// appear before both elements, and the next card (if any) must appear
+// after them. The existing Hide-Docker-Containers knob must also remain
+// inside the same card, so we pin all three siblings at once.
+func TestSettingsHTML_ScanKnobsLiveInsideAdvancedCard(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read settings.html: %v", err)
+	}
+	content := string(data)
+
+	cardIdx := strings.Index(content, `id="card-advanced"`)
+	if cardIdx < 0 {
+		t.Fatalf("card-advanced block not found in settings.html")
+	}
+
+	// Determine the card's byte range: from its anchor to the start of
+	// the next <div class="card"> (or end of file).
+	rel := strings.Index(content[cardIdx+1:], `<div class="card"`)
+	var cardEnd int
+	if rel < 0 {
+		cardEnd = len(content)
+	} else {
+		cardEnd = cardIdx + 1 + rel
+	}
+	body := content[cardIdx:cardEnd]
+
+	mustContainInside := []struct {
+		name   string
+		substr string
+	}{
+		{"wake-drives toggle id", `id="wake-drives-for-smart"`},
+		{"max-age input id", `id="smart-max-age-days"`},
+		{"max-age min attribute", `min="0"`},
+		{"max-age max attribute", `max="30"`},
+		{"hide-docker knob label", `Hide Docker containers from dashboard`},
+		// Disclosure element must still wrap the expert-only content.
+		{"details element", `<details`},
+		{"summary element", `<summary`},
+	}
+	for _, tc := range mustContainInside {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(body, tc.substr) {
+				t.Errorf("card-advanced missing %q — expected substring inside the card body: %q", tc.name, tc.substr)
+			}
+		})
+	}
+
+	// Intra-card ordering: wake-drives toggle must appear before the
+	// max-age input (design decision in #256: SMART scan knobs grouped
+	// together, wake-drives first), and both must appear before the
+	// Hide-Docker-Containers knob (its own group).
+	toggleIdx := strings.Index(body, `id="wake-drives-for-smart"`)
+	maxAgeIdx := strings.Index(body, `id="smart-max-age-days"`)
+	hideDockerIdx := strings.Index(body, `Hide Docker containers from dashboard`)
+	if toggleIdx < 0 || maxAgeIdx < 0 || hideDockerIdx < 0 {
+		t.Fatalf("ordering markers missing (toggle=%d maxAge=%d hideDocker=%d)", toggleIdx, maxAgeIdx, hideDockerIdx)
+	}
+	if !(toggleIdx < maxAgeIdx) {
+		t.Errorf("wake-drives toggle should appear before the max-age input (wake=%d maxAge=%d)", toggleIdx, maxAgeIdx)
+	}
+	if !(maxAgeIdx < hideDockerIdx) {
+		t.Errorf("max-age input should appear before the Hide-Docker-Containers knob (maxAge=%d hideDocker=%d)", maxAgeIdx, hideDockerIdx)
+	}
+}

--- a/internal/api/settings_advanced_scans_card_test.go
+++ b/internal/api/settings_advanced_scans_card_test.go
@@ -7,15 +7,22 @@ import (
 	"testing"
 )
 
-// TestSettingsHTML_AdvancedScansCard pins the structural contract of
-// the new "Advanced Scan Settings" card introduced by issue #237.
+// TestSettingsHTML_AdvancedScanKnobs pins the structural contract of
+// the SMART scan-policy knobs (wake-drives toggle + max-age input).
 //
-// The card lives alongside the existing generic Advanced card; it
-// holds the scan-policy knobs (wake-drives toggle + new max-age
-// input). The existing Advanced card keeps the Hide Docker
-// Containers knob. Separating the two concerns is user story 22 in
-// PRD #236.
-func TestSettingsHTML_AdvancedScansCard(t *testing.T) {
+// History:
+//   - #237 (V1a of PRD #236) introduced these knobs inside a new dedicated
+//     Advanced Scan Settings card.
+//   - #256 reversed that split after UAT feedback (two "Advanced"-prefixed
+//     cards on one page was clutter, not clarity). The knobs now live
+//     inside the single generic Advanced card id="card-advanced".
+//
+// This test keeps the original V1a intent — every pre-click validation
+// attribute and JSON-binding symbol must still be present — but pinned
+// against the new home (card-advanced). The companion test
+// TestSettingsHTML_ScanKnobsLiveInsideAdvancedCard verifies they live
+// inside that specific card via byte-offset ordering.
+func TestSettingsHTML_AdvancedScanKnobs(t *testing.T) {
 	path := filepath.Join("templates", "settings.html")
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -27,10 +34,10 @@ func TestSettingsHTML_AdvancedScansCard(t *testing.T) {
 		name   string
 		substr string
 	}{
-		// New card anchor + title + sticky-nav entry.
-		{"card anchor", `id="card-advanced-scans"`},
-		{"card title", `Advanced Scan Settings`},
-		{"nav link to new card", `href="#card-advanced-scans"`},
+		// Generic Advanced card anchor + sticky-nav entry — this is the
+		// new home for the scan knobs since #256.
+		{"advanced card anchor", `id="card-advanced"`},
+		{"nav link to advanced card", `href="#card-advanced"`},
 
 		// Max-age input: id + nested JSON key on the load and save
 		// paths. Range validation is a separate assertion below.
@@ -47,7 +54,7 @@ func TestSettingsHTML_AdvancedScansCard(t *testing.T) {
 		// convention (PRD user stories 5 + 23).
 		{"max-age explanation mentions disabled", `disabled`},
 
-		// Wake-drives toggle lives HERE now, not in the legacy card.
+		// Wake-drives toggle still present under its stable id.
 		{"wake-drives toggle still present", `id="wake-drives-for-smart"`},
 	}
 	for _, tc := range mustContain {
@@ -58,28 +65,17 @@ func TestSettingsHTML_AdvancedScansCard(t *testing.T) {
 		})
 	}
 
-	// The wake-drives toggle must appear AFTER the new card opens
-	// and BEFORE the legacy Advanced card opens. This enforces that
-	// the toggle moved — it's no longer inside id="card-advanced".
-	newCardIdx := strings.Index(content, `id="card-advanced-scans"`)
-	legacyCardIdx := strings.Index(content, `id="card-advanced"`)
+	// After #256 both the wake-drives toggle and the Hide-Docker-Containers
+	// knob must live inside the same card-advanced block; the toggle appears
+	// first (SMART group), the Docker knob second (Docker group). If this
+	// assertion fails the merge regressed.
+	advancedIdx := strings.Index(content, `id="card-advanced"`)
 	toggleIdx := strings.Index(content, `id="wake-drives-for-smart"`)
-	if newCardIdx < 0 || legacyCardIdx < 0 || toggleIdx < 0 {
-		t.Fatalf("missing required markers (new=%d legacy=%d toggle=%d)", newCardIdx, legacyCardIdx, toggleIdx)
-	}
-	if !(newCardIdx < toggleIdx && toggleIdx < legacyCardIdx) {
-		t.Errorf("wake-drives toggle must sit between the new card (at %d) and the legacy card (at %d); got toggle at %d — did it get left behind in the legacy Advanced card?", newCardIdx, legacyCardIdx, toggleIdx)
-	}
-
-	// The Hide-Docker-Containers knob must remain inside the legacy
-	// Advanced card. Its marker phrase is unique enough to serve as
-	// an anchor. If this assertion fails someone moved the wrong
-	// thing.
 	hideDockerIdx := strings.Index(content, `Hide Docker containers from dashboard`)
-	if hideDockerIdx < 0 {
-		t.Fatalf("Hide Docker containers label vanished from settings.html")
+	if advancedIdx < 0 || toggleIdx < 0 || hideDockerIdx < 0 {
+		t.Fatalf("missing required markers (advanced=%d toggle=%d hideDocker=%d)", advancedIdx, toggleIdx, hideDockerIdx)
 	}
-	if hideDockerIdx < legacyCardIdx {
-		t.Errorf("Hide Docker containers knob must stay inside the legacy Advanced card (at %d); got marker at %d — did this move by mistake?", legacyCardIdx, hideDockerIdx)
+	if !(advancedIdx < toggleIdx && toggleIdx < hideDockerIdx) {
+		t.Errorf("wake-drives toggle must sit inside the Advanced card (at %d) AND before the Hide-Docker-Containers knob (at %d); got toggle at %d — did #256's merge regress?", advancedIdx, hideDockerIdx, toggleIdx)
 	}
 }

--- a/internal/api/settings_wake_drives_for_smart_test.go
+++ b/internal/api/settings_wake_drives_for_smart_test.go
@@ -14,8 +14,10 @@ import (
 
 // TestSettingsHTMLIncludesWakeDrivesForSMARTToggle verifies the settings
 // template ships the wake-drives toggle + disclaimer required by issue #198.
-// Since #237 the toggle lives inside the new "Advanced Scan Settings"
-// card (id="card-advanced-scans"), not the legacy generic Advanced card.
+// Originally (pre-#237) the toggle lived directly inside the generic
+// Advanced card. #237 moved it out to a dedicated "Advanced Scan Settings"
+// card; #256 merged it back into the generic Advanced card (id="card-advanced")
+// after UAT flagged the two-card split as clutter.
 //
 // This is a cross-reference test: it confirms the HTML mentions every
 // symbol the JS load/save wiring expects, so a future refactor that
@@ -32,10 +34,10 @@ func TestSettingsHTMLIncludesWakeDrivesForSMARTToggle(t *testing.T) {
 		name   string
 		substr string
 	}{
-		// New Advanced Scan Settings card anchor (#237).
-		{"advanced scans card anchor", `id="card-advanced-scans"`},
-		// Section nav link to the new card.
-		{"advanced scans nav link", `href="#card-advanced-scans"`},
+		// Generic Advanced card anchor (post-#256 home).
+		{"advanced card anchor", `id="card-advanced"`},
+		// Section nav link to the Advanced card.
+		{"advanced nav link", `href="#card-advanced"`},
 		// Disclosure element — using <details>/<summary> per the issue's
 		// guidance (no extra JS needed).
 		{"details element", `<details`},

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -63,7 +63,6 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
     <a href="#card-replacement-cost" class="btn btn-secondary btn-sm" style="text-decoration:none">Replacement Cost</a>
     <a href="#card-speedtest" class="btn btn-secondary btn-sm" style="text-decoration:none">Speed Test</a>
     <a href="#card-backup" class="btn btn-secondary btn-sm" style="text-decoration:none">Backup</a>
-    <a href="#card-advanced-scans" class="btn btn-secondary btn-sm" style="text-decoration:none">Advanced Scans</a>
     <a href="#card-advanced" class="btn btn-secondary btn-sm" style="text-decoration:none">Advanced</a>
   </div>
 
@@ -888,15 +887,25 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
     </div>
   </div>
 
-  <!-- 9. Advanced Scan Settings (#237) -->
-  <div class="card" id="card-advanced-scans">
-    <div class="card-title">Advanced Scan Settings</div>
-    <div class="card-desc">Fine-grained control over how NAS Doctor schedules SMART reads and related scans. Defaults are safe — change only if you understand the trade-offs.</div>
-    <details style="margin-top:8px" open>
-      <summary style="cursor:pointer;padding:6px 0;font-weight:600;font-size:13px;color:var(--text)">Show scan-policy options</summary>
+  <!-- 9. Advanced -->
+  <!--
+    History: #237 split scan-policy knobs into a dedicated "Advanced Scan
+    Settings" card. v0.9.8-rc1 UAT (issue #256) flagged the two-card layout
+    as noise — merged back into this single Advanced card with a descriptor
+    cue so users can see what's inside before expanding.
+  -->
+  <div class="card" id="card-advanced">
+    <div class="card-title">Advanced</div>
+    <div class="card-desc">Expert-only knobs for SMART scan controls (wake drives, max-age safety net), Docker container visibility, and more. Defaults are safe — only change these if you understand the trade-offs.</div>
+    <details style="margin-top:8px">
+      <summary style="cursor:pointer;padding:6px 0;font-weight:600;font-size:13px;color:var(--text)">Show advanced options</summary>
       <div style="margin-top:14px;padding-top:12px;border-top:1px solid var(--border)">
 
-        <!-- Wake drives for SMART check (moved from legacy Advanced card, #198) -->
+        <!-- SMART scan controls (wake-drives + max-age) — merged from the
+             retired "Advanced Scan Settings" card per #256. Wake-drives
+             came from #198; max-age from #237 (schema) + #238 (wiring). -->
+        <div style="font-weight:600;font-size:13px;color:var(--text);margin-bottom:10px">SMART scan controls</div>
+
         <div class="toggle-wrap">
           <div class="toggle" id="wake-drives-for-smart" onclick="this.classList.toggle('on');saveSettings()"><div class="toggle-knob"></div></div>
           <span class="toggle-label">Wake drives for SMART check</span>
@@ -908,8 +917,7 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
           Only enable if your drives never spin down, or if you deliberately need every-cycle SMART monitoring and accept the wear cost.
         </p>
 
-        <!-- Max days without SMART read (#237 schema; #238 wires into the scheduler) -->
-        <div style="margin-top:18px;padding-top:14px;border-top:1px solid var(--border)">
+        <div style="margin-top:18px">
           <label for="smart-max-age-days" style="display:block;font-weight:600;font-size:13px;color:var(--text);margin-bottom:4px">Max days without SMART read</label>
           <div style="display:flex;align-items:center;gap:10px">
             <input type="number" id="smart-max-age-days" min="0" max="30" step="1" value="7" onchange="saveSettings()" style="width:80px;text-align:center">
@@ -922,18 +930,9 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
             Valid range 0&ndash;30.
           </p>
         </div>
-      </div>
-    </details>
-  </div>
 
-  <!-- 10. Advanced -->
-  <div class="card" id="card-advanced">
-    <div class="card-title">Advanced</div>
-    <div class="card-desc">Expert-only knobs. Defaults are safe — only change these if you understand the trade-offs.</div>
-    <details style="margin-top:8px">
-      <summary style="cursor:pointer;padding:6px 0;font-weight:600;font-size:13px;color:var(--text)">Show advanced options</summary>
-      <div style="margin-top:14px;padding-top:12px;border-top:1px solid var(--border)">
-        <div>
+        <!-- Docker container visibility — unchanged from pre-#237. -->
+        <div style="margin-top:22px;padding-top:16px;border-top:1px solid var(--border)">
           <div style="display:block;font-weight:600;font-size:13px;color:var(--text);margin-bottom:4px">Hide Docker containers from dashboard</div>
           <p style="font-size:12px;color:var(--text2);margin-top:4px;margin-bottom:10px;line-height:1.5">
             Tick the containers you want hidden from the <strong>Docker Containers section</strong>.


### PR DESCRIPTION
Closes #256

## Summary

UAT on v0.9.8-rc1 flagged the two-card split from #237 (V1a of PRD #236) as clutter — two \"Advanced\"-prefixed cards on the same page added noise without clarity. This PR reverses the structural decision from #237 while keeping the schema + behaviour work from #238 intact: the SMART scan-policy knobs (wake-drives toggle + max-age input) move BACK into the single existing Advanced card, and the card's descriptor is enhanced to hint at what's inside so users can gauge whether to expand it.

**No backend / schema / API changes.** Pure `settings.html` template edit + test reshape.

## Layout inside `card-advanced`

1. **SMART scan controls** (new subheading)
   - Wake drives for SMART check (toggle) — pre-#237 position restored
   - Max days without SMART read (numeric input, 0–30, 0=disable) — moved from the retired card
2. Horizontal divider
3. Hide Docker containers from dashboard (unchanged)

## Descriptor

Before:
> Expert-only knobs. Defaults are safe — only change these if you understand the trade-offs.

After:
> Expert-only knobs for SMART scan controls (wake drives, max-age safety net), Docker container visibility, and more. Defaults are safe — only change these if you understand the trade-offs.

## Tests

- **New** `TestSettingsHTML_NoOrphanAdvancedScansCardReference` — repo-wide grep regression guard; fails if any file outside the guard test still mentions the retired `card-advanced-scans` anchor (template, nav, tests, comments, README, etc.)
- **New** `TestSettingsHTML_AdvancedCardDescriptorMentionsScanKeywords` — pins the descriptor cue by regex-matching the first `<div class=\"card-desc\">` inside `card-advanced` against `smart scan controls` and `max-age` (case-insensitive)
- **New** `TestSettingsHTML_ScanKnobsLiveInsideAdvancedCard` — byte-offset-scoped assertions that both SMART knobs + the Docker knob sit inside `card-advanced`, in the chosen order (wake-drives → max-age → Docker)
- **Reshaped** existing V1a tests (`settings_advanced_scans_card_test.go`, `settings_wake_drives_for_smart_test.go`) — intent preserved (knobs exist, validation attributes present, nav link works), assertions retargeted at `card-advanced`

All existing tests including `settings_smart_*` and `TestSettingsRoundTrip_WakeDrivesForSMART` remain green; the nested JSON schema (`smart.wake_drives`, `smart.max_age_days`) is untouched.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all packages green
- `docker build .` — skipped (no backend changes; Dockerfile unaffected)
- Repo-wide grep for `card-advanced-scans` returns zero hits outside the orphan-guard test file

## Related

- Parent PRD: #236
- Reversed slice: #237 (V1a — card split design)
- Untouched sibling slice: #238 (V1b — scheduler max-age wiring)