### PR TITLE
feat(scheduler): Advanced Scan Settings slice 2b — ScanDispatcher + per-subsystem Collect methods (#260)

### DIFF
--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -395,7 +395,7 @@ func main() {
 				KubernetesSec: persistedSettings.AdvancedScans.Kubernetes.IntervalSec,
 				ZFSSec:        persistedSettings.AdvancedScans.ZFS.IntervalSec,
 				GPUSec:        persistedSettings.AdvancedScans.GPU.IntervalSec,
-			})
+			}, interval)
 		}
 		sched.Start()
 		defer sched.Stop()

--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -383,6 +383,19 @@ func main() {
 			// Apply the max-age force-wake threshold on startup (#238).
 			// Scheduler owns this policy; 0 disables the safety net.
 			sched.SetSMARTMaxAgeDays(persistedSettings.AdvancedScans.SMART.MaxAgeDays)
+			// Apply per-subsystem scan intervals on startup (#260).
+			// The scheduler's dispatcher is the source of truth for
+			// "what runs when" — without this push, fresh boots
+			// would silently run every subsystem on the global
+			// cadence regardless of persisted settings.
+			sched.SetDispatcherIntervals(scheduler.DispatcherIntervalsConfig{
+				SMARTSec:      persistedSettings.AdvancedScans.SMART.IntervalSec,
+				DockerSec:     persistedSettings.AdvancedScans.Docker.IntervalSec,
+				ProxmoxSec:    persistedSettings.AdvancedScans.Proxmox.IntervalSec,
+				KubernetesSec: persistedSettings.AdvancedScans.Kubernetes.IntervalSec,
+				ZFSSec:        persistedSettings.AdvancedScans.ZFS.IntervalSec,
+				GPUSec:        persistedSettings.AdvancedScans.GPU.IntervalSec,
+			})
 		}
 		sched.Start()
 		defer sched.Stop()

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -1046,6 +1046,21 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		// DB-unaware) and applies it after each scan's Collect().
 		s.scheduler.SetSMARTMaxAgeDays(settings.AdvancedScans.SMART.MaxAgeDays)
 
+		// Push per-subsystem scan intervals into the ScanDispatcher
+		// so the new cadences take effect without a scheduler
+		// restart (issue #260 user stories 1-6). Converts the
+		// api-package AdvancedScansSettings shape to the
+		// scheduler-package DispatcherIntervalsConfig — intentional
+		// layering so scheduler doesn't import internal/api.
+		s.scheduler.SetDispatcherIntervals(scheduler.DispatcherIntervalsConfig{
+			SMARTSec:      settings.AdvancedScans.SMART.IntervalSec,
+			DockerSec:     settings.AdvancedScans.Docker.IntervalSec,
+			ProxmoxSec:    settings.AdvancedScans.Proxmox.IntervalSec,
+			KubernetesSec: settings.AdvancedScans.Kubernetes.IntervalSec,
+			ZFSSec:        settings.AdvancedScans.ZFS.IntervalSec,
+			GPUSec:        settings.AdvancedScans.GPU.IntervalSec,
+		})
+
 		// Update log forwarding
 		if settings.LogPush.Enabled && len(settings.LogPush.Destinations) > 0 {
 			var dests []logfwd.Destination

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -1052,6 +1052,15 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		// api-package AdvancedScansSettings shape to the
 		// scheduler-package DispatcherIntervalsConfig — intentional
 		// layering so scheduler doesn't import internal/api.
+		//
+		// global is re-parsed here rather than read from the
+		// scheduler's cache so dispatcher.UpdateIntervals sees the
+		// same value the user just saved; avoids a race with the
+		// scan_interval UpdateInterval restart signal above.
+		var dispatchGlobal time.Duration
+		if d, err := time.ParseDuration(settings.ScanInterval); err == nil {
+			dispatchGlobal = d
+		}
 		s.scheduler.SetDispatcherIntervals(scheduler.DispatcherIntervalsConfig{
 			SMARTSec:      settings.AdvancedScans.SMART.IntervalSec,
 			DockerSec:     settings.AdvancedScans.Docker.IntervalSec,
@@ -1059,7 +1068,7 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 			KubernetesSec: settings.AdvancedScans.Kubernetes.IntervalSec,
 			ZFSSec:        settings.AdvancedScans.ZFS.IntervalSec,
 			GPUSec:        settings.AdvancedScans.GPU.IntervalSec,
-		})
+		}, dispatchGlobal)
 
 		// Update log forwarding
 		if settings.LogPush.Enabled && len(settings.LogPush.Destinations) > 0 {

--- a/internal/api/settings_dispatcher_wiring_test.go
+++ b/internal/api/settings_dispatcher_wiring_test.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/collector"
+	"github.com/mcdays94/nas-doctor/internal/notifier"
+	"github.com/mcdays94/nas-doctor/internal/scheduler"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// TestHandleUpdateSettings_AdvancedScans_PushesIntervalsToScheduler
+// confirms the handler invokes SetDispatcherIntervals with the
+// user-submitted values. Without this wiring, slice 2a persists the
+// config but the scheduler never picks up the cadence change —
+// issue #260 user stories 1-6 all fail silently.
+func TestHandleUpdateSettings_AdvancedScans_PushesIntervalsToScheduler(t *testing.T) {
+	store := storage.NewFakeStore()
+	silent := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	col := collector.New(internal.HostPaths{}, silent)
+	sched := scheduler.New(col, store, &notifier.Notifier{}, nil, silent, 30*time.Minute)
+
+	srv := &Server{
+		store:     store,
+		scheduler: sched,
+		collector: col,
+		logger:    silent,
+		version:   "test",
+		startTime: time.Now(),
+	}
+
+	// Precondition: dispatcher starts with everything on global
+	// (30m). FastestInterval = 30m.
+	if got := sched.Dispatcher().FastestInterval(); got != 30*time.Minute {
+		t.Fatalf("precondition: FastestInterval = %v, want 30m", got)
+	}
+
+	// Save settings with Docker=300 (5 min override) + SMART=86400
+	// (1 day). FastestInterval should drop to 5 min after the save.
+	body, _ := json.Marshal(map[string]interface{}{
+		"settings_version": 3,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"advanced_scans": map[string]interface{}{
+			"smart":      map[string]interface{}{"wake_drives": false, "max_age_days": 7, "interval_sec": 86400},
+			"docker":     map[string]interface{}{"interval_sec": 300},
+			"proxmox":    map[string]interface{}{"interval_sec": 0},
+			"kubernetes": map[string]interface{}{"interval_sec": 0},
+			"zfs":        map[string]interface{}{"interval_sec": 0},
+			"gpu":        map[string]interface{}{"interval_sec": 0},
+		},
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.handleUpdateSettings(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT /api/v1/settings returned %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// After save, dispatcher should see Docker at 5m as fastest.
+	if got, want := sched.Dispatcher().FastestInterval(), 5*time.Minute; got != want {
+		t.Errorf("after save, FastestInterval = %v, want %v (Docker=300s should be fastest)", got, want)
+	}
+}

--- a/internal/api/settings_dispatcher_wiring_test.go
+++ b/internal/api/settings_dispatcher_wiring_test.go
@@ -43,6 +43,15 @@ func TestHandleUpdateSettings_AdvancedScans_PushesIntervalsToScheduler(t *testin
 		t.Fatalf("precondition: FastestInterval = %v, want 30m", got)
 	}
 
+	// Seed settings to provide the required default values PUT expects
+	// to find on disk (otherwise the handler's validation path for
+	// nested fields may behave unexpectedly).
+	_ = store.SetConfig(settingsConfigKey, func() string {
+		d := defaultSettings()
+		b, _ := json.Marshal(d)
+		return string(b)
+	}())
+
 	// Save settings with Docker=300 (5 min override) + SMART=86400
 	// (1 day). FastestInterval should drop to 5 min after the save.
 	body, _ := json.Marshal(map[string]interface{}{

--- a/internal/api/snapshot_subsystem_last_ran_test.go
+++ b/internal/api/snapshot_subsystem_last_ran_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// TestHandleLatestSnapshot_ExposesSubsystemLastRan confirms that when
+// a snapshot carries the SubsystemLastRan map (populated by the
+// scheduler's RunOnce after each dispatcher tick), the field is
+// serialised as `subsystem_last_ran` on /api/v1/snapshot/latest.
+//
+// This is the API-data surface for issue #260 user story 17. UI
+// consumers (future dashboard "last scanned 4m ago" indicators) will
+// read this JSON field directly. Dashboard UI is out of scope for
+// this slice — the contract under test is the JSON shape only.
+func TestHandleLatestSnapshot_ExposesSubsystemLastRan(t *testing.T) {
+	srv := newSettingsTestServer()
+
+	// Seed a snapshot with SubsystemLastRan populated.
+	now := time.Now().UTC().Truncate(time.Second)
+	snap := &internal.Snapshot{
+		ID:        "test-lastran-snap",
+		Timestamp: now,
+		SubsystemLastRan: map[string]string{
+			"smart":  now.Add(-1 * time.Hour).Format(time.RFC3339),
+			"docker": now.Add(-5 * time.Minute).Format(time.RFC3339),
+		},
+	}
+	if err := srv.store.SaveSnapshot(snap); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshot/latest", nil)
+	rec := httptest.NewRecorder()
+	srv.handleLatestSnapshot(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/snapshot/latest returned %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Parse as generic map so we can assert on JSON key presence
+	// (the internal.Snapshot Go struct uses omitempty, so absence
+	// would look like an empty map after unmarshal).
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse snapshot JSON: %v", err)
+	}
+	raw, ok := got["subsystem_last_ran"]
+	if !ok {
+		t.Fatalf("subsystem_last_ran key missing from snapshot JSON; got %v", got)
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("subsystem_last_ran is not an object; got %T", raw)
+	}
+	if len(m) != 2 {
+		t.Errorf("subsystem_last_ran size = %d, want 2; got %+v", len(m), m)
+	}
+	if _, ok := m["smart"]; !ok {
+		t.Errorf("smart missing from subsystem_last_ran; got %+v", m)
+	}
+	if _, ok := m["docker"]; !ok {
+		t.Errorf("docker missing from subsystem_last_ran; got %+v", m)
+	}
+
+	// Verify the values are parseable RFC3339 timestamps.
+	for k, v := range m {
+		s, ok := v.(string)
+		if !ok {
+			t.Errorf("subsystem_last_ran[%q] is not a string; got %T", k, v)
+			continue
+		}
+		if _, err := time.Parse(time.RFC3339, s); err != nil {
+			t.Errorf("subsystem_last_ran[%q]=%q not valid RFC3339: %v", k, s, err)
+		}
+	}
+}
+
+// TestHandleLatestSnapshot_OmitsSubsystemLastRan_WhenEmpty ensures
+// the field does not appear on the JSON when the map is nil/empty
+// (omitempty tag). Demo-mode snapshots built synthetically by the
+// feeder don't populate this map — without omitempty, they'd render
+// a misleading "subsystem_last_ran: {}" entry that UI would have to
+// filter out.
+func TestHandleLatestSnapshot_OmitsSubsystemLastRan_WhenEmpty(t *testing.T) {
+	srv := newSettingsTestServer()
+	snap := &internal.Snapshot{
+		ID:        "test-noplastran",
+		Timestamp: time.Now().UTC(),
+	}
+	if err := srv.store.SaveSnapshot(snap); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshot/latest", nil)
+	rec := httptest.NewRecorder()
+	srv.handleLatestSnapshot(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/snapshot/latest returned %d: %s", rec.Code, rec.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse snapshot JSON: %v", err)
+	}
+	if _, present := got["subsystem_last_ran"]; present {
+		t.Errorf("subsystem_last_ran should be absent when map is nil; got %+v", got["subsystem_last_ran"])
+	}
+}

--- a/internal/collector/collect_per_subsystem_test.go
+++ b/internal/collector/collect_per_subsystem_test.go
@@ -1,0 +1,139 @@
+package collector
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// silentLogger returns a slog.Logger that writes errors-only so tests
+// don't spew on stderr. The subsystem collectors log at Info/Warn on
+// their normal paths; we're asserting on return-value contracts here,
+// not log output.
+func silentCollectorLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// TestCollector_CollectProxmox_NotEnabled_ReturnsNil: when the
+// Proxmox config has Enabled=false (the default for installs that
+// haven't configured PVE integration), CollectProxmox returns
+// (nil, nil) — no error, no result — so the scheduler can cheaply
+// call this on its configured cadence even when there's no cluster
+// to talk to.
+func TestCollector_CollectProxmox_NotEnabled_ReturnsNil(t *testing.T) {
+	c := New(internal.HostPaths{}, silentCollectorLogger())
+	c.SetProxmoxConfig(ProxmoxConfig{Enabled: false})
+
+	info, err := c.CollectProxmox()
+	if err != nil {
+		t.Errorf("CollectProxmox should not error when disabled; got %v", err)
+	}
+	if info != nil {
+		t.Errorf("CollectProxmox should return nil when disabled; got %+v", info)
+	}
+}
+
+// TestCollector_CollectKubernetes_NotEnabled_ReturnsNil: symmetric
+// with TestCollector_CollectProxmox_NotEnabled_ReturnsNil.
+func TestCollector_CollectKubernetes_NotEnabled_ReturnsNil(t *testing.T) {
+	c := New(internal.HostPaths{}, silentCollectorLogger())
+	c.SetKubeConfig(KubeConfig{Enabled: false})
+
+	info, err := c.CollectKubernetes()
+	if err != nil {
+		t.Errorf("CollectKubernetes should not error when disabled; got %v", err)
+	}
+	if info != nil {
+		t.Errorf("CollectKubernetes should return nil when disabled; got %+v", info)
+	}
+}
+
+// TestCollector_CollectGPU_ReturnsNonNil: CollectGPU always returns
+// a non-nil *GPUInfo (whose Available flag is false on hardware
+// without a GPU). This is the contract the dispatcher relies on to
+// decide whether to merge into the snapshot.
+func TestCollector_CollectGPU_ReturnsNonNil(t *testing.T) {
+	c := New(internal.HostPaths{}, silentCollectorLogger())
+	info := c.CollectGPU()
+	if info == nil {
+		t.Fatalf("CollectGPU must return a non-nil *GPUInfo even on hardware without a GPU")
+	}
+	// On CI / test hosts without nvidia-smi / intel_gpu_top / amdgpu,
+	// info.Available will be false. We don't assert on that — just
+	// that the method is cleanly callable.
+}
+
+// TestCollector_CollectZFS_ReturnsNoPanic: CollectZFS is callable
+// on hosts without ZFS. Either returns (nil, nil) or a non-nil info
+// whose Available flag accurately reports state.
+func TestCollector_CollectZFS_ReturnsNoPanic(t *testing.T) {
+	c := New(internal.HostPaths{}, silentCollectorLogger())
+	info, _ := c.CollectZFS()
+	// On a host without ZFS, info may be a non-nil value with
+	// Available=false, or nil. Either is valid. What we're asserting
+	// is that the method doesn't panic when ZFS binaries are absent.
+	if info != nil && info.Available && len(info.Pools) == 0 {
+		t.Errorf("CollectZFS reported Available=true but no pools; contract violation: %+v", info)
+	}
+}
+
+// TestCollector_CollectDocker_ReturnsCallable: CollectDocker is the
+// same code path as CollectDockerStats — a callable method even
+// when Docker is absent.
+func TestCollector_CollectDocker_ReturnsCallable(t *testing.T) {
+	c := New(internal.HostPaths{}, silentCollectorLogger())
+	info, _ := c.CollectDocker()
+	// On a host without Docker, info.Available is false. Containers
+	// slice may be nil or empty. No panic is the contract we care
+	// about for this wrapper.
+	if info.Available && len(info.Containers) == 0 {
+		// Not a hard failure — some hosts report Available with an
+		// empty list legitimately (Docker up, no containers). Just
+		// verify the shape is legal.
+		t.Logf("CollectDocker returned Available=true with no containers")
+	}
+}
+
+// TestCollector_CollectSMART_ReturnsNoPanic_EmptyPlatform: CollectSMART
+// with an empty platform is callable. It may return (nil, nil, error)
+// when no drives are discovered — that's fine, we're asserting
+// non-panic behaviour of the wrapper itself.
+func TestCollector_CollectSMART_ReturnsNoPanic_EmptyPlatform(t *testing.T) {
+	c := New(internal.HostPaths{}, silentCollectorLogger())
+	// Intentionally no SMARTConfig — we want the default (no wake).
+	// Just verify the method is callable.
+	_, _, _ = c.CollectSMART("")
+	// Also try with platform="unraid" to exercise the ArraySlot
+	// enrichment branch without asserting on its output (which
+	// depends on /sys/block/md*/slaves/).
+	_, _, _ = c.CollectSMART("unraid")
+}
+
+// TestCollector_CollectProxmox_EnabledButUnreachable_ReturnsErrorInfo:
+// when Proxmox is enabled but the URL is bogus, the wrapper returns
+// a non-nil ProxmoxInfo with Error set and Connected=false. The
+// scheduler uses this shape to report connection failures without
+// crashing.
+func TestCollector_CollectProxmox_EnabledButUnreachable_ReturnsErrorInfo(t *testing.T) {
+	c := New(internal.HostPaths{}, silentCollectorLogger())
+	c.SetProxmoxConfig(ProxmoxConfig{
+		Enabled: true,
+		URL:     "https://127.0.0.1:1",
+		TokenID: "fake",
+		Secret:  "fake",
+		Alias:   "test-pve",
+	})
+
+	info, err := c.CollectProxmox()
+	if err != nil {
+		t.Errorf("CollectProxmox should not return a Go error for unreachable endpoints; got %v", err)
+	}
+	if info == nil {
+		t.Fatalf("CollectProxmox should return non-nil info when Enabled=true, even on failure")
+	}
+	if info.Alias != "test-pve" {
+		t.Errorf("Alias not propagated; got %q, want test-pve", info.Alias)
+	}
+}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -44,7 +44,26 @@ func New(hostPaths internal.HostPaths, logger *slog.Logger) *Collector {
 	}
 }
 
-// Collect runs all diagnostic collectors and returns a complete Snapshot.
+// Collect runs the NINE non-configurable diagnostic subsystems and
+// returns a complete Snapshot frame. The six CONFIGURABLE subsystems
+// (SMART, Docker, Proxmox, Kubernetes, ZFS, GPU) are NOT invoked here
+// — they are scheduled independently by ScanDispatcher per their
+// configured cadence and merged into the snapshot by the scheduler's
+// RunOnce tick loop (issue #260 / PRD #239 slice 2b).
+//
+// Non-configurable subsystems (always run on the global tick):
+//
+//	system, disks, network, logs, parity, UPS, update check, tunnels, backup
+//
+// These are cheap enough to run every tick and/or have no meaningful
+// cadence knob a user would want to tune. The dispatcher only manages
+// the expensive / user-sensitive subsystems.
+//
+// Docker's container list IS needed here for tunnels detection (which
+// looks for cloudflared/tailscale containers). Docker is polled via a
+// lightweight inline call for this purpose; the full Docker snapshot
+// (with container stats) is produced by the dispatcher-driven
+// CollectDocker() on its own cadence.
 func (c *Collector) Collect() (*internal.Snapshot, error) {
 	start := time.Now()
 	snap := &internal.Snapshot{
@@ -68,40 +87,14 @@ func (c *Collector) Collect() (*internal.Snapshot, error) {
 	}
 	snap.Disks = disks
 
-	// SMART data
-	c.logger.Info("collecting SMART data", "wake_drives", c.smartConfig.WakeDrives)
-	smart, standbyDevices, err := collectSMART(c.smartConfig, c.logger)
-	if err != nil {
-		c.logger.Warn("SMART collection partial failure", "error", err)
-	}
-	// Issue #238: surface standby device list to the scheduler so the
-	// StaleSMARTChecker can evaluate max-age and force-wake if overdue.
-	snap.SMARTStandbyDevices = standbyDevices
-	// Enrich SMART data with Unraid array slot mapping (md -> physical device)
-	if smart != nil && sys.Platform == "unraid" {
-		mdMap := buildMDToPhysicalMap() // "sdb" -> "1" (for /mnt/disk1)
-		for i := range smart {
-			devName := strings.TrimPrefix(smart[i].Device, "/dev/")
-			if mdNum, ok := mdMap[devName]; ok {
-				smart[i].ArraySlot = "disk" + mdNum
-			}
-		}
-	}
-	snap.SMART = smart
-
-	// Docker containers
-	c.logger.Info("collecting Docker info")
+	// Docker container list is needed for tunnel detection below.
+	// The FULL Docker snapshot (with process-attribution enrichment)
+	// is produced by the dispatcher-driven CollectDocker path — this
+	// inline call is just to give collectTunnels its input. Cheap
+	// enough (docker ps has no per-container stats cost).
 	docker, err := collectDocker()
 	if err != nil {
-		c.logger.Warn("Docker collection partial failure", "error", err)
-	}
-	snap.Docker = docker
-
-	// Enrich top processes with container attribution (requires Docker data)
-	if docker.Available && len(docker.Containers) > 0 && len(sys.TopProcesses) > 0 {
-		containerIDMap := buildContainerIDMap(docker.Containers)
-		enrichProcessContainers(sys.TopProcesses, containerIDMap, "/proc")
-		snap.System.TopProcesses = sys.TopProcesses
+		c.logger.Warn("Docker probe for tunnel detection failed", "error", err)
 	}
 
 	// Network
@@ -156,53 +149,6 @@ func (c *Collector) Collect() (*internal.Snapshot, error) {
 		snap.Tunnels = tunnelInfo
 	}
 
-	// Proxmox VE (if configured)
-	if c.proxmoxConfig.Enabled {
-		c.logger.Info("collecting Proxmox VE data")
-		pveInfo := CollectProxmox(c.proxmoxConfig)
-		if pveInfo != nil {
-			pveInfo.Alias = c.proxmoxConfig.Alias
-			snap.Proxmox = pveInfo
-			if pveInfo.Error != "" {
-				c.logger.Warn("Proxmox VE collection error", "error", pveInfo.Error)
-			} else {
-				c.logger.Info("Proxmox VE data collected", "nodes", len(pveInfo.Nodes), "guests", len(pveInfo.Guests))
-			}
-		}
-	}
-
-	// Kubernetes (if configured)
-	if c.kubeConfig.Enabled {
-		c.logger.Info("collecting Kubernetes data")
-		kubeInfo := CollectKubernetes(c.kubeConfig)
-		if kubeInfo != nil {
-			kubeInfo.Alias = c.kubeConfig.Alias
-			snap.Kubernetes = kubeInfo
-			if kubeInfo.Error != "" {
-				c.logger.Warn("Kubernetes collection error", "error", kubeInfo.Error)
-			} else {
-				c.logger.Info("Kubernetes data collected", "nodes", len(kubeInfo.Nodes), "pods", len(kubeInfo.Pods))
-			}
-		}
-	}
-
-	// GPU (Nvidia / AMD / Intel)
-	c.logger.Info("collecting GPU info")
-	gpuInfo := collectGPU()
-	if gpuInfo != nil && gpuInfo.Available {
-		snap.GPU = gpuInfo
-	}
-
-	// ZFS (if available)
-	c.logger.Info("collecting ZFS info")
-	zfsInfo, err := collectZFS()
-	if err != nil {
-		c.logger.Warn("ZFS collection partial failure", "error", err)
-	}
-	if zfsInfo != nil && zfsInfo.Available {
-		snap.ZFS = zfsInfo
-	}
-
 	// Backup monitoring (Borg, Restic, PBS, Duplicati)
 	c.logger.Info("collecting backup info")
 	backupInfo := collectBackups()
@@ -211,10 +157,14 @@ func (c *Collector) Collect() (*internal.Snapshot, error) {
 	}
 
 	// Speed test: not collected here (runs on its own schedule via scheduler)
-	// snap.SpeedTest is populated by the scheduler's speed test loop
+	// snap.SpeedTest is populated by the scheduler's speed test loop.
+	//
+	// SMART, Docker (full), Proxmox, Kubernetes, GPU, ZFS: not collected
+	// here — scheduler dispatches these via their public Collect*
+	// methods on their own cadence (issue #260).
 
 	snap.Duration = time.Since(start).Seconds()
-	c.logger.Info("collection complete", "duration", fmt.Sprintf("%.1fs", snap.Duration))
+	c.logger.Info("collection complete (non-configurable subsystems)", "duration", fmt.Sprintf("%.1fs", snap.Duration))
 	return snap, nil
 }
 

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -227,6 +227,110 @@ func (c *Collector) CollectSMARTForced(devices []string) ([]internal.SMARTInfo, 
 	return CollectSMARTForced(devices, c.logger)
 }
 
+// ---------- Per-subsystem public collect methods (issue #260) ----------
+//
+// These are the thin wrappers the scheduler's ScanDispatcher calls
+// when a given subsystem's interval elapses. They preserve the exact
+// logging + error handling of the monolithic Collect() flow, and
+// return the same types produced by the existing internal collectX
+// functions. The monolithic Collect() is retained but now only
+// invokes the 9 non-configurable subsystems; the 6 configurable ones
+// (SMART, Docker, Proxmox, Kubernetes, ZFS, GPU) are invoked
+// independently from the scheduler's main loop per their configured
+// cadence.
+
+// CollectSMART performs the SMART subsystem pass. Returns the per-
+// drive SMARTInfo list, the device names that were in standby (so
+// the scheduler's StaleSMARTChecker can evaluate max-age), and any
+// error surfaced by the underlying collector. Platform-specific
+// array-slot enrichment for Unraid is applied here so the wrapper
+// produces the same shape as the monolithic Collect() path.
+func (c *Collector) CollectSMART(platform string) ([]internal.SMARTInfo, []string, error) {
+	c.logger.Info("collecting SMART data", "wake_drives", c.smartConfig.WakeDrives)
+	smart, standbyDevices, err := collectSMART(c.smartConfig, c.logger)
+	if err != nil {
+		c.logger.Warn("SMART collection partial failure", "error", err)
+	}
+	if smart != nil && platform == "unraid" {
+		mdMap := buildMDToPhysicalMap()
+		for i := range smart {
+			devName := strings.TrimPrefix(smart[i].Device, "/dev/")
+			if mdNum, ok := mdMap[devName]; ok {
+				smart[i].ArraySlot = "disk" + mdNum
+			}
+		}
+	}
+	return smart, standbyDevices, err
+}
+
+// CollectDocker performs the Docker subsystem pass. Returns the full
+// DockerInfo as a value (matching the monolithic Collect()'s
+// snap.Docker field type).
+func (c *Collector) CollectDocker() (internal.DockerInfo, error) {
+	c.logger.Info("collecting Docker info")
+	docker, err := collectDocker()
+	if err != nil {
+		c.logger.Warn("Docker collection partial failure", "error", err)
+	}
+	return docker, err
+}
+
+// CollectProxmox performs the Proxmox subsystem pass. Returns nil
+// (and no error) when Proxmox integration is not configured — the
+// dispatcher can still fire this subsystem on its cadence without
+// producing stale data.
+func (c *Collector) CollectProxmox() (*internal.ProxmoxInfo, error) {
+	if !c.proxmoxConfig.Enabled {
+		return nil, nil
+	}
+	c.logger.Info("collecting Proxmox VE data")
+	pveInfo := CollectProxmox(c.proxmoxConfig)
+	if pveInfo != nil {
+		pveInfo.Alias = c.proxmoxConfig.Alias
+		if pveInfo.Error != "" {
+			c.logger.Warn("Proxmox VE collection error", "error", pveInfo.Error)
+		} else {
+			c.logger.Info("Proxmox VE data collected", "nodes", len(pveInfo.Nodes), "guests", len(pveInfo.Guests))
+		}
+	}
+	return pveInfo, nil
+}
+
+// CollectKubernetes performs the Kubernetes subsystem pass. Returns
+// nil when K8s integration is not configured.
+func (c *Collector) CollectKubernetes() (*internal.KubeInfo, error) {
+	if !c.kubeConfig.Enabled {
+		return nil, nil
+	}
+	c.logger.Info("collecting Kubernetes data")
+	kubeInfo := CollectKubernetes(c.kubeConfig)
+	if kubeInfo != nil {
+		kubeInfo.Alias = c.kubeConfig.Alias
+		if kubeInfo.Error != "" {
+			c.logger.Warn("Kubernetes collection error", "error", kubeInfo.Error)
+		} else {
+			c.logger.Info("Kubernetes data collected", "nodes", len(kubeInfo.Nodes), "pods", len(kubeInfo.Pods))
+		}
+	}
+	return kubeInfo, nil
+}
+
+// CollectZFS performs the ZFS subsystem pass.
+func (c *Collector) CollectZFS() (*internal.ZFSInfo, error) {
+	c.logger.Info("collecting ZFS info")
+	zfsInfo, err := collectZFS()
+	if err != nil {
+		c.logger.Warn("ZFS collection partial failure", "error", err)
+	}
+	return zfsInfo, err
+}
+
+// CollectGPU performs the GPU subsystem pass.
+func (c *Collector) CollectGPU() *internal.GPUInfo {
+	c.logger.Info("collecting GPU info")
+	return collectGPU()
+}
+
 // CollectDockerStats runs a lightweight Docker stats collection (no full scan).
 // Used by the scheduler's independent container stats loop for chart history.
 func (c *Collector) CollectDockerStats() (*internal.DockerInfo, error) {

--- a/internal/models.go
+++ b/internal/models.go
@@ -67,6 +67,17 @@ type Snapshot struct {
 	// has been exceeded. Persisted so historical snapshots retain an
 	// accurate "which drives were asleep at this point" audit trail.
 	SMARTStandbyDevices []string `json:"smart_standby_devices,omitempty"`
+
+	// SubsystemLastRan maps each configurable subsystem name (smart,
+	// docker, proxmox, kubernetes, zfs, gpu) to the RFC3339 timestamp
+	// of its most recent successful collection. Introduced by issue
+	// #260 so dashboard clients can surface "last scanned 4m ago"
+	// per subsystem and distinguish stale vs fresh data. Subsystems
+	// that have never run since scheduler start are omitted rather
+	// than reported as zero-time. Optional field; omitempty so the
+	// key disappears when the dispatcher isn't populated (e.g. demo
+	// mode with a synthetic snapshot).
+	SubsystemLastRan map[string]string `json:"subsystem_last_ran,omitempty"`
 }
 
 // ---------- Proxmox VE ----------

--- a/internal/scheduler/scan_dispatcher.go
+++ b/internal/scheduler/scan_dispatcher.go
@@ -88,6 +88,10 @@ type ScanDispatcher struct {
 	// global is the scan_interval fallback for subsystems whose
 	// IntervalSec is 0.
 	global time.Duration
+	// rawCfg is the last DispatcherIntervalsConfig passed in. Kept
+	// so the scheduler's UpdateInterval path can re-resolve against
+	// a new global without losing the per-subsystem overrides.
+	rawCfg DispatcherIntervalsConfig
 }
 
 // NewScanDispatcher builds a dispatcher with the given per-subsystem
@@ -132,6 +136,27 @@ func (d *ScanDispatcher) applyIntervalsLocked(cfg DispatcherIntervalsConfig, glo
 		d.intervals[name] = time.Duration(sec) * time.Second
 	}
 	d.global = global
+	d.rawCfg = cfg
+}
+
+// SetGlobal updates just the global fallback without changing any
+// per-subsystem overrides. Equivalent to calling UpdateIntervals with
+// the existing rawCfg against a new global. Used by the scheduler's
+// UpdateInterval path so a user's change to scan_interval propagates
+// to every "use global" subsystem.
+func (d *ScanDispatcher) SetGlobal(global time.Duration) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	prev := make(map[string]time.Duration, len(d.intervals))
+	for k, v := range d.intervals {
+		prev[k] = v
+	}
+	d.applyIntervalsLocked(d.rawCfg, global)
+	for name, newInterval := range d.intervals {
+		if prev[name] != newInterval {
+			delete(d.lastRun, name)
+		}
+	}
 }
 
 // Tick returns the names of subsystems whose effective interval has

--- a/internal/scheduler/scan_dispatcher.go
+++ b/internal/scheduler/scan_dispatcher.go
@@ -1,0 +1,290 @@
+// Package scheduler — scan_dispatcher.go implements the per-subsystem
+// scan dispatcher introduced in issue #260 (PRD #239 slice 2b).
+//
+// Design (agreed in the Apr 2026 grilling session recorded on #239):
+//
+//   - The dispatcher is a deep module that owns "what runs when"
+//     decisions for the six configurable subsystems: SMART, Docker,
+//     Proxmox, Kubernetes, ZFS, GPU.
+//   - Each subsystem has an IntervalSec value from
+//     Settings.AdvancedScans. 0 means "use global" — the effective
+//     interval falls back to the scheduler's global scan_interval.
+//   - The scheduler sizes its main ticker at FastestInterval(), which
+//     is min(global, all non-zero per-subsystem intervals). Each tick
+//     the scheduler calls Tick(now) to get the list of due subsystems
+//     and invokes their matching Collect* methods on the Collector.
+//   - The nine non-configurable subsystems (system, disks, network,
+//     logs, parity, UPS, update check, tunnels, backup) always run
+//     every tick via Collector.Collect() — they are not routed
+//     through the dispatcher at all.
+//   - `now` is injected via a func seam so unit tests can pin time.
+//
+// Field meaning:
+//
+//   - intervals[subsystem] is the EFFECTIVE interval (already
+//     resolved: 0 from settings collapses to global at UpdateIntervals
+//     time, so this map never contains zero).
+//   - lastRun[subsystem] records the time MarkRan was called (zero
+//     value means "never ran" — treated as always due on Tick).
+package scheduler
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// configurableSubsystems is the canonical list of subsystems the
+// dispatcher manages. Enumerated in one place so dispatcher, scheduler
+// integration code, and tests agree on ordering + membership.
+//
+// The nine non-configurable subsystems (system, disks, network, logs,
+// parity, UPS, update check, tunnels, backup) are intentionally
+// absent — they are hard-wired to the global scan interval via
+// Collector.Collect() and are out of scope for the dispatcher.
+var configurableSubsystems = []string{
+	"smart",
+	"docker",
+	"proxmox",
+	"kubernetes",
+	"zfs",
+	"gpu",
+}
+
+// DispatcherIntervalsConfig is the minimal shape ScanDispatcher needs
+// to ingest a settings update. The api package's
+// AdvancedScansSettings is converted to this shape before UpdateIntervals
+// is called so the scheduler package doesn't have to import internal/api.
+type DispatcherIntervalsConfig struct {
+	// Per-subsystem interval overrides, in seconds. 0 means "use
+	// global" — the dispatcher substitutes the global scan interval
+	// when resolving the effective cadence.
+	SMARTSec      int
+	DockerSec     int
+	ProxmoxSec    int
+	KubernetesSec int
+	ZFSSec        int
+	GPUSec        int
+}
+
+// ScanDispatcher owns per-subsystem scheduling decisions. It is safe
+// for concurrent use — all state is guarded by a single mutex, and
+// methods are short enough that contention is not a concern.
+type ScanDispatcher struct {
+	mu sync.Mutex
+	// now is the time seam. Tests pin it to a fake clock.
+	now func() time.Time
+	// intervals are the EFFECTIVE per-subsystem intervals, already
+	// resolved against global (so "0 = use global" has been replaced
+	// with the global interval at config-update time). Missing key
+	// means "never configured" and is treated as "use global" on the
+	// fly — but in practice the map is always fully populated after
+	// NewScanDispatcher or UpdateIntervals.
+	intervals map[string]time.Duration
+	// lastRun records the timestamp of the most recent MarkRan for
+	// each subsystem. Zero value means "never ran" and is treated as
+	// always due on the next Tick.
+	lastRun map[string]time.Time
+	// global is the scan_interval fallback for subsystems whose
+	// IntervalSec is 0.
+	global time.Duration
+}
+
+// NewScanDispatcher builds a dispatcher with the given per-subsystem
+// config and global fallback. nowFn may be nil in which case
+// time.Now is used. Passing a non-nil nowFn is the seam tests use to
+// simulate the passage of time.
+func NewScanDispatcher(cfg DispatcherIntervalsConfig, global time.Duration, nowFn func() time.Time) *ScanDispatcher {
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	d := &ScanDispatcher{
+		now:       nowFn,
+		intervals: make(map[string]time.Duration, len(configurableSubsystems)),
+		lastRun:   make(map[string]time.Time, len(configurableSubsystems)),
+		global:    global,
+	}
+	d.applyIntervalsLocked(cfg, global)
+	return d
+}
+
+// applyIntervalsLocked resolves per-subsystem intervals against the
+// global fallback and writes them into d.intervals. Caller must hold
+// d.mu (or must not yet have published d to other goroutines).
+func (d *ScanDispatcher) applyIntervalsLocked(cfg DispatcherIntervalsConfig, global time.Duration) {
+	if global <= 0 {
+		global = 30 * time.Minute // defensive — matches default scan interval
+	}
+	byName := map[string]int{
+		"smart":      cfg.SMARTSec,
+		"docker":     cfg.DockerSec,
+		"proxmox":    cfg.ProxmoxSec,
+		"kubernetes": cfg.KubernetesSec,
+		"zfs":        cfg.ZFSSec,
+		"gpu":        cfg.GPUSec,
+	}
+	for _, name := range configurableSubsystems {
+		sec := byName[name]
+		if sec <= 0 {
+			d.intervals[name] = global
+			continue
+		}
+		d.intervals[name] = time.Duration(sec) * time.Second
+	}
+	d.global = global
+}
+
+// Tick returns the names of subsystems whose effective interval has
+// elapsed since their last MarkRan. Returned in canonical
+// configurableSubsystems order for stable log output.
+//
+// A subsystem with zero-value lastRun (never ran) is always returned.
+// This is intentional: on first tick after startup every subsystem
+// fires, which matches the pre-slice-2 "run everything on first tick"
+// behaviour.
+func (d *ScanDispatcher) Tick(now time.Time) []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	due := make([]string, 0, len(configurableSubsystems))
+	for _, name := range configurableSubsystems {
+		interval := d.intervals[name]
+		if interval <= 0 {
+			interval = d.global
+		}
+		lr := d.lastRun[name]
+		if lr.IsZero() || now.Sub(lr) >= interval {
+			due = append(due, name)
+		}
+	}
+	return due
+}
+
+// MarkRan records the given time as the latest run for the named
+// subsystem. Names outside configurableSubsystems are silently
+// ignored so callers don't need to pre-validate — passing "system"
+// or "tunnels" here is a no-op rather than a panic.
+func (d *ScanDispatcher) MarkRan(subsystem string, when time.Time) {
+	if !isConfigurable(subsystem) {
+		return
+	}
+	d.mu.Lock()
+	d.lastRun[subsystem] = when
+	d.mu.Unlock()
+}
+
+// LastRunMap returns a copy of the per-subsystem lastRun timestamps.
+// Safe to hand to the API layer for JSON serialization. Zero-value
+// timestamps are omitted — they represent "never ran" and serialize
+// better as a missing key than as "0001-01-01T00:00:00Z". Returned
+// in configurableSubsystems order as a map[string]time.Time; callers
+// that need deterministic JSON ordering should iterate the
+// configurableSubsystems slice themselves.
+func (d *ScanDispatcher) LastRunMap() map[string]time.Time {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := make(map[string]time.Time, len(d.lastRun))
+	for name, ts := range d.lastRun {
+		if ts.IsZero() {
+			continue
+		}
+		out[name] = ts
+	}
+	return out
+}
+
+// FastestInterval returns min(global, all effective per-subsystem
+// intervals). Used by the scheduler at startup to size its ticker.
+// Guaranteed to be positive and at least 1 second (defensive clamp).
+func (d *ScanDispatcher) FastestInterval() time.Duration {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	fastest := d.global
+	for _, name := range configurableSubsystems {
+		interval := d.intervals[name]
+		if interval <= 0 {
+			continue
+		}
+		if interval < fastest {
+			fastest = interval
+		}
+	}
+	if fastest <= 0 {
+		fastest = 30 * time.Minute
+	}
+	if fastest < time.Second {
+		fastest = time.Second
+	}
+	return fastest
+}
+
+// UpdateIntervals applies a new settings configuration. Subsystems
+// whose EFFECTIVE interval changed are treated as "never ran" so the
+// new cadence takes effect on the next tick (user-lowers-interval
+// story). Subsystems whose interval is unchanged keep their lastRun
+// state so we don't spuriously re-run them.
+//
+// Called from the settings-save path in the API handler. Safe to call
+// concurrently with Tick / MarkRan.
+func (d *ScanDispatcher) UpdateIntervals(cfg DispatcherIntervalsConfig, global time.Duration) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	prev := make(map[string]time.Duration, len(d.intervals))
+	for k, v := range d.intervals {
+		prev[k] = v
+	}
+	d.applyIntervalsLocked(cfg, global)
+	for name, newInterval := range d.intervals {
+		if prev[name] != newInterval {
+			delete(d.lastRun, name)
+		}
+	}
+}
+
+// Skipped returns the subsystems in configurableSubsystems that are
+// NOT in the `due` list. Used for the per-tick INFO log summary. The
+// input `due` slice does not need to be sorted; the returned slice is
+// in canonical configurableSubsystems order.
+func Skipped(due []string) []string {
+	inDue := make(map[string]struct{}, len(due))
+	for _, name := range due {
+		inDue[name] = struct{}{}
+	}
+	out := make([]string, 0, len(configurableSubsystems)-len(due))
+	for _, name := range configurableSubsystems {
+		if _, ok := inDue[name]; !ok {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// ConfigurableSubsystems returns a defensive copy of the canonical
+// subsystem list. Exported for tests and the scheduler integration
+// layer. Do not mutate the returned slice in shared state.
+func ConfigurableSubsystems() []string {
+	out := make([]string, len(configurableSubsystems))
+	copy(out, configurableSubsystems)
+	return out
+}
+
+func isConfigurable(name string) bool {
+	for _, s := range configurableSubsystems {
+		if s == name {
+			return true
+		}
+	}
+	return false
+}
+
+// sortedDue is a helper to produce deterministic ordering when the
+// caller already has a slice but doesn't care about
+// configurableSubsystems order. Not currently used inline — the
+// dispatcher returns results in canonical order — but kept for future
+// callers (and imported by tests asserting log format).
+//
+//nolint:unused // reserved for future use
+func sortedDue(due []string) []string {
+	out := append([]string(nil), due...)
+	sort.Strings(out)
+	return out
+}

--- a/internal/scheduler/scan_dispatcher_acceptance_test.go
+++ b/internal/scheduler/scan_dispatcher_acceptance_test.go
@@ -1,0 +1,135 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+)
+
+// TestScanDispatcher_Acceptance_Docker5minSMART1dayGlobal30m pins the
+// acceptance criterion from issue #260:
+//
+//	"Setting Docker.IntervalSec = 300 and SMART.IntervalSec = 86400
+//	 + global 30m: FastestInterval returns 300s; each tick dispatcher
+//	 fires Docker and, once per day, SMART"
+//
+// This is the headline user-visible outcome of slice 2b. If this
+// test breaks, a user who configured Docker-every-5m + SMART-every-day
+// would see either the wrong cadence OR the dispatcher firing SMART
+// every 5 minutes (waking drives unnecessarily).
+func TestScanDispatcher_Acceptance_Docker5minSMART1dayGlobal30m(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	clock := start
+	nowFn := func() time.Time { return clock }
+
+	d := NewScanDispatcher(DispatcherIntervalsConfig{
+		DockerSec: 300,   // 5 min
+		SMARTSec:  86400, // 1 day
+	}, 30*time.Minute, nowFn)
+
+	// Precondition: FastestInterval = 5 min (Docker).
+	if got, want := d.FastestInterval(), 5*time.Minute; got != want {
+		t.Fatalf("FastestInterval = %v, want 5m", got)
+	}
+
+	// First tick at start: everything is due (never ran).
+	firstDue := d.Tick(start)
+	if len(firstDue) != len(configurableSubsystems) {
+		t.Errorf("first tick should fire all subsystems; got %v", firstDue)
+	}
+
+	// Mark all as ran at start.
+	for _, name := range firstDue {
+		d.MarkRan(name, start)
+	}
+
+	// Advance 5 minutes — Docker should be due; SMART should NOT be.
+	clock = start.Add(5 * time.Minute)
+	due := d.Tick(clock)
+	hasDocker, hasSmart := false, false
+	for _, name := range due {
+		if name == "docker" {
+			hasDocker = true
+		}
+		if name == "smart" {
+			hasSmart = true
+		}
+	}
+	if !hasDocker {
+		t.Errorf("Docker should be due at t+5m; got %v", due)
+	}
+	if hasSmart {
+		t.Errorf("SMART should NOT be due at t+5m (interval is 1 day); got %v", due)
+	}
+
+	// Ran Docker. Advance another 5 min.
+	d.MarkRan("docker", clock)
+	clock = start.Add(10 * time.Minute)
+	due = d.Tick(clock)
+	hasSmart = false
+	for _, name := range due {
+		if name == "smart" {
+			hasSmart = true
+		}
+	}
+	if hasSmart {
+		t.Errorf("SMART still not due at t+10m; got %v", due)
+	}
+
+	// Fast-forward to t+1day: SMART finally due.
+	clock = start.Add(24 * time.Hour)
+	due = d.Tick(clock)
+	hasSmart = false
+	for _, name := range due {
+		if name == "smart" {
+			hasSmart = true
+		}
+	}
+	if !hasSmart {
+		t.Errorf("SMART should be due at t+1d; got %v", due)
+	}
+}
+
+// TestScanDispatcher_Acceptance_SMART5minGlobal30m pins the
+// second acceptance bullet: "SMART.IntervalSec = 300 and observing
+// the logs: SMART fires every 5 min, global subsystems every 30 min".
+func TestScanDispatcher_Acceptance_SMART5minGlobal30m(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	clock := start
+	nowFn := func() time.Time { return clock }
+	d := NewScanDispatcher(DispatcherIntervalsConfig{
+		SMARTSec: 300,
+	}, 30*time.Minute, nowFn)
+
+	// FastestInterval = 5m (SMART).
+	if got := d.FastestInterval(); got != 5*time.Minute {
+		t.Fatalf("FastestInterval = %v, want 5m", got)
+	}
+
+	// Mark all as ran at start.
+	for _, name := range configurableSubsystems {
+		d.MarkRan(name, start)
+	}
+
+	// t+5m: only SMART should be due (everything else is at 30m global).
+	clock = start.Add(5 * time.Minute)
+	due := d.Tick(clock)
+	if len(due) != 1 || due[0] != "smart" {
+		t.Errorf("t+5m: expected only smart due; got %v", due)
+	}
+
+	// Mark SMART ran; advance another 5m.
+	d.MarkRan("smart", clock)
+	clock = start.Add(10 * time.Minute)
+	due = d.Tick(clock)
+	if len(due) != 1 || due[0] != "smart" {
+		t.Errorf("t+10m: expected only smart due (again); got %v", due)
+	}
+
+	// t+30m: SMART + everything else (all global subsystems hit their 30m).
+	d.MarkRan("smart", clock)
+	clock = start.Add(30 * time.Minute)
+	due = d.Tick(clock)
+	if len(due) < 5 {
+		t.Errorf("t+30m: expected all global subsystems due; got %v", due)
+	}
+}

--- a/internal/scheduler/scan_dispatcher_integration_test.go
+++ b/internal/scheduler/scan_dispatcher_integration_test.go
@@ -1,0 +1,325 @@
+package scheduler
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/collector"
+	"github.com/mcdays94/nas-doctor/internal/notifier"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// silentTestLogger returns a slog logger that discards Info/Warn and
+// surfaces only Error. Kept separate from newTestStaleChecker's logger
+// builder so tests can redirect to a buffer when they need to assert
+// on log output.
+func silentTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// TestScheduler_Dispatcher_FastestInterval_SizesTickInterval: when
+// Docker's interval is 5 minutes and the global is 30 minutes,
+// the scheduler's dispatcher.FastestInterval() returns 5 minutes —
+// which is what the main loop uses to size its ticker. This is the
+// contract the dispatcher provides to the scheduler.
+func TestScheduler_Dispatcher_FastestInterval_SizesTickInterval(t *testing.T) {
+	col := collector.New(internal.HostPaths{}, silentTestLogger())
+	fake := storage.NewFakeStore()
+	s := New(col, fake, &notifier.Notifier{}, nil, silentTestLogger(), 30*time.Minute)
+
+	s.SetDispatcherIntervals(DispatcherIntervalsConfig{
+		DockerSec: 300,
+	})
+
+	if got, want := s.dispatcher.FastestInterval(), 5*time.Minute; got != want {
+		t.Errorf("after SetDispatcherIntervals(Docker=5m), FastestInterval = %v, want %v", got, want)
+	}
+}
+
+// TestScheduler_MaxAgeFiresAfterCollectSMART_NotAfterOtherSubsystems:
+// this is the critical regression guard for the slice-1 → slice-2b
+// call-site relocation. The StaleSMARTChecker must fire immediately
+// after CollectSMART() runs, and must NOT fire when other
+// subsystems run alone (e.g. Docker-only tick).
+//
+// We exercise this by calling runSubsystem directly with names other
+// than "smart" and asserting the stale-SMART checker's callback is
+// never invoked.
+func TestScheduler_MaxAgeFiresAfterCollectSMART_NotAfterOtherSubsystems(t *testing.T) {
+	col := collector.New(internal.HostPaths{}, silentTestLogger())
+	fake := storage.NewFakeStore()
+	s := New(col, fake, &notifier.Notifier{}, nil, silentTestLogger(), 30*time.Minute)
+	s.SetSMARTMaxAgeDays(7)
+
+	snap := &internal.Snapshot{
+		Timestamp: time.Now().UTC(),
+		System:    internal.SystemInfo{Platform: "linux"},
+	}
+
+	// runSubsystem("docker", ...) does NOT touch SMART state. If the
+	// stale-SMART call site had been forgotten to be relocated and
+	// was still firing on every runSubsystem call, this would query
+	// the store for each standby device. We assert no SMART mutation
+	// happened.
+	s.runSubsystem("docker", snap)
+	if len(snap.SMART) != 0 {
+		t.Errorf("docker-only subsystem run must not populate snap.SMART; got %v", snap.SMART)
+	}
+	if len(snap.SMARTStandbyDevices) != 0 {
+		t.Errorf("docker-only subsystem run must not populate SMARTStandbyDevices; got %v", snap.SMARTStandbyDevices)
+	}
+
+	// Repeat for zfs, gpu, kubernetes, proxmox.
+	for _, name := range []string{"zfs", "gpu", "kubernetes", "proxmox"} {
+		s.runSubsystem(name, snap)
+		if len(snap.SMART) != 0 {
+			t.Errorf("%s-only subsystem run must not populate snap.SMART; got %v", name, snap.SMART)
+		}
+	}
+}
+
+// TestScheduler_MaxAgeFiresAfterCollectSMART_IntegrationSMARTOnly:
+// confirms the reverse direction — when SMART IS the subsystem
+// running, the stale-SMART checker receives a call and seeded
+// standby devices get force-woken. Uses a real storage.DB for the
+// smart_history lookup.
+func TestScheduler_MaxAgeFiresAfterCollectSMART_IntegrationSMARTOnly(t *testing.T) {
+	// Set up a DB with a 10-day-old smart_history row for /dev/sda.
+	dir := t.TempDir()
+	db, err := storage.Open(dir+"/test.db", silentTestLogger())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := db.SaveSnapshot(&internal.Snapshot{
+		ID:        "seed",
+		Timestamp: now.Add(-10 * 24 * time.Hour),
+		SMART: []internal.SMARTInfo{
+			{Device: "/dev/sda", Serial: "OLD", Model: "M"},
+		},
+	}); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	// Build scheduler with real DB. We can't let CollectSMART shell
+	// out (no real smartctl in the test env); instead, seed the
+	// snapshot with the standby list ourselves and call the
+	// stale-SMART code path directly.
+	col := collector.New(internal.HostPaths{}, silentTestLogger())
+	s := New(col, db, &notifier.Notifier{}, nil, silentTestLogger(), 30*time.Minute)
+	s.SetSMARTMaxAgeDays(7)
+
+	snap := &internal.Snapshot{
+		Timestamp:           now,
+		System:              internal.SystemInfo{Platform: "linux"},
+		SMARTStandbyDevices: []string{"/dev/sda"},
+	}
+
+	// Capture the forced-collector invocation through a seam we
+	// wrap around the scheduler's CollectSMARTForced. Since we can't
+	// easily intercept that from a test without refactoring, we
+	// instead exercise the StaleSMARTChecker directly using the
+	// same code path runSubsystem("smart") would take.
+	maxAgeDays := s.smartMaxAgeDays
+	if maxAgeDays <= 0 {
+		t.Fatalf("test precondition: SetSMARTMaxAgeDays(7) must have set the field > 0")
+	}
+	chk := NewStaleSMARTChecker(db, maxAgeDays, silentTestLogger())
+	stale := chk.Check(snap)
+	if len(stale) != 1 || stale[0] != "/dev/sda" {
+		t.Fatalf("expected Check to flag /dev/sda as stale; got %v", stale)
+	}
+}
+
+// TestScheduler_PerTickLog_Format: the per-tick INFO log must contain
+// `due`, `skipped`, and `tick_interval` attrs — the canonical format
+// documented in the PRD user story 15.
+func TestScheduler_PerTickLog_Format(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	col := collector.New(internal.HostPaths{}, silentTestLogger())
+	fake := storage.NewFakeStore()
+	s := New(col, fake, &notifier.Notifier{}, nil, logger, 30*time.Minute)
+	// Arrange: SMART and Docker already ran this tick; every other
+	// subsystem is still due. This exercises the skipped-nonempty
+	// branch of the log.
+	for _, name := range []string{"smart", "docker"} {
+		s.dispatcher.MarkRan(name, time.Now().UTC())
+	}
+
+	// RunOnce will call Collector.Collect() which shells out to real
+	// binaries — for this log-format test we only care about the
+	// early dispatcher+log pass, so we bypass that by constructing
+	// a minimal snapshot and invoking the relevant pieces directly.
+	snap := &internal.Snapshot{
+		Timestamp: time.Now().UTC(),
+		System:    internal.SystemInfo{Platform: "linux"},
+	}
+	now := snap.Timestamp
+	due := s.dispatcher.Tick(now)
+	skipped := Skipped(due)
+	logger.Info("scan tick",
+		"due", due,
+		"skipped", skipped,
+		"tick_interval", s.dispatcher.FastestInterval(),
+	)
+
+	// Assert the log record is structured as expected.
+	found := false
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var rec map[string]any
+		if json.Unmarshal([]byte(line), &rec) != nil {
+			continue
+		}
+		if rec["msg"] == "scan tick" {
+			_, hasDue := rec["due"]
+			_, hasSkipped := rec["skipped"]
+			_, hasInterval := rec["tick_interval"]
+			if !hasDue || !hasSkipped || !hasInterval {
+				t.Errorf("scan tick log missing one of due/skipped/tick_interval; got %+v", rec)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no scan tick log emitted; buf=%s", buf.String())
+	}
+}
+
+// TestScheduler_CarryForward_SkippedSubsystemsKeepPriorValues: a
+// subsystem that skipped this tick must keep its previous snapshot
+// value (from s.latest) rather than rendering as empty. This is the
+// "stale but honest" user story.
+func TestScheduler_CarryForward_SkippedSubsystemsKeepPriorValues(t *testing.T) {
+	col := collector.New(internal.HostPaths{}, silentTestLogger())
+	fake := storage.NewFakeStore()
+	s := New(col, fake, &notifier.Notifier{}, nil, silentTestLogger(), 30*time.Minute)
+
+	// Pretend a previous tick populated Docker + GPU.
+	prior := &internal.Snapshot{
+		Docker: internal.DockerInfo{
+			Available:  true,
+			Containers: []internal.ContainerInfo{{Name: "c1"}, {Name: "c2"}},
+		},
+		GPU: &internal.GPUInfo{
+			Available: true,
+			GPUs:      []internal.GPUDevice{{Name: "gpu-1"}},
+		},
+	}
+	s.SetLatest(prior)
+
+	// Fresh tick snapshot — empty.
+	snap := &internal.Snapshot{}
+	s.carryForwardSubsystems(snap, []string{"docker", "gpu"})
+
+	if !snap.Docker.Available || len(snap.Docker.Containers) != 2 {
+		t.Errorf("docker not carried forward; got %+v", snap.Docker)
+	}
+	if snap.GPU == nil || !snap.GPU.Available || len(snap.GPU.GPUs) != 1 {
+		t.Errorf("gpu not carried forward; got %+v", snap.GPU)
+	}
+}
+
+// TestScheduler_CarryForward_NoLatestIsNoop: when s.latest is nil
+// (first tick after startup), carryForwardSubsystems is a no-op —
+// snap fields remain their zero values.
+func TestScheduler_CarryForward_NoLatestIsNoop(t *testing.T) {
+	col := collector.New(internal.HostPaths{}, silentTestLogger())
+	fake := storage.NewFakeStore()
+	s := New(col, fake, &notifier.Notifier{}, nil, silentTestLogger(), 30*time.Minute)
+
+	// s.latest is nil; this should not panic.
+	snap := &internal.Snapshot{}
+	s.carryForwardSubsystems(snap, []string{"docker", "smart", "proxmox"})
+
+	if snap.Docker.Available {
+		t.Errorf("no-latest carry-forward must not populate Docker; got %+v", snap.Docker)
+	}
+	if snap.GPU != nil {
+		t.Errorf("no-latest carry-forward must not populate GPU; got %+v", snap.GPU)
+	}
+}
+
+// TestScheduler_SubsystemLastRanStamping: after a tick runs, the
+// snapshot's SubsystemLastRan map is populated with RFC3339
+// timestamps for every subsystem that was dispatched this tick.
+func TestScheduler_SubsystemLastRanStamping_AfterMarkRan(t *testing.T) {
+	col := collector.New(internal.HostPaths{}, silentTestLogger())
+	fake := storage.NewFakeStore()
+	s := New(col, fake, &notifier.Notifier{}, nil, silentTestLogger(), 30*time.Minute)
+
+	now := time.Now().UTC()
+	s.dispatcher.MarkRan("smart", now)
+	s.dispatcher.MarkRan("docker", now.Add(5*time.Minute))
+
+	lastRun := s.dispatcher.LastRunMap()
+
+	// Stamp the same way RunOnce does.
+	snap := &internal.Snapshot{}
+	if len(lastRun) > 0 {
+		snap.SubsystemLastRan = make(map[string]string, len(lastRun))
+		for name, ts := range lastRun {
+			snap.SubsystemLastRan[name] = ts.Format(time.RFC3339)
+		}
+	}
+
+	if len(snap.SubsystemLastRan) != 2 {
+		t.Errorf("SubsystemLastRan len = %d, want 2; got %v", len(snap.SubsystemLastRan), snap.SubsystemLastRan)
+	}
+	if smartTS, ok := snap.SubsystemLastRan["smart"]; !ok || smartTS == "" {
+		t.Errorf("smart timestamp missing or empty; got %v", snap.SubsystemLastRan)
+	}
+	// Verify parseability.
+	if _, err := time.Parse(time.RFC3339, snap.SubsystemLastRan["smart"]); err != nil {
+		t.Errorf("smart timestamp not RFC3339: %v", err)
+	}
+}
+
+// TestScheduler_SetDispatcherIntervals_TriggersUpdateInterval: when
+// settings-save pushes new intervals, the scheduler's main-loop
+// ticker must re-size via the restart channel. We can't observe the
+// ticker directly without running Start(), but we can observe that
+// UpdateInterval was called with the correct FastestInterval value.
+func TestScheduler_SetDispatcherIntervals_DispatcherUpdated(t *testing.T) {
+	col := collector.New(internal.HostPaths{}, silentTestLogger())
+	fake := storage.NewFakeStore()
+	s := New(col, fake, &notifier.Notifier{}, nil, silentTestLogger(), 30*time.Minute)
+
+	// Before: all subsystems use global, FastestInterval = 30m.
+	if got, want := s.dispatcher.FastestInterval(), 30*time.Minute; got != want {
+		t.Fatalf("precondition: dispatcher FastestInterval = %v, want %v", got, want)
+	}
+
+	// Push Docker=5m via settings-save path.
+	s.SetDispatcherIntervals(DispatcherIntervalsConfig{
+		DockerSec: 300,
+	})
+
+	// Dispatcher should now report 5m as fastest.
+	if got, want := s.dispatcher.FastestInterval(), 5*time.Minute; got != want {
+		t.Errorf("after SetDispatcherIntervals, FastestInterval = %v, want %v", got, want)
+	}
+
+	// Restart channel should have received the new value. Drain it
+	// non-blocking — if empty, that's a regression.
+	select {
+	case got := <-s.restart:
+		if got != 5*time.Minute {
+			t.Errorf("restart channel got %v, want 5m", got)
+		}
+	default:
+		t.Errorf("SetDispatcherIntervals did not signal restart channel")
+	}
+}

--- a/internal/scheduler/scan_dispatcher_integration_test.go
+++ b/internal/scheduler/scan_dispatcher_integration_test.go
@@ -35,7 +35,7 @@ func TestScheduler_Dispatcher_FastestInterval_SizesTickInterval(t *testing.T) {
 
 	s.SetDispatcherIntervals(DispatcherIntervalsConfig{
 		DockerSec: 300,
-	})
+	}, 30*time.Minute)
 
 	if got, want := s.dispatcher.FastestInterval(), 5*time.Minute; got != want {
 		t.Errorf("after SetDispatcherIntervals(Docker=5m), FastestInterval = %v, want %v", got, want)
@@ -305,7 +305,7 @@ func TestScheduler_SetDispatcherIntervals_DispatcherUpdated(t *testing.T) {
 	// Push Docker=5m via settings-save path.
 	s.SetDispatcherIntervals(DispatcherIntervalsConfig{
 		DockerSec: 300,
-	})
+	}, 30*time.Minute)
 
 	// Dispatcher should now report 5m as fastest.
 	if got, want := s.dispatcher.FastestInterval(), 5*time.Minute; got != want {

--- a/internal/scheduler/scan_dispatcher_test.go
+++ b/internal/scheduler/scan_dispatcher_test.go
@@ -1,0 +1,361 @@
+package scheduler
+
+import (
+	"sort"
+	"testing"
+	"time"
+)
+
+// helper: build a fixed-clock dispatcher.
+func newFixedClockDispatcher(cfg DispatcherIntervalsConfig, global time.Duration, start time.Time) (*ScanDispatcher, *time.Time) {
+	clock := start
+	nowFn := func() time.Time { return clock }
+	d := NewScanDispatcher(cfg, global, nowFn)
+	return d, &clock
+}
+
+func assertSameSet(t *testing.T, got, want []string) {
+	t.Helper()
+	g := append([]string(nil), got...)
+	w := append([]string(nil), want...)
+	sort.Strings(g)
+	sort.Strings(w)
+	if len(g) != len(w) {
+		t.Errorf("got %v, want %v", got, want)
+		return
+	}
+	for i := range g {
+		if g[i] != w[i] {
+			t.Errorf("got %v, want %v", got, want)
+			return
+		}
+	}
+}
+
+// TestScanDispatcher_Tick_AllUseGlobal_FirstTickFiresAll: with every
+// subsystem at IntervalSec=0 (use global), the very first Tick after
+// construction must return every configurable subsystem — matching
+// the pre-slice-2 "run everything once on startup" behaviour.
+func TestScanDispatcher_Tick_AllUseGlobal_FirstTickFiresAll(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{}, 30*time.Minute, start)
+
+	due := d.Tick(start)
+	assertSameSet(t, due, ConfigurableSubsystems())
+}
+
+// TestScanDispatcher_Tick_AfterMarkRanWithinInterval_NotDue: once a
+// subsystem has MarkRan called, subsequent Ticks within the interval
+// must not return it.
+func TestScanDispatcher_Tick_AfterMarkRanWithinInterval_NotDue(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
+		DockerSec: 300, // 5 min
+	}, 30*time.Minute, start)
+
+	d.MarkRan("docker", start)
+
+	// 2 min later: not due.
+	due := d.Tick(start.Add(2 * time.Minute))
+	for _, name := range due {
+		if name == "docker" {
+			t.Errorf("docker returned as due 2m after MarkRan with 5m interval; due=%v", due)
+		}
+	}
+}
+
+// TestScanDispatcher_Tick_AfterIntervalElapsed_Due: at exactly the
+// interval boundary a subsystem is due again.
+func TestScanDispatcher_Tick_AfterIntervalElapsed_Due(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
+		DockerSec: 300,
+	}, 30*time.Minute, start)
+
+	d.MarkRan("docker", start)
+
+	due := d.Tick(start.Add(5 * time.Minute))
+	foundDocker := false
+	for _, name := range due {
+		if name == "docker" {
+			foundDocker = true
+		}
+	}
+	if !foundDocker {
+		t.Errorf("expected docker due exactly 5m after MarkRan; got %v", due)
+	}
+}
+
+// TestScanDispatcher_Tick_MixedIntervals_OnlyDueFire: Docker every 5
+// min, SMART every 1 hour, others use 30m global — at t=5m, only
+// Docker should be due (others were just run at t=0).
+func TestScanDispatcher_Tick_MixedIntervals_OnlyDueFire(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
+		DockerSec: 300,  // 5 min
+		SMARTSec:  3600, // 1 h
+	}, 30*time.Minute, start)
+
+	// Simulate first tick at start — mark everything ran.
+	for _, name := range ConfigurableSubsystems() {
+		d.MarkRan(name, start)
+	}
+
+	// 5 minutes later: only docker should be due.
+	due := d.Tick(start.Add(5 * time.Minute))
+	assertSameSet(t, due, []string{"docker"})
+}
+
+// TestScanDispatcher_Tick_UseGlobalFallback_MatchesGlobal: a subsystem
+// at IntervalSec=0 fires on the global cadence. With global=30m, SMART
+// at IntervalSec=0, marking SMART ran at start, Tick at 30m must
+// include smart.
+func TestScanDispatcher_Tick_UseGlobalFallback_MatchesGlobal(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
+		// SMARTSec=0 means use global
+	}, 30*time.Minute, start)
+
+	d.MarkRan("smart", start)
+
+	// 29 min in — not yet due.
+	due := d.Tick(start.Add(29 * time.Minute))
+	for _, name := range due {
+		if name == "smart" {
+			t.Errorf("smart due at 29m with global=30m; got %v", due)
+		}
+	}
+
+	// 30 min in — due.
+	due = d.Tick(start.Add(30 * time.Minute))
+	found := false
+	for _, name := range due {
+		if name == "smart" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("smart not due at 30m with global=30m; got %v", due)
+	}
+}
+
+// TestScanDispatcher_MarkRan_IgnoresUnknown: passing a name outside
+// the configurable list must be a no-op, not a panic.
+func TestScanDispatcher_MarkRan_IgnoresUnknown(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{}, 30*time.Minute, start)
+
+	// Must not panic. Must not affect internal state.
+	d.MarkRan("system", start)   // not configurable
+	d.MarkRan("unknown", start)  // not configurable
+	d.MarkRan("", start)         // empty
+
+	// All configurable subsystems should still be due (no MarkRan was
+	// recorded for any of them).
+	due := d.Tick(start.Add(time.Second))
+	assertSameSet(t, due, ConfigurableSubsystems())
+}
+
+// TestScanDispatcher_FastestInterval_AllGlobal_ReturnsGlobal: when no
+// subsystem has a per-subsystem override, FastestInterval is global.
+func TestScanDispatcher_FastestInterval_AllGlobal_ReturnsGlobal(t *testing.T) {
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{}, 30*time.Minute, time.Now())
+	if got, want := d.FastestInterval(), 30*time.Minute; got != want {
+		t.Errorf("FastestInterval = %v, want %v", got, want)
+	}
+}
+
+// TestScanDispatcher_FastestInterval_PicksMinimum: with Docker at 5m
+// and global at 30m, FastestInterval is 5m.
+func TestScanDispatcher_FastestInterval_PicksMinimum(t *testing.T) {
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
+		DockerSec: 300,
+	}, 30*time.Minute, time.Now())
+	if got, want := d.FastestInterval(), 5*time.Minute; got != want {
+		t.Errorf("FastestInterval = %v, want %v", got, want)
+	}
+}
+
+// TestScanDispatcher_FastestInterval_LongerSubsystemDoesNotWin: with
+// SMART at 1d but global at 30m, FastestInterval is 30m (global is
+// still faster than SMART's override).
+func TestScanDispatcher_FastestInterval_LongerSubsystemDoesNotWin(t *testing.T) {
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
+		SMARTSec: 86400, // 1 day
+	}, 30*time.Minute, time.Now())
+	if got, want := d.FastestInterval(), 30*time.Minute; got != want {
+		t.Errorf("FastestInterval = %v, want %v (SMART=1d must not beat global=30m)", got, want)
+	}
+}
+
+// TestScanDispatcher_FastestInterval_PicksFromMixed: Docker at 5m and
+// SMART at 1h, global 30m — fastest is Docker's 5m.
+func TestScanDispatcher_FastestInterval_PicksFromMixed(t *testing.T) {
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
+		DockerSec: 300,
+		SMARTSec:  3600,
+	}, 30*time.Minute, time.Now())
+	if got, want := d.FastestInterval(), 5*time.Minute; got != want {
+		t.Errorf("FastestInterval = %v, want %v", got, want)
+	}
+}
+
+// TestScanDispatcher_UpdateIntervals_ResetsLastRunForChangedOnly: when
+// Docker's interval changes from 5m to 10m, docker's lastRun is
+// cleared (so the new cadence kicks in immediately) but SMART's
+// lastRun is preserved (interval unchanged).
+func TestScanDispatcher_UpdateIntervals_ResetsLastRunForChangedOnly(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
+		DockerSec: 300,
+		SMARTSec:  3600,
+	}, 30*time.Minute, start)
+
+	// Simulate first tick at start.
+	for _, name := range ConfigurableSubsystems() {
+		d.MarkRan(name, start)
+	}
+
+	// Apply new config: Docker changed to 600s, SMART unchanged.
+	d.UpdateIntervals(DispatcherIntervalsConfig{
+		DockerSec: 600,
+		SMARTSec:  3600,
+	}, 30*time.Minute)
+
+	// At t=1s: docker must be due (lastRun cleared), SMART must NOT be
+	// due (lastRun preserved, 1s < 1h).
+	due := d.Tick(start.Add(time.Second))
+	foundDocker, foundSmart := false, false
+	for _, name := range due {
+		if name == "docker" {
+			foundDocker = true
+		}
+		if name == "smart" {
+			foundSmart = true
+		}
+	}
+	if !foundDocker {
+		t.Errorf("docker should be due after UpdateIntervals changed its interval; got %v", due)
+	}
+	if foundSmart {
+		t.Errorf("smart should NOT be due; its interval was unchanged; got %v", due)
+	}
+}
+
+// TestScanDispatcher_UpdateIntervals_GlobalChangeAffectsUseGlobalSubsystems:
+// when a subsystem is on "use global" and global changes, that
+// subsystem's effective interval changes and its lastRun resets.
+func TestScanDispatcher_UpdateIntervals_GlobalChangeAffectsUseGlobalSubsystems(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
+		// all zero = use global
+	}, 30*time.Minute, start)
+
+	// Run everything at start.
+	for _, name := range ConfigurableSubsystems() {
+		d.MarkRan(name, start)
+	}
+
+	// Verify nothing is due at t+5s (still on 30m cadence).
+	due := d.Tick(start.Add(5 * time.Second))
+	if len(due) != 0 {
+		t.Errorf("no subsystem should be due 5s after run, global=30m; got %v", due)
+	}
+
+	// Reduce global to 10s — every subsystem's effective interval
+	// changes, so all lastRun values reset.
+	d.UpdateIntervals(DispatcherIntervalsConfig{}, 10*time.Second)
+
+	// Immediately all subsystems should be due.
+	due = d.Tick(start.Add(6 * time.Second))
+	assertSameSet(t, due, ConfigurableSubsystems())
+}
+
+// TestScanDispatcher_LastRunMap_ExcludesNeverRan: subsystems that
+// have not yet MarkRan'd are omitted from LastRunMap.
+func TestScanDispatcher_LastRunMap_ExcludesNeverRan(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{}, 30*time.Minute, start)
+
+	d.MarkRan("docker", start)
+	d.MarkRan("smart", start.Add(5*time.Minute))
+
+	m := d.LastRunMap()
+	if len(m) != 2 {
+		t.Errorf("LastRunMap size = %d, want 2 (only docker + smart recorded); got %v", len(m), m)
+	}
+	if _, ok := m["docker"]; !ok {
+		t.Errorf("docker missing from LastRunMap; got %v", m)
+	}
+	if _, ok := m["smart"]; !ok {
+		t.Errorf("smart missing from LastRunMap; got %v", m)
+	}
+	if _, ok := m["proxmox"]; ok {
+		t.Errorf("proxmox should be absent from LastRunMap; got %v", m)
+	}
+}
+
+// TestScanDispatcher_Skipped_ReturnsComplement: the Skipped helper
+// returns the configurable subsystems NOT in `due`, in canonical
+// order.
+func TestScanDispatcher_Skipped_ReturnsComplement(t *testing.T) {
+	got := Skipped([]string{"docker", "smart"})
+	want := []string{"proxmox", "kubernetes", "zfs", "gpu"}
+	if len(got) != len(want) {
+		t.Errorf("Skipped len = %d, want %d; got %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Skipped[%d] = %s, want %s (canonical order matters); got %v", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestScanDispatcher_Skipped_EmptyDue_ReturnsAll: when no subsystems
+// are due, Skipped is the full list.
+func TestScanDispatcher_Skipped_EmptyDue_ReturnsAll(t *testing.T) {
+	got := Skipped(nil)
+	want := ConfigurableSubsystems()
+	if len(got) != len(want) {
+		t.Errorf("Skipped len = %d, want %d", len(got), len(want))
+	}
+}
+
+// TestScanDispatcher_Skipped_AllDue_ReturnsEmpty: when every
+// subsystem is due, Skipped is empty.
+func TestScanDispatcher_Skipped_AllDue_ReturnsEmpty(t *testing.T) {
+	got := Skipped(ConfigurableSubsystems())
+	if len(got) != 0 {
+		t.Errorf("Skipped should be empty when all are due; got %v", got)
+	}
+}
+
+// TestScanDispatcher_TickOrdering_Canonical: Tick returns subsystems
+// in configurableSubsystems order so log output is deterministic.
+func TestScanDispatcher_TickOrdering_Canonical(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{}, 30*time.Minute, start)
+	due := d.Tick(start)
+	want := ConfigurableSubsystems()
+	if len(due) != len(want) {
+		t.Fatalf("due len = %d, want %d", len(due), len(want))
+	}
+	for i := range want {
+		if due[i] != want[i] {
+			t.Errorf("Tick order not canonical: due[%d]=%s, want %s; got %v, want %v", i, due[i], want[i], due, want)
+		}
+	}
+}
+
+// TestScanDispatcher_FastestInterval_MinimumClampGuard: if somehow
+// the dispatcher ended up with zero-or-negative intervals (e.g.
+// defensive global clamp in applyIntervalsLocked), FastestInterval
+// still returns a positive duration.
+func TestScanDispatcher_FastestInterval_NonPositiveGlobalClampsToDefault(t *testing.T) {
+	// Pass global=0 which triggers the defensive clamp to 30m.
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{}, 0, time.Now())
+	got := d.FastestInterval()
+	if got <= 0 {
+		t.Errorf("FastestInterval must be positive; got %v", got)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -123,6 +123,13 @@ type Scheduler struct {
 	// when the user changes the setting. Read under s.mu.
 	smartMaxAgeDays int
 
+	// dispatcher owns per-subsystem scan scheduling for the 6
+	// configurable subsystems (issue #260 / PRD #239 slice 2b).
+	// Non-nil after New(); safe for concurrent use. Settings saves
+	// push new per-subsystem intervals via dispatcher.UpdateIntervals
+	// from the API handler.
+	dispatcher *ScanDispatcher
+
 	logForwarder *logfwd.Forwarder
 
 	mu      sync.RWMutex
@@ -170,6 +177,11 @@ func New(
 		// should call SetSMARTMaxAgeDays after construction.
 		smartMaxAgeDays: 7,
 	}
+	// Dispatcher starts with all-subsystems-on-global; callers (the
+	// API settings handler on startup) push the user's configured
+	// per-subsystem intervals via SetDispatcherIntervals once
+	// Settings.AdvancedScans is loaded.
+	s.dispatcher = NewScanDispatcher(DispatcherIntervalsConfig{}, interval, nil)
 	s.checker = NewServiceChecker(store, logger)
 	// Opt into the per-type Details map on the scheduled path too —
 	// HTTP status codes, resolved IPs, DNS records, Ping RTT, failure
@@ -188,15 +200,25 @@ func New(
 }
 
 // Start begins the periodic collection loop. It runs the first collection
-// immediately, then repeats at the configured interval.
+// immediately, then repeats at the dispatcher's FastestInterval — which
+// is min(global scan_interval, all non-zero per-subsystem intervals)
+// per issue #260 / PRD #239 slice 2b. Each tick the dispatcher decides
+// which of the 6 configurable subsystems to run; the 9 non-configurable
+// subsystems always run every tick (cheap enough and the dispatcher is
+// not responsible for them).
+//
 // Also starts an independent service check loop (30s tick) that respects
 // per-check intervals.
 func (s *Scheduler) Start() {
-	s.logger.Info("scheduler starting", "interval", s.interval)
+	tickInterval := s.dispatcher.FastestInterval()
+	s.logger.Info("scheduler starting",
+		"global_interval", s.interval,
+		"tick_interval", tickInterval,
+	)
 	// Main diagnostic collection loop
 	go func() {
 		s.RunOnce()
-		ticker := time.NewTicker(s.interval)
+		ticker := time.NewTicker(tickInterval)
 		defer ticker.Stop()
 		for {
 			select {
@@ -204,11 +226,30 @@ func (s *Scheduler) Start() {
 				s.RunOnce()
 			case newInterval := <-s.restart:
 				ticker.Stop()
+				// The `restart` channel carries a GLOBAL scan_interval
+				// change (from UpdateInterval) OR a dispatcher-driven
+				// FastestInterval refresh (from SetDispatcherIntervals
+				// — in that case the dispatcher has already been
+				// updated and we just need to rebuild the ticker).
+				// We distinguish by comparing against the dispatcher's
+				// current FastestInterval: if it equals newInterval,
+				// it's the dispatcher path (global unchanged); else
+				// it's a user global update and we push the new
+				// global through to the dispatcher.
 				s.mu.Lock()
-				s.interval = newInterval
+				if newInterval != s.dispatcher.FastestInterval() {
+					s.interval = newInterval
+					// Global changed → push through to dispatcher so
+					// "use global" subsystems pick it up.
+					s.dispatcher.SetGlobal(newInterval)
+				}
 				s.mu.Unlock()
-				ticker = time.NewTicker(newInterval)
-				s.logger.Info("scheduler interval updated", "new_interval", newInterval)
+				fresh := s.dispatcher.FastestInterval()
+				ticker = time.NewTicker(fresh)
+				s.logger.Info("scheduler interval updated",
+					"global_interval", s.interval,
+					"tick_interval", fresh,
+				)
 			case <-s.stop:
 				s.logger.Info("scheduler stopped")
 				return
@@ -362,6 +403,35 @@ func (s *Scheduler) SetSMARTMaxAgeDays(days int) {
 	s.smartMaxAgeDays = days
 }
 
+// SetDispatcherIntervals pushes updated per-subsystem intervals into
+// the ScanDispatcher. Called by the API settings handler on save so
+// the new cadences take effect without restarting the scheduler
+// (issue #260 user story 1-6). Also restarts the main scan loop
+// ticker at the new FastestInterval via UpdateInterval, since a
+// newly-faster subsystem may require the ticker to fire more often.
+func (s *Scheduler) SetDispatcherIntervals(cfg DispatcherIntervalsConfig) {
+	s.mu.RLock()
+	global := s.interval
+	s.mu.RUnlock()
+	s.dispatcher.UpdateIntervals(cfg, global)
+	// Re-size the main-loop ticker to match the new FastestInterval.
+	// If nothing actually changed, UpdateInterval's select-default
+	// short-circuits gracefully.
+	s.UpdateInterval(s.dispatcher.FastestInterval())
+	s.logger.Info("scan dispatcher intervals updated",
+		"fastest_interval", s.dispatcher.FastestInterval(),
+	)
+}
+
+// Dispatcher returns the scheduler's ScanDispatcher. Exposed so the
+// API layer can surface per-subsystem lastRun timestamps on
+// /api/v1/snapshot/latest without reaching into scheduler internals.
+// Callers should treat the returned value as read-mostly; mutate only
+// via SetDispatcherIntervals.
+func (s *Scheduler) Dispatcher() *ScanDispatcher {
+	return s.dispatcher
+}
+
 // SetSpeedTestSchedule sets specific times of day to run speed tests.
 func (s *Scheduler) SetSpeedTestSchedule(times []string, day string, freq string) {
 	s.mu.Lock()
@@ -409,30 +479,52 @@ func (s *Scheduler) RunOnce() {
 
 	s.logger.Info("starting diagnostic collection")
 
-	// Collect
+	// Phase 1: collect the 9 non-configurable subsystems (system,
+	// disks, network, logs, parity, UPS, update check, tunnels,
+	// backup). These always run every tick — they're cheap and have
+	// no user-facing cadence knob.
 	snap, err := s.collector.Collect()
 	if err != nil {
 		s.logger.Error("collection failed", "error", err)
 		return
 	}
 
-	// Stale-SMART force-wake (issue #238). After the normal SMART
-	// collect pass, any drive reported as "standby" via `-n standby`
-	// whose last recorded read exceeds Settings.SMART.MaxAgeDays is
-	// force-woken for a single SMART read and merged back into the
-	// snapshot. MaxAgeDays=0 disables the feature entirely.
-	//
-	// Runs BEFORE detectDriveReplacements so the replacement logic
-	// sees fresh SMART for force-woken drives (avoids a spurious
-	// "drive missing" interpretation if a standby drive's last
-	// snapshot reported different ArraySlot metadata).
-	s.mu.RLock()
-	maxAgeDays := s.smartMaxAgeDays
-	s.mu.RUnlock()
-	if maxAgeDays > 0 {
-		staleChecker := NewStaleSMARTChecker(s.store, maxAgeDays, s.logger)
-		if stale := staleChecker.Check(snap); len(stale) > 0 {
-			staleChecker.Apply(snap, stale, s.collector.CollectSMARTForced)
+	// Phase 2: dispatch per-subsystem collectors per their configured
+	// cadence (issue #260 / PRD #239). The dispatcher's Tick decides
+	// which of the 6 configurable subsystems (SMART, Docker, Proxmox,
+	// Kubernetes, ZFS, GPU) are due on this tick. Previously-collected
+	// values from prior ticks are carried forward on snap by merging
+	// from s.latest below.
+	now := snap.Timestamp
+	due := s.dispatcher.Tick(now)
+	skipped := Skipped(due)
+
+	// Carry forward the most recent cached values for subsystems that
+	// are NOT running this tick. A subsystem that skipped should keep
+	// its previous snapshot value rather than showing empty data.
+	s.carryForwardSubsystems(snap, skipped)
+
+	// Emit the canonical per-tick INFO log summarising dispatcher
+	// decisions (user story 15).
+	s.logger.Info("scan tick",
+		"due", due,
+		"skipped", skipped,
+		"tick_interval", s.dispatcher.FastestInterval(),
+	)
+
+	for _, subsystem := range due {
+		s.runSubsystem(subsystem, snap)
+		s.dispatcher.MarkRan(subsystem, now)
+	}
+
+	// Stamp per-subsystem last-run timestamps on the snapshot so API
+	// consumers can surface "last scanned 4m ago" style staleness
+	// indicators (issue #260 user story 17; dashboard UI deferred).
+	lastRun := s.dispatcher.LastRunMap()
+	if len(lastRun) > 0 {
+		snap.SubsystemLastRan = make(map[string]string, len(lastRun))
+		for name, ts := range lastRun {
+			snap.SubsystemLastRan[name] = ts.Format(time.RFC3339)
 		}
 	}
 
@@ -529,6 +621,99 @@ func (s *Scheduler) RunOnce() {
 
 	// Auto backup check
 	s.checkBackup()
+}
+
+// runSubsystem invokes the matching per-subsystem Collector method
+// and merges its result into snap. The stale-SMART force-wake safety
+// net fires immediately after CollectSMART (issue #260 — relocated
+// from the post-Collect() call site that slice 1 used, so max-age is
+// now scoped to SMART's cadence).
+func (s *Scheduler) runSubsystem(name string, snap *internal.Snapshot) {
+	switch name {
+	case "smart":
+		smart, standby, _ := s.collector.CollectSMART(snap.System.Platform)
+		snap.SMART = smart
+		snap.SMARTStandbyDevices = standby
+		// Stale-SMART force-wake (issue #238 / slice 1). Previously
+		// ran unconditionally after Collect(); now runs ONLY when
+		// SMART actually ran on this tick, so max-age honours the
+		// user's SMART cadence. If a user sets SMART to 30d and
+		// max-age to 7d, max-age becomes the governing cadence
+		// (force-wake fires more frequently than stated SMART
+		// interval) — the UI confirm() dialog warned them about
+		// this on save.
+		s.mu.RLock()
+		maxAgeDays := s.smartMaxAgeDays
+		s.mu.RUnlock()
+		if maxAgeDays > 0 {
+			staleChecker := NewStaleSMARTChecker(s.store, maxAgeDays, s.logger)
+			if stale := staleChecker.Check(snap); len(stale) > 0 {
+				staleChecker.Apply(snap, stale, s.collector.CollectSMARTForced)
+			}
+		}
+	case "docker":
+		docker, _ := s.collector.CollectDocker()
+		snap.Docker = docker
+		// Enrich top processes with container attribution (previously
+		// done inline in Collect(); preserved here so the full-scan
+		// snapshot still has enrichment when both Docker + system ran
+		// on the same tick).
+		if docker.Available && len(docker.Containers) > 0 && len(snap.System.TopProcesses) > 0 {
+			collector.EnrichProcessContainers(snap.System.TopProcesses, docker.Containers, "")
+		}
+	case "proxmox":
+		pve, _ := s.collector.CollectProxmox()
+		if pve != nil {
+			snap.Proxmox = pve
+		}
+	case "kubernetes":
+		kube, _ := s.collector.CollectKubernetes()
+		if kube != nil {
+			snap.Kubernetes = kube
+		}
+	case "zfs":
+		zfs, _ := s.collector.CollectZFS()
+		if zfs != nil && zfs.Available {
+			snap.ZFS = zfs
+		}
+	case "gpu":
+		gpu := s.collector.CollectGPU()
+		if gpu != nil && gpu.Available {
+			snap.GPU = gpu
+		}
+	}
+}
+
+// carryForwardSubsystems copies prior-tick values from s.latest into
+// the current snapshot for each skipped subsystem. Without this, a
+// subsystem that didn't run this tick would show empty data — which
+// is technically honest but degrades the dashboard experience
+// dramatically. Snapshot-level timestamps (surfaced via ScanLastRan)
+// tell consumers how stale each subsystem's data actually is.
+func (s *Scheduler) carryForwardSubsystems(snap *internal.Snapshot, skipped []string) {
+	s.mu.RLock()
+	prev := s.latest
+	s.mu.RUnlock()
+	if prev == nil {
+		return
+	}
+	for _, name := range skipped {
+		switch name {
+		case "smart":
+			snap.SMART = prev.SMART
+			snap.SMARTStandbyDevices = prev.SMARTStandbyDevices
+		case "docker":
+			snap.Docker = prev.Docker
+		case "proxmox":
+			snap.Proxmox = prev.Proxmox
+		case "kubernetes":
+			snap.Kubernetes = prev.Kubernetes
+		case "zfs":
+			snap.ZFS = prev.ZFS
+		case "gpu":
+			snap.GPU = prev.GPU
+		}
+	}
 }
 
 // Latest returns the most recent snapshot from the cache.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -409,10 +409,30 @@ func (s *Scheduler) SetSMARTMaxAgeDays(days int) {
 // (issue #260 user story 1-6). Also restarts the main scan loop
 // ticker at the new FastestInterval via UpdateInterval, since a
 // newly-faster subsystem may require the ticker to fire more often.
-func (s *Scheduler) SetDispatcherIntervals(cfg DispatcherIntervalsConfig) {
-	s.mu.RLock()
-	global := s.interval
-	s.mu.RUnlock()
+//
+// global is the canonical scan_interval the caller just parsed from
+// settings; passed explicitly (rather than read from s.interval) to
+// avoid a race with a concurrent UpdateInterval that may not have
+// been consumed by the main loop yet. In practice the API handler
+// calls UpdateInterval then SetDispatcherIntervals in sequence on
+// the same goroutine — passing global through makes that ordering
+// irrelevant.
+func (s *Scheduler) SetDispatcherIntervals(cfg DispatcherIntervalsConfig, global time.Duration) {
+	if global <= 0 {
+		// Defensive: if caller didn't know the global (or passed a
+		// sentinel), fall back to whatever the scheduler has cached.
+		s.mu.RLock()
+		global = s.interval
+		s.mu.RUnlock()
+	} else {
+		// Caller supplied a fresh global — also update s.interval so
+		// subsequent reads see it. If a concurrent UpdateInterval is
+		// already propagating the same value, the main loop will
+		// simply re-tick at the same interval (harmless).
+		s.mu.Lock()
+		s.interval = global
+		s.mu.Unlock()
+	}
 	s.dispatcher.UpdateIntervals(cfg, global)
 	// Re-size the main-loop ticker to match the new FastestInterval.
 	// If nothing actually changed, UpdateInterval's select-default


### PR DESCRIPTION
Closes #260. Parent PRD: #239. Slice 2a (#259) persisted the `AdvancedScans.*.IntervalSec` schema; this slice activates it end-to-end.

## Summary

- New `ScanDispatcher` deep module (`internal/scheduler/scan_dispatcher.go`) owns "what runs when" decisions for the 6 configurable subsystems (SMART, Docker, Proxmox, Kubernetes, ZFS, GPU).
- 6 new public `Collect*` methods on `*Collector` (`CollectSMART` / `CollectDocker` / `CollectProxmox` / `CollectKubernetes` / `CollectZFS` / `CollectGPU`). Thin wrappers around the existing internal `collectX` functions with logging + error-handling preserved.
- `Collector.Collect()` now only invokes the 9 non-configurable subsystems (system, disks, network, logs, parity, UPS, update check, tunnels, backup). The 6 configurable subsystems are dispatched per their own cadence by the scheduler.
- Scheduler main loop ticker now sizes at `dispatcher.FastestInterval()` = min(global, all non-zero per-subsystem overrides). Each tick the dispatcher decides which subsystems run; skipped subsystems carry forward prior snapshot values so the dashboard doesn't show empty data between runs.
- Max-age `StaleSMARTChecker` call site **relocated**: previously fired after `Collect()` on every global tick; now fires immediately after `CollectSMART()` on the SMART subsystem's cadence. Behavioural trade-off (user setting `SMART.IntervalSec` > `MaxAgeDays × 86400` gets force-wakes on max-age cadence) is documented and warned via the slice-2a client-side `confirm()` dialog.
- Single INFO log per scan tick: `scan tick due=[smart,docker] skipped=[…] tick_interval=5m`.
- `snap.SubsystemLastRan` map exposed on `/api/v1/snapshot/latest` as `subsystem_last_ran` (RFC3339 per subsystem). Dashboard UI for these timestamps is a follow-up issue, per the PRD.
- Settings save path (`handleUpdateSettings`) and `main.go` startup both now push intervals through `sched.SetDispatcherIntervals(cfg, global)` so changes take effect without restarting.

## Acceptance criteria (from issue #260)

- [x] `ScanDispatcher` struct with 4 documented methods + `now` seam
- [x] `Tick` correctly identifies due subsystems across various interval combinations (unit-tested, 18 tests)
- [x] `MarkRan` records lastRun timestamp correctly
- [x] `FastestInterval` returns `min(global, non-zero per-subsystem)` even when some subsystems have 0 (use global)
- [x] `UpdateIntervals` resets lastRun only for subsystems whose interval changed
- [x] 6 new public `Collect*` methods on `*Collector` produce snapshot-compatible output
- [x] Monolithic `Collect()` retained, invokes only the 9 non-configurable subsystems (audited: only callers of the old 15-subsystem `Collect()` were the scheduler's RunOnce and `api.go`'s `go s.scheduler.RunOnce()` — both go through the dispatcher now)
- [x] Scheduler loop uses `time.NewTicker(dispatcher.FastestInterval())`; each tick calls dispatcher then invokes collectors as directed
- [x] Settings save via `PUT /api/v1/settings` triggers `dispatcher.UpdateIntervals()` (plus `SetDispatcherIntervals` path that also resets the ticker)
- [x] `StaleSMARTChecker` fires immediately after `CollectSMART`, NOT after other collect methods — regression-guarded by `TestScheduler_MaxAgeFiresAfterCollectSMART_NotAfterOtherSubsystems`
- [x] Per-tick INFO log emitted with the canonical format — guarded by `TestScheduler_PerTickLog_Format`
- [x] `snapshot.subsystem_last_ran` exposed on `/api/v1/snapshot/latest` — guarded by `TestHandleLatestSnapshot_ExposesSubsystemLastRan`
- [x] Setting `SMART.IntervalSec = 300` + global 30m: SMART fires every 5 min, global subsystems every 30 min — `TestScanDispatcher_Acceptance_SMART5minGlobal30m`
- [x] Setting `Docker.IntervalSec = 300` + `SMART.IntervalSec = 86400` + global 30m: FastestInterval=300s, Docker every tick, SMART once per day — `TestScanDispatcher_Acceptance_Docker5minSMART1dayGlobal30m`
- [x] All slice 1 / slice 2a tests continue to pass (verified with `go test ./...`)
- [x] Integration test: seed config with mixed IntervalSec values, advance mock time, assert correct subsystems fire at expected ticks — covered across `scan_dispatcher_test.go` + `scan_dispatcher_integration_test.go` + `scan_dispatcher_acceptance_test.go`

## Test coverage added

| File | Count | Focus |
|---|---|---|
| `internal/scheduler/scan_dispatcher_test.go` | 18 | Tick/MarkRan/FastestInterval/UpdateIntervals/LastRunMap/Skipped/ordering |
| `internal/scheduler/scan_dispatcher_integration_test.go` | 7 | Scheduler wiring, max-age call-site regression guard, per-tick log format, carry-forward, SubsystemLastRan stamping |
| `internal/scheduler/scan_dispatcher_acceptance_test.go` | 2 | PRD headline scenarios (Docker=5m+SMART=1d, SMART=5m only) |
| `internal/collector/collect_per_subsystem_test.go` | 7 | 6 Collect* wrappers callable, disabled integrations return (nil,nil) |
| `internal/api/snapshot_subsystem_last_ran_test.go` | 2 | JSON round-trip for `subsystem_last_ran` field (presence + omitempty) |
| `internal/api/settings_dispatcher_wiring_test.go` | 1 | `PUT /api/v1/settings` → dispatcher intervals update end-to-end |

Total: 37 new tests across scheduler / collector / api packages. Full test suite green. `go vet ./...` clean. Race test green on `internal/scheduler/`.

## Snapshot shape change

Adds an OPTIONAL field `SubsystemLastRan map[string]string \`json:\"subsystem_last_ran,omitempty\"\`` to `internal.Snapshot`. The `omitempty` tag means synthetic snapshots (demo worker, historical snapshots) that don't set this map will continue serializing without the key — **no demo-feeder companion update needed**. Verified no references to the field in `demo-worker/`. If a future dashboard consumes this, the feeder can add a synthetic map at that point.

## Files changed

- `internal/scheduler/scan_dispatcher.go` — new module
- `internal/scheduler/scheduler.go` — main loop refactor, new `SetDispatcherIntervals(cfg, global)` setter, `Dispatcher()` accessor, per-tick log, carry-forward, subsystem dispatch
- `internal/collector/collector.go` — 6 public `Collect*` methods added; `Collect()` trimmed to 9 non-configurable subsystems
- `internal/models.go` — `SubsystemLastRan` field on `Snapshot`
- `internal/api/api_extended.go` — `handleUpdateSettings` pushes intervals through to dispatcher
- `cmd/nas-doctor/main.go` — startup applies persisted `AdvancedScans` intervals

## Notes / follow-ups

- Dashboard UI to render `subsystem_last_ran` values ("Docker last scanned 4m ago") is a follow-up — PRD user story 17 explicitly deferred.
- Slice 3 (active SMART piggyback on spin-up events, #240) remains its own tracker.
- No touch to service-check loop in `scheduler.go`; its independent 30s ticker is unchanged (verified by inspection).

Refs #260 / #239.