### PR TITLE
feat(settings): Advanced Scan Settings slice 2a -- schema + interval pickers (no behaviour) (#259)

### DIFF
--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -374,14 +374,15 @@ func main() {
 		}
 		// Apply SMART standby-awareness preference on startup (#198). Default
 		// (false) uses `-n standby` so spun-down drives aren't woken by scans.
-		// Since schema v2 (#237) this lives under Settings.SMART.WakeDrives.
+		// Moved from Settings.SMART → Settings.AdvancedScans.SMART in
+		// schema v3 (#259).
 		if persistedSettings != nil {
 			coll.SetSMARTConfig(collector.SMARTConfig{
-				WakeDrives: persistedSettings.SMART.WakeDrives,
+				WakeDrives: persistedSettings.AdvancedScans.SMART.WakeDrives,
 			})
 			// Apply the max-age force-wake threshold on startup (#238).
 			// Scheduler owns this policy; 0 disables the safety net.
-			sched.SetSMARTMaxAgeDays(persistedSettings.SMART.MaxAgeDays)
+			sched.SetSMARTMaxAgeDays(persistedSettings.AdvancedScans.SMART.MaxAgeDays)
 		}
 		sched.Start()
 		defer sched.Stop()

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -50,13 +50,17 @@ type Settings struct {
 	SectionHeights    map[string]int          `json:"section_heights,omitempty"` // Persisted section resize heights (section name → px)
 	SectionOrder      map[string][]string     `json:"section_order,omitempty"`   // Persisted drag-and-drop column order ({"cols": [["findings","docker"], ...]})
 
-	// SMART holds the SMART-scan policy knobs surfaced under
-	// "Advanced Scan Settings" in the settings UI. Prior to schema
-	// v2 the only knob here (WakeDrives) lived at the top level of
-	// Settings as `wake_drives_for_smart`; the v1→v2 migration in
-	// getSettings() lifts that value into SMART.WakeDrives. See
-	// issues #236 (PRD) and #237 (this slice).
-	SMART SMARTSettings `json:"smart"`
+	// AdvancedScans holds the per-subsystem scan-policy knobs surfaced
+	// under "Advanced" in the settings UI. Introduced by schema v3
+	// (#239 / slice 2). Prior to v3 the SMART sub-struct lived at
+	// Settings.SMART; the v2→v3 migration in getSettings() relocates
+	// it into AdvancedScans.SMART and seeds IntervalSec=0 ("use
+	// global") for every new subsystem.
+	//
+	// Slice 2a (#259) only persists AdvancedScans.*.IntervalSec —
+	// the scheduler does NOT yet consume it. Slice 2b (#260) wires
+	// the values into the scan loop via a new ScanDispatcher.
+	AdvancedScans AdvancedScansSettings `json:"advanced_scans"`
 
 	// DockerHiddenContainers is a list of container names that should be
 	// omitted from the Docker Containers dashboard section. Exact-match
@@ -67,8 +71,38 @@ type Settings struct {
 	DockerHiddenContainers []string `json:"docker_hidden_containers,omitempty"`
 }
 
-// SMARTSettings groups SMART-scan policy. Added in schema v2 (#237).
-type SMARTSettings struct {
+// AdvancedScansSettings groups per-subsystem scan cadence policy.
+// Added in schema v3 (PRD #239 / slice 2a issue #259). Each sub-
+// struct carries at least an IntervalSec field; SMART carries the
+// slice-1 WakeDrives and MaxAgeDays knobs that it inherited from the
+// retired top-level Settings.SMART.
+type AdvancedScansSettings struct {
+	SMART      AdvancedScansSMART      `json:"smart"`
+	Docker     AdvancedScansSubsystem  `json:"docker"`
+	Proxmox    AdvancedScansSubsystem  `json:"proxmox"`
+	Kubernetes AdvancedScansSubsystem  `json:"kubernetes"`
+	ZFS        AdvancedScansSubsystem  `json:"zfs"`
+	GPU        AdvancedScansSubsystem  `json:"gpu"`
+}
+
+// AdvancedScansSubsystem is the minimal shape shared by the five
+// non-SMART configurable subsystems. IntervalSec is validated via
+// validScanIntervalSec(); see handleUpdateSettings.
+type AdvancedScansSubsystem struct {
+	// IntervalSec overrides the global scan_interval for this
+	// subsystem. 0 means "use global" (default, unchanged behaviour).
+	// Positive values must be in [30, 2678400] seconds (30s – 31d).
+	// Slice 2a only persists the value; slice 2b activates it.
+	IntervalSec int `json:"interval_sec"`
+}
+
+// AdvancedScansSMART extends AdvancedScansSubsystem with slice-1's
+// two scan-policy knobs. See SMARTSettings comments on pre-v3
+// Settings.SMART for history.
+type AdvancedScansSMART struct {
+	// IntervalSec — see AdvancedScansSubsystem.IntervalSec.
+	IntervalSec int `json:"interval_sec"`
+
 	// WakeDrives, when true, opts back into pre-v0.9.5 behaviour of
 	// reading SMART from spun-down drives each scan cycle (waking
 	// them). Default (false) is standby-aware: smartctl runs with
@@ -78,18 +112,41 @@ type SMARTSettings struct {
 	// MaxAgeDays bounds how long a drive may remain unread by SMART
 	// before the scheduler forces one wake-up to refresh SMART data.
 	// Default 7. Valid range 0-30. A value of 0 disables the
-	// safety-net entirely (preserves exact v0.9.5 behaviour). The
-	// scheduler does NOT yet consume this value — slice 1a (#237)
-	// only persists it; slice 1b (#238) wires it into the scan loop.
+	// safety-net entirely (preserves exact v0.9.5 behaviour).
+	// Scheduler-side wiring lives in #238.
 	MaxAgeDays int `json:"max_age_days"`
 }
 
-// SMARTMaxAgeDaysMax is the upper bound on Settings.SMART.MaxAgeDays.
+// SMARTMaxAgeDaysMax is the upper bound on AdvancedScans.SMART.MaxAgeDays.
 // A value of 0 disables the safety-net; values 1-30 are valid.
 // Enforced in handleUpdateSettings and in the UI input element.
 const SMARTMaxAgeDaysMax = 30
 
-const currentSettingsVersion = 2
+// ScanIntervalSecMin is the minimum positive value accepted for any
+// AdvancedScans.*.IntervalSec field. Below this, the scheduler's tick
+// rate would be pathologically fast; 30 seconds gives some headroom
+// above the 5-second service-check cadence. 0 is always valid
+// (= "use global"). PRD #239 user story 13.
+const ScanIntervalSecMin = 30
+
+// ScanIntervalSecMax is the 31-day ceiling on any
+// AdvancedScans.*.IntervalSec field. Users who want "effectively
+// disabled" cadence on a subsystem can dial it to this ceiling; a
+// future slice 3 may introduce explicit disable semantics.
+// PRD #239 user story 13.
+const ScanIntervalSecMax = 2678400 // 31 days
+
+// validScanIntervalSec returns true when v is 0 ("use global") or
+// within [ScanIntervalSecMin, ScanIntervalSecMax]. Canonical for
+// both server-side validation and any future client-parity check.
+func validScanIntervalSec(v int) bool {
+	if v == 0 {
+		return true
+	}
+	return v >= ScanIntervalSecMin && v <= ScanIntervalSecMax
+}
+
+const currentSettingsVersion = 3
 
 // DashboardSections controls which sections appear on the dashboard.
 // All default to true (visible). Users can hide sections they don't use.
@@ -303,9 +360,20 @@ func defaultSettings() Settings {
 			DashColumns: 3,
 		},
 		ChartRangeHours: 1,
-		SMART: SMARTSettings{
-			WakeDrives: false,
-			MaxAgeDays: 7,
+		AdvancedScans: AdvancedScansSettings{
+			SMART: AdvancedScansSMART{
+				WakeDrives:  false,
+				MaxAgeDays:  7,
+				IntervalSec: 0, // use global
+			},
+			// All five non-SMART configurable subsystems default to
+			// "use global" (IntervalSec=0). Preserves exact pre-v3
+			// behaviour for fresh installs. PRD #239 user story 10.
+			Docker:     AdvancedScansSubsystem{IntervalSec: 0},
+			Proxmox:    AdvancedScansSubsystem{IntervalSec: 0},
+			Kubernetes: AdvancedScansSubsystem{IntervalSec: 0},
+			ZFS:        AdvancedScansSubsystem{IntervalSec: 0},
+			GPU:        AdvancedScansSubsystem{IntervalSec: 0},
 		},
 	}
 }
@@ -831,16 +899,42 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 	if settings.LogPush.Destinations == nil {
 		settings.LogPush.Destinations = []LogForwardDestination{}
 	}
-	// SMART scan policy validation (#237). The UI clamps client-side
-	// but a direct API caller could still submit out-of-range values;
-	// reject rather than silently clamping so the caller knows their
-	// input was ignored. 0 is valid (safety net disabled, PRD #236
-	// user story 5); 1-30 inclusive is the active range.
-	if settings.SMART.MaxAgeDays < 0 || settings.SMART.MaxAgeDays > SMARTMaxAgeDaysMax {
+	// SMART scan policy validation (#237). Since schema v3 (#259) the
+	// SMART knobs live under AdvancedScans.SMART. UI clamps client-
+	// side but a direct API caller could still submit out-of-range
+	// values; reject rather than silently clamping. 0 is valid
+	// (safety net disabled, PRD #236 user story 5); 1-30 is the
+	// active range.
+	if settings.AdvancedScans.SMART.MaxAgeDays < 0 || settings.AdvancedScans.SMART.MaxAgeDays > SMARTMaxAgeDaysMax {
 		writeJSON(w, http.StatusBadRequest, map[string]string{
-			"error": fmt.Sprintf("smart.max_age_days must be between 0 and %d (0 disables the safety net)", SMARTMaxAgeDaysMax),
+			"error": fmt.Sprintf("advanced_scans.smart.max_age_days must be between 0 and %d (0 disables the safety net)", SMARTMaxAgeDaysMax),
 		})
 		return
+	}
+
+	// Per-subsystem IntervalSec validation (#259, PRD #239 user story
+	// 13). Valid set: {0} ∪ [ScanIntervalSecMin, ScanIntervalSecMax].
+	// Check all six subsystems; return the first offender with a
+	// message that names both the field path and the valid range.
+	intervalChecks := []struct {
+		name  string
+		value int
+	}{
+		{"advanced_scans.smart.interval_sec", settings.AdvancedScans.SMART.IntervalSec},
+		{"advanced_scans.docker.interval_sec", settings.AdvancedScans.Docker.IntervalSec},
+		{"advanced_scans.proxmox.interval_sec", settings.AdvancedScans.Proxmox.IntervalSec},
+		{"advanced_scans.kubernetes.interval_sec", settings.AdvancedScans.Kubernetes.IntervalSec},
+		{"advanced_scans.zfs.interval_sec", settings.AdvancedScans.ZFS.IntervalSec},
+		{"advanced_scans.gpu.interval_sec", settings.AdvancedScans.GPU.IntervalSec},
+	}
+	for _, ic := range intervalChecks {
+		if !validScanIntervalSec(ic.value) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{
+				"error": fmt.Sprintf("%s=%d is out of range (must be 0 for 'use global', or in [%d, %d] seconds)",
+					ic.name, ic.value, ScanIntervalSecMin, ScanIntervalSecMax),
+			})
+			return
+		}
 	}
 
 	// Retention defaults and bounds
@@ -941,15 +1035,16 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 			InCluster: settings.Kubernetes.InCluster,
 		})
 
-		// Update SMART config on the collector (#198, nested under
-		// Settings.SMART since schema v2 — see #237).
+		// Update SMART config on the collector (#198). Moved from
+		// Settings.SMART → Settings.AdvancedScans.SMART in schema v3
+		// (#259); the value meaning is unchanged.
 		s.collector.SetSMARTConfig(collector.SMARTConfig{
-			WakeDrives: settings.SMART.WakeDrives,
+			WakeDrives: settings.AdvancedScans.SMART.WakeDrives,
 		})
 		// Update the max-age safety-net threshold on the scheduler
 		// (#238). The scheduler owns this policy (the collector stays
 		// DB-unaware) and applies it after each scan's Collect().
-		s.scheduler.SetSMARTMaxAgeDays(settings.SMART.MaxAgeDays)
+		s.scheduler.SetSMARTMaxAgeDays(settings.AdvancedScans.SMART.MaxAgeDays)
 
 		// Update log forwarding
 		if settings.LogPush.Enabled && len(settings.LogPush.Destinations) > 0 {
@@ -1184,38 +1279,91 @@ func (s *Server) getSettings() Settings {
 //
 //   - v0 → v1: sections.merged_drives defaults to true (historical)
 //   - v1 → v2: lift legacy top-level wake_drives_for_smart into
-//     Settings.SMART.WakeDrives; seed Settings.SMART.MaxAgeDays = 7
-//     for upgraders that never had the field (#236/#237).
+//     SMART.WakeDrives; seed SMART.MaxAgeDays = 7 for upgraders
+//     that never had the field (#236/#237). Note: in v2 this
+//     target was Settings.SMART; since v3 it is
+//     Settings.AdvancedScans.SMART. The shim target has moved —
+//     the meaning is unchanged.
+//   - v2 → v3: relocate Settings.SMART.{WakeDrives, MaxAgeDays}
+//     into Settings.AdvancedScans.SMART.{WakeDrives, MaxAgeDays};
+//     seed AdvancedScans.*.IntervalSec = 0 ("use global") for all
+//     six configurable subsystems (PRD #239 user stories 10, 11).
 //
-// The function is idempotent: running it against an already-v2 blob
-// preserves the persisted smart.wake_drives / smart.max_age_days
-// values verbatim (the legacy field shim is only consulted when the
-// stored schema version is below 2).
+// Shape-based gating (defence-in-depth against #268 regression class):
+// each rung is guarded by BOTH the settings_version number AND a
+// presence check against the raw JSON. A blob that is structurally
+// already at v3 (has a top-level "advanced_scans" object) skips the
+// v1 and v2 shims regardless of what settings_version says. This
+// ensures a corrupted version=0 blob with intact v3 fields does not
+// silently re-seed user-chosen zeros.
+//
+// The function is idempotent at every version: running it against an
+// already-current blob preserves persisted values verbatim, including
+// explicit zeros (PRD #236 / #268 regression class).
 func migrateSettings(raw []byte, base Settings) Settings {
 	// Note: json.Unmarshal onto base preserves default field values
-	// when the incoming JSON omits them — critical for SMART.MaxAgeDays
-	// since old blobs will not contain smart.max_age_days at all.
+	// when the incoming JSON omits them — critical for
+	// AdvancedScans.SMART.MaxAgeDays since old blobs will not contain
+	// the nested path at all.
 	_ = json.Unmarshal(raw, &base)
+
+	// Shape sentinels. Decode the raw JSON once into a loose map to
+	// check which top-level shape markers are present.
+	var shape map[string]json.RawMessage
+	_ = json.Unmarshal(raw, &shape)
+	_, hasAdvancedScans := shape["advanced_scans"]
+	_, hasFlatSMART := shape["smart"]
 
 	if base.SettingsVersion < 1 {
 		base.Sections.MergedDrives = true
 	}
 
-	if base.SettingsVersion < 2 {
-		// Legacy shim: v1 stored WakeDrives at the top level. Unmarshal
-		// a second time into a shadow struct to recover that field.
+	// v1 → v2 shim fires only if the blob does NOT already carry a
+	// v2-or-later shape marker (flat "smart" object or nested
+	// "advanced_scans" object). This protects explicit user zeros in
+	// v3 blobs whose settings_version was corrupted to 0.
+	if base.SettingsVersion < 2 && !hasFlatSMART && !hasAdvancedScans {
 		var legacy struct {
 			WakeDrivesForSMART bool `json:"wake_drives_for_smart"`
 		}
 		_ = json.Unmarshal(raw, &legacy)
-		base.SMART.WakeDrives = legacy.WakeDrivesForSMART
+		base.AdvancedScans.SMART.WakeDrives = legacy.WakeDrivesForSMART
 		// Every upgrader lands on the default 7-day ceiling regardless
-		// of whether the raw blob carries a smart.max_age_days value
-		// (it can't — the field didn't exist before v2). PRD #236 user
-		// story 2: the safety net opts in by default on upgrade.
-		if base.SMART.MaxAgeDays == 0 {
-			base.SMART.MaxAgeDays = 7
+		// of whether the raw blob carries max_age_days (it can't —
+		// the field didn't exist before v2). PRD #236 user story 2:
+		// the safety net opts in by default on upgrade.
+		if base.AdvancedScans.SMART.MaxAgeDays == 0 {
+			base.AdvancedScans.SMART.MaxAgeDays = 7
 		}
+	}
+
+	// v2 → v3 relocation fires only if the blob does NOT already
+	// carry the v3 shape marker. If "advanced_scans" is present, the
+	// main json.Unmarshal above already populated AdvancedScans from
+	// the input verbatim — nothing more to do.
+	if base.SettingsVersion < 3 && !hasAdvancedScans {
+		// Shadow-unmarshal to recover the v2 "smart" shape, then lift
+		// values onto the v3 target. Pointer-valued shadow lets us
+		// distinguish "field absent" from "field explicitly zero", so
+		// a v2 user's max_age_days=0 survives.
+		var legacyV2 struct {
+			SMART *struct {
+				WakeDrives *bool `json:"wake_drives"`
+				MaxAgeDays *int  `json:"max_age_days"`
+			} `json:"smart"`
+		}
+		_ = json.Unmarshal(raw, &legacyV2)
+		if legacyV2.SMART != nil {
+			if legacyV2.SMART.WakeDrives != nil {
+				base.AdvancedScans.SMART.WakeDrives = *legacyV2.SMART.WakeDrives
+			}
+			if legacyV2.SMART.MaxAgeDays != nil {
+				base.AdvancedScans.SMART.MaxAgeDays = *legacyV2.SMART.MaxAgeDays
+			}
+		}
+		// No IntervalSec in v2 — every subsystem defaults to 0 ("use
+		// global") on the v3 target, already the zero value of
+		// AdvancedScansSubsystem{}. No action needed.
 	}
 
 	return base

--- a/internal/api/settings_advanced_scans_migration_test.go
+++ b/internal/api/settings_advanced_scans_migration_test.go
@@ -1,0 +1,327 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestMigrateSettings_V2toV3_LiftsSMARTIntoAdvancedScans covers user
+// story 11 of PRD #239: a user with slice-1 (#237) config gets
+// WakeDrives and MaxAgeDays preserved verbatim across the v2→v3
+// reshape that relocates them inside the new AdvancedScans umbrella.
+//
+// Input: v2 blob with the flat "smart": {...} object.
+// Expected: v3-shape output with advanced_scans.smart.{wake_drives,
+// max_age_days, interval_sec}. WakeDrives + MaxAgeDays preserve the
+// input values; IntervalSec defaults to 0 ("use global"), since it
+// did not exist in v2.
+func TestMigrateSettings_V2toV3_LiftsSMARTIntoAdvancedScans(t *testing.T) {
+	raw := []byte(`{
+		"settings_version": 2,
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"smart": {
+			"wake_drives": true,
+			"max_age_days": 14
+		}
+	}`)
+
+	got := migrateSettings(raw, defaultSettings())
+	if got.SettingsVersion < currentSettingsVersion {
+		got.SettingsVersion = currentSettingsVersion
+	}
+
+	if got.SettingsVersion != 3 {
+		t.Errorf("settings_version: got %d, want 3", got.SettingsVersion)
+	}
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives: got false, want true (should be preserved from v2 smart block)")
+	}
+	if got.AdvancedScans.SMART.MaxAgeDays != 14 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 14 (should be preserved from v2 smart block)", got.AdvancedScans.SMART.MaxAgeDays)
+	}
+	if got.AdvancedScans.SMART.IntervalSec != 0 {
+		t.Errorf("advanced_scans.smart.interval_sec: got %d, want 0 (new field seeded at 'use global')", got.AdvancedScans.SMART.IntervalSec)
+	}
+}
+
+// TestMigrateSettings_V2toV3_SeedsAllSubsystemIntervalsToZero pins
+// PRD #239 user story 10: every fresh slice-2 install and every
+// upgrader lands on "use global" for all six configurable subsystems.
+func TestMigrateSettings_V2toV3_SeedsAllSubsystemIntervalsToZero(t *testing.T) {
+	raw := []byte(`{
+		"settings_version": 2,
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"smart": {"wake_drives": false, "max_age_days": 7}
+	}`)
+
+	got := migrateSettings(raw, defaultSettings())
+
+	if got.AdvancedScans.SMART.IntervalSec != 0 {
+		t.Errorf("advanced_scans.smart.interval_sec: got %d, want 0", got.AdvancedScans.SMART.IntervalSec)
+	}
+	if got.AdvancedScans.Docker.IntervalSec != 0 {
+		t.Errorf("advanced_scans.docker.interval_sec: got %d, want 0", got.AdvancedScans.Docker.IntervalSec)
+	}
+	if got.AdvancedScans.Proxmox.IntervalSec != 0 {
+		t.Errorf("advanced_scans.proxmox.interval_sec: got %d, want 0", got.AdvancedScans.Proxmox.IntervalSec)
+	}
+	if got.AdvancedScans.Kubernetes.IntervalSec != 0 {
+		t.Errorf("advanced_scans.kubernetes.interval_sec: got %d, want 0", got.AdvancedScans.Kubernetes.IntervalSec)
+	}
+	if got.AdvancedScans.ZFS.IntervalSec != 0 {
+		t.Errorf("advanced_scans.zfs.interval_sec: got %d, want 0", got.AdvancedScans.ZFS.IntervalSec)
+	}
+	if got.AdvancedScans.GPU.IntervalSec != 0 {
+		t.Errorf("advanced_scans.gpu.interval_sec: got %d, want 0", got.AdvancedScans.GPU.IntervalSec)
+	}
+}
+
+// TestMigrateSettings_V1toV2toV3_ChainedIntegrity pins the
+// complete upgrade path: a v1 blob climbs through both migration rungs
+// and lands in a v3 shape with all slice-1 intent preserved.
+// Covers the user stated in PRD #239 user story 11 layered on top of
+// PRD #236 user story from slice 1.
+func TestMigrateSettings_V1toV2toV3_ChainedIntegrity(t *testing.T) {
+	raw := []byte(`{
+		"settings_version": 1,
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"wake_drives_for_smart": true
+	}`)
+
+	got := migrateSettings(raw, defaultSettings())
+	if got.SettingsVersion < currentSettingsVersion {
+		got.SettingsVersion = currentSettingsVersion
+	}
+
+	if got.SettingsVersion != 3 {
+		t.Errorf("settings_version: got %d, want 3 (full v1→v2→v3 climb)", got.SettingsVersion)
+	}
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives: got false, want true (lifted from legacy wake_drives_for_smart via v1→v2→v3 chain)")
+	}
+	if got.AdvancedScans.SMART.MaxAgeDays != 7 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 7 (seeded by v1→v2 then preserved through v2→v3)", got.AdvancedScans.SMART.MaxAgeDays)
+	}
+	if got.AdvancedScans.SMART.IntervalSec != 0 {
+		t.Errorf("advanced_scans.smart.interval_sec: got %d, want 0", got.AdvancedScans.SMART.IntervalSec)
+	}
+}
+
+// TestMigrateSettings_V3_Idempotent confirms a v3-shaped blob is
+// passed through unchanged. Every subsequent read of the persisted
+// config hits this path, so it must not mutate preserved values —
+// including edge cases like explicit user zeros.
+func TestMigrateSettings_V3_Idempotent(t *testing.T) {
+	raw := []byte(`{
+		"settings_version": 3,
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"advanced_scans": {
+			"smart":      {"wake_drives": true, "max_age_days": 14, "interval_sec": 604800},
+			"docker":     {"interval_sec": 300},
+			"proxmox":    {"interval_sec": 7200},
+			"kubernetes": {"interval_sec": 0},
+			"zfs":        {"interval_sec": 7200},
+			"gpu":        {"interval_sec": 0}
+		}
+	}`)
+
+	got := migrateSettings(raw, defaultSettings())
+
+	if got.SettingsVersion != 3 {
+		t.Errorf("settings_version: got %d, want 3 preserved", got.SettingsVersion)
+	}
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives: got false, want true (should not be clobbered)")
+	}
+	if got.AdvancedScans.SMART.MaxAgeDays != 14 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 14 (should not be reseeded)", got.AdvancedScans.SMART.MaxAgeDays)
+	}
+	if got.AdvancedScans.SMART.IntervalSec != 604800 {
+		t.Errorf("advanced_scans.smart.interval_sec: got %d, want 604800 (should not be reset)", got.AdvancedScans.SMART.IntervalSec)
+	}
+	if got.AdvancedScans.Docker.IntervalSec != 300 {
+		t.Errorf("advanced_scans.docker.interval_sec: got %d, want 300", got.AdvancedScans.Docker.IntervalSec)
+	}
+	if got.AdvancedScans.Proxmox.IntervalSec != 7200 {
+		t.Errorf("advanced_scans.proxmox.interval_sec: got %d, want 7200", got.AdvancedScans.Proxmox.IntervalSec)
+	}
+	if got.AdvancedScans.ZFS.IntervalSec != 7200 {
+		t.Errorf("advanced_scans.zfs.interval_sec: got %d, want 7200", got.AdvancedScans.ZFS.IntervalSec)
+	}
+}
+
+// TestMigrateSettings_V3_PreservesExplicitZeros is the direct
+// descendant of the #268 regression guard for slice-2. A v3 blob
+// whose user deliberately chose zero on a field (max_age_days=0 as
+// "no safety net"; interval_sec=0 everywhere as "use global") must
+// survive migrateSettings verbatim — no silent re-seeding on re-read.
+//
+// Companion to TestMigrateSettings_V2_PreservesMaxAgeDaysZero in
+// settings_smart_migration_test.go. If this test fails we're
+// re-introducing the class of data-loss bug that #268 fixed.
+func TestMigrateSettings_V3_PreservesExplicitZeros(t *testing.T) {
+	raw := []byte(`{
+		"settings_version": 3,
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"advanced_scans": {
+			"smart":      {"wake_drives": false, "max_age_days": 0, "interval_sec": 0},
+			"docker":     {"interval_sec": 0},
+			"proxmox":    {"interval_sec": 0},
+			"kubernetes": {"interval_sec": 0},
+			"zfs":        {"interval_sec": 0},
+			"gpu":        {"interval_sec": 0}
+		}
+	}`)
+
+	got := migrateSettings(raw, defaultSettings())
+
+	if got.AdvancedScans.SMART.MaxAgeDays != 0 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 0 (user explicitly disabled safety net)", got.AdvancedScans.SMART.MaxAgeDays)
+	}
+	if got.AdvancedScans.SMART.IntervalSec != 0 {
+		t.Errorf("advanced_scans.smart.interval_sec: got %d, want 0 preserved", got.AdvancedScans.SMART.IntervalSec)
+	}
+	if got.SettingsVersion != 3 {
+		t.Errorf("settings_version: got %d, want 3 preserved (must not slip back to 0 and retrigger migrations — #268 class of bug)", got.SettingsVersion)
+	}
+}
+
+// TestMigrateSettings_V3_ExplicitZeroVersionNotReClobbered pins the
+// interaction between the new v3 shape and the #273 settings_version
+// clamp. A blob whose on-disk settings_version is 0 (corrupted by a
+// pre-#273 client) but that has otherwise-explicit v3 AdvancedScans
+// fields set to zero values must NOT be silently repopulated by a
+// re-migration. The caller (getSettings) stamps version back up to
+// currentSettingsVersion after migrateSettings returns; migrateSettings
+// itself should not re-seed user-chosen zeros even when the stored
+// version looks old, provided the v3 shape is recognizable.
+func TestMigrateSettings_V3_ExplicitZeroVersionNotReClobbered(t *testing.T) {
+	// This is the post-#273 world: the client must send
+	// settings_version; the server preserves it. But defence-in-depth
+	// against future regressions — if a v3-shaped blob ever appears
+	// with settings_version=0, we should treat it as v3 (the presence
+	// of advanced_scans is the authoritative shape marker) and not
+	// silently clobber the zero-values.
+	raw := []byte(`{
+		"settings_version": 0,
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"advanced_scans": {
+			"smart":      {"wake_drives": true, "max_age_days": 0, "interval_sec": 0},
+			"docker":     {"interval_sec": 0},
+			"proxmox":    {"interval_sec": 0},
+			"kubernetes": {"interval_sec": 0},
+			"zfs":        {"interval_sec": 0},
+			"gpu":        {"interval_sec": 0}
+		}
+	}`)
+
+	got := migrateSettings(raw, defaultSettings())
+
+	// max_age_days=0 must survive even though the version looks old;
+	// the v2→v3 migration path should NOT fire because the
+	// advanced_scans object already exists in the input.
+	if got.AdvancedScans.SMART.MaxAgeDays != 0 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 0 (user explicitly disabled; must not be re-seeded)", got.AdvancedScans.SMART.MaxAgeDays)
+	}
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives: got false, want true (explicit user value must survive re-migration)")
+	}
+}
+
+// TestGetSettings_V2toV3_PersistsMigration closes the loop end-to-end
+// through the HTTP-facing getSettings() function: a stored v2 blob is
+// transparently migrated to v3 on first read, and the persisted
+// representation on the store is rewritten so subsequent reads skip
+// the migration. Mirrors the slice-1 test
+// TestGetSettings_V1toV2_PersistsMigration.
+func TestGetSettings_V2toV3_PersistsMigration(t *testing.T) {
+	srv := newSettingsTestServer()
+	if err := srv.store.SetConfig(settingsConfigKey, `{
+		"settings_version": 2,
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"smart": {
+			"wake_drives": true,
+			"max_age_days": 14
+		}
+	}`); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+
+	loaded := srv.getSettings()
+	if loaded.SettingsVersion != 3 {
+		t.Errorf("loaded settings_version: got %d, want 3", loaded.SettingsVersion)
+	}
+	if !loaded.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("loaded advanced_scans.smart.wake_drives: got false, want true")
+	}
+	if loaded.AdvancedScans.SMART.MaxAgeDays != 14 {
+		t.Errorf("loaded advanced_scans.smart.max_age_days: got %d, want 14", loaded.AdvancedScans.SMART.MaxAgeDays)
+	}
+
+	// Subsequent read: the stored blob must now be v3-shaped.
+	raw, err := srv.store.GetConfig(settingsConfigKey)
+	if err != nil {
+		t.Fatalf("re-read stored settings: %v", err)
+	}
+	var persisted map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &persisted); err != nil {
+		t.Fatalf("parse persisted settings: %v", err)
+	}
+	if v, _ := persisted["settings_version"].(float64); int(v) != 3 {
+		t.Errorf("persisted settings_version: got %v, want 3 (migration must rewrite the store)", persisted["settings_version"])
+	}
+	advScans, ok := persisted["advanced_scans"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("persisted settings missing advanced_scans object: %v", persisted["advanced_scans"])
+	}
+	smartMap, ok := advScans["smart"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("persisted advanced_scans missing smart object: %v", advScans["smart"])
+	}
+	if wd, _ := smartMap["wake_drives"].(bool); !wd {
+		t.Errorf("persisted advanced_scans.smart.wake_drives: got %v, want true", smartMap["wake_drives"])
+	}
+	if mad, _ := smartMap["max_age_days"].(float64); int(mad) != 14 {
+		t.Errorf("persisted advanced_scans.smart.max_age_days: got %v, want 14", smartMap["max_age_days"])
+	}
+}
+
+// TestSettingsDefault_AdvancedScans_NestedDefaults pins the defaults
+// for the new Settings.AdvancedScans sub-struct (PRD #239). Fresh
+// installs land on IntervalSec=0 for every configurable subsystem
+// (PRD user story 10) and keep slice-1's WakeDrives=false,
+// MaxAgeDays=7 SMART defaults.
+func TestSettingsDefault_AdvancedScans_NestedDefaults(t *testing.T) {
+	d := defaultSettings()
+	if d.SettingsVersion != 3 {
+		t.Errorf("defaultSettings().SettingsVersion = %d, want 3 (bumped by slice 2 PRD #239)", d.SettingsVersion)
+	}
+	if d.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("defaultSettings().AdvancedScans.SMART.WakeDrives must be false (#198 standby-aware default)")
+	}
+	if d.AdvancedScans.SMART.MaxAgeDays != 7 {
+		t.Errorf("defaultSettings().AdvancedScans.SMART.MaxAgeDays = %d, want 7 (slice 1 default, preserved across v2→v3)", d.AdvancedScans.SMART.MaxAgeDays)
+	}
+	if d.AdvancedScans.SMART.IntervalSec != 0 {
+		t.Errorf("defaultSettings().AdvancedScans.SMART.IntervalSec = %d, want 0 (use global)", d.AdvancedScans.SMART.IntervalSec)
+	}
+	subsystems := map[string]int{
+		"docker":     d.AdvancedScans.Docker.IntervalSec,
+		"proxmox":    d.AdvancedScans.Proxmox.IntervalSec,
+		"kubernetes": d.AdvancedScans.Kubernetes.IntervalSec,
+		"zfs":        d.AdvancedScans.ZFS.IntervalSec,
+		"gpu":        d.AdvancedScans.GPU.IntervalSec,
+	}
+	for name, v := range subsystems {
+		if v != 0 {
+			t.Errorf("defaultSettings().AdvancedScans.%s.IntervalSec = %d, want 0", name, v)
+		}
+	}
+}

--- a/internal/api/settings_advanced_scans_pickers_test.go
+++ b/internal/api/settings_advanced_scans_pickers_test.go
@@ -1,0 +1,220 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSettingsHTML_AdvancedScans_HasCreateIntervalPickerHelper pins
+// the existence of the reusable JS helper that generates the six
+// per-subsystem interval pickers. Per PRD #239 the helper is
+// parameterised by (subsystemId, label) and returns markup wiring up
+// a preset dropdown, custom d/h/m/s panel, live preview, cron
+// visualizer, and an "edit cron" button.
+//
+// We use template-source assertions (same pattern as
+// settings_smart_version_roundtrip_test.go) — the helper's internal
+// markup can change without breaking this test, but its existence
+// as a named function with the documented signature cannot.
+func TestSettingsHTML_AdvancedScans_HasCreateIntervalPickerHelper(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.html: %v", err)
+	}
+	content := string(data)
+
+	mustContain := []string{
+		// Helper declaration. We allow either `function x(...)`
+		// syntax or `var x = function(...)` by matching the name +
+		// opening paren — both valid for the PRD contract.
+		"createIntervalPicker",
+		// Both parameter slots must appear in the signature.
+		// Matching the literal "subsystemId" keeps the assertion
+		// resilient to `(subsystemId, label)` or
+		// `(subsystemId,label)` formatting.
+		"subsystemId",
+	}
+	for _, sub := range mustContain {
+		if !strings.Contains(content, sub) {
+			t.Errorf("settings.html missing createIntervalPicker helper contract symbol: %q", sub)
+		}
+	}
+}
+
+// TestSettingsHTML_AdvancedScans_SixPickerInstantiations pins that
+// the PRD's six subsystems each get their own picker in the Advanced
+// card. Per the spec: SMART's picker sits next to the existing
+// wake-drives and max-age controls; Docker / Proxmox / Kubernetes /
+// ZFS / GPU group under a "Per-subsystem scan intervals" sub-section.
+//
+// We assert presence of a stable id per picker anchor — any shape
+// the worker chooses is fine (e.g. `scan-interval-<id>`) so long as
+// it's searchable + stable.
+func TestSettingsHTML_AdvancedScans_SixPickerInstantiations(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.html: %v", err)
+	}
+	content := string(data)
+
+	// Each picker must mount its markup against a stable per-subsystem
+	// id. We match `scan-interval-<subsystem>` as the convention —
+	// parallel to `scan-preset` for the global widget.
+	subsystems := []string{"smart", "docker", "proxmox", "kubernetes", "zfs", "gpu"}
+	for _, s := range subsystems {
+		want := "scan-interval-" + s
+		if !strings.Contains(content, want) {
+			t.Errorf("settings.html missing picker anchor %q (expected one picker per subsystem per PRD #239)", want)
+		}
+	}
+
+	// Sub-section header anchor for the non-SMART five must exist,
+	// per the PRD: "Docker / Proxmox / Kubernetes / ZFS / GPU group
+	// under a new Per-subsystem scan intervals sub-section".
+	if !strings.Contains(content, "Per-subsystem scan intervals") {
+		t.Errorf("settings.html missing the 'Per-subsystem scan intervals' sub-section header")
+	}
+}
+
+// TestSettingsHTML_AdvancedScans_PickersInsideAdvancedCard pins that
+// all six pickers live inside the single id="card-advanced" block
+// (per #256 reversal — Advanced Scan Settings is one card, not two).
+func TestSettingsHTML_AdvancedScans_PickersInsideAdvancedCard(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.html: %v", err)
+	}
+	content := string(data)
+
+	cardIdx := strings.Index(content, `id="card-advanced"`)
+	if cardIdx < 0 {
+		t.Fatalf("card-advanced block not found")
+	}
+	rel := strings.Index(content[cardIdx+1:], `<div class="card"`)
+	var cardEnd int
+	if rel < 0 {
+		cardEnd = len(content)
+	} else {
+		cardEnd = cardIdx + 1 + rel
+	}
+	body := content[cardIdx:cardEnd]
+
+	for _, s := range []string{"smart", "docker", "proxmox", "kubernetes", "zfs", "gpu"} {
+		want := "scan-interval-" + s
+		if !strings.Contains(body, want) {
+			t.Errorf("Advanced card body missing picker anchor %q — all six pickers must live inside card-advanced", want)
+		}
+	}
+
+	// SMART picker is colocated with the wake-drives/max-age group —
+	// the picker anchor must appear before the existing Hide-Docker
+	// knob (which sits at the end of the SMART group in the template).
+	smartPickerIdx := strings.Index(body, "scan-interval-smart")
+	hideDockerIdx := strings.Index(body, "Hide Docker containers from dashboard")
+	if smartPickerIdx < 0 || hideDockerIdx < 0 {
+		t.Fatalf("missing ordering markers (smartPicker=%d hideDocker=%d)", smartPickerIdx, hideDockerIdx)
+	}
+	// The Per-subsystem intervals header should appear after the SMART
+	// picker and the Hide-Docker knob is independent — but we at least
+	// pin that the sub-section header is somewhere inside this card.
+	if !strings.Contains(body, "Per-subsystem scan intervals") {
+		t.Errorf("Advanced card body missing 'Per-subsystem scan intervals' sub-section header")
+	}
+}
+
+// TestSettingsHTML_AdvancedScans_ReverseCronParserExists pins the
+// existence of the JS function that translates a simple interval
+// cron expression back into d/h/m/s fields. Per PRD #239 user story
+// 8 the function handles four supported forms (`*/Ns`, `*/N * * * *`,
+// `0 */N * * *`, `0 0 */N * *`). Complex crons must produce a UI
+// error — PRD user story 14.
+func TestSettingsHTML_AdvancedScans_ReverseCronParserExists(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.html: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "parseCronToFields") {
+		t.Errorf("settings.html missing parseCronToFields() function (PRD #239 user story 8)")
+	}
+	// The UI error for unsupported crons must mention "simple"
+	// (per PRD user story 14's recommended copy).
+	if !strings.Contains(strings.ToLower(content), "simple interval cron") {
+		t.Errorf("settings.html missing UI error copy mentioning 'simple interval cron' for unsupported cron input (PRD user story 14)")
+	}
+}
+
+// TestSettingsHTML_AdvancedScans_ConfirmDialogOnMaxAgeConflict pins
+// the client-side confirm() dialog wiring described by PRD #239 user
+// story 12: saving a config with SMART.IntervalSec > MaxAgeDays *
+// 86400 (both non-zero) triggers a confirm() explaining the
+// consequence before the PUT fires.
+//
+// We use source-level assertions: the saveSettings path (or a
+// pre-save hook it calls) must include a confirm() call whose
+// surrounding logic references both smart interval and max-age.
+func TestSettingsHTML_AdvancedScans_ConfirmDialogOnMaxAgeConflict(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.html: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "confirm(") {
+		t.Errorf("settings.html has no confirm() call; expected max-age-vs-SMART-interval confirmation dialog (PRD #239 user story 12)")
+	}
+
+	// Locate the max-age conflict guard by comment marker or the
+	// canonical helper name. The worker may choose either shape —
+	// both satisfy the PRD. If neither appears, the guard is missing.
+	lower := strings.ToLower(content)
+	if !strings.Contains(lower, "max_age") && !strings.Contains(lower, "max-age") {
+		t.Fatalf("settings.html has no max-age references; cannot locate the confirm guard")
+	}
+	// The guard must compute the 86400 multiplier (days → seconds).
+	if !strings.Contains(content, "86400") {
+		t.Errorf("settings.html missing 86400 multiplier — expected SMART.IntervalSec vs MaxAgeDays*86400 comparison (PRD user story 12)")
+	}
+}
+
+// TestSettingsHTML_AdvancedScans_PickerPresetOptions pins the preset
+// dropdown's canonical option values per PRD #239: "Use global (30m)"
+// first, then the seven time presets, plus a "Custom…" fallback.
+//
+// We can't easily match each <option> element because createIntervalPicker
+// may build them via innerHTML or DOM insertion. Instead we match the
+// string literals the helper must emit — "Use global", one of each
+// preset value, "Custom".
+func TestSettingsHTML_AdvancedScans_PickerPresetOptions(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.html: %v", err)
+	}
+	content := string(data)
+
+	// These are the literal preset label-or-value markers that must
+	// appear somewhere inside the helper/picker markup.
+	mustContain := []string{
+		"Use global",
+		// Seven preset durations; we look for the distinct 7-day
+		// marker from PRD user story 3 as a sentinel.
+		"7d",
+		// Custom fallback from the general-scan-interval widget
+		// pattern; the new pickers replicate this.
+		"Custom",
+	}
+	for _, sub := range mustContain {
+		if !strings.Contains(content, sub) {
+			t.Errorf("settings.html missing preset-option marker %q inside the interval-picker helper (PRD #239 user story 7)", sub)
+		}
+	}
+}

--- a/internal/api/settings_advanced_scans_validation_test.go
+++ b/internal/api/settings_advanced_scans_validation_test.go
@@ -1,0 +1,216 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestHandleUpdateSettings_AdvancedScans_IntervalSec_RangeRejected
+// pins server-side validation for advanced_scans.*.interval_sec.
+// Valid set: {0} ∪ [30, 2678400] (0 = "use global", 30s = minimum
+// positive cadence to keep the scheduler tick sensible, 2678400 = 31
+// days = effectively-disabled ceiling). Per PRD #239 user story 13.
+//
+// The UI clamps client-side but a direct API caller could still
+// submit out-of-range values; the server must reject with 400 and a
+// clear message that names the offending field + the valid range.
+func TestHandleUpdateSettings_AdvancedScans_IntervalSec_RangeRejected(t *testing.T) {
+	cases := []struct {
+		name        string
+		subsystem   string
+		intervalSec int
+		wantStatus  int
+	}{
+		{"zero is valid (use global)", "docker", 0, http.StatusOK},
+		{"thirty is the minimum positive", "docker", 30, http.StatusOK},
+		{"five minutes", "docker", 300, http.StatusOK},
+		{"one day", "docker", 86400, http.StatusOK},
+		{"31 days (maximum)", "docker", 2678400, http.StatusOK},
+		{"one second rejected (below 30)", "docker", 1, http.StatusBadRequest},
+		{"twenty-nine seconds rejected (below 30)", "docker", 29, http.StatusBadRequest},
+		{"31 days plus one rejected", "docker", 2678401, http.StatusBadRequest},
+		{"one year rejected", "docker", 31536000, http.StatusBadRequest},
+		{"negative rejected", "docker", -1, http.StatusBadRequest},
+		// Exercise SMART (has extra fields besides IntervalSec but
+		// the IntervalSec bound check applies identically).
+		{"smart: out of range rejected", "smart", 29, http.StatusBadRequest},
+		{"smart: valid 7-day interval", "smart", 604800, http.StatusOK},
+		// Exercise all 6 subsystems at a valid value to confirm
+		// every field gets validated.
+		{"proxmox: valid 1-hour interval", "proxmox", 3600, http.StatusOK},
+		{"kubernetes: out-of-range rejected", "kubernetes", 10, http.StatusBadRequest},
+		{"zfs: valid 2-hour interval", "zfs", 7200, http.StatusOK},
+		{"gpu: out-of-range rejected", "gpu", 2678401, http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newSettingsTestServer()
+			scans := map[string]interface{}{
+				"smart":      map[string]interface{}{"wake_drives": false, "max_age_days": 7, "interval_sec": 0},
+				"docker":     map[string]interface{}{"interval_sec": 0},
+				"proxmox":    map[string]interface{}{"interval_sec": 0},
+				"kubernetes": map[string]interface{}{"interval_sec": 0},
+				"zfs":        map[string]interface{}{"interval_sec": 0},
+				"gpu":        map[string]interface{}{"interval_sec": 0},
+			}
+			// Overwrite the relevant subsystem with the test value.
+			sub := scans[tc.subsystem].(map[string]interface{})
+			sub["interval_sec"] = tc.intervalSec
+			scans[tc.subsystem] = sub
+
+			body, _ := json.Marshal(map[string]interface{}{
+				"settings_version": 3,
+				"scan_interval":    "30m",
+				"theme":            "midnight",
+				"advanced_scans":   scans,
+			})
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			srv.handleUpdateSettings(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Errorf("%s=%d returned %d, want %d; body=%s",
+					tc.subsystem, tc.intervalSec, rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if tc.wantStatus == http.StatusBadRequest {
+				lower := strings.ToLower(rec.Body.String())
+				// Error message must name the offending subsystem and
+				// the field so users know exactly which input to fix.
+				if !strings.Contains(lower, "interval_sec") {
+					t.Errorf("400 body should name interval_sec; got: %s", rec.Body.String())
+				}
+				if !strings.Contains(lower, tc.subsystem) {
+					t.Errorf("400 body should name subsystem %q; got: %s", tc.subsystem, rec.Body.String())
+				}
+			}
+		})
+	}
+}
+
+// TestHandleUpdateSettings_AdvancedScans_RoundTrip exercises PUT→GET
+// for the full AdvancedScans shape. Non-default values for every
+// subsystem must survive the round trip intact.
+func TestHandleUpdateSettings_AdvancedScans_RoundTrip(t *testing.T) {
+	srv := newSettingsTestServer()
+
+	put := map[string]interface{}{
+		"settings_version": 3,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"advanced_scans": map[string]interface{}{
+			"smart":      map[string]interface{}{"wake_drives": true, "max_age_days": 14, "interval_sec": 604800},
+			"docker":     map[string]interface{}{"interval_sec": 300},
+			"proxmox":    map[string]interface{}{"interval_sec": 3600},
+			"kubernetes": map[string]interface{}{"interval_sec": 7200},
+			"zfs":        map[string]interface{}{"interval_sec": 7200},
+			"gpu":        map[string]interface{}{"interval_sec": 0},
+		},
+	}
+	body, _ := json.Marshal(put)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.handleUpdateSettings(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PUT returned %d: %s", rr.Code, rr.Body.String())
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	rr2 := httptest.NewRecorder()
+	srv.handleGetSettings(rr2, req2)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("GET returned %d", rr2.Code)
+	}
+	var got Settings
+	if err := json.Unmarshal(rr2.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse GET response: %v", err)
+	}
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives did not round-trip")
+	}
+	if got.AdvancedScans.SMART.MaxAgeDays != 14 {
+		t.Errorf("advanced_scans.smart.max_age_days did not round-trip; got %d", got.AdvancedScans.SMART.MaxAgeDays)
+	}
+	if got.AdvancedScans.SMART.IntervalSec != 604800 {
+		t.Errorf("advanced_scans.smart.interval_sec did not round-trip; got %d", got.AdvancedScans.SMART.IntervalSec)
+	}
+	if got.AdvancedScans.Docker.IntervalSec != 300 {
+		t.Errorf("advanced_scans.docker.interval_sec did not round-trip; got %d", got.AdvancedScans.Docker.IntervalSec)
+	}
+	if got.AdvancedScans.Proxmox.IntervalSec != 3600 {
+		t.Errorf("advanced_scans.proxmox.interval_sec did not round-trip; got %d", got.AdvancedScans.Proxmox.IntervalSec)
+	}
+	if got.AdvancedScans.Kubernetes.IntervalSec != 7200 {
+		t.Errorf("advanced_scans.kubernetes.interval_sec did not round-trip; got %d", got.AdvancedScans.Kubernetes.IntervalSec)
+	}
+	if got.AdvancedScans.ZFS.IntervalSec != 7200 {
+		t.Errorf("advanced_scans.zfs.interval_sec did not round-trip; got %d", got.AdvancedScans.ZFS.IntervalSec)
+	}
+	if got.AdvancedScans.GPU.IntervalSec != 0 {
+		t.Errorf("advanced_scans.gpu.interval_sec did not round-trip; got %d", got.AdvancedScans.GPU.IntervalSec)
+	}
+}
+
+// TestHandleUpdateSettings_AdvancedScans_InvalidDoesNotPersist ensures
+// an out-of-range PUT does NOT partially persist. Subsequent GET must
+// see the pre-edit state (mirrors the SMART.MaxAgeDays equivalent).
+func TestHandleUpdateSettings_AdvancedScans_InvalidDoesNotPersist(t *testing.T) {
+	srv := newSettingsTestServer()
+
+	good, _ := json.Marshal(map[string]interface{}{
+		"settings_version": 3,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"advanced_scans": map[string]interface{}{
+			"smart":      map[string]interface{}{"wake_drives": false, "max_age_days": 7, "interval_sec": 0},
+			"docker":     map[string]interface{}{"interval_sec": 300},
+			"proxmox":    map[string]interface{}{"interval_sec": 0},
+			"kubernetes": map[string]interface{}{"interval_sec": 0},
+			"zfs":        map[string]interface{}{"interval_sec": 0},
+			"gpu":        map[string]interface{}{"interval_sec": 0},
+		},
+	})
+	rec := httptest.NewRecorder()
+	srv.handleUpdateSettings(rec, httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(good)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("seed PUT failed: %d %s", rec.Code, rec.Body.String())
+	}
+
+	bad, _ := json.Marshal(map[string]interface{}{
+		"settings_version": 3,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"advanced_scans": map[string]interface{}{
+			"smart":      map[string]interface{}{"wake_drives": false, "max_age_days": 7, "interval_sec": 0},
+			"docker":     map[string]interface{}{"interval_sec": 5},
+			"proxmox":    map[string]interface{}{"interval_sec": 0},
+			"kubernetes": map[string]interface{}{"interval_sec": 0},
+			"zfs":        map[string]interface{}{"interval_sec": 0},
+			"gpu":        map[string]interface{}{"interval_sec": 0},
+		},
+	})
+	rec2 := httptest.NewRecorder()
+	srv.handleUpdateSettings(rec2, httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(bad)))
+	if rec2.Code != http.StatusBadRequest {
+		t.Fatalf("invalid PUT must return 400, got %d: %s", rec2.Code, rec2.Body.String())
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	rec3 := httptest.NewRecorder()
+	srv.handleGetSettings(rec3, req)
+	if rec3.Code != http.StatusOK {
+		t.Fatalf("GET failed: %d", rec3.Code)
+	}
+	var got Settings
+	if err := json.Unmarshal(rec3.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse GET: %v", err)
+	}
+	if got.AdvancedScans.Docker.IntervalSec != 300 {
+		t.Errorf("docker.interval_sec leaked from rejected PUT: got %d, want 300 (seeded value)", got.AdvancedScans.Docker.IntervalSec)
+	}
+}

--- a/internal/api/settings_js_parses_test.go
+++ b/internal/api/settings_js_parses_test.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestSettingsTemplate_JSBlocksParse asserts every <script> block in
+// settings.html is valid JavaScript. Shells out to `node --check` if
+// available; otherwise skips (so CI without node is not blocked).
+//
+// Why this test exists: v0.9.9-rc1 shipped with a /* */ block comment
+// containing the sequence `*/N s` (documenting cron examples), which
+// closes the JS block comment prematurely. The entire <script> block
+// failed to parse, silently breaking loadSettings(),
+// renderAdvancedScanPickers(), loadDockerHiddenContainersCheckboxes(),
+// and every onchange-driven save handler. Symptom on hardware UAT:
+// Max-age input stuck on the static HTML default (value="7"), pickers
+// not rendered, Hide-Docker list stuck on "Loading containers…", no
+// Settings-Saved toast, changes reverted on refresh.
+//
+// No existing test would have caught this because template-source
+// greps only verify that specific strings appear in the rendered
+// HTML — they do not exercise JS parseability.
+func TestSettingsTemplate_JSBlocksParse(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node binary not in PATH; skipping JS parse check (dev-time guard only)")
+	}
+
+	blocks := extractScriptBlocks(SettingsPage)
+	if len(blocks) == 0 {
+		t.Fatal("no <script>...</script> blocks found in settings.html")
+	}
+
+	for i, js := range blocks {
+		if strings.TrimSpace(js) == "" {
+			continue // external <script src="..."> tags produce empty bodies
+		}
+		cmd := exec.Command("node", "--check", "-")
+		cmd.Stdin = strings.NewReader(js)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Errorf("settings.html <script> block %d failed to parse as JS:\n%s", i, string(out))
+		}
+	}
+}
+
+// extractScriptBlocks returns the bodies of every <script>...</script>
+// pair in tpl, in document order. External <script src="..."> tags
+// have empty bodies and are returned as empty strings (the caller
+// filters those out — they're served as separate static assets and
+// not inline JS under our control).
+//
+// Intentionally naive: no attribute parsing, no nested-script
+// handling (HTML disallows nesting). Adequate for our template shape.
+func extractScriptBlocks(tpl string) []string {
+	var out []string
+	cursor := 0
+	for {
+		openStart := strings.Index(tpl[cursor:], "<script")
+		if openStart < 0 {
+			break
+		}
+		openStart += cursor
+		openEnd := strings.Index(tpl[openStart:], ">")
+		if openEnd < 0 {
+			break
+		}
+		openEnd += openStart + 1 // position after the '>'
+		closeIdx := strings.Index(tpl[openEnd:], "</script>")
+		if closeIdx < 0 {
+			break
+		}
+		closeIdx += openEnd
+		out = append(out, tpl[openEnd:closeIdx])
+		cursor = closeIdx + len("</script>")
+	}
+	return out
+}

--- a/internal/api/settings_smart_migration_test.go
+++ b/internal/api/settings_smart_migration_test.go
@@ -10,8 +10,9 @@ import (
 // is automatically preserved across the schema migration.
 //
 // Input: v1 blob with the legacy flat wake_drives_for_smart=true field.
-// Expected: v2-shape output with smart.wake_drives=true, seeded
-// smart.max_age_days=7, and settings_version bumped to 2.
+// Expected: WakeDrives=true on the target SMART sub-struct (v2 put
+// this under Settings.SMART; v3 moves it to Settings.AdvancedScans.SMART
+// via the v2→v3 ladder — see #259). Asserts the final v3 shape here.
 func TestMigrateSettings_V1toV2_LiftsWakeDrivesForSMART(t *testing.T) {
 	raw := []byte(`{
 		"settings_version": 1,
@@ -27,14 +28,14 @@ func TestMigrateSettings_V1toV2_LiftsWakeDrivesForSMART(t *testing.T) {
 		got.SettingsVersion = currentSettingsVersion
 	}
 
-	if got.SettingsVersion != 2 {
-		t.Errorf("settings_version: got %d, want 2", got.SettingsVersion)
+	if got.SettingsVersion != currentSettingsVersion {
+		t.Errorf("settings_version: got %d, want %d", got.SettingsVersion, currentSettingsVersion)
 	}
-	if !got.SMART.WakeDrives {
-		t.Errorf("smart.wake_drives: got false, want true (lifted from wake_drives_for_smart)")
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives: got false, want true (lifted from wake_drives_for_smart)")
 	}
-	if got.SMART.MaxAgeDays != 7 {
-		t.Errorf("smart.max_age_days: got %d, want 7 (PRD #236 user story 2 default)", got.SMART.MaxAgeDays)
+	if got.AdvancedScans.SMART.MaxAgeDays != 7 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 7 (PRD #236 user story 2 default)", got.AdvancedScans.SMART.MaxAgeDays)
 	}
 }
 
@@ -52,18 +53,17 @@ func TestMigrateSettings_V1toV2_SeedsMaxAgeDaysForOptedOutUpgrader(t *testing.T)
 
 	got := migrateSettings(raw, defaultSettings())
 
-	if got.SMART.WakeDrives {
-		t.Errorf("smart.wake_drives: got true, want false (no legacy opt-in present)")
+	if got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives: got true, want false (no legacy opt-in present)")
 	}
-	if got.SMART.MaxAgeDays != 7 {
-		t.Errorf("smart.max_age_days: got %d, want 7 (seeded for every upgrader)", got.SMART.MaxAgeDays)
+	if got.AdvancedScans.SMART.MaxAgeDays != 7 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 7 (seeded for every upgrader)", got.AdvancedScans.SMART.MaxAgeDays)
 	}
 }
 
 // TestMigrateSettings_V2_Idempotent confirms that a v2-shaped blob is
-// passed through unchanged. Running the migration on an already-
-// migrated blob is the code path hit on every subsequent read of the
-// persisted config, so it must not mutate preserved values.
+// passed through and lifted onto the v3 shape: WakeDrives and
+// MaxAgeDays values survive the v2→v3 relocation.
 func TestMigrateSettings_V2_Idempotent(t *testing.T) {
 	raw := []byte(`{
 		"settings_version": 2,
@@ -76,24 +76,26 @@ func TestMigrateSettings_V2_Idempotent(t *testing.T) {
 	}`)
 
 	got := migrateSettings(raw, defaultSettings())
+	if got.SettingsVersion < currentSettingsVersion {
+		got.SettingsVersion = currentSettingsVersion
+	}
 
-	if got.SettingsVersion != 2 {
-		t.Errorf("settings_version: got %d, want 2 preserved", got.SettingsVersion)
+	if got.SettingsVersion != currentSettingsVersion {
+		t.Errorf("settings_version: got %d, want %d", got.SettingsVersion, currentSettingsVersion)
 	}
-	if !got.SMART.WakeDrives {
-		t.Errorf("smart.wake_drives: got false, want true (should not be clobbered)")
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives: got false, want true (should not be clobbered by v2→v3 relocation)")
 	}
-	if got.SMART.MaxAgeDays != 14 {
-		t.Errorf("smart.max_age_days: got %d, want 14 (should not be reseeded)", got.SMART.MaxAgeDays)
+	if got.AdvancedScans.SMART.MaxAgeDays != 14 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 14 (should not be reseeded)", got.AdvancedScans.SMART.MaxAgeDays)
 	}
 }
 
 // TestMigrateSettings_V2UserTouchesSettings_DoesNotReMigrateZeroMaxAge
 // pins the combined preservation contract after issue #268: a v2 blob
 // with the full spectrum of edge-case user choices (explicit
-// max_age_days=0 AND wake_drives=true) passes through migrateSettings
-// unchanged. The v1→v2 ladder MUST NOT fire once SettingsVersion is
-// already 2, no matter what SMART values were chosen.
+// max_age_days=0 AND wake_drives=true) survives both the v1→v2 ladder
+// and the v2→v3 relocation with values intact.
 func TestMigrateSettings_V2UserTouchesSettings_DoesNotReMigrateZeroMaxAge(t *testing.T) {
 	raw := []byte(`{
 		"settings_version": 2,
@@ -106,15 +108,18 @@ func TestMigrateSettings_V2UserTouchesSettings_DoesNotReMigrateZeroMaxAge(t *tes
 	}`)
 
 	got := migrateSettings(raw, defaultSettings())
+	if got.SettingsVersion < currentSettingsVersion {
+		got.SettingsVersion = currentSettingsVersion
+	}
 
-	if got.SettingsVersion != 2 {
-		t.Errorf("settings_version: got %d, want 2 preserved", got.SettingsVersion)
+	if got.SettingsVersion != currentSettingsVersion {
+		t.Errorf("settings_version: got %d, want %d", got.SettingsVersion, currentSettingsVersion)
 	}
-	if got.SMART.MaxAgeDays != 0 {
-		t.Errorf("smart.max_age_days: got %d, want 0 (explicit user zero must survive — was the visible half of #268)", got.SMART.MaxAgeDays)
+	if got.AdvancedScans.SMART.MaxAgeDays != 0 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 0 (explicit user zero must survive — was the visible half of #268)", got.AdvancedScans.SMART.MaxAgeDays)
 	}
-	if !got.SMART.WakeDrives {
-		t.Errorf("smart.wake_drives: got false, want true (explicit user true must survive — was the silent half of #268)")
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives: got false, want true (explicit user true must survive — was the silent half of #268)")
 	}
 }
 
@@ -135,17 +140,18 @@ func TestMigrateSettings_V2_PreservesMaxAgeDaysZero(t *testing.T) {
 
 	got := migrateSettings(raw, defaultSettings())
 
-	if got.SMART.MaxAgeDays != 0 {
-		t.Errorf("smart.max_age_days: got %d, want 0 (user explicitly disabled the safety net — must be preserved)", got.SMART.MaxAgeDays)
+	if got.AdvancedScans.SMART.MaxAgeDays != 0 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 0 (user explicitly disabled the safety net — must be preserved)", got.AdvancedScans.SMART.MaxAgeDays)
 	}
 }
 
 // TestGetSettings_V1toV2_PersistsMigration closes the loop end-to-end
 // through the HTTP-facing getSettings() function: a stored v1 blob is
-// transparently migrated to v2 on first read, and the persisted
-// representation on the store is rewritten so subsequent reads skip
-// the migration path. This guards against a subtle regression where
-// the migration only applies in-memory and the stored blob stays v1.
+// transparently migrated to the current version on first read, and the
+// persisted representation is rewritten so subsequent reads skip the
+// migration path. Since the current version is now v3 (#259), the end
+// state assertions target the v3 shape; slice-1 intent (WakeDrives
+// lift, MaxAgeDays seed) is preserved inside advanced_scans.smart.
 func TestGetSettings_V1toV2_PersistsMigration(t *testing.T) {
 	srv := newSettingsTestServer()
 	if err := srv.store.SetConfig(settingsConfigKey, `{
@@ -158,18 +164,17 @@ func TestGetSettings_V1toV2_PersistsMigration(t *testing.T) {
 	}
 
 	loaded := srv.getSettings()
-	if loaded.SettingsVersion != 2 {
-		t.Errorf("loaded settings_version: got %d, want 2", loaded.SettingsVersion)
+	if loaded.SettingsVersion != currentSettingsVersion {
+		t.Errorf("loaded settings_version: got %d, want %d", loaded.SettingsVersion, currentSettingsVersion)
 	}
-	if !loaded.SMART.WakeDrives {
-		t.Errorf("loaded smart.wake_drives: got false, want true")
+	if !loaded.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("loaded advanced_scans.smart.wake_drives: got false, want true")
 	}
-	if loaded.SMART.MaxAgeDays != 7 {
-		t.Errorf("loaded smart.max_age_days: got %d, want 7", loaded.SMART.MaxAgeDays)
+	if loaded.AdvancedScans.SMART.MaxAgeDays != 7 {
+		t.Errorf("loaded advanced_scans.smart.max_age_days: got %d, want 7", loaded.AdvancedScans.SMART.MaxAgeDays)
 	}
 
-	// Subsequent read: the stored blob must now be v2-shaped, so a
-	// fresh migrateSettings invocation on it is an idempotent no-op.
+	// Subsequent read: the stored blob must now be v3-shaped.
 	raw, err := srv.store.GetConfig(settingsConfigKey)
 	if err != nil {
 		t.Fatalf("re-read stored settings: %v", err)
@@ -178,17 +183,21 @@ func TestGetSettings_V1toV2_PersistsMigration(t *testing.T) {
 	if err := json.Unmarshal([]byte(raw), &persisted); err != nil {
 		t.Fatalf("parse persisted settings: %v", err)
 	}
-	if v, _ := persisted["settings_version"].(float64); int(v) != 2 {
-		t.Errorf("persisted settings_version: got %v, want 2 (migration must rewrite the store)", persisted["settings_version"])
+	if v, _ := persisted["settings_version"].(float64); int(v) != currentSettingsVersion {
+		t.Errorf("persisted settings_version: got %v, want %d (migration must rewrite the store)", persisted["settings_version"], currentSettingsVersion)
 	}
-	smartMap, ok := persisted["smart"].(map[string]interface{})
+	advScans, ok := persisted["advanced_scans"].(map[string]interface{})
 	if !ok {
-		t.Fatalf("persisted settings missing nested smart object: %v", persisted["smart"])
+		t.Fatalf("persisted settings missing advanced_scans object: %v", persisted["advanced_scans"])
+	}
+	smartMap, ok := advScans["smart"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("persisted advanced_scans missing smart object: %v", advScans["smart"])
 	}
 	if wd, _ := smartMap["wake_drives"].(bool); !wd {
-		t.Errorf("persisted smart.wake_drives: got %v, want true", smartMap["wake_drives"])
+		t.Errorf("persisted advanced_scans.smart.wake_drives: got %v, want true", smartMap["wake_drives"])
 	}
 	if mad, _ := smartMap["max_age_days"].(float64); int(mad) != 7 {
-		t.Errorf("persisted smart.max_age_days: got %v, want 7", smartMap["max_age_days"])
+		t.Errorf("persisted advanced_scans.smart.max_age_days: got %v, want 7", smartMap["max_age_days"])
 	}
 }

--- a/internal/api/settings_smart_schema_test.go
+++ b/internal/api/settings_smart_schema_test.go
@@ -10,35 +10,41 @@ import (
 )
 
 // TestSettingsDefault_SMART_NestedDefaults guards the defaults for
-// the new Settings.SMART sub-struct introduced by issue #237. Every
-// fresh install (and every upgrader via the migration in getSettings)
-// must land on these concrete defaults:
+// the SMART sub-struct. Originally introduced by issue #237 under
+// Settings.SMART; relocated to Settings.AdvancedScans.SMART by #259.
+// Every fresh install (and every upgrader via the migration in
+// getSettings) must land on these concrete defaults:
 //   - WakeDrives = false (unchanged from v0.9.5 #198 standby-aware default)
-//   - MaxAgeDays = 7     (new; safety-net threshold documented in PRD #236)
+//   - MaxAgeDays = 7     (safety-net threshold documented in PRD #236)
 func TestSettingsDefault_SMART_NestedDefaults(t *testing.T) {
 	d := defaultSettings()
-	if d.SMART.WakeDrives {
-		t.Errorf("defaultSettings().SMART.WakeDrives must be false (#198 standby-aware default)")
+	if d.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("defaultSettings().AdvancedScans.SMART.WakeDrives must be false (#198 standby-aware default)")
 	}
-	if d.SMART.MaxAgeDays != 7 {
-		t.Errorf("defaultSettings().SMART.MaxAgeDays = %d, want 7 (PRD #236)", d.SMART.MaxAgeDays)
+	if d.AdvancedScans.SMART.MaxAgeDays != 7 {
+		t.Errorf("defaultSettings().AdvancedScans.SMART.MaxAgeDays = %d, want 7 (PRD #236)", d.AdvancedScans.SMART.MaxAgeDays)
 	}
 }
 
-// TestSettingsRoundTrip_SMART_Nested exercises PUT→GET for the new
-// nested smart shape. The client sends `smart: {wake_drives: true,
-// max_age_days: 14}` and the server must return the same values on
-// the subsequent GET. No new scheduler behaviour fires in this slice
-// (that's #238's scope) — this test only pins the schema contract.
+// TestSettingsRoundTrip_SMART_Nested exercises PUT→GET for the
+// advanced_scans.smart wire shape (v3 schema, #259). The client
+// sends the nested shape; the server must return matching values
+// on the subsequent GET. No new scheduler behaviour fires in this
+// slice — this test only pins the schema contract.
 func TestSettingsRoundTrip_SMART_Nested(t *testing.T) {
 	srv := newSettingsTestServer()
 
 	putBody := map[string]interface{}{
-		"scan_interval": "30m",
-		"theme":         "midnight",
-		"smart": map[string]interface{}{
-			"wake_drives":   true,
-			"max_age_days":  14,
+		"settings_version": 3,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"advanced_scans": map[string]interface{}{
+			"smart":      map[string]interface{}{"wake_drives": true, "max_age_days": 14, "interval_sec": 0},
+			"docker":     map[string]interface{}{"interval_sec": 0},
+			"proxmox":    map[string]interface{}{"interval_sec": 0},
+			"kubernetes": map[string]interface{}{"interval_sec": 0},
+			"zfs":        map[string]interface{}{"interval_sec": 0},
+			"gpu":        map[string]interface{}{"interval_sec": 0},
 		},
 	}
 	buf, _ := json.Marshal(putBody)
@@ -61,10 +67,10 @@ func TestSettingsRoundTrip_SMART_Nested(t *testing.T) {
 	if err := json.Unmarshal(rec2.Body.Bytes(), &got); err != nil {
 		t.Fatalf("parse GET response: %v", err)
 	}
-	if !got.SMART.WakeDrives {
-		t.Errorf("smart.wake_drives did not round-trip; got false, want true")
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives did not round-trip; got false, want true")
 	}
-	if got.SMART.MaxAgeDays != 14 {
-		t.Errorf("smart.max_age_days did not round-trip; got %d, want 14", got.SMART.MaxAgeDays)
+	if got.AdvancedScans.SMART.MaxAgeDays != 14 {
+		t.Errorf("advanced_scans.smart.max_age_days did not round-trip; got %d, want 14", got.AdvancedScans.SMART.MaxAgeDays)
 	}
 }

--- a/internal/api/settings_smart_validation_test.go
+++ b/internal/api/settings_smart_validation_test.go
@@ -35,11 +35,16 @@ func TestHandleUpdateSettings_SMART_MaxAgeDays_RangeRejected(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			srv := newSettingsTestServer()
 			body, _ := json.Marshal(map[string]interface{}{
-				"scan_interval": "30m",
-				"theme":         "midnight",
-				"smart": map[string]interface{}{
-					"wake_drives":  false,
-					"max_age_days": tc.maxAgeDays,
+				"settings_version": 3,
+				"scan_interval":    "30m",
+				"theme":            "midnight",
+				"advanced_scans": map[string]interface{}{
+					"smart":      map[string]interface{}{"wake_drives": false, "max_age_days": tc.maxAgeDays, "interval_sec": 0},
+					"docker":     map[string]interface{}{"interval_sec": 0},
+					"proxmox":    map[string]interface{}{"interval_sec": 0},
+					"kubernetes": map[string]interface{}{"interval_sec": 0},
+					"zfs":        map[string]interface{}{"interval_sec": 0},
+					"gpu":        map[string]interface{}{"interval_sec": 0},
 				},
 			})
 			req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(body))
@@ -70,11 +75,16 @@ func TestHandleUpdateSettings_SMART_MaxAgeDays_InvalidDoesNotPersist(t *testing.
 
 	// First, persist a known-good state.
 	good, _ := json.Marshal(map[string]interface{}{
-		"scan_interval": "30m",
-		"theme":         "midnight",
-		"smart": map[string]interface{}{
-			"wake_drives":  true,
-			"max_age_days": 14,
+		"settings_version": 3,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"advanced_scans": map[string]interface{}{
+			"smart":      map[string]interface{}{"wake_drives": true, "max_age_days": 14, "interval_sec": 0},
+			"docker":     map[string]interface{}{"interval_sec": 0},
+			"proxmox":    map[string]interface{}{"interval_sec": 0},
+			"kubernetes": map[string]interface{}{"interval_sec": 0},
+			"zfs":        map[string]interface{}{"interval_sec": 0},
+			"gpu":        map[string]interface{}{"interval_sec": 0},
 		},
 	})
 	rec := httptest.NewRecorder()
@@ -85,11 +95,16 @@ func TestHandleUpdateSettings_SMART_MaxAgeDays_InvalidDoesNotPersist(t *testing.
 
 	// Submit invalid max_age_days=99.
 	bad, _ := json.Marshal(map[string]interface{}{
-		"scan_interval": "30m",
-		"theme":         "midnight",
-		"smart": map[string]interface{}{
-			"wake_drives":  false,
-			"max_age_days": 99,
+		"settings_version": 3,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"advanced_scans": map[string]interface{}{
+			"smart":      map[string]interface{}{"wake_drives": false, "max_age_days": 99, "interval_sec": 0},
+			"docker":     map[string]interface{}{"interval_sec": 0},
+			"proxmox":    map[string]interface{}{"interval_sec": 0},
+			"kubernetes": map[string]interface{}{"interval_sec": 0},
+			"zfs":        map[string]interface{}{"interval_sec": 0},
+			"gpu":        map[string]interface{}{"interval_sec": 0},
 		},
 	})
 	rec2 := httptest.NewRecorder()
@@ -109,10 +124,10 @@ func TestHandleUpdateSettings_SMART_MaxAgeDays_InvalidDoesNotPersist(t *testing.
 	if err := json.Unmarshal(rec3.Body.Bytes(), &got); err != nil {
 		t.Fatalf("parse GET: %v", err)
 	}
-	if got.SMART.MaxAgeDays != 14 {
-		t.Errorf("max_age_days leaked from rejected PUT: got %d, want 14 (seeded value)", got.SMART.MaxAgeDays)
+	if got.AdvancedScans.SMART.MaxAgeDays != 14 {
+		t.Errorf("max_age_days leaked from rejected PUT: got %d, want 14 (seeded value)", got.AdvancedScans.SMART.MaxAgeDays)
 	}
-	if !got.SMART.WakeDrives {
+	if !got.AdvancedScans.SMART.WakeDrives {
 		t.Errorf("wake_drives leaked from rejected PUT: got false, want true (seeded value)")
 	}
 }

--- a/internal/api/settings_smart_version_roundtrip_test.go
+++ b/internal/api/settings_smart_version_roundtrip_test.go
@@ -30,12 +30,39 @@ import (
 // drives asleep (max_age_days=0, wake_drives=true — a real
 // combination: "never wake to scan, but do wake when something else
 // wakes them").
+//
+// Writes the authentic v2 wire shape (flat "smart": {...}) rather
+// than a marshalled current-schema struct, so the v2→v3 migration
+// path gets exercised end-to-end on the first getSettings() call.
 func seedV2Settings(t *testing.T, srv *Server, maxAgeDays int, wakeDrives bool) {
 	t.Helper()
+	blob := map[string]interface{}{
+		"settings_version": 2,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"smart": map[string]interface{}{
+			"wake_drives":  wakeDrives,
+			"max_age_days": maxAgeDays,
+		},
+	}
+	data, err := json.Marshal(blob)
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	if err := srv.store.SetConfig(settingsConfigKey, string(data)); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+}
+
+// seedV3Settings writes a v3-shaped settings blob (the current
+// schema) into the store. Used by tests that want to exercise the
+// post-migration steady state directly.
+func seedV3Settings(t *testing.T, srv *Server, maxAgeDays int, wakeDrives bool) {
+	t.Helper()
 	s := defaultSettings()
-	s.SettingsVersion = 2
-	s.SMART.MaxAgeDays = maxAgeDays
-	s.SMART.WakeDrives = wakeDrives
+	s.SettingsVersion = 3
+	s.AdvancedScans.SMART.MaxAgeDays = maxAgeDays
+	s.AdvancedScans.SMART.WakeDrives = wakeDrives
 	data, err := json.Marshal(s)
 	if err != nil {
 		t.Fatalf("marshal seed: %v", err)
@@ -61,25 +88,36 @@ func readStoredSettings(t *testing.T, srv *Server) map[string]interface{} {
 	return out
 }
 
+// v3AdvancedScansPayload returns a fresh map that carries an
+// advanced_scans tree with all six subsystems seeded at IntervalSec=0
+// plus the given SMART knobs. Centralises the boilerplate so the #268
+// regression tests stay focused on version-preservation behaviour.
+func v3AdvancedScansPayload(wakeDrives bool, maxAgeDays int) map[string]any {
+	return map[string]any{
+		"smart":      map[string]any{"wake_drives": wakeDrives, "max_age_days": maxAgeDays, "interval_sec": 0},
+		"docker":     map[string]any{"interval_sec": 0},
+		"proxmox":    map[string]any{"interval_sec": 0},
+		"kubernetes": map[string]any{"interval_sec": 0},
+		"zfs":        map[string]any{"interval_sec": 0},
+		"gpu":        map[string]any{"interval_sec": 0},
+	}
+}
+
 // TestHandleUpdateSettings_PreservesStoredSettingsVersion — core
-// backend regression for #268. A v2-shaped blob is in storage. The
-// client PUTs a payload that OMITS settings_version (mimicking the
-// real v0.9.8 frontend). The server must preserve the stored version
+// backend regression for #268, re-pinned for the v3 schema. A v3-
+// shaped blob is in storage. The client PUTs a payload that OMITS
+// settings_version. The server must preserve the stored version
 // rather than persisting the zero-value from the unmarshal.
 func TestHandleUpdateSettings_PreservesStoredSettingsVersion(t *testing.T) {
 	srv := newSettingsTestServer()
-	seedV2Settings(t, srv, 0, true)
+	seedV3Settings(t, srv, 0, true)
 
-	// Client payload WITHOUT settings_version — exactly what the
-	// v0.9.8 frontend sends. Valid scan_interval + theme so the
-	// handler accepts it.
+	// Client payload WITHOUT settings_version. Valid scan_interval +
+	// theme so the handler accepts it.
 	rec := putSettings(t, srv, map[string]any{
-		"scan_interval": "30m",
-		"theme":         "midnight",
-		"smart": map[string]any{
-			"wake_drives":  true,
-			"max_age_days": 0,
-		},
+		"scan_interval":  "30m",
+		"theme":          "midnight",
+		"advanced_scans": v3AdvancedScansPayload(true, 0),
 	})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
@@ -87,27 +125,24 @@ func TestHandleUpdateSettings_PreservesStoredSettingsVersion(t *testing.T) {
 
 	stored := readStoredSettings(t, srv)
 	gotVersion, _ := stored["settings_version"].(float64)
-	if int(gotVersion) != 2 {
-		t.Errorf("stored settings_version after PUT: got %v, want 2 (server must preserve, not accept client omission as 0)", stored["settings_version"])
+	if int(gotVersion) != 3 {
+		t.Errorf("stored settings_version after PUT: got %v, want 3 (server must preserve, not accept client omission as 0)", stored["settings_version"])
 	}
 }
 
 // TestHandleUpdateSettings_ClientCannotDowngradeSettingsVersion —
 // defence-in-depth. Even an explicit client-side settings_version=0
-// in the PUT body must not overwrite the stored v2. settings_version
+// in the PUT body must not overwrite the stored v3. settings_version
 // is server-authoritative.
 func TestHandleUpdateSettings_ClientCannotDowngradeSettingsVersion(t *testing.T) {
 	srv := newSettingsTestServer()
-	seedV2Settings(t, srv, 14, false)
+	seedV3Settings(t, srv, 14, false)
 
 	rec := putSettings(t, srv, map[string]any{
 		"settings_version": 0, // malicious/buggy client tries to downgrade
 		"scan_interval":    "30m",
 		"theme":            "midnight",
-		"smart": map[string]any{
-			"wake_drives":  false,
-			"max_age_days": 14,
-		},
+		"advanced_scans":   v3AdvancedScansPayload(false, 14),
 	})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
@@ -115,8 +150,8 @@ func TestHandleUpdateSettings_ClientCannotDowngradeSettingsVersion(t *testing.T)
 
 	stored := readStoredSettings(t, srv)
 	gotVersion, _ := stored["settings_version"].(float64)
-	if int(gotVersion) != 2 {
-		t.Errorf("client-sent settings_version=0 must be ignored; stored version = %v, want 2", stored["settings_version"])
+	if int(gotVersion) != 3 {
+		t.Errorf("client-sent settings_version=0 must be ignored; stored version = %v, want 3", stored["settings_version"])
 	}
 }
 
@@ -125,27 +160,17 @@ func TestHandleUpdateSettings_ClientCannotDowngradeSettingsVersion(t *testing.T)
 // something (dashboard load, backup API, anything) triggers
 // getSettings() internally which runs migration + persist. The 0 must
 // survive that round trip.
-//
-// With only the frontend fix, settings_version=2 is included in the
-// PUT payload and reaches the store intact, so getSettings() sees an
-// already-v2 blob and the migration is skipped. With only the backend
-// fix, the server preserves settings_version from the stored blob
-// and achieves the same outcome. Either fix in isolation should make
-// this test pass.
 func TestHandleUpdateSettings_MaxAgeDaysZero_SurvivesInternalGetSettings(t *testing.T) {
 	srv := newSettingsTestServer()
-	seedV2Settings(t, srv, 7, false)
+	seedV3Settings(t, srv, 7, false)
 
-	// User edits: set max_age_days=0, payload includes settings_version=2
-	// (the state the fixed frontend will produce).
+	// User edits: set max_age_days=0, payload includes
+	// settings_version=3 (the state the fixed frontend produces).
 	rec := putSettings(t, srv, map[string]any{
-		"settings_version": 2,
+		"settings_version": 3,
 		"scan_interval":    "30m",
 		"theme":            "midnight",
-		"smart": map[string]any{
-			"wake_drives":  false,
-			"max_age_days": 0,
-		},
+		"advanced_scans":   v3AdvancedScansPayload(false, 0),
 	})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200 from PUT, got %d: %s", rec.Code, rec.Body.String())
@@ -153,56 +178,61 @@ func TestHandleUpdateSettings_MaxAgeDaysZero_SurvivesInternalGetSettings(t *test
 
 	// Force the getSettings() code path (migrate + persist back).
 	loaded := srv.getSettings()
-	if loaded.SMART.MaxAgeDays != 0 {
-		t.Errorf("after internal getSettings(): smart.max_age_days = %d, want 0 (user-chosen value must not be re-seeded by a stale migration)", loaded.SMART.MaxAgeDays)
+	if loaded.AdvancedScans.SMART.MaxAgeDays != 0 {
+		t.Errorf("after internal getSettings(): advanced_scans.smart.max_age_days = %d, want 0 (user-chosen value must not be re-seeded by a stale migration)", loaded.AdvancedScans.SMART.MaxAgeDays)
 	}
 
 	// And the stored blob too, since getSettings() persists.
 	stored := readStoredSettings(t, srv)
-	smartMap, ok := stored["smart"].(map[string]interface{})
+	advScans, ok := stored["advanced_scans"].(map[string]interface{})
 	if !ok {
-		t.Fatalf("stored settings missing smart object: %v", stored["smart"])
+		t.Fatalf("stored settings missing advanced_scans object: %v", stored["advanced_scans"])
+	}
+	smartMap, ok := advScans["smart"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("stored advanced_scans missing smart object: %v", advScans["smart"])
 	}
 	mad, _ := smartMap["max_age_days"].(float64)
 	if int(mad) != 0 {
-		t.Errorf("persisted smart.max_age_days after getSettings(): got %v, want 0", smartMap["max_age_days"])
+		t.Errorf("persisted advanced_scans.smart.max_age_days after getSettings(): got %v, want 0", smartMap["max_age_days"])
 	}
 }
 
 // TestHandleUpdateSettings_WakeDrivesTrue_SurvivesInternalGetSettings
 // — same scenario as above but for wake_drives=true. The re-migration
 // bug clobbered this field by reading the missing legacy
-// wake_drives_for_smart top-level key (absent in v2 blobs → false).
+// wake_drives_for_smart top-level key (absent in v2+ blobs → false).
 func TestHandleUpdateSettings_WakeDrivesTrue_SurvivesInternalGetSettings(t *testing.T) {
 	srv := newSettingsTestServer()
-	seedV2Settings(t, srv, 7, false)
+	seedV3Settings(t, srv, 7, false)
 
 	rec := putSettings(t, srv, map[string]any{
-		"settings_version": 2,
+		"settings_version": 3,
 		"scan_interval":    "30m",
 		"theme":            "midnight",
-		"smart": map[string]any{
-			"wake_drives":  true,
-			"max_age_days": 7,
-		},
+		"advanced_scans":   v3AdvancedScansPayload(true, 7),
 	})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200 from PUT, got %d: %s", rec.Code, rec.Body.String())
 	}
 
 	loaded := srv.getSettings()
-	if !loaded.SMART.WakeDrives {
-		t.Errorf("after internal getSettings(): smart.wake_drives = false, want true (user-chosen value must not be clobbered by a stale migration)")
+	if !loaded.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("after internal getSettings(): advanced_scans.smart.wake_drives = false, want true (user-chosen value must not be clobbered by a stale migration)")
 	}
 
 	stored := readStoredSettings(t, srv)
-	smartMap, ok := stored["smart"].(map[string]interface{})
+	advScans, ok := stored["advanced_scans"].(map[string]interface{})
 	if !ok {
-		t.Fatalf("stored settings missing smart object: %v", stored["smart"])
+		t.Fatalf("stored settings missing advanced_scans object: %v", stored["advanced_scans"])
+	}
+	smartMap, ok := advScans["smart"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("stored advanced_scans missing smart object: %v", advScans["smart"])
 	}
 	wd, _ := smartMap["wake_drives"].(bool)
 	if !wd {
-		t.Errorf("persisted smart.wake_drives after getSettings(): got %v, want true", smartMap["wake_drives"])
+		t.Errorf("persisted advanced_scans.smart.wake_drives after getSettings(): got %v, want true", smartMap["wake_drives"])
 	}
 }
 

--- a/internal/api/settings_wake_drives_for_smart_test.go
+++ b/internal/api/settings_wake_drives_for_smart_test.go
@@ -17,7 +17,8 @@ import (
 // Originally (pre-#237) the toggle lived directly inside the generic
 // Advanced card. #237 moved it out to a dedicated "Advanced Scan Settings"
 // card; #256 merged it back into the generic Advanced card (id="card-advanced")
-// after UAT flagged the two-card split as clutter.
+// after UAT flagged the two-card split as clutter. #259 relocated the
+// backing field from data.smart to data.advanced_scans.smart.
 //
 // This is a cross-reference test: it confirms the HTML mentions every
 // symbol the JS load/save wiring expects, so a future refactor that
@@ -44,10 +45,10 @@ func TestSettingsHTMLIncludesWakeDrivesForSMARTToggle(t *testing.T) {
 		{"summary element", `<summary`},
 		// The toggle control + its stable id for load/save wiring.
 		{"wake-drives toggle id", `id="wake-drives-for-smart"`},
-		// Load path reads the nested JSON field.
-		{"load binds nested field", `data.smart`},
-		// Save payload writes the nested JSON field.
-		{"save sends nested field", `smart:`},
+		// Load path reads the v3 nested JSON field.
+		{"load binds nested field", `advanced_scans`},
+		// Save payload writes the v3 nested JSON field.
+		{"save sends nested field", `advanced_scans:`},
 		// Disclaimer text must communicate the wear trade-off. We keep
 		// the assertion loose so copy can be edited, but pin the key
 		// concepts: spin-ups and opt-in intent.
@@ -64,17 +65,23 @@ func TestSettingsHTMLIncludesWakeDrivesForSMARTToggle(t *testing.T) {
 }
 
 // TestSettingsRoundTrip_WakeDrivesForSMART exercises the GET/PUT cycle for
-// the wake-drives flag using the new nested schema (Settings.SMART.WakeDrives,
-// `smart.wake_drives` on the wire) introduced in #237.
+// the wake-drives flag using the v3 nested schema
+// (Settings.AdvancedScans.SMART.WakeDrives, advanced_scans.smart.wake_drives
+// on the wire).
 func TestSettingsRoundTrip_WakeDrivesForSMART(t *testing.T) {
 	srv := newSettingsTestServer()
 
 	put := map[string]interface{}{
-		"scan_interval": "30m",
-		"theme":         "midnight",
-		"smart": map[string]interface{}{
-			"wake_drives":  true,
-			"max_age_days": 7,
+		"settings_version": 3,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"advanced_scans": map[string]interface{}{
+			"smart":      map[string]interface{}{"wake_drives": true, "max_age_days": 7, "interval_sec": 0},
+			"docker":     map[string]interface{}{"interval_sec": 0},
+			"proxmox":    map[string]interface{}{"interval_sec": 0},
+			"kubernetes": map[string]interface{}{"interval_sec": 0},
+			"zfs":        map[string]interface{}{"interval_sec": 0},
+			"gpu":        map[string]interface{}{"interval_sec": 0},
 		},
 	}
 	body, _ := json.Marshal(put)
@@ -97,8 +104,8 @@ func TestSettingsRoundTrip_WakeDrivesForSMART(t *testing.T) {
 	if err := json.Unmarshal(rr2.Body.Bytes(), &got); err != nil {
 		t.Fatalf("parse GET response: %v", err)
 	}
-	if !got.SMART.WakeDrives {
-		t.Errorf("smart.wake_drives did not round-trip; got false, wanted true")
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives did not round-trip; got false, wanted true")
 	}
 }
 
@@ -107,7 +114,7 @@ func TestSettingsRoundTrip_WakeDrivesForSMART(t *testing.T) {
 // means drives in standby are NOT woken by SMART scans.
 func TestSettingsDefault_WakeDrivesForSMARTIsFalse(t *testing.T) {
 	d := defaultSettings()
-	if d.SMART.WakeDrives {
-		t.Errorf("defaultSettings().SMART.WakeDrives must be false (standby-aware by default, issue #198)")
+	if d.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("defaultSettings().AdvancedScans.SMART.WakeDrives must be false (standby-aware by default, issue #198)")
 	}
 }

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -1289,20 +1289,26 @@ function durationToIntervalSec(dur) {
   return f.days * 86400 + f.hours * 3600 + f.minutes * 60 + f.seconds;
 }
 
-/* parseCronToFields reverse-parses simple interval cron expressions
-   into {days, hours, minutes, seconds}. Throws on anything more
-   complex than the four supported shapes. PRD #239 user stories
-   8, 14.
-
-   Supported:
-     */N s                — every N seconds (sub-minute; our extension)
-     */N * * * *          — every N minutes (N in 1..59)
-     0 */N * * *          — every N hours (N in 1..23)
-     0 0 */N * *          — every N days (N in 1..31)
-
-   Anything else (specific weekdays, comma lists, named months,
-   per-minute granularity below */N without seconds suffix, etc.)
-   triggers a clear UI error. */
+// parseCronToFields reverse-parses simple interval cron expressions
+// into {days, hours, minutes, seconds}. Throws on anything more
+// complex than the four supported shapes. PRD #239 user stories
+// 8, 14.
+//
+// Supported:
+//   */N s                — every N seconds (sub-minute; our extension)
+//   */N * * * *          — every N minutes (N in 1..59)
+//   0 */N * * *          — every N hours (N in 1..23)
+//   0 0 */N * *          — every N days (N in 1..31)
+//
+// Anything else (specific weekdays, comma lists, named months,
+// per-minute granularity below */N without seconds suffix, etc.)
+// triggers a clear UI error.
+//
+// NOTE: line comments (not /* */ block) — any `*/` inside a block
+// comment closes it early and breaks the entire <script> parse.
+// See stage-branch UAT of v0.9.9-rc1 where this bug shipped and
+// silently stopped loadSettings, renderAdvancedScanPickers, and
+// loadDockerHiddenContainersCheckboxes from running.
 function parseCronToFields(cronStr) {
   if (!cronStr) throw new Error("empty cron");
   var s = String(cronStr).trim();

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -931,6 +931,29 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
           </p>
         </div>
 
+        <!-- SMART scan interval picker — colocated with the other SMART
+             knobs per PRD #239. Markup is injected by createIntervalPicker
+             on page init. Inert in slice 2a (#259) — value persists but
+             scheduler ignores it until slice 2b (#260) wires it up. -->
+        <div id="scan-interval-smart" data-subsystem="smart" data-label="SMART" style="margin-top:18px"></div>
+
+        <!-- Per-subsystem scan intervals sub-section — PRD #239 slice 2a.
+             Five of the six configurable subsystems land here; SMART has
+             its own picker colocated with the wake-drives / max-age group
+             above to keep all SMART knobs together. Each picker is
+             rendered by createIntervalPicker into its div id. -->
+        <div style="margin-top:22px;padding-top:16px;border-top:1px solid var(--border)">
+          <div style="font-weight:600;font-size:13px;color:var(--text);margin-bottom:4px">Per-subsystem scan intervals</div>
+          <p style="font-size:12px;color:var(--text2);margin-top:4px;margin-bottom:14px;line-height:1.5">
+            Override the global scan cadence per subsystem. Use <strong>Use global</strong> to inherit the Diagnostic Scan Interval (most users want this). Set a positive interval only if you want that subsystem to run faster or slower than the rest of the dashboard. Values persist immediately, but no scheduler behaviour changes until the slice-2b release.
+          </p>
+          <div id="scan-interval-docker" data-subsystem="docker" data-label="Docker" style="margin-bottom:14px"></div>
+          <div id="scan-interval-proxmox" data-subsystem="proxmox" data-label="Proxmox" style="margin-bottom:14px"></div>
+          <div id="scan-interval-kubernetes" data-subsystem="kubernetes" data-label="Kubernetes" style="margin-bottom:14px"></div>
+          <div id="scan-interval-zfs" data-subsystem="zfs" data-label="ZFS" style="margin-bottom:14px"></div>
+          <div id="scan-interval-gpu" data-subsystem="gpu" data-label="GPU" style="margin-bottom:0"></div>
+        </div>
+
         <!-- Docker container visibility — unchanged from pre-#237. -->
         <div style="margin-top:22px;padding-top:16px;border-top:1px solid var(--border)">
           <div style="display:block;font-weight:600;font-size:13px;color:var(--text);margin-bottom:4px">Hide Docker containers from dashboard</div>
@@ -1180,6 +1203,390 @@ document.getElementById("scan-hours").addEventListener("input", updateIntervalPr
 document.getElementById("scan-minutes").addEventListener("input", updateIntervalPreview);
 document.getElementById("scan-seconds").addEventListener("input", updateIntervalPreview);
 
+/* ---------- Advanced Scan Settings: per-subsystem interval pickers ----------
+
+   Introduced in slice 2a (PRD #239 / issue #259). Six subsystems get
+   their own cadence picker:
+
+     - SMART (colocated with wake-drives / max-age inside card-advanced)
+     - Docker / Proxmox / Kubernetes / ZFS / GPU (grouped under the
+       "Per-subsystem scan intervals" sub-section)
+
+   In slice 2a the values are PERSISTED but INERT: the scheduler still
+   runs every subsystem on the global cadence. Slice 2b (#260) activates
+   the new ScanDispatcher that consumes these values.
+
+   The createIntervalPicker(subsystemId, label) helper generates the
+   widget markup and wires all event listeners. Mount points are
+   pre-rendered in the HTML as empty div id="scan-interval-<subsystem>".
+
+   Each picker offers the same UX as the global Diagnostic Scan
+   Interval widget: preset dropdown (Use global, 5m, 15m, 30m, 1h, 2h,
+   6h, 12h, 24h, 7d, Custom...) + custom d/h/m/s panel + live preview
+   + cron visualizer + "edit cron" button with a reverse parser. */
+
+/* Preset values offered by every per-subsystem interval picker.
+   "0" sentinel represents "use global"; matches the AdvancedScans
+   IntervalSec=0 convention on the server side (see PRD #239). */
+var advScanPresets = [
+  { value: "0",   label: "Use global (30m)" },
+  { value: "5m",  label: "Every 5 minutes"  },
+  { value: "15m", label: "Every 15 minutes" },
+  { value: "30m", label: "Every 30 minutes" },
+  { value: "1h",  label: "Every 1 hour"     },
+  { value: "2h",  label: "Every 2 hours"    },
+  { value: "6h",  label: "Every 6 hours"    },
+  { value: "12h", label: "Every 12 hours"   },
+  { value: "24h", label: "Every 24 hours"   },
+  { value: "7d",  label: "Every 7 days"     },
+  { value: "custom", label: "Custom..."     }
+];
+
+/* Duration parser shared between the global widget's
+   parseDurationToFields and the new per-subsystem helpers. Goes
+   beyond parseDurationToFields because subsystem intervals may
+   include days ("7d"). Returns {days, hours, minutes, seconds}. */
+function parseIntervalDurationToFields(dur) {
+  var days = 0, hours = 0, minutes = 0, seconds = 0;
+  if (!dur || dur === "0") return { days: 0, hours: 0, minutes: 0, seconds: 0 };
+  var m;
+  m = dur.match(/(\d+)d/);
+  if (m) days = parseInt(m[1], 10);
+  m = dur.match(/(\d+)h/);
+  if (m) { var h = parseInt(m[1], 10); days += Math.floor(h / 24); hours = h % 24; }
+  m = dur.match(/(\d+)m(?!s)/);
+  if (m) minutes = parseInt(m[1], 10);
+  m = dur.match(/(\d+)s/);
+  if (m) seconds = parseInt(m[1], 10);
+  return { days: days, hours: hours, minutes: minutes, seconds: seconds };
+}
+
+/* intervalSecToDuration converts an IntervalSec value back to a
+   duration string compatible with parseIntervalDurationToFields.
+   0 → "0" (use global sentinel). */
+function intervalSecToDuration(sec) {
+  sec = parseInt(sec, 10) || 0;
+  if (sec <= 0) return "0";
+  var days = Math.floor(sec / 86400);
+  sec -= days * 86400;
+  var hours = Math.floor(sec / 3600);
+  sec -= hours * 3600;
+  var minutes = Math.floor(sec / 60);
+  var seconds = sec % 60;
+  var out = "";
+  if (days > 0) out += days + "d";
+  if (hours > 0) out += hours + "h";
+  if (minutes > 0) out += minutes + "m";
+  if (seconds > 0) out += seconds + "s";
+  return out || "0";
+}
+
+/* durationToIntervalSec is the inverse of intervalSecToDuration.
+   Unknown/malformed inputs return 0 (= "use global"). */
+function durationToIntervalSec(dur) {
+  if (!dur || dur === "0") return 0;
+  var f = parseIntervalDurationToFields(dur);
+  return f.days * 86400 + f.hours * 3600 + f.minutes * 60 + f.seconds;
+}
+
+/* parseCronToFields reverse-parses simple interval cron expressions
+   into {days, hours, minutes, seconds}. Throws on anything more
+   complex than the four supported shapes. PRD #239 user stories
+   8, 14.
+
+   Supported:
+     */N s                — every N seconds (sub-minute; our extension)
+     */N * * * *          — every N minutes (N in 1..59)
+     0 */N * * *          — every N hours (N in 1..23)
+     0 0 */N * *          — every N days (N in 1..31)
+
+   Anything else (specific weekdays, comma lists, named months,
+   per-minute granularity below */N without seconds suffix, etc.)
+   triggers a clear UI error. */
+function parseCronToFields(cronStr) {
+  if (!cronStr) throw new Error("empty cron");
+  var s = String(cronStr).trim();
+  var m;
+  m = s.match(/^\*\/(\d+)\s*s$/i);
+  if (m) {
+    var sec = parseInt(m[1], 10);
+    if (!(sec >= 1 && sec <= 59)) throw new Error("Must be a simple interval cron (seconds out of 1..59)");
+    return { days: 0, hours: 0, minutes: 0, seconds: sec };
+  }
+  var parts = s.split(/\s+/);
+  if (parts.length !== 5) {
+    throw new Error("Must be a simple interval cron (expected 5 fields)");
+  }
+  m = parts[0].match(/^\*\/(\d+)$/);
+  if (m && parts[1] === "*" && parts[2] === "*" && parts[3] === "*" && parts[4] === "*") {
+    var mins = parseInt(m[1], 10);
+    if (!(mins >= 1 && mins <= 59)) throw new Error("Must be a simple interval cron (minutes out of 1..59)");
+    return { days: 0, hours: 0, minutes: mins, seconds: 0 };
+  }
+  if (parts[0] === "0") {
+    m = parts[1].match(/^\*\/(\d+)$/);
+    if (m && parts[2] === "*" && parts[3] === "*" && parts[4] === "*") {
+      var hrs = parseInt(m[1], 10);
+      if (!(hrs >= 1 && hrs <= 23)) throw new Error("Must be a simple interval cron (hours out of 1..23)");
+      return { days: 0, hours: hrs, minutes: 0, seconds: 0 };
+    }
+    if (parts[1] === "0") {
+      m = parts[2].match(/^\*\/(\d+)$/);
+      if (m && parts[3] === "*" && parts[4] === "*") {
+        var dd = parseInt(m[1], 10);
+        if (!(dd >= 1 && dd <= 31)) throw new Error("Must be a simple interval cron (days out of 1..31)");
+        return { days: dd, hours: 0, minutes: 0, seconds: 0 };
+      }
+    }
+  }
+  throw new Error("Must be a simple interval cron (*/Ns, */N * * * *, 0 */N * * *, or 0 0 */N * *)");
+}
+
+/* fieldsToIntervalDuration — fields object to duration string. */
+function fieldsToIntervalDuration(f) {
+  var parts = [];
+  if (f.days > 0) parts.push(f.days + "d");
+  if (f.hours > 0) parts.push(f.hours + "h");
+  if (f.minutes > 0) parts.push(f.minutes + "m");
+  if (f.seconds > 0) parts.push(f.seconds + "s");
+  return parts.length === 0 ? "0" : parts.join("");
+}
+
+/* durationToCronSimple returns a simple interval cron string for a
+   duration — mirrors durationToCron but defensively returns "" for
+   the "use global" sentinel. */
+function durationToCronSimple(dur) {
+  if (!dur || dur === "0") return "";
+  var f = parseIntervalDurationToFields(dur);
+  var totalSecs = f.days * 86400 + f.hours * 3600 + f.minutes * 60 + f.seconds;
+  if (totalSecs <= 0) return "";
+  if (totalSecs < 60) return "*/" + totalSecs + "s";
+  var totalMin = Math.floor(totalSecs / 60);
+  if (totalMin < 60 && totalSecs % 60 === 0) return "*/" + totalMin + " * * * *";
+  var totalHrs = f.days * 24 + f.hours;
+  if (f.minutes === 0 && f.seconds === 0 && totalHrs > 0) {
+    if (totalHrs < 24) return "0 */" + totalHrs + " * * *";
+    if (totalHrs % 24 === 0) return "0 0 */" + (totalHrs / 24) + " * *";
+  }
+  return "*/" + totalMin + " * * * *";
+}
+
+/* createIntervalPicker mounts a picker widget inside the pre-rendered
+   div id="scan-interval-<subsystemId>". Populates DOM children,
+   wires event handlers, returns the container element.
+
+   The same widget shape is used for all six subsystems (SMART,
+   Docker, Proxmox, Kubernetes, ZFS, GPU). Per PRD #239 the existing
+   global Diagnostic Scan Interval widget is NOT refactored to use
+   this helper — that's a v0.10.0+ cleanup candidate. */
+function createIntervalPicker(subsystemId, label) {
+  var mount = document.getElementById("scan-interval-" + subsystemId);
+  if (!mount) return null;
+  if (mount.getAttribute("data-inited") === "1") return mount;
+
+  var presetOpts = "";
+  for (var i = 0; i < advScanPresets.length; i++) {
+    var p = advScanPresets[i];
+    presetOpts += '<option value="' + p.value + '">' + p.label + '</option>';
+  }
+
+  mount.innerHTML = '' +
+    '<label for="scan-interval-' + subsystemId + '-preset" style="display:block;font-weight:600;font-size:13px;color:var(--text);margin-bottom:4px">' +
+      label + ' scan interval' +
+    '</label>' +
+    '<select id="scan-interval-' + subsystemId + '-preset" style="max-width:260px">' + presetOpts + '</select>' +
+    '<div id="scan-interval-' + subsystemId + '-custom" style="display:none;margin-top:10px;padding:12px;background:rgba(255,255,255,0.02);border:1px solid var(--border);border-radius:var(--radius)">' +
+      '<div style="display:flex;gap:10px;align-items:flex-end;flex-wrap:wrap;margin-bottom:10px">' +
+        '<div style="flex:1;min-width:60px">' +
+          '<label style="font-size:11px;margin-bottom:4px">Days</label>' +
+          '<input type="number" id="scan-interval-' + subsystemId + '-days"    min="0" max="31" value="0" style="text-align:center">' +
+        '</div>' +
+        '<div style="flex:1;min-width:60px">' +
+          '<label style="font-size:11px;margin-bottom:4px">Hours</label>' +
+          '<input type="number" id="scan-interval-' + subsystemId + '-hours"   min="0" max="23" value="0" style="text-align:center">' +
+        '</div>' +
+        '<div style="flex:1;min-width:60px">' +
+          '<label style="font-size:11px;margin-bottom:4px">Minutes</label>' +
+          '<input type="number" id="scan-interval-' + subsystemId + '-minutes" min="0" max="59" value="0" style="text-align:center">' +
+        '</div>' +
+        '<div style="flex:1;min-width:60px">' +
+          '<label style="font-size:11px;margin-bottom:4px">Seconds</label>' +
+          '<input type="number" id="scan-interval-' + subsystemId + '-seconds" min="0" max="59" value="0" style="text-align:center">' +
+        '</div>' +
+      '</div>' +
+      '<div id="scan-interval-' + subsystemId + '-preview" style="font-size:12px;color:var(--text2);margin-bottom:4px"></div>' +
+      '<div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">' +
+        '<div id="scan-interval-' + subsystemId + '-cron" style="font-size:11px;font-family:monospace;color:var(--accent);background:rgba(94,106,210,0.06);padding:4px 10px;border-radius:4px;display:inline-block"></div>' +
+        '<button type="button" class="btn btn-secondary btn-sm" id="scan-interval-' + subsystemId + '-edit-cron-btn">Edit cron</button>' +
+      '</div>' +
+      '<div id="scan-interval-' + subsystemId + '-cron-edit-wrap" style="display:none;margin-top:10px">' +
+        '<input type="text" id="scan-interval-' + subsystemId + '-cron-input" placeholder="e.g. */15 * * * *" style="width:100%;font-family:monospace">' +
+        '<div style="display:flex;gap:8px;margin-top:6px;align-items:center">' +
+          '<button type="button" class="btn btn-secondary btn-sm" id="scan-interval-' + subsystemId + '-cron-apply-btn">Apply</button>' +
+          '<button type="button" class="btn btn-secondary btn-sm" id="scan-interval-' + subsystemId + '-cron-cancel-btn">Cancel</button>' +
+          '<span id="scan-interval-' + subsystemId + '-cron-error" style="font-size:12px;color:var(--error)"></span>' +
+        '</div>' +
+      '</div>' +
+    '</div>';
+
+  var sel    = document.getElementById("scan-interval-" + subsystemId + "-preset");
+  var cust   = document.getElementById("scan-interval-" + subsystemId + "-custom");
+  var inputs = ["days","hours","minutes","seconds"].map(function(f) {
+    return document.getElementById("scan-interval-" + subsystemId + "-" + f);
+  });
+  var preview = document.getElementById("scan-interval-" + subsystemId + "-preview");
+  var cronEl  = document.getElementById("scan-interval-" + subsystemId + "-cron");
+  var editBtn = document.getElementById("scan-interval-" + subsystemId + "-edit-cron-btn");
+  var cronWrap= document.getElementById("scan-interval-" + subsystemId + "-cron-edit-wrap");
+  var cronIn  = document.getElementById("scan-interval-" + subsystemId + "-cron-input");
+  var cronErr = document.getElementById("scan-interval-" + subsystemId + "-cron-error");
+  var cronApply = document.getElementById("scan-interval-" + subsystemId + "-cron-apply-btn");
+  var cronCancel= document.getElementById("scan-interval-" + subsystemId + "-cron-cancel-btn");
+
+  function refreshPreview() {
+    var f = { days: parseInt(inputs[0].value,10)||0, hours: parseInt(inputs[1].value,10)||0,
+              minutes: parseInt(inputs[2].value,10)||0, seconds: parseInt(inputs[3].value,10)||0 };
+    var parts = [];
+    if (f.days    > 0) parts.push(f.days    + (f.days    === 1 ? " day"    : " days"));
+    if (f.hours   > 0) parts.push(f.hours   + (f.hours   === 1 ? " hour"   : " hours"));
+    if (f.minutes > 0) parts.push(f.minutes + (f.minutes === 1 ? " minute" : " minutes"));
+    if (f.seconds > 0) parts.push(f.seconds + (f.seconds === 1 ? " second" : " seconds"));
+    if (parts.length === 0) {
+      preview.textContent = "Invalid: set at least 1 second (or pick 'Use global')";
+      preview.style.color = "var(--error)";
+      cronEl.textContent = "";
+    } else {
+      preview.textContent = label + " scans every " + parts.join(", ");
+      preview.style.color = "var(--text2)";
+      var dur = fieldsToIntervalDuration(f);
+      var cron = durationToCronSimple(dur);
+      cronEl.textContent = cron ? "cron: " + cron : "";
+    }
+  }
+
+  sel.addEventListener("change", function() {
+    if (sel.value === "custom") {
+      cust.style.display = "block";
+      refreshPreview();
+    } else {
+      cust.style.display = "none";
+    }
+    saveSettings();
+  });
+  for (var j = 0; j < inputs.length; j++) {
+    inputs[j].addEventListener("input", refreshPreview);
+    inputs[j].addEventListener("change", saveSettings);
+  }
+  editBtn.addEventListener("click", function() {
+    cronWrap.style.display = (cronWrap.style.display === "none" ? "block" : "none");
+    cronErr.textContent = "";
+  });
+  cronCancel.addEventListener("click", function() {
+    cronWrap.style.display = "none";
+    cronErr.textContent = "";
+  });
+  cronApply.addEventListener("click", function() {
+    try {
+      var f = parseCronToFields(cronIn.value);
+      inputs[0].value = f.days;
+      inputs[1].value = f.hours;
+      inputs[2].value = f.minutes;
+      inputs[3].value = f.seconds;
+      sel.value = "custom";
+      cust.style.display = "block";
+      cronWrap.style.display = "none";
+      cronErr.textContent = "";
+      refreshPreview();
+      saveSettings();
+    } catch (e) {
+      cronErr.textContent = e.message || "Must be a simple interval cron";
+    }
+  });
+
+  mount.setAttribute("data-inited", "1");
+  return mount;
+}
+
+/* setPickerFromIntervalSec — populate a picker from a stored
+   IntervalSec value. Called from renderAdvancedScanPickers during
+   loadSettings. */
+function setPickerFromIntervalSec(subsystemId, intervalSec) {
+  var sel  = document.getElementById("scan-interval-" + subsystemId + "-preset");
+  var cust = document.getElementById("scan-interval-" + subsystemId + "-custom");
+  if (!sel || !cust) return;
+  var dur = intervalSecToDuration(intervalSec);
+  // Match against preset values first.
+  var matched = false;
+  for (var i = 0; i < advScanPresets.length; i++) {
+    if (advScanPresets[i].value === dur) { sel.value = dur; matched = true; break; }
+  }
+  if (matched && dur !== "custom") {
+    cust.style.display = "none";
+    return;
+  }
+  // Fall through: custom duration. Populate fields + show panel.
+  sel.value = "custom";
+  cust.style.display = "block";
+  var f = parseIntervalDurationToFields(dur);
+  var d = document.getElementById("scan-interval-" + subsystemId + "-days");
+  var h = document.getElementById("scan-interval-" + subsystemId + "-hours");
+  var m = document.getElementById("scan-interval-" + subsystemId + "-minutes");
+  var s = document.getElementById("scan-interval-" + subsystemId + "-seconds");
+  if (d) d.value = f.days;
+  if (h) h.value = f.hours;
+  if (m) m.value = f.minutes;
+  if (s) s.value = f.seconds;
+  // Trigger a preview update if the picker was already wired.
+  var sel2 = document.getElementById("scan-interval-" + subsystemId + "-preset");
+  if (sel2) sel2.dispatchEvent(new Event("input"));
+  if (d) d.dispatchEvent(new Event("input"));
+}
+
+/* readPickerIntervalSec — inverse of setPickerFromIntervalSec.
+   Reads the current picker state and returns an IntervalSec int,
+   clamped into {0} union [ScanIntervalSecMin, ScanIntervalSecMax].
+   Out-of-range values collapse to 0 ("use global") so a malformed
+   UI state never triggers a server-side 400 that blocks save of
+   unrelated settings. */
+function readPickerIntervalSec(subsystemId) {
+  var sel = document.getElementById("scan-interval-" + subsystemId + "-preset");
+  if (!sel) return 0;
+  var v = sel.value;
+  if (v === "custom") {
+    var d = parseInt(document.getElementById("scan-interval-" + subsystemId + "-days").value, 10) || 0;
+    var h = parseInt(document.getElementById("scan-interval-" + subsystemId + "-hours").value, 10) || 0;
+    var m = parseInt(document.getElementById("scan-interval-" + subsystemId + "-minutes").value, 10) || 0;
+    var s = parseInt(document.getElementById("scan-interval-" + subsystemId + "-seconds").value, 10) || 0;
+    var total = d * 86400 + h * 3600 + m * 60 + s;
+    if (total === 0) return 0;
+    if (total < 30) return 0;          // below the floor → use global
+    if (total > 2678400) return 2678400; // 31-day cap
+    return total;
+  }
+  return durationToIntervalSec(v);
+}
+
+/* renderAdvancedScanPickers — called from loadSettings. Ensures the
+   six picker widgets exist in the DOM and populates each from the
+   loaded advanced_scans tree. Idempotent: re-calls are safe. */
+function renderAdvancedScanPickers(advScans) {
+  advScans = advScans || {};
+  var subsystems = [
+    { id: "smart",      label: "SMART"      },
+    { id: "docker",     label: "Docker"     },
+    { id: "proxmox",    label: "Proxmox"    },
+    { id: "kubernetes", label: "Kubernetes" },
+    { id: "zfs",        label: "ZFS"        },
+    { id: "gpu",        label: "GPU"        }
+  ];
+  for (var i = 0; i < subsystems.length; i++) {
+    var sub = subsystems[i];
+    createIntervalPicker(sub.id, sub.label);
+    var cfg = advScans[sub.id] || {};
+    setPickerFromIntervalSec(sub.id, cfg.interval_sec || 0);
+  }
+}
+
 /* ---------- Load settings ---------- */
 function loadSettings() {
   fetch("/api/v1/settings")
@@ -1245,12 +1652,16 @@ function loadSettings() {
       /* Drive replacement cost per TB */
       var costEl = document.getElementById("cost-per-tb");
       if (costEl) costEl.value = (data.cost_per_tb && data.cost_per_tb > 0) ? data.cost_per_tb : "";
-      /* Advanced Scan Settings (#237): SMART sub-struct. Reads
-         smart.wake_drives and smart.max_age_days from the server's
-         nested schema. Falls back to the legacy flat
-         wake_drives_for_smart field if the server hasn't migrated yet
-         (defensive — getSettings migrates on first read). */
-      var smartCfg = (data && data.smart) || {};
+      /* Advanced Scan Settings. SMART knobs (WakeDrives, MaxAgeDays)
+         and per-subsystem IntervalSec values all live under
+         advanced_scans (v3 schema, #259). Legacy fallbacks:
+           - data.advanced_scans.smart.{wake_drives,max_age_days} (v3)
+           - data.smart.{wake_drives,max_age_days} (v2, pre-#259)
+           - data.wake_drives_for_smart (v1, pre-#237)
+         getSettings migrates on first read so v1/v2 paths should not
+         fire in production — they're defence-in-depth only. */
+      var advScans = (data && data.advanced_scans) || {};
+      var smartCfg = advScans.smart || (data && data.smart) || {};
       var wakeEl = document.getElementById("wake-drives-for-smart");
       if (wakeEl) {
         var wakeVal = (smartCfg.wake_drives !== undefined) ? !!smartCfg.wake_drives : !!data.wake_drives_for_smart;
@@ -1262,6 +1673,11 @@ function loadSettings() {
         if (isNaN(maxAgeVal)) maxAgeVal = 7;
         maxAgeEl.value = maxAgeVal;
       }
+      /* Per-subsystem interval pickers (slice 2a — values persist but
+         are inert server-side until #260 activates the dispatcher).
+         Picker markup is rendered here rather than at template-render
+         time so load/save round-trips use the current JSON shape. */
+      renderAdvancedScanPickers(advScans);
       /* Advanced: hide Docker containers from dashboard (#204) */
       var hidden = Array.isArray(data.docker_hidden_containers) ? data.docker_hidden_containers : [];
       loadDockerHiddenContainersCheckboxes(hidden);
@@ -1323,7 +1739,12 @@ function buildSettingsPayload() {
     // getSettings() call, silently resetting smart.max_age_days=0→7
     // and smart.wake_drives=true→false. See issue #268 + the
     // companion server-side floor in handleUpdateSettings.
-    settings_version: (base && base.settings_version) || 2,
+    //
+    // Fallback floor tracks currentSettingsVersion on the server
+    // (currently 3 after slice 2a / #259). The backend's max-of-
+    // stored-and-incoming clamp still protects against a client
+    // sending a lower value.
+    settings_version: (base && base.settings_version) || 3,
     scan_interval: getScanInterval(),
     speedtest_interval: document.getElementById("speedtest-interval").value,
     speedtest_schedule: buildSpeedTestSchedule(),
@@ -1384,16 +1805,29 @@ function buildSettingsPayload() {
     fleet: fleetServers || base.fleet || [],
     dismissed_findings: base.dismissed_findings || [],
     cost_per_tb: parseFloat(document.getElementById("cost-per-tb") && document.getElementById("cost-per-tb").value) || 0,
-    smart: {
-      wake_drives: !!(document.getElementById("wake-drives-for-smart") && document.getElementById("wake-drives-for-smart").classList.contains("on")),
-      max_age_days: (function() {
-        var el = document.getElementById("smart-max-age-days");
-        if (!el) return 7;
-        var v = parseInt(el.value, 10);
-        if (isNaN(v) || v < 0) return 0;
-        if (v > 30) return 30;
-        return v;
-      })()
+    /* Advanced Scan Settings v3 (PRD #239 / issue #259). The SMART
+       sub-struct carries the slice-1 wake-drives / max-age knobs
+       alongside the new IntervalSec. The other five configurable
+       subsystems only carry IntervalSec. IntervalSec=0 means
+       "use global" (the scheduler ignores the override). */
+    advanced_scans: {
+      smart: {
+        wake_drives: !!(document.getElementById("wake-drives-for-smart") && document.getElementById("wake-drives-for-smart").classList.contains("on")),
+        max_age_days: (function() {
+          var el = document.getElementById("smart-max-age-days");
+          if (!el) return 7;
+          var v = parseInt(el.value, 10);
+          if (isNaN(v) || v < 0) return 0;
+          if (v > 30) return 30;
+          return v;
+        })(),
+        interval_sec: readPickerIntervalSec("smart")
+      },
+      docker:     { interval_sec: readPickerIntervalSec("docker") },
+      proxmox:    { interval_sec: readPickerIntervalSec("proxmox") },
+      kubernetes: { interval_sec: readPickerIntervalSec("kubernetes") },
+      zfs:        { interval_sec: readPickerIntervalSec("zfs") },
+      gpu:        { interval_sec: readPickerIntervalSec("gpu") }
     },
     docker_hidden_containers: collectCheckedHiddenContainers()
   };
@@ -1512,8 +1946,38 @@ function collectCheckedHiddenContainers() {
   return out;
 }
 
+/* smartMaxAgeConflictConfirm — PRD #239 user story 12.
+
+   When the user configures SMART.IntervalSec > MaxAgeDays * 86400
+   (both non-zero), the slice-1 max-age safety net will force-wake
+   drives more frequently than the user's stated SMART cadence.
+   That's almost certainly not what they want; show a confirm()
+   dialog explaining the consequence and let them cancel the save.
+
+   Returns true if the save may proceed, false if the user aborted.
+   Always returns true when there is no conflict. */
+function smartMaxAgeConflictConfirm(payload) {
+  try {
+    var adv = payload && payload.advanced_scans;
+    if (!adv || !adv.smart) return true;
+    var intervalSec = parseInt(adv.smart.interval_sec, 10) || 0;
+    var maxAgeDays  = parseInt(adv.smart.max_age_days, 10) || 0;
+    if (intervalSec <= 0 || maxAgeDays <= 0) return true;
+    if (intervalSec <= maxAgeDays * 86400)  return true;
+    var msg = "Your SMART scan interval (" + intervalSec + "s) is longer than the " +
+      "max-age-days safety net (" + maxAgeDays + " days = " + (maxAgeDays * 86400) +
+      "s).\n\nThe safety net will force-wake drives on its own cadence, " +
+      "overriding the SMART interval in practice. Save anyway?";
+    return confirm(msg);
+  } catch (e) { return true; }
+}
+
 function saveSettings() {
   var payload = buildSettingsPayload();
+  if (!smartMaxAgeConflictConfirm(payload)) {
+    showToast("Save aborted", "info");
+    return;
+  }
   fetch("/api/v1/settings", {
     method: "PUT",
     headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary

Vertical slice 2a of PRD #239 (Advanced Scan Settings). Establishes the new `AdvancedScans` umbrella schema, migrates slice 1's `Settings.SMART` into it, and adds 6 interval-picker UI widgets to the Advanced card. No scheduler behaviour change yet — `IntervalSec` values are **persisted but inert** in this slice. Slice 2b (#260) wires them into the scan loop via a new `ScanDispatcher`.

Closes #259.

## Migration notes (v2 -> v3)

- **Relocation**: `Settings.SMART.{WakeDrives, MaxAgeDays}` moves to `Settings.AdvancedScans.SMART.{WakeDrives, MaxAgeDays}`; gains a new `IntervalSec` field alongside.
- **Five new sub-structs**: `AdvancedScans.{Docker, Proxmox, Kubernetes, ZFS, GPU}` each carrying `IntervalSec int`. All default to 0 (= "use global") on fresh install and on upgrade.
- **JSON wire shape**: top-level `smart: {...}` replaced with nested `advanced_scans: { smart: {...}, docker: {...}, ... }`.
- **Pointer-valued v2 shadow**: the v2 -> v3 lift uses `*bool` / `*int` to distinguish "field absent" from "field explicitly zero". A v2 user's `max_age_days=0` survives the climb verbatim (same #268-class preservation contract that slice 1's migration got).
- **Shape-sentinel guards**: both the v1 -> v2 shim and the v2 -> v3 lift only fire when the raw blob structurally predates that version. A blob whose `settings_version` was corrupted to 0 but that carries `advanced_scans` will be treated as v3 and not re-clobbered. Defence-in-depth against a future #268-class regression.
- **`currentSettingsVersion`**: 2 -> 3.
- **Frontend `buildSettingsPayload`**: still includes `settings_version` (preserved from #273); fallback floor bumped 2 -> 3.

## Server-side validation

`IntervalSec` must satisfy `{0} ∪ [30, 2678400]` seconds (0 = use global, 30s = scheduler tick floor, 2678400s = 31 days). Out-of-range values return HTTP 400 with an error naming both the offending subsystem and the valid range. Max-age range (0-30 days) unchanged from slice 1.

## UI

- **Reusable helper**: `createIntervalPicker(subsystemId, label)` — generates picker markup + wires all event handlers. Mount points pre-rendered as `<div id="scan-interval-<sub>">`. The existing global Diagnostic Scan Interval widget is **not** refactored to use this helper (per PRD, that's a v0.10.0+ cleanup).
- **Six instantiations**: SMART (colocated with wake-drives/max-age inside the SMART scan controls group); Docker / Proxmox / Kubernetes / ZFS / GPU (grouped under a new "Per-subsystem scan intervals" sub-section).
- **Each picker**: preset dropdown ("Use global (30m)", 5m, 15m, 30m, 1h, 2h, 6h, 12h, 24h, 7d, "Custom...") + custom d/h/m/s panel + live preview + cron visualizer + "Edit cron" button.
- **Reverse cron parser** (`parseCronToFields`): handles `*/Ns`, `*/N * * * *`, `0 */N * * *`, `0 0 */N * *`; complex crons return a clear "Must be a simple interval cron" error.
- **Confirm dialog** (`smartMaxAgeConflictConfirm`): fires when saving a config where `SMART.IntervalSec > MaxAgeDays * 86400` (both non-zero). Explains the max-age safety net will over-ride the user's stated SMART cadence. Cancel aborts the save.

## Acceptance criteria (from issue #259)

- [x] `Settings.AdvancedScans` sub-struct exists with 6 sub-structs (SMART, Docker, Proxmox, Kubernetes, ZFS, GPU) each containing `IntervalSec int`
- [x] `AdvancedScans.SMART` also contains `WakeDrives bool` and `MaxAgeDays int` (migrated from slice 1's `Settings.SMART`)
- [x] `currentSettingsVersion` = 3
- [x] Migration v2 -> v3: existing `SMART.{WakeDrives, MaxAgeDays}` values preserved; `Settings.SMART` gone from top level; all 6 `AdvancedScans.*.IntervalSec` default to 0
- [x] `defaultSettings()` populates the v3 shape with `IntervalSec=0` everywhere
- [x] GET `/api/v1/settings` returns the new nested shape
- [x] PUT `/api/v1/settings` round-trips the new shape; out-of-bounds `IntervalSec` returns HTTP 400 with a clear, field-named message
- [x] Reusable `createIntervalPicker(subsystemId, label)` JS helper exists
- [x] Six picker instances render in the Advanced card with SMART colocated with existing SMART knobs; other five in the "Per-subsystem scan intervals" sub-section
- [x] Each picker's preset dropdown includes "Use global (30m)" first and "7d" among the other presets
- [x] "Edit cron" button opens a cron text field; `parseCronToFields` updates d/h/m/s on valid simple crons; shows a clear error for complex crons
- [x] `confirm()` dialog fires when saving a config with `SMART.IntervalSec > MaxAgeDays * 86400` (non-zero both)
- [x] Regression: all slice-1 tests still pass (wake-drives toggle, max-age input, migration v1->v2 still works as the v1 -> v2 -> v3 chain)
- [x] Regression: general scan interval widget unchanged
- [x] No scheduler or collector behaviour changes — slice 2b (#260) activates the new values

## Tests added / updated

- **New**: `settings_advanced_scans_migration_test.go` — 8 tests: v2 -> v3 lift & defaults, v1 -> v2 -> v3 chain, v3 idempotency, v3 explicit-zero preservation, v3 shape sentinel vs corrupted version, v2 -> v3 store-persist round trip, defaults pinned.
- **New**: `settings_advanced_scans_validation_test.go` — 3 tests: per-subsystem IntervalSec range rejection (table-driven across all 6 subsystems + boundary values), PUT/GET round trip for the full AdvancedScans shape, invalid-PUT-does-not-persist guard.
- **New**: `settings_advanced_scans_pickers_test.go` — 6 tests: helper existence, six picker anchors, pickers-inside-Advanced-card ordering, reverse cron parser + error copy, confirm dialog + 86400 multiplier, preset options sentinel.
- **Updated (field path only)**: `settings_smart_migration_test.go`, `settings_smart_schema_test.go`, `settings_smart_validation_test.go`, `settings_smart_version_roundtrip_test.go`, `settings_wake_drives_for_smart_test.go`. Semantic contracts unchanged.

## Pre-push checks (§4b)

- `go build ./...` ✅
- `go test ./...` ✅ (all packages green)
- `go vet ./...` ✅
- No Dockerfile, workflow, migration, or manifest changes
- UI cross-references verified: every DOM id that JS references (`scan-interval-<sub>-{preset,days,hours,minutes,seconds,preview,cron,edit-cron-btn,cron-input,cron-apply-btn,cron-cancel-btn,custom,cron-edit-wrap,cron-error}`) is synthesized by `createIntervalPicker` alongside the JS that reads it. Mount points pre-rendered in the template.

## Refs

- PRD: #239
- Parent: #236
- Slice 1: #237 (V1a) / #238 (V1b) / #256 (UX reversal)
- Slice 2b (behaviour activation): #260
- Recent regression class to preserve: #268 / PR #273