### PR TITLE
feat(demo): showcase traceroute service-check type in demo feeder

### DIFF
--- a/demo-worker/feeder/src/index.ts
+++ b/demo-worker/feeder/src/index.ts
@@ -638,6 +638,15 @@ function buildServiceChecks(): unknown[] {
   sc("sc-dns-local", "Local DNS (Pi-hole)", "dns", "10.0.1.53", false, 0, "critical", 8);
   sc("sc-dns-resolve", "Public DNS Resolution", "dns", "1.1.1.1", true, 15, "critical");
 
+  // ── Traceroute checks (v0.9.7 #189) ──
+  // Per-hop reachability + loss monitoring for upstream paths. Showcases the
+  // traceroute service-check type + the teal pill-trace pill styling. Real
+  // targets so the demo reflects what a NAS owner might actually monitor:
+  // one short hop to Google DNS (ISP path health) and one longer cloud-edge
+  // path (multi-hop CDN/cloud reachability).
+  sc("sc-trace-google", "Upstream to Google DNS", "traceroute", "8.8.8.8", true, 12, "warning");
+  sc("sc-trace-aws-eu", "AWS eu-west-1 path", "traceroute", "52.28.0.1", true, 45, "info");
+
   // ── SMB / NFS checks ──
   sc("sc-smb-media", "SMB: Media Share", "smb", "//10.0.1.50/media", true, 8, "warning");
   sc("sc-smb-backup", "SMB: Backup Share", "smb", "//10.0.1.50/backups", true, 12, "warning");


### PR DESCRIPTION
## Summary

Adds two `traceroute`-type checks to the demo worker's `buildServiceChecks` output so the v0.9.7 #189 traceroute feature is visible on https://nasdoctordemo.mdias.info without needing a visitor to click "Add check".

## Changes

- `demo-worker/feeder/src/index.ts` — two new entries in `buildServiceChecks()`, between the DNS and SMB/NFS blocks:
  - `sc-trace-google` — "Upstream to Google DNS" (8.8.8.8), up, ~12ms baseline, warning severity
  - `sc-trace-aws-eu` — "AWS eu-west-1 path" (52.28.0.1), up, ~45ms baseline, info severity

Both targets are real public IPs matching what a NAS owner might realistically monitor (ISP upstream path + a common cloud-edge anycast address).

## Manual verification

```
$ (cd demo-worker/feeder && npx tsc --noEmit)          # clean
$ (cd demo-worker/feeder && npm test)
  Test Files  1 passed (1)
  Tests       23 passed (23)
```

## Deployment

After merge: re-trigger `Deploy Demo Worker` workflow. Feeder cron runs every 5 min; first tick post-deploy will surface the two new traceroute entries on all five platforms. Pill styling will render via the existing `.pill-trace` CSS in the captured `shared.css` (v0.9.7 palette).

## Scope

Demo-only. No production Go code touched. Widget-coverage regression test remains green because assertions are shape-based (required fields on top_processes, speed_test, backup, gpu, etc.), not type-specific on service_checks.

## Closes

Non-issue change — no tracker was filed. This is a direct UI polish on the demo.