### PR TITLE
fix(api): clamp SettingsVersion on PUT to prevent silent version downgrade

### DIFF
--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -837,6 +837,18 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		settings.Retention.NotifyLogDays = 30
 	}
 
+	// Preserve settings_version. A client payload that omits the field
+	// unmarshals to SettingsVersion==0 and the unfiltered Marshal below
+	// would persist it verbatim, permanently downgrading the record
+	// and re-triggering the v1->v2 migration on every subsequent
+	// getSettings() — which silently reset smart.max_age_days back to
+	// 7 and smart.wake_drives to false. Clamp to currentSettingsVersion
+	// so both "no field sent" and "explicit downgrade attempt" cannot
+	// corrupt the stored version.
+	if settings.SettingsVersion < currentSettingsVersion {
+		settings.SettingsVersion = currentSettingsVersion
+	}
+
 	// Persist
 	data, err := json.Marshal(settings)
 	if err != nil {


### PR DESCRIPTION
Fixes mcdays94/nas-doctor#268.

## Problem

A frontend PUT `/api/v1/settings` payload that omits `settings_version` (per the issue, v0.9.8 `buildSettingsPayload` does exactly this) unmarshals to `SettingsVersion==0` and the unfiltered `Marshal` below persists it verbatim. Every subsequent internal `getSettings()` call then re-runs the v1→v2 migration, which:

1. Resets `smart.max_age_days` back to 7 when the stored value is 0 (intended only to seed upgraders).
2. Overrides `smart.wake_drives` with the legacy flat `wake_drives_for_smart` field — absent in v2 blobs, so it silently becomes `false`.

`getSettings` then persists the corrupted state, making the flip permanent. User-visible symptom: "Max days without SMART read" 7 → 0 reverts to 7 after refresh; `wake_drives: true` silently resets to `false`.

## Fix

Clamp `settings.SettingsVersion` to at least `currentSettingsVersion` before `Marshal`, per Fix B in the issue. Both "no settings_version sent" and "explicit downgrade attempt" now cannot corrupt the stored record. Existing installs whose DB already has `settings_version: 0` self-heal on the next save.

## Test

`go test ./internal/api/...` clean. (Happy to add the specific regression tests the issue proposes if maintainers prefer — the minimal fix is this one clamp.)