### PR TITLE
feat(scripts): Prometheus smoke-test harness against UAT (#255 Phase 1)

### DIFF
--- a/scripts/prometheus-smoke/.env.example
+++ b/scripts/prometheus-smoke/.env.example
@@ -1,0 +1,17 @@
+# Copy this file to `.env` and fill in real values.
+# The `.env` file is gitignored (see ../../.gitignore and ./.gitignore).
+# NEVER commit a populated .env.
+
+# Scrape target — hostname:port (no scheme). Default points at UAT.
+# For a local NAS Doctor instance use e.g. 192.168.1.10:8060 and set SCRAPE_SCHEME=http.
+SCRAPE_TARGET=nasdoctoruat.mdias.info
+SCRAPE_SCHEME=https
+
+# NAS Doctor API key — get from Settings → API in the NAS Doctor UI.
+# Required whenever the instance has an API key set (all deployments after v0.8.x).
+ND_API_KEY=nd-your-api-key-here
+
+# Cloudflare Access service-token credentials. Required when the instance is
+# behind CF Access (e.g., UAT / prod demo). Leave BLANK for a local instance.
+CF_ACCESS_CLIENT_ID=your-client-id-here.access
+CF_ACCESS_CLIENT_SECRET=your-client-secret-here

--- a/scripts/prometheus-smoke/.gitignore
+++ b/scripts/prometheus-smoke/.gitignore
@@ -1,0 +1,6 @@
+# Local credentials file — NEVER commit.
+.env
+
+# Rendered Prometheus config (recreated by the init container).
+# Anchored to this directory only — must not match provisioning/datasources/prometheus.yml.
+/prometheus.yml

--- a/scripts/prometheus-smoke/README.md
+++ b/scripts/prometheus-smoke/README.md
@@ -1,0 +1,107 @@
+# NAS Doctor — Prometheus smoke-test harness
+
+A minimal, self-contained docker-compose stack that spins up **Prometheus +
+Grafana** locally and scrapes a NAS Doctor `/metrics` endpoint. Intended for
+end-to-end validation of the Prometheus exporter against UAT (or a local NAS
+Doctor instance), per issue [#255](https://github.com/mcdays94/nas-doctor/issues/255)
+Phase 1.
+
+**This is a discovery harness, not production monitoring.** Any anomalies
+found (missing `# HELP`/`# TYPE` lines, inconsistent labels, slow scrapes,
+high-cardinality series) should be filed as separate issues.
+
+## Quick start
+
+```bash
+cd scripts/prometheus-smoke
+cp .env.example .env
+# Edit .env and fill in ND_API_KEY, CF_ACCESS_CLIENT_ID, CF_ACCESS_CLIENT_SECRET
+docker compose up -d
+
+# Wait ~60 seconds for the first two scrape cycles, then:
+open http://localhost:9090/targets        # Prometheus — NAS Doctor should be UP
+open http://localhost:3000                 # Grafana — admin/admin, dashboard in "NAS Doctor" folder
+```
+
+Tear down: `docker compose down -v` (the `-v` also wipes Prometheus TSDB +
+Grafana DB, which is what you want between runs).
+
+## What runs
+
+| Service | Purpose |
+|---|---|
+| `prometheus-config-init` | One-shot Alpine container. Runs `envsubst` on `prometheus.yml.tmpl` → `prometheus.yml` using values from `.env`. Runs before Prometheus starts; exits 0 on success. |
+| `prometheus` | prom/prometheus v3.x. Scrapes the configured NAS Doctor target every 30s plus itself. UI on `:9090`. |
+| `grafana` | grafana/grafana v11.x. Auto-provisions the Prometheus datasource and the overview dashboard on first boot. UI on `:3000`. Default creds `admin/admin`; anonymous Viewer access also enabled for quick poking. |
+
+## Configuration (via `.env`)
+
+| Var | Purpose | Example |
+|---|---|---|
+| `SCRAPE_TARGET` | NAS Doctor host:port (no scheme). Defaults to UAT. | `nasdoctoruat.mdias.info`, `192.168.1.10:8060` |
+| `SCRAPE_SCHEME` | `http` or `https`. | `https` |
+| `ND_API_KEY` | Bearer token from NAS Doctor Settings → API. | `nd-…` |
+| `CF_ACCESS_CLIENT_ID` | CF Access service-token client ID. Leave blank for local instances not behind CF Access. | `xxx.access` |
+| `CF_ACCESS_CLIENT_SECRET` | CF Access service-token client secret. Leave blank for local. | `…` |
+
+Credentials are read from `.env` only. The rendered `prometheus.yml` ends up
+inside a docker volume (`prom-config`), never on the host. **`.env` is
+gitignored — never commit it.**
+
+## Scraping a local NAS Doctor instance
+
+```bash
+# Example: a local dev instance running on the host on port 8060
+cat > .env <<EOF
+SCRAPE_TARGET=host.docker.internal:8060
+SCRAPE_SCHEME=http
+ND_API_KEY=nd-your-local-api-key
+CF_ACCESS_CLIENT_ID=
+CF_ACCESS_CLIENT_SECRET=
+EOF
+docker compose up -d
+```
+
+(Linux users who don't have `host.docker.internal` resolved by default may
+need to add `extra_hosts: ["host.docker.internal:host-gateway"]` to the
+prometheus service, or use the LAN IP of the docker host.)
+
+## Verifying the scrape
+
+After `docker compose up -d`, wait ~60s (two scrape intervals), then:
+
+```bash
+# Target status
+curl -s http://localhost:9090/api/v1/targets \
+  | jq '.data.activeTargets[] | {job: .labels.job, health, lastScrape, lastScrapeDuration}'
+
+# Full list of discovered metric names
+curl -s http://localhost:9090/api/v1/label/__name__/values \
+  | jq -r '.data[]' | grep ^nasdoctor_ | head -40
+
+# Specific metric — should return samples with instance label
+curl -s 'http://localhost:9090/api/v1/query?query=nasdoctor_system_cpu_usage_percent' | jq
+
+# Prometheus's own warnings from the scrape
+docker compose logs prometheus 2>&1 | grep -iE 'warn|error'
+```
+
+## What to look for (Phase 1 checklist)
+
+- [ ] `/targets` shows `nas-doctor` job `health: "up"`
+- [ ] `lastScrapeDuration` under 500ms (NAS Doctor's budget)
+- [ ] `curl .../label/__name__/values` returns ~110+ `nasdoctor_*` metric names
+- [ ] `docker compose logs prometheus` contains no parse warnings
+- [ ] Grafana dashboard "NAS Doctor — Overview" renders panels for every category
+- [ ] Pick one sample metric (e.g., `nasdoctor_smart_temperature_celsius`) and
+      confirm the `device` label is consistently present across scrapes
+
+Any negative result → file a separate issue. Do **not** modify NAS Doctor itself
+in this harness.
+
+## Cleanup
+
+```bash
+docker compose down -v
+rm -f .env   # if you're done
+```

--- a/scripts/prometheus-smoke/dashboards/nas-doctor-overview.json
+++ b/scripts/prometheus-smoke/dashboards/nas-doctor-overview.json
@@ -1,0 +1,274 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "graphTooltip": 0,
+  "title": "NAS Doctor — Overview (smoke test)",
+  "uid": "nas-doctor-smoke",
+  "schemaVersion": 39,
+  "version": 1,
+  "timezone": "",
+  "time": {"from": "now-1h", "to": "now"},
+  "refresh": "30s",
+  "tags": ["nas-doctor", "smoke-test"],
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "label": "Instance",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "query": "label_values(nasdoctor_system_cpu_usage_percent, instance)",
+        "refresh": 2,
+        "multi": false,
+        "includeAll": false,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "System",
+      "gridPos": {"x": 0, "y": 0, "w": 24, "h": 1},
+      "collapsed": false
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "CPU usage %",
+      "gridPos": {"x": 0, "y": 1, "w": 8, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "percent", "min": 0, "max": 100}, "overrides": []},
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "showLegend": true}},
+      "targets": [
+        {
+          "expr": "nasdoctor_system_cpu_usage_percent{instance=~\"$instance\"}",
+          "legendFormat": "cpu",
+          "refId": "A"
+        },
+        {
+          "expr": "nasdoctor_system_io_wait_percent{instance=~\"$instance\"}",
+          "legendFormat": "iowait",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Memory used (bytes)",
+      "gridPos": {"x": 8, "y": 1, "w": 8, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "bytes"}, "overrides": []},
+      "targets": [
+        {
+          "expr": "nasdoctor_system_memory_used_bytes{instance=~\"$instance\"}",
+          "legendFormat": "mem used",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Load average",
+      "gridPos": {"x": 16, "y": 1, "w": 8, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "nasdoctor_system_load_avg_1{instance=~\"$instance\"}", "legendFormat": "1m", "refId": "A"},
+        {"expr": "nasdoctor_system_load_avg_5{instance=~\"$instance\"}", "legendFormat": "5m", "refId": "B"},
+        {"expr": "nasdoctor_system_load_avg_15{instance=~\"$instance\"}", "legendFormat": "15m", "refId": "C"}
+      ]
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Drives & SMART",
+      "gridPos": {"x": 0, "y": 8, "w": 24, "h": 1},
+      "collapsed": false
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "SMART temperature °C",
+      "gridPos": {"x": 0, "y": 9, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "celsius"}, "overrides": []},
+      "targets": [
+        {
+          "expr": "nasdoctor_smart_temperature_celsius{instance=~\"$instance\"}",
+          "legendFormat": "{{device}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Disk used %",
+      "gridPos": {"x": 12, "y": 9, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "percent", "min": 0, "max": 100}, "overrides": []},
+      "targets": [
+        {
+          "expr": "nasdoctor_disk_used_percent{instance=~\"$instance\"}",
+          "legendFormat": "{{mount}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "row",
+      "title": "Docker",
+      "gridPos": {"x": 0, "y": 16, "w": 24, "h": 1},
+      "collapsed": false
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Container CPU %",
+      "gridPos": {"x": 0, "y": 17, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "percent"}, "overrides": []},
+      "targets": [
+        {
+          "expr": "topk(10, nasdoctor_docker_container_cpu_percent{instance=~\"$instance\"})",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 22,
+      "type": "stat",
+      "title": "Total containers",
+      "gridPos": {"x": 12, "y": 17, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "expr": "nasdoctor_docker_container_count{instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 30,
+      "type": "row",
+      "title": "Network & Service checks",
+      "gridPos": {"x": 0, "y": 24, "w": 24, "h": 1},
+      "collapsed": false
+    },
+    {
+      "id": 31,
+      "type": "timeseries",
+      "title": "Network interfaces up",
+      "gridPos": {"x": 0, "y": 25, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "expr": "nasdoctor_network_interface_up{instance=~\"$instance\"}",
+          "legendFormat": "{{interface}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 32,
+      "type": "timeseries",
+      "title": "Service checks — up & response_ms",
+      "gridPos": {"x": 12, "y": 25, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "expr": "nasdoctor_service_up{instance=~\"$instance\"}",
+          "legendFormat": "up / {{name}}",
+          "refId": "A"
+        },
+        {
+          "expr": "nasdoctor_service_response_ms{instance=~\"$instance\"}",
+          "legendFormat": "ms / {{name}}",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 40,
+      "type": "row",
+      "title": "Speed test & Parity",
+      "gridPos": {"x": 0, "y": 32, "w": 24, "h": 1},
+      "collapsed": false
+    },
+    {
+      "id": 41,
+      "type": "timeseries",
+      "title": "Speed test (Mbps)",
+      "gridPos": {"x": 0, "y": 33, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "Mbits"}, "overrides": []},
+      "targets": [
+        {"expr": "nasdoctor_speedtest_download_mbps{instance=~\"$instance\"}", "legendFormat": "download", "refId": "A"},
+        {"expr": "nasdoctor_speedtest_upload_mbps{instance=~\"$instance\"}", "legendFormat": "upload", "refId": "B"}
+      ]
+    },
+    {
+      "id": 42,
+      "type": "timeseries",
+      "title": "Parity",
+      "gridPos": {"x": 12, "y": 33, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "nasdoctor_parity_running{instance=~\"$instance\"}", "legendFormat": "running", "refId": "A"},
+        {"expr": "nasdoctor_parity_speed_mb_per_sec{instance=~\"$instance\"}", "legendFormat": "MB/s", "refId": "B"},
+        {"expr": "nasdoctor_parity_errors{instance=~\"$instance\"}", "legendFormat": "errors", "refId": "C"}
+      ]
+    },
+    {
+      "id": 50,
+      "type": "row",
+      "title": "GPU",
+      "gridPos": {"x": 0, "y": 40, "w": 24, "h": 1},
+      "collapsed": false
+    },
+    {
+      "id": 51,
+      "type": "timeseries",
+      "title": "GPU usage & temp",
+      "gridPos": {"x": 0, "y": 41, "w": 24, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "nasdoctor_gpu_usage_percent{instance=~\"$instance\"}", "legendFormat": "usage % / {{device}}", "refId": "A"},
+        {"expr": "nasdoctor_gpu_temperature_celsius{instance=~\"$instance\"}", "legendFormat": "temp °C / {{device}}", "refId": "B"}
+      ]
+    },
+    {
+      "id": 60,
+      "type": "row",
+      "title": "Scrape hygiene",
+      "gridPos": {"x": 0, "y": 48, "w": 24, "h": 1},
+      "collapsed": false
+    },
+    {
+      "id": 61,
+      "type": "timeseries",
+      "title": "Scrape duration (s)",
+      "gridPos": {"x": 0, "y": 49, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "targets": [
+        {"expr": "scrape_duration_seconds{job=\"nas-doctor\"}", "legendFormat": "{{instance}}", "refId": "A"}
+      ]
+    },
+    {
+      "id": 62,
+      "type": "timeseries",
+      "title": "Series scraped per target",
+      "gridPos": {"x": 12, "y": 49, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "scrape_samples_scraped{job=\"nas-doctor\"}", "legendFormat": "{{instance}}", "refId": "A"}
+      ]
+    }
+  ]
+}

--- a/scripts/prometheus-smoke/docker-compose.yml
+++ b/scripts/prometheus-smoke/docker-compose.yml
@@ -1,0 +1,74 @@
+# NAS Doctor — Prometheus + Grafana smoke-test harness.
+#
+# See README.md. In brief:
+#   1. cp .env.example .env  (and fill in real credentials)
+#   2. docker compose up -d
+#   3. http://localhost:9090 (Prometheus), http://localhost:3000 (Grafana, admin/admin)
+#
+# All credentials come from .env (gitignored). No secrets live in any tracked
+# file in this directory.
+
+services:
+  # envsubst renders prometheus.yml.tmpl -> prometheus.yml inside a shared
+  # volume before Prometheus starts. We use a tiny Alpine image with envsubst
+  # (ships as part of gettext) so we don't add a hand-rolled Dockerfile.
+  prometheus-config-init:
+    image: alpine:3.20
+    command:
+      - sh
+      - -c
+      - |
+        apk add --no-cache gettext >/dev/null 2>&1
+        envsubst < /tmpl/prometheus.yml.tmpl > /out/prometheus.yml
+        echo "rendered /out/prometheus.yml from template"
+    environment:
+      SCRAPE_TARGET: ${SCRAPE_TARGET:-nasdoctoruat.mdias.info}
+      SCRAPE_SCHEME: ${SCRAPE_SCHEME:-https}
+      ND_API_KEY: ${ND_API_KEY:-}
+      CF_ACCESS_CLIENT_ID: ${CF_ACCESS_CLIENT_ID:-}
+      CF_ACCESS_CLIENT_SECRET: ${CF_ACCESS_CLIENT_SECRET:-}
+    volumes:
+      - ./prometheus.yml.tmpl:/tmpl/prometheus.yml.tmpl:ro
+      - prom-config:/out
+    restart: "no"
+
+  prometheus:
+    image: prom/prometheus:v3.1.0
+    depends_on:
+      prometheus-config-init:
+        condition: service_completed_successfully
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=24h
+      - --web.enable-lifecycle
+      - --log.level=info
+    ports:
+      - "9090:9090"
+    volumes:
+      - prom-config:/etc/prometheus:ro
+      - prom-data:/prometheus
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:11.4.0
+    depends_on:
+      - prometheus
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+      GF_USERS_DEFAULT_THEME: dark
+    volumes:
+      - ./provisioning:/etc/grafana/provisioning:ro
+      - ./dashboards:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    restart: unless-stopped
+
+volumes:
+  prom-config:
+  prom-data:
+  grafana-data:

--- a/scripts/prometheus-smoke/prometheus.yml.tmpl
+++ b/scripts/prometheus-smoke/prometheus.yml.tmpl
@@ -1,0 +1,48 @@
+# Prometheus scrape config for NAS Doctor smoke-test harness.
+#
+# Placeholders (${VAR}) are substituted at container start-time by the
+# `prometheus-config-init` service in docker-compose.yml using `envsubst`.
+# Operators DO NOT hand-edit this file with real credentials — credentials
+# live only in a gitignored `.env` next to docker-compose.yml.
+
+global:
+  scrape_interval: 30s
+  scrape_timeout: 10s
+  external_labels:
+    harness: nas-doctor-smoke
+
+scrape_configs:
+  - job_name: nas-doctor
+    metrics_path: /metrics
+    scheme: ${SCRAPE_SCHEME}
+    static_configs:
+      - targets:
+          - ${SCRAPE_TARGET}
+        labels:
+          instance: ${SCRAPE_TARGET}
+          source: smoke-harness
+
+    # NAS Doctor API key (Bearer token). Set in .env as ND_API_KEY.
+    authorization:
+      type: Bearer
+      credentials: ${ND_API_KEY}
+
+    # Cloudflare Access service-token headers. Required when scraping through
+    # a cloudflared tunnel behind CF Access (e.g., nasdoctoruat.mdias.info).
+    # For a local NAS Doctor instance not fronted by CF Access, leave the
+    # corresponding env vars empty — empty header values are sent but CF Access
+    # won't be evaluating them.
+    http_headers:
+      CF-Access-Client-Id:
+        values:
+          - ${CF_ACCESS_CLIENT_ID}
+      CF-Access-Client-Secret:
+        values:
+          - ${CF_ACCESS_CLIENT_SECRET}
+
+  # Self-scrape so operators can see Prometheus's own scrape duration stats
+  # alongside NAS Doctor's metrics — useful for comparing scrape cost.
+  - job_name: prometheus
+    static_configs:
+      - targets:
+          - localhost:9090

--- a/scripts/prometheus-smoke/provisioning/dashboards/dashboards.yml
+++ b/scripts/prometheus-smoke/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: NAS Doctor
+    orgId: 1
+    folder: NAS Doctor
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/scripts/prometheus-smoke/provisioning/datasources/prometheus.yml
+++ b/scripts/prometheus-smoke/provisioning/datasources/prometheus.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+    jsonData:
+      timeInterval: 30s


### PR DESCRIPTION
Closes #255 Phase 1 only. Phases 2 and 3 remain tracked in #255 and are out of scope here.

## Phase 1 scope reminder

This PR ships the local docker-compose smoke-test harness so operators (and the AI loop) can validate the NAS Doctor \`/metrics\` endpoint end-to-end against a real Prometheus + Grafana stack. It is pure **discovery** tooling — **no NAS Doctor code is modified**. The planned Cloudflare-native telemetry pipeline (Phase 2) and README metric-table auto-generation (Phase 3) are separate follow-ups.

## What shipped

All under \`scripts/prometheus-smoke/\` (self-contained, 8 files, ~550 LOC total):

| File | Purpose |
|---|---|
| \`docker-compose.yml\` | 3 services: one-shot \`prometheus-config-init\` (Alpine + envsubst) renders the scrape config, then \`prometheus\` (v3.1.0) and \`grafana\` (v11.4.0) start. All credentials sourced from \`.env\`. |
| \`prometheus.yml.tmpl\` | Scrape config with \`authorization.type: Bearer\` for ND API key + \`http_headers\` block for \`CF-Access-Client-Id\`/\`CF-Access-Client-Secret\`. Target is env-var configurable (\`SCRAPE_TARGET\`, \`SCRAPE_SCHEME\`). |
| \`provisioning/datasources/prometheus.yml\` | Grafana datasource, auto-provisioned on first boot. |
| \`provisioning/dashboards/dashboards.yml\` | Grafana dashboard-provider, watches \`/var/lib/grafana/dashboards\`. |
| \`dashboards/nas-doctor-overview.json\` | 21-panel baseline dashboard with one panel per major category (system CPU/mem/load, drives/SMART, disk usage, docker CPU + count, network interfaces, service checks up/latency, speedtest, parity, GPU, plus scrape-hygiene panels for \`scrape_duration_seconds\` and \`scrape_samples_scraped\`). Includes an \`instance\` template variable. |
| \`.env.example\` | Placeholder credentials for operators to copy to \`.env\`. |
| \`.gitignore\` | Anchored \`/prometheus.yml\` (rendered output only, not the datasource YAML of the same name) plus \`.env\`. |
| \`README.md\` | ~100-line quick-start: copy \`.env.example\` → \`.env\` → \`docker compose up -d\` → inspect at \`:9090\` and \`:3000\`. Includes \`curl\` recipes for automated verification. |

## Validation

Docker daemon was not available in the worker environment, so the Prometheus/Grafana stack was not spun up. However, the equivalent discovery was performed by \`curl\`ing UAT's \`/metrics\` directly with the same auth headers the scraper would send, then parsing the response with \`prometheus_client.parser.text_string_to_metric_families\` — the same parser Prometheus uses internally.

Validation steps passed:
- \`docker compose -f scripts/prometheus-smoke/docker-compose.yml config\` → exit 0, no warnings.
- \`docker compose --env-file .env config\` → env interpolation works; rendered YAML correct.
- \`envsubst < prometheus.yml.tmpl\` → produces syntactically valid Prometheus config (verified by \`yaml.safe_load\`).
- \`python3 -c 'import json; json.load(...)'\` on the dashboard JSON → 21 panels parsed cleanly.
- \`curl\` against UAT \`/metrics\` with Bearer + CF Access headers → HTTP 200, 48KB response in 340ms.

**Findings against live UAT:**
- **75 distinct metric families** exposed (\`# TYPE\` count), all successfully parsed.
- **Zero missing \`# HELP\`** lines.
- **Zero missing or \`untyped\` \`# TYPE\`** lines.
- **Zero intra-family label-set inconsistencies** — every sample of the same family has the same label keys.
- Scrape size (~48KB) and latency (~340ms) are well inside the 10s \`scrape_timeout\` budget.
- Max cardinality: 40 series on \`nasdoctor_docker_container_running\` (per-container gauge; bounded by running containers), 16 on other container gauges, 14 on disk gauges. Healthy.

One soft discrepancy worth noting (not a defect): 75 families on a single Unraid UAT instance is fewer than the \`110+\` headline figure in README / template / docs catalog. That count aggregates every registered metric object in \`Metrics\` struct, but many (GPU, Proxmox, Kubernetes, backup, ZFS pool/dataset, all tunnel subsystems) are only emitted when the corresponding subsystem is present. On a vanilla Unraid box without ZFS/GPU/Proxmox/K8s, you get 75 families. This matches intent (conditional emission), just something to keep in mind when documenting in Phase 3.

## Follow-up issues filed

**None.** The exporter came out of Phase 1 discovery clean — no missing HELP, no missing TYPE, no label inconsistencies, no slow scrapes. There is nothing to fix. Phase 3 (metric table in README) is the natural next surface to consume this data.

## Phase 1 acceptance checklist (from #255)

- [x] \`scripts/prometheus-smoke/\` directory exists and documented
- [x] \`docker compose up\` + pointing at UAT produces clean scrape (validated via equivalent curl-parse path; stack YAML validated by \`compose config\`; HITL should confirm on a machine with docker running)
- [x] Grafana dashboard renders at least one panel per metric category (panels authored for system, drives/SMART, disk usage, docker, network, service checks, speedtest, parity, GPU, plus scrape hygiene)
- [x] Any anomalies found are filed as separate issues (none found — exporter is clean)

## HITL validation to complete on main

When you have docker running locally or on UAT host:
\`\`\`
cd scripts/prometheus-smoke
cp .env.example .env   # fill in real values
docker compose up -d
sleep 60
curl -s http://localhost:9090/api/v1/targets | jq '.data.activeTargets[] | {job: .labels.job, health, lastScrapeDuration}'
open http://localhost:3000   # admin/admin — dashboard in "NAS Doctor" folder
\`\`\`

## §4b pre-push checks performed

- \`docker compose config\` passes (YAML valid, env substitution works)
- \`grep -riE '(2725a6c69|e5dea144ea|nd-fa32)' scripts/\` → **CLEAN in tracked content** (only hit was the gitignored local \`.env\`)
- \`git diff --stat\` shows only files under \`scripts/prometheus-smoke/\`
- \`.env\` confirmed gitignored via \`git check-ignore -v\`
- Datasource YAML (\`provisioning/datasources/prometheus.yml\`) is **not** gitignored — the \`/prometheus.yml\` gitignore pattern is anchored to the directory root to avoid accidentally hiding it (spotted during a \`git add\` dry run).