### PR TITLE
fix(demo): sync snapshot.service_checks with buildServiceChecks() — follow-up to #267

### DIFF
--- a/demo-worker/feeder/src/index.ts
+++ b/demo-worker/feeder/src/index.ts
@@ -396,6 +396,14 @@ export function transformSnapshot(d: Record<string, unknown>, p: PlatformProfile
     docker: { available: true, version: "24.0.7", containers },
     ups, zfs, gpu, parity, tunnels, proxmox, kubernetes,
     speed_test, backup,
+    // Keep the snapshot's service_checks in sync with what the feeder
+    // writes to /api/v1/service-checks. Without this the dashboard
+    // Service Checks widget (which reads snapshot.service_checks)
+    // diverges from the /service-checks page — notably, the v0.9.7
+    // traceroute entries added in #267 would only render on the page
+    // and stay hidden on the widget. Both surfaces now show identical
+    // data because both flow through the same buildServiceChecks().
+    service_checks: buildServiceChecks(),
     findings,
   };
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #267. The traceroute service-check entries shipped in that PR appeared on the `/service-checks` page (26 entries, 8 types) but were missing from the dashboard Service Checks widget (7 entries, 6 types — the stale captured seed).

Root cause: `transformSnapshot()` in the feeder wasn't replacing `snapshot.service_checks`, so the widget kept the Go-binary's `--demo` mode defaults while `/api/v1/service-checks` got the richer feeder-built list.

## Fix

One line: `transformSnapshot()` now includes `service_checks: buildServiceChecks()` in its returned object, mirroring the same function used for the standalone endpoint. Both surfaces now render identical data.

## Manual verification

```
$ (cd demo-worker/feeder && npx tsc --noEmit)          # clean
$ (cd demo-worker/feeder && npm test)
  Test Files  1 passed (1)
  Tests       23 passed (23)
```

## Post-merge verification plan

After merge + `gh workflow run "Deploy Demo Worker"`, feeder's next 5-min tick will populate the new shape. Expected delta:

| Endpoint | Before | After |
|---|---|---|
| `GET /api/v1/service-checks` | 26 entries, 7 types (incl. traceroute) | unchanged |
| `GET /api/v1/snapshot/latest` → `.service_checks` | 7 entries, 6 types | 26 entries, 7 types (matches) |
| Dashboard Service Checks widget | missing traceroute | shows traceroute pills |