### PR TITLE
fix(settings): preserve settings_version across save, heal SMART field clobber (#268)

### DIFF
--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -684,6 +684,23 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Preserve server-authoritative settings_version. The client must
+	// never be able to downgrade or omit this field. If the stored blob
+	// has a higher version, keep it. Guards against issue #268: a v0.9.8
+	// frontend that omitted settings_version persisted version=0, which
+	// re-triggered the v1→v2 migration on next getSettings() and
+	// silently clobbered smart.max_age_days=0 back to 7 and
+	// smart.wake_drives=true back to false.
+	if raw, err := s.store.GetConfig(settingsConfigKey); err == nil && raw != "" {
+		var existing Settings
+		if json.Unmarshal([]byte(raw), &existing) == nil && existing.SettingsVersion > settings.SettingsVersion {
+			settings.SettingsVersion = existing.SettingsVersion
+		}
+	}
+	if settings.SettingsVersion < currentSettingsVersion {
+		settings.SettingsVersion = currentSettingsVersion
+	}
+
 	// Basic validation
 	if settings.ScanInterval == "" {
 		settings.ScanInterval = "30m"

--- a/internal/api/settings_smart_migration_test.go
+++ b/internal/api/settings_smart_migration_test.go
@@ -88,6 +88,36 @@ func TestMigrateSettings_V2_Idempotent(t *testing.T) {
 	}
 }
 
+// TestMigrateSettings_V2UserTouchesSettings_DoesNotReMigrateZeroMaxAge
+// pins the combined preservation contract after issue #268: a v2 blob
+// with the full spectrum of edge-case user choices (explicit
+// max_age_days=0 AND wake_drives=true) passes through migrateSettings
+// unchanged. The v1→v2 ladder MUST NOT fire once SettingsVersion is
+// already 2, no matter what SMART values were chosen.
+func TestMigrateSettings_V2UserTouchesSettings_DoesNotReMigrateZeroMaxAge(t *testing.T) {
+	raw := []byte(`{
+		"settings_version": 2,
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"smart": {
+			"wake_drives": true,
+			"max_age_days": 0
+		}
+	}`)
+
+	got := migrateSettings(raw, defaultSettings())
+
+	if got.SettingsVersion != 2 {
+		t.Errorf("settings_version: got %d, want 2 preserved", got.SettingsVersion)
+	}
+	if got.SMART.MaxAgeDays != 0 {
+		t.Errorf("smart.max_age_days: got %d, want 0 (explicit user zero must survive — was the visible half of #268)", got.SMART.MaxAgeDays)
+	}
+	if !got.SMART.WakeDrives {
+		t.Errorf("smart.wake_drives: got false, want true (explicit user true must survive — was the silent half of #268)")
+	}
+}
+
 // TestMigrateSettings_V2_PreservesMaxAgeDaysZero ensures that a user
 // who has deliberately disabled the safety net (set max_age_days=0)
 // does not silently get it re-enabled by the migration. Idempotency

--- a/internal/api/settings_smart_version_roundtrip_test.go
+++ b/internal/api/settings_smart_version_roundtrip_test.go
@@ -1,0 +1,262 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Tests in this file pin the end-to-end contract that fixed issue #268:
+//
+//   - The client MUST include settings_version in PUT payloads AND the
+//     server MUST preserve a stored server-authoritative version across
+//     any save, never letting a client omit or downgrade it.
+//
+// Without both halves, an older/misbehaving frontend can corrupt the
+// stored settings_version to 0, which re-triggers the v1→v2 migration
+// on the next internal getSettings() call. That migration:
+//   - overwrites smart.wake_drives with the legacy flat
+//     wake_drives_for_smart field (absent in v2 blobs → false), and
+//   - flips smart.max_age_days=0 back to the 7-day seed.
+//
+// Both silent resets are user-visible data loss.
+
+// seedV2Settings writes a v2-shaped settings blob into the store,
+// simulating the persisted state of a user who has already upgraded
+// past the v1→v2 migration and deliberately configured SMART to keep
+// drives asleep (max_age_days=0, wake_drives=true — a real
+// combination: "never wake to scan, but do wake when something else
+// wakes them").
+func seedV2Settings(t *testing.T, srv *Server, maxAgeDays int, wakeDrives bool) {
+	t.Helper()
+	s := defaultSettings()
+	s.SettingsVersion = 2
+	s.SMART.MaxAgeDays = maxAgeDays
+	s.SMART.WakeDrives = wakeDrives
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	if err := srv.store.SetConfig(settingsConfigKey, string(data)); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+}
+
+// readStoredSettings returns the raw JSON blob persisted in the store,
+// decoded through a map so we can assert on absence of version fields
+// as well as presence.
+func readStoredSettings(t *testing.T, srv *Server) map[string]interface{} {
+	t.Helper()
+	raw, err := srv.store.GetConfig(settingsConfigKey)
+	if err != nil {
+		t.Fatalf("read stored settings: %v", err)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("decode stored settings: %v", err)
+	}
+	return out
+}
+
+// TestHandleUpdateSettings_PreservesStoredSettingsVersion — core
+// backend regression for #268. A v2-shaped blob is in storage. The
+// client PUTs a payload that OMITS settings_version (mimicking the
+// real v0.9.8 frontend). The server must preserve the stored version
+// rather than persisting the zero-value from the unmarshal.
+func TestHandleUpdateSettings_PreservesStoredSettingsVersion(t *testing.T) {
+	srv := newSettingsTestServer()
+	seedV2Settings(t, srv, 0, true)
+
+	// Client payload WITHOUT settings_version — exactly what the
+	// v0.9.8 frontend sends. Valid scan_interval + theme so the
+	// handler accepts it.
+	rec := putSettings(t, srv, map[string]any{
+		"scan_interval": "30m",
+		"theme":         "midnight",
+		"smart": map[string]any{
+			"wake_drives":  true,
+			"max_age_days": 0,
+		},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	stored := readStoredSettings(t, srv)
+	gotVersion, _ := stored["settings_version"].(float64)
+	if int(gotVersion) != 2 {
+		t.Errorf("stored settings_version after PUT: got %v, want 2 (server must preserve, not accept client omission as 0)", stored["settings_version"])
+	}
+}
+
+// TestHandleUpdateSettings_ClientCannotDowngradeSettingsVersion —
+// defence-in-depth. Even an explicit client-side settings_version=0
+// in the PUT body must not overwrite the stored v2. settings_version
+// is server-authoritative.
+func TestHandleUpdateSettings_ClientCannotDowngradeSettingsVersion(t *testing.T) {
+	srv := newSettingsTestServer()
+	seedV2Settings(t, srv, 14, false)
+
+	rec := putSettings(t, srv, map[string]any{
+		"settings_version": 0, // malicious/buggy client tries to downgrade
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"smart": map[string]any{
+			"wake_drives":  false,
+			"max_age_days": 14,
+		},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	stored := readStoredSettings(t, srv)
+	gotVersion, _ := stored["settings_version"].(float64)
+	if int(gotVersion) != 2 {
+		t.Errorf("client-sent settings_version=0 must be ignored; stored version = %v, want 2", stored["settings_version"])
+	}
+}
+
+// TestHandleUpdateSettings_MaxAgeDaysZero_SurvivesInternalGetSettings
+// — the full end-to-end scenario users hit: set max_age_days=0, save,
+// something (dashboard load, backup API, anything) triggers
+// getSettings() internally which runs migration + persist. The 0 must
+// survive that round trip.
+//
+// With only the frontend fix, settings_version=2 is included in the
+// PUT payload and reaches the store intact, so getSettings() sees an
+// already-v2 blob and the migration is skipped. With only the backend
+// fix, the server preserves settings_version from the stored blob
+// and achieves the same outcome. Either fix in isolation should make
+// this test pass.
+func TestHandleUpdateSettings_MaxAgeDaysZero_SurvivesInternalGetSettings(t *testing.T) {
+	srv := newSettingsTestServer()
+	seedV2Settings(t, srv, 7, false)
+
+	// User edits: set max_age_days=0, payload includes settings_version=2
+	// (the state the fixed frontend will produce).
+	rec := putSettings(t, srv, map[string]any{
+		"settings_version": 2,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"smart": map[string]any{
+			"wake_drives":  false,
+			"max_age_days": 0,
+		},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 from PUT, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Force the getSettings() code path (migrate + persist back).
+	loaded := srv.getSettings()
+	if loaded.SMART.MaxAgeDays != 0 {
+		t.Errorf("after internal getSettings(): smart.max_age_days = %d, want 0 (user-chosen value must not be re-seeded by a stale migration)", loaded.SMART.MaxAgeDays)
+	}
+
+	// And the stored blob too, since getSettings() persists.
+	stored := readStoredSettings(t, srv)
+	smartMap, ok := stored["smart"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("stored settings missing smart object: %v", stored["smart"])
+	}
+	mad, _ := smartMap["max_age_days"].(float64)
+	if int(mad) != 0 {
+		t.Errorf("persisted smart.max_age_days after getSettings(): got %v, want 0", smartMap["max_age_days"])
+	}
+}
+
+// TestHandleUpdateSettings_WakeDrivesTrue_SurvivesInternalGetSettings
+// — same scenario as above but for wake_drives=true. The re-migration
+// bug clobbered this field by reading the missing legacy
+// wake_drives_for_smart top-level key (absent in v2 blobs → false).
+func TestHandleUpdateSettings_WakeDrivesTrue_SurvivesInternalGetSettings(t *testing.T) {
+	srv := newSettingsTestServer()
+	seedV2Settings(t, srv, 7, false)
+
+	rec := putSettings(t, srv, map[string]any{
+		"settings_version": 2,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"smart": map[string]any{
+			"wake_drives":  true,
+			"max_age_days": 7,
+		},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 from PUT, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	loaded := srv.getSettings()
+	if !loaded.SMART.WakeDrives {
+		t.Errorf("after internal getSettings(): smart.wake_drives = false, want true (user-chosen value must not be clobbered by a stale migration)")
+	}
+
+	stored := readStoredSettings(t, srv)
+	smartMap, ok := stored["smart"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("stored settings missing smart object: %v", stored["smart"])
+	}
+	wd, _ := smartMap["wake_drives"].(bool)
+	if !wd {
+		t.Errorf("persisted smart.wake_drives after getSettings(): got %v, want true", smartMap["wake_drives"])
+	}
+}
+
+// TestSettingsHTMLPayloadIncludesSettingsVersion — frontend regression
+// guard. buildSettingsPayload() must include settings_version in the
+// returned payload object so the backend has an incoming value to
+// preserve. This is the user-facing half of the fix; without it, the
+// backend's max-of-stored-and-incoming still works (stored wins over
+// missing), but future backend refactors that loosen the guard must
+// still receive an explicit version from the UI.
+func TestSettingsHTMLPayloadIncludesSettingsVersion(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.html: %v", err)
+	}
+	content := string(data)
+
+	fnStart := strings.Index(content, "function buildSettingsPayload()")
+	if fnStart == -1 {
+		t.Fatalf("could not locate buildSettingsPayload() in settings.html")
+	}
+	// Locate the returned object literal. We scan from the function
+	// start for "return {" and then find the matching close-brace at
+	// brace-depth 0 within the block. Simple brace counter is
+	// sufficient because the returned object has no embedded strings
+	// containing unbalanced braces in this codebase.
+	returnStart := strings.Index(content[fnStart:], "return {")
+	if returnStart == -1 {
+		t.Fatalf("could not locate `return {` inside buildSettingsPayload()")
+	}
+	returnStart += fnStart + len("return ")
+	depth := 0
+	returnEnd := -1
+	for i := returnStart; i < len(content); i++ {
+		switch content[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				returnEnd = i + 1
+				break
+			}
+		}
+		if returnEnd != -1 {
+			break
+		}
+	}
+	if returnEnd == -1 {
+		t.Fatalf("could not find matching brace for buildSettingsPayload() return object")
+	}
+	payload := content[returnStart:returnEnd]
+	if !strings.Contains(payload, "settings_version") {
+		t.Errorf("buildSettingsPayload() return object must include a settings_version key (issue #268). Payload was:\n%s", payload)
+	}
+}

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -1317,6 +1317,13 @@ function buildSettingsPayload() {
   };
 
   return {
+    // Preserve server-authoritative settings_version from the loaded
+    // blob. Without this, the backend saw settings_version=0 on every
+    // save and re-ran the v1→v2 migration on the next internal
+    // getSettings() call, silently resetting smart.max_age_days=0→7
+    // and smart.wake_drives=true→false. See issue #268 + the
+    // companion server-side floor in handleUpdateSettings.
+    settings_version: (base && base.settings_version) || 2,
     scan_interval: getScanInterval(),
     speedtest_interval: document.getElementById("speedtest-interval").value,
     speedtest_schedule: buildSpeedTestSchedule(),


### PR DESCRIPTION
## Summary

- **v0.9.8 regression hotfix**: SMART settings saves were corrupting the stored `settings_version` from `2` to `0`, which re-triggered the v1→v2 migration on the next internal `getSettings()` call and silently reset `smart.max_age_days=0 → 7` and `smart.wake_drives=true → false`.
- Three causal layers, fixed at two of them:
  - **Frontend** (primary): `buildSettingsPayload()` now includes `settings_version`, pulled from the loaded `base.settings_version` with a 2 fallback.
  - **Backend** (defence-in-depth + heal): `handleUpdateSettings()` now reads the stored blob, takes the max of stored/incoming `settings_version`, and floors at `currentSettingsVersion`. The client cannot downgrade or omit this field.
  - **Migration** (left alone, by design): the v1→v2 ladder is correct for real upgraders and only misfired because the pseudo-downgrade above put a v2 user back through it. Once `settings_version` round-trips cleanly, the migration is a no-op.
- Six regression tests added — three root-cause RED→GREEN on `main`, three end-to-end guards that pin the complete contract.

## Root cause

Quoted from issue #268:

> The payload object returned by `buildSettingsPayload()` does NOT include `settings_version`. So every PUT body has it missing. Backend unmarshals onto zero-value `Settings`, so `SettingsVersion = 0` gets persisted.
>
> The next internal `getSettings()` call re-runs `migrateSettings` which:
> 1. Sets `smart.max_age_days = 7` if the current value is `0` (intended to seed upgraders, misfires here)
> 2. Overrides `smart.wake_drives` with the legacy flat `wake_drives_for_smart` field (which is absent in v2 blobs, so it resolves to `false`)

## Fix

### Frontend — `internal/api/templates/settings.html` (7 lines including comment)

```js
return {
  // Preserve server-authoritative settings_version from the loaded
  // blob. …
  settings_version: (base && base.settings_version) || 2,
  scan_interval: getScanInterval(),
  // … rest unchanged
};
```

### Backend — `internal/api/api_extended.go` (15 lines including comment, in `handleUpdateSettings` right after the JSON unmarshal)

```go
// Preserve server-authoritative settings_version. …
if raw, err := s.store.GetConfig(settingsConfigKey); err == nil && raw != "" {
    var existing Settings
    if json.Unmarshal([]byte(raw), &existing) == nil && existing.SettingsVersion > settings.SettingsVersion {
        settings.SettingsVersion = existing.SettingsVersion
    }
}
if settings.SettingsVersion < currentSettingsVersion {
    settings.SettingsVersion = currentSettingsVersion
}
```

## Tests added

1. **`TestHandleUpdateSettings_PreservesStoredSettingsVersion`** (RED on `main`) — pins that a PUT omitting `settings_version` must not clobber a stored v2 down to 0. Catches the root-cause backend bug.
2. **`TestHandleUpdateSettings_ClientCannotDowngradeSettingsVersion`** (RED on `main`) — pins that an explicit client-sent `settings_version: 0` is ignored. Defence-in-depth.
3. **`TestSettingsHTMLPayloadIncludesSettingsVersion`** (RED on `main`) — parses `buildSettingsPayload()` out of the template via brace-matching and asserts `settings_version` appears in the returned object literal. Frontend regression guard.
4. **`TestHandleUpdateSettings_MaxAgeDaysZero_SurvivesInternalGetSettings`** (guard) — end-to-end: fixed frontend sends `settings_version: 2, max_age_days: 0`; dashboard load triggers `srv.getSettings()`; assert stored `max_age_days` is still 0 after the migrate+persist loop. The visible half of the bug.
5. **`TestHandleUpdateSettings_WakeDrivesTrue_SurvivesInternalGetSettings`** (guard) — same for `wake_drives: true`. The silent half of the bug.
6. **`TestMigrateSettings_V2UserTouchesSettings_DoesNotReMigrateZeroMaxAge`** (migration guard, added to `settings_smart_migration_test.go`) — pins that `migrateSettings` on a v2 blob with the edge-case combo (`max_age_days: 0, wake_drives: true`) is a no-op. Anchors the migration contract against future refactors.

Tests 1, 2, 3 fail on `062fa87` (v0.9.8 ship commit); all 6 pass after the two fix commits.

## Manual verification

```
$ go test ./... 2>&1 | tail -11
ok  	github.com/mcdays94/nas-doctor/cmd/nas-doctor	0.833s
?   	github.com/mcdays94/nas-doctor/internal	[no test files]
ok  	github.com/mcdays94/nas-doctor/internal/analyzer	0.443s
ok  	github.com/mcdays94/nas-doctor/internal/api	2.106s
ok  	github.com/mcdays94/nas-doctor/internal/collector	1.780s
?   	github.com/mcdays94/nas-doctor/internal/demo	[no test files]
?   	github.com/mcdays94/nas-doctor/internal/fleet	[no test files]
?   	github.com/mcdays94/nas-doctor/internal/logfwd	[no test files]
ok  	github.com/mcdays94/nas-doctor/internal/notifier	0.488s
ok  	github.com/mcdays94/nas-doctor/internal/scheduler	7.125s
ok  	github.com/mcdays94/nas-doctor/internal/storage	1.174s

$ go build ./... && echo "build OK"
build OK

$ go vet ./...
(no output)
```

All existing tests green. No unrelated regressions. Scope check confirms only `internal/api/` files touched (4 files: 1 source, 1 template, 2 test).

Docker build check skipped — no Dockerfile changes; Go stdlib-only diff; the CI workflow's `docker build` will re-verify on PR push.

## Healing

Existing v0.9.8 installs whose DB already contains `settings_version: 0` from this bug **self-heal on the next settings save** thanks to the backend's floor clause (`if settings.SettingsVersion < currentSettingsVersion { settings.SettingsVersion = currentSettingsVersion }`). Users do not need to manually edit `nas-doctor.db` or re-enter their SMART preferences — as long as they re-save their chosen `max_age_days` and `wake_drives` values once post-upgrade. The heal also applies to any internal `getSettings()` call since that path also floors the version on persist.

## Closes

Closes #268.