### PR TITLE
Release v0.9.9: Advanced Scan Settings slice 2 (V2a + V2b) + Prometheus Phase 1 + rc hotfixes

### DIFF
--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -395,7 +395,7 @@ func main() {
 				KubernetesSec: persistedSettings.AdvancedScans.Kubernetes.IntervalSec,
 				ZFSSec:        persistedSettings.AdvancedScans.ZFS.IntervalSec,
 				GPUSec:        persistedSettings.AdvancedScans.GPU.IntervalSec,
-			})
+			}, interval)
 		}
 		sched.Start()
 		defer sched.Stop()

--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -383,6 +383,19 @@ func main() {
 			// Apply the max-age force-wake threshold on startup (#238).
 			// Scheduler owns this policy; 0 disables the safety net.
 			sched.SetSMARTMaxAgeDays(persistedSettings.AdvancedScans.SMART.MaxAgeDays)
+			// Apply per-subsystem scan intervals on startup (#260).
+			// The scheduler's dispatcher is the source of truth for
+			// "what runs when" — without this push, fresh boots
+			// would silently run every subsystem on the global
+			// cadence regardless of persisted settings.
+			sched.SetDispatcherIntervals(scheduler.DispatcherIntervalsConfig{
+				SMARTSec:      persistedSettings.AdvancedScans.SMART.IntervalSec,
+				DockerSec:     persistedSettings.AdvancedScans.Docker.IntervalSec,
+				ProxmoxSec:    persistedSettings.AdvancedScans.Proxmox.IntervalSec,
+				KubernetesSec: persistedSettings.AdvancedScans.Kubernetes.IntervalSec,
+				ZFSSec:        persistedSettings.AdvancedScans.ZFS.IntervalSec,
+				GPUSec:        persistedSettings.AdvancedScans.GPU.IntervalSec,
+			})
 		}
 		sched.Start()
 		defer sched.Stop()

--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -374,14 +374,15 @@ func main() {
 		}
 		// Apply SMART standby-awareness preference on startup (#198). Default
 		// (false) uses `-n standby` so spun-down drives aren't woken by scans.
-		// Since schema v2 (#237) this lives under Settings.SMART.WakeDrives.
+		// Moved from Settings.SMART → Settings.AdvancedScans.SMART in
+		// schema v3 (#259).
 		if persistedSettings != nil {
 			coll.SetSMARTConfig(collector.SMARTConfig{
-				WakeDrives: persistedSettings.SMART.WakeDrives,
+				WakeDrives: persistedSettings.AdvancedScans.SMART.WakeDrives,
 			})
 			// Apply the max-age force-wake threshold on startup (#238).
 			// Scheduler owns this policy; 0 disables the safety net.
-			sched.SetSMARTMaxAgeDays(persistedSettings.SMART.MaxAgeDays)
+			sched.SetSMARTMaxAgeDays(persistedSettings.AdvancedScans.SMART.MaxAgeDays)
 		}
 		sched.Start()
 		defer sched.Stop()

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -1046,6 +1046,21 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		// DB-unaware) and applies it after each scan's Collect().
 		s.scheduler.SetSMARTMaxAgeDays(settings.AdvancedScans.SMART.MaxAgeDays)
 
+		// Push per-subsystem scan intervals into the ScanDispatcher
+		// so the new cadences take effect without a scheduler
+		// restart (issue #260 user stories 1-6). Converts the
+		// api-package AdvancedScansSettings shape to the
+		// scheduler-package DispatcherIntervalsConfig — intentional
+		// layering so scheduler doesn't import internal/api.
+		s.scheduler.SetDispatcherIntervals(scheduler.DispatcherIntervalsConfig{
+			SMARTSec:      settings.AdvancedScans.SMART.IntervalSec,
+			DockerSec:     settings.AdvancedScans.Docker.IntervalSec,
+			ProxmoxSec:    settings.AdvancedScans.Proxmox.IntervalSec,
+			KubernetesSec: settings.AdvancedScans.Kubernetes.IntervalSec,
+			ZFSSec:        settings.AdvancedScans.ZFS.IntervalSec,
+			GPUSec:        settings.AdvancedScans.GPU.IntervalSec,
+		})
+
 		// Update log forwarding
 		if settings.LogPush.Enabled && len(settings.LogPush.Destinations) > 0 {
 			var dests []logfwd.Destination

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -1052,6 +1052,15 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		// api-package AdvancedScansSettings shape to the
 		// scheduler-package DispatcherIntervalsConfig — intentional
 		// layering so scheduler doesn't import internal/api.
+		//
+		// global is re-parsed here rather than read from the
+		// scheduler's cache so dispatcher.UpdateIntervals sees the
+		// same value the user just saved; avoids a race with the
+		// scan_interval UpdateInterval restart signal above.
+		var dispatchGlobal time.Duration
+		if d, err := time.ParseDuration(settings.ScanInterval); err == nil {
+			dispatchGlobal = d
+		}
 		s.scheduler.SetDispatcherIntervals(scheduler.DispatcherIntervalsConfig{
 			SMARTSec:      settings.AdvancedScans.SMART.IntervalSec,
 			DockerSec:     settings.AdvancedScans.Docker.IntervalSec,
@@ -1059,7 +1068,7 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 			KubernetesSec: settings.AdvancedScans.Kubernetes.IntervalSec,
 			ZFSSec:        settings.AdvancedScans.ZFS.IntervalSec,
 			GPUSec:        settings.AdvancedScans.GPU.IntervalSec,
-		})
+		}, dispatchGlobal)
 
 		// Update log forwarding
 		if settings.LogPush.Enabled && len(settings.LogPush.Destinations) > 0 {

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -50,13 +50,17 @@ type Settings struct {
 	SectionHeights    map[string]int          `json:"section_heights,omitempty"` // Persisted section resize heights (section name → px)
 	SectionOrder      map[string][]string     `json:"section_order,omitempty"`   // Persisted drag-and-drop column order ({"cols": [["findings","docker"], ...]})
 
-	// SMART holds the SMART-scan policy knobs surfaced under
-	// "Advanced Scan Settings" in the settings UI. Prior to schema
-	// v2 the only knob here (WakeDrives) lived at the top level of
-	// Settings as `wake_drives_for_smart`; the v1→v2 migration in
-	// getSettings() lifts that value into SMART.WakeDrives. See
-	// issues #236 (PRD) and #237 (this slice).
-	SMART SMARTSettings `json:"smart"`
+	// AdvancedScans holds the per-subsystem scan-policy knobs surfaced
+	// under "Advanced" in the settings UI. Introduced by schema v3
+	// (#239 / slice 2). Prior to v3 the SMART sub-struct lived at
+	// Settings.SMART; the v2→v3 migration in getSettings() relocates
+	// it into AdvancedScans.SMART and seeds IntervalSec=0 ("use
+	// global") for every new subsystem.
+	//
+	// Slice 2a (#259) only persists AdvancedScans.*.IntervalSec —
+	// the scheduler does NOT yet consume it. Slice 2b (#260) wires
+	// the values into the scan loop via a new ScanDispatcher.
+	AdvancedScans AdvancedScansSettings `json:"advanced_scans"`
 
 	// DockerHiddenContainers is a list of container names that should be
 	// omitted from the Docker Containers dashboard section. Exact-match
@@ -67,8 +71,38 @@ type Settings struct {
 	DockerHiddenContainers []string `json:"docker_hidden_containers,omitempty"`
 }
 
-// SMARTSettings groups SMART-scan policy. Added in schema v2 (#237).
-type SMARTSettings struct {
+// AdvancedScansSettings groups per-subsystem scan cadence policy.
+// Added in schema v3 (PRD #239 / slice 2a issue #259). Each sub-
+// struct carries at least an IntervalSec field; SMART carries the
+// slice-1 WakeDrives and MaxAgeDays knobs that it inherited from the
+// retired top-level Settings.SMART.
+type AdvancedScansSettings struct {
+	SMART      AdvancedScansSMART      `json:"smart"`
+	Docker     AdvancedScansSubsystem  `json:"docker"`
+	Proxmox    AdvancedScansSubsystem  `json:"proxmox"`
+	Kubernetes AdvancedScansSubsystem  `json:"kubernetes"`
+	ZFS        AdvancedScansSubsystem  `json:"zfs"`
+	GPU        AdvancedScansSubsystem  `json:"gpu"`
+}
+
+// AdvancedScansSubsystem is the minimal shape shared by the five
+// non-SMART configurable subsystems. IntervalSec is validated via
+// validScanIntervalSec(); see handleUpdateSettings.
+type AdvancedScansSubsystem struct {
+	// IntervalSec overrides the global scan_interval for this
+	// subsystem. 0 means "use global" (default, unchanged behaviour).
+	// Positive values must be in [30, 2678400] seconds (30s – 31d).
+	// Slice 2a only persists the value; slice 2b activates it.
+	IntervalSec int `json:"interval_sec"`
+}
+
+// AdvancedScansSMART extends AdvancedScansSubsystem with slice-1's
+// two scan-policy knobs. See SMARTSettings comments on pre-v3
+// Settings.SMART for history.
+type AdvancedScansSMART struct {
+	// IntervalSec — see AdvancedScansSubsystem.IntervalSec.
+	IntervalSec int `json:"interval_sec"`
+
 	// WakeDrives, when true, opts back into pre-v0.9.5 behaviour of
 	// reading SMART from spun-down drives each scan cycle (waking
 	// them). Default (false) is standby-aware: smartctl runs with
@@ -78,18 +112,41 @@ type SMARTSettings struct {
 	// MaxAgeDays bounds how long a drive may remain unread by SMART
 	// before the scheduler forces one wake-up to refresh SMART data.
 	// Default 7. Valid range 0-30. A value of 0 disables the
-	// safety-net entirely (preserves exact v0.9.5 behaviour). The
-	// scheduler does NOT yet consume this value — slice 1a (#237)
-	// only persists it; slice 1b (#238) wires it into the scan loop.
+	// safety-net entirely (preserves exact v0.9.5 behaviour).
+	// Scheduler-side wiring lives in #238.
 	MaxAgeDays int `json:"max_age_days"`
 }
 
-// SMARTMaxAgeDaysMax is the upper bound on Settings.SMART.MaxAgeDays.
+// SMARTMaxAgeDaysMax is the upper bound on AdvancedScans.SMART.MaxAgeDays.
 // A value of 0 disables the safety-net; values 1-30 are valid.
 // Enforced in handleUpdateSettings and in the UI input element.
 const SMARTMaxAgeDaysMax = 30
 
-const currentSettingsVersion = 2
+// ScanIntervalSecMin is the minimum positive value accepted for any
+// AdvancedScans.*.IntervalSec field. Below this, the scheduler's tick
+// rate would be pathologically fast; 30 seconds gives some headroom
+// above the 5-second service-check cadence. 0 is always valid
+// (= "use global"). PRD #239 user story 13.
+const ScanIntervalSecMin = 30
+
+// ScanIntervalSecMax is the 31-day ceiling on any
+// AdvancedScans.*.IntervalSec field. Users who want "effectively
+// disabled" cadence on a subsystem can dial it to this ceiling; a
+// future slice 3 may introduce explicit disable semantics.
+// PRD #239 user story 13.
+const ScanIntervalSecMax = 2678400 // 31 days
+
+// validScanIntervalSec returns true when v is 0 ("use global") or
+// within [ScanIntervalSecMin, ScanIntervalSecMax]. Canonical for
+// both server-side validation and any future client-parity check.
+func validScanIntervalSec(v int) bool {
+	if v == 0 {
+		return true
+	}
+	return v >= ScanIntervalSecMin && v <= ScanIntervalSecMax
+}
+
+const currentSettingsVersion = 3
 
 // DashboardSections controls which sections appear on the dashboard.
 // All default to true (visible). Users can hide sections they don't use.
@@ -303,9 +360,20 @@ func defaultSettings() Settings {
 			DashColumns: 3,
 		},
 		ChartRangeHours: 1,
-		SMART: SMARTSettings{
-			WakeDrives: false,
-			MaxAgeDays: 7,
+		AdvancedScans: AdvancedScansSettings{
+			SMART: AdvancedScansSMART{
+				WakeDrives:  false,
+				MaxAgeDays:  7,
+				IntervalSec: 0, // use global
+			},
+			// All five non-SMART configurable subsystems default to
+			// "use global" (IntervalSec=0). Preserves exact pre-v3
+			// behaviour for fresh installs. PRD #239 user story 10.
+			Docker:     AdvancedScansSubsystem{IntervalSec: 0},
+			Proxmox:    AdvancedScansSubsystem{IntervalSec: 0},
+			Kubernetes: AdvancedScansSubsystem{IntervalSec: 0},
+			ZFS:        AdvancedScansSubsystem{IntervalSec: 0},
+			GPU:        AdvancedScansSubsystem{IntervalSec: 0},
 		},
 	}
 }
@@ -831,16 +899,42 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 	if settings.LogPush.Destinations == nil {
 		settings.LogPush.Destinations = []LogForwardDestination{}
 	}
-	// SMART scan policy validation (#237). The UI clamps client-side
-	// but a direct API caller could still submit out-of-range values;
-	// reject rather than silently clamping so the caller knows their
-	// input was ignored. 0 is valid (safety net disabled, PRD #236
-	// user story 5); 1-30 inclusive is the active range.
-	if settings.SMART.MaxAgeDays < 0 || settings.SMART.MaxAgeDays > SMARTMaxAgeDaysMax {
+	// SMART scan policy validation (#237). Since schema v3 (#259) the
+	// SMART knobs live under AdvancedScans.SMART. UI clamps client-
+	// side but a direct API caller could still submit out-of-range
+	// values; reject rather than silently clamping. 0 is valid
+	// (safety net disabled, PRD #236 user story 5); 1-30 is the
+	// active range.
+	if settings.AdvancedScans.SMART.MaxAgeDays < 0 || settings.AdvancedScans.SMART.MaxAgeDays > SMARTMaxAgeDaysMax {
 		writeJSON(w, http.StatusBadRequest, map[string]string{
-			"error": fmt.Sprintf("smart.max_age_days must be between 0 and %d (0 disables the safety net)", SMARTMaxAgeDaysMax),
+			"error": fmt.Sprintf("advanced_scans.smart.max_age_days must be between 0 and %d (0 disables the safety net)", SMARTMaxAgeDaysMax),
 		})
 		return
+	}
+
+	// Per-subsystem IntervalSec validation (#259, PRD #239 user story
+	// 13). Valid set: {0} ∪ [ScanIntervalSecMin, ScanIntervalSecMax].
+	// Check all six subsystems; return the first offender with a
+	// message that names both the field path and the valid range.
+	intervalChecks := []struct {
+		name  string
+		value int
+	}{
+		{"advanced_scans.smart.interval_sec", settings.AdvancedScans.SMART.IntervalSec},
+		{"advanced_scans.docker.interval_sec", settings.AdvancedScans.Docker.IntervalSec},
+		{"advanced_scans.proxmox.interval_sec", settings.AdvancedScans.Proxmox.IntervalSec},
+		{"advanced_scans.kubernetes.interval_sec", settings.AdvancedScans.Kubernetes.IntervalSec},
+		{"advanced_scans.zfs.interval_sec", settings.AdvancedScans.ZFS.IntervalSec},
+		{"advanced_scans.gpu.interval_sec", settings.AdvancedScans.GPU.IntervalSec},
+	}
+	for _, ic := range intervalChecks {
+		if !validScanIntervalSec(ic.value) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{
+				"error": fmt.Sprintf("%s=%d is out of range (must be 0 for 'use global', or in [%d, %d] seconds)",
+					ic.name, ic.value, ScanIntervalSecMin, ScanIntervalSecMax),
+			})
+			return
+		}
 	}
 
 	// Retention defaults and bounds
@@ -941,15 +1035,16 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 			InCluster: settings.Kubernetes.InCluster,
 		})
 
-		// Update SMART config on the collector (#198, nested under
-		// Settings.SMART since schema v2 — see #237).
+		// Update SMART config on the collector (#198). Moved from
+		// Settings.SMART → Settings.AdvancedScans.SMART in schema v3
+		// (#259); the value meaning is unchanged.
 		s.collector.SetSMARTConfig(collector.SMARTConfig{
-			WakeDrives: settings.SMART.WakeDrives,
+			WakeDrives: settings.AdvancedScans.SMART.WakeDrives,
 		})
 		// Update the max-age safety-net threshold on the scheduler
 		// (#238). The scheduler owns this policy (the collector stays
 		// DB-unaware) and applies it after each scan's Collect().
-		s.scheduler.SetSMARTMaxAgeDays(settings.SMART.MaxAgeDays)
+		s.scheduler.SetSMARTMaxAgeDays(settings.AdvancedScans.SMART.MaxAgeDays)
 
 		// Update log forwarding
 		if settings.LogPush.Enabled && len(settings.LogPush.Destinations) > 0 {
@@ -1184,38 +1279,91 @@ func (s *Server) getSettings() Settings {
 //
 //   - v0 → v1: sections.merged_drives defaults to true (historical)
 //   - v1 → v2: lift legacy top-level wake_drives_for_smart into
-//     Settings.SMART.WakeDrives; seed Settings.SMART.MaxAgeDays = 7
-//     for upgraders that never had the field (#236/#237).
+//     SMART.WakeDrives; seed SMART.MaxAgeDays = 7 for upgraders
+//     that never had the field (#236/#237). Note: in v2 this
+//     target was Settings.SMART; since v3 it is
+//     Settings.AdvancedScans.SMART. The shim target has moved —
+//     the meaning is unchanged.
+//   - v2 → v3: relocate Settings.SMART.{WakeDrives, MaxAgeDays}
+//     into Settings.AdvancedScans.SMART.{WakeDrives, MaxAgeDays};
+//     seed AdvancedScans.*.IntervalSec = 0 ("use global") for all
+//     six configurable subsystems (PRD #239 user stories 10, 11).
 //
-// The function is idempotent: running it against an already-v2 blob
-// preserves the persisted smart.wake_drives / smart.max_age_days
-// values verbatim (the legacy field shim is only consulted when the
-// stored schema version is below 2).
+// Shape-based gating (defence-in-depth against #268 regression class):
+// each rung is guarded by BOTH the settings_version number AND a
+// presence check against the raw JSON. A blob that is structurally
+// already at v3 (has a top-level "advanced_scans" object) skips the
+// v1 and v2 shims regardless of what settings_version says. This
+// ensures a corrupted version=0 blob with intact v3 fields does not
+// silently re-seed user-chosen zeros.
+//
+// The function is idempotent at every version: running it against an
+// already-current blob preserves persisted values verbatim, including
+// explicit zeros (PRD #236 / #268 regression class).
 func migrateSettings(raw []byte, base Settings) Settings {
 	// Note: json.Unmarshal onto base preserves default field values
-	// when the incoming JSON omits them — critical for SMART.MaxAgeDays
-	// since old blobs will not contain smart.max_age_days at all.
+	// when the incoming JSON omits them — critical for
+	// AdvancedScans.SMART.MaxAgeDays since old blobs will not contain
+	// the nested path at all.
 	_ = json.Unmarshal(raw, &base)
+
+	// Shape sentinels. Decode the raw JSON once into a loose map to
+	// check which top-level shape markers are present.
+	var shape map[string]json.RawMessage
+	_ = json.Unmarshal(raw, &shape)
+	_, hasAdvancedScans := shape["advanced_scans"]
+	_, hasFlatSMART := shape["smart"]
 
 	if base.SettingsVersion < 1 {
 		base.Sections.MergedDrives = true
 	}
 
-	if base.SettingsVersion < 2 {
-		// Legacy shim: v1 stored WakeDrives at the top level. Unmarshal
-		// a second time into a shadow struct to recover that field.
+	// v1 → v2 shim fires only if the blob does NOT already carry a
+	// v2-or-later shape marker (flat "smart" object or nested
+	// "advanced_scans" object). This protects explicit user zeros in
+	// v3 blobs whose settings_version was corrupted to 0.
+	if base.SettingsVersion < 2 && !hasFlatSMART && !hasAdvancedScans {
 		var legacy struct {
 			WakeDrivesForSMART bool `json:"wake_drives_for_smart"`
 		}
 		_ = json.Unmarshal(raw, &legacy)
-		base.SMART.WakeDrives = legacy.WakeDrivesForSMART
+		base.AdvancedScans.SMART.WakeDrives = legacy.WakeDrivesForSMART
 		// Every upgrader lands on the default 7-day ceiling regardless
-		// of whether the raw blob carries a smart.max_age_days value
-		// (it can't — the field didn't exist before v2). PRD #236 user
-		// story 2: the safety net opts in by default on upgrade.
-		if base.SMART.MaxAgeDays == 0 {
-			base.SMART.MaxAgeDays = 7
+		// of whether the raw blob carries max_age_days (it can't —
+		// the field didn't exist before v2). PRD #236 user story 2:
+		// the safety net opts in by default on upgrade.
+		if base.AdvancedScans.SMART.MaxAgeDays == 0 {
+			base.AdvancedScans.SMART.MaxAgeDays = 7
 		}
+	}
+
+	// v2 → v3 relocation fires only if the blob does NOT already
+	// carry the v3 shape marker. If "advanced_scans" is present, the
+	// main json.Unmarshal above already populated AdvancedScans from
+	// the input verbatim — nothing more to do.
+	if base.SettingsVersion < 3 && !hasAdvancedScans {
+		// Shadow-unmarshal to recover the v2 "smart" shape, then lift
+		// values onto the v3 target. Pointer-valued shadow lets us
+		// distinguish "field absent" from "field explicitly zero", so
+		// a v2 user's max_age_days=0 survives.
+		var legacyV2 struct {
+			SMART *struct {
+				WakeDrives *bool `json:"wake_drives"`
+				MaxAgeDays *int  `json:"max_age_days"`
+			} `json:"smart"`
+		}
+		_ = json.Unmarshal(raw, &legacyV2)
+		if legacyV2.SMART != nil {
+			if legacyV2.SMART.WakeDrives != nil {
+				base.AdvancedScans.SMART.WakeDrives = *legacyV2.SMART.WakeDrives
+			}
+			if legacyV2.SMART.MaxAgeDays != nil {
+				base.AdvancedScans.SMART.MaxAgeDays = *legacyV2.SMART.MaxAgeDays
+			}
+		}
+		// No IntervalSec in v2 — every subsystem defaults to 0 ("use
+		// global") on the v3 target, already the zero value of
+		// AdvancedScansSubsystem{}. No action needed.
 	}
 
 	return base

--- a/internal/api/settings_advanced_scans_migration_test.go
+++ b/internal/api/settings_advanced_scans_migration_test.go
@@ -1,0 +1,327 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestMigrateSettings_V2toV3_LiftsSMARTIntoAdvancedScans covers user
+// story 11 of PRD #239: a user with slice-1 (#237) config gets
+// WakeDrives and MaxAgeDays preserved verbatim across the v2→v3
+// reshape that relocates them inside the new AdvancedScans umbrella.
+//
+// Input: v2 blob with the flat "smart": {...} object.
+// Expected: v3-shape output with advanced_scans.smart.{wake_drives,
+// max_age_days, interval_sec}. WakeDrives + MaxAgeDays preserve the
+// input values; IntervalSec defaults to 0 ("use global"), since it
+// did not exist in v2.
+func TestMigrateSettings_V2toV3_LiftsSMARTIntoAdvancedScans(t *testing.T) {
+	raw := []byte(`{
+		"settings_version": 2,
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"smart": {
+			"wake_drives": true,
+			"max_age_days": 14
+		}
+	}`)
+
+	got := migrateSettings(raw, defaultSettings())
+	if got.SettingsVersion < currentSettingsVersion {
+		got.SettingsVersion = currentSettingsVersion
+	}
+
+	if got.SettingsVersion != 3 {
+		t.Errorf("settings_version: got %d, want 3", got.SettingsVersion)
+	}
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives: got false, want true (should be preserved from v2 smart block)")
+	}
+	if got.AdvancedScans.SMART.MaxAgeDays != 14 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 14 (should be preserved from v2 smart block)", got.AdvancedScans.SMART.MaxAgeDays)
+	}
+	if got.AdvancedScans.SMART.IntervalSec != 0 {
+		t.Errorf("advanced_scans.smart.interval_sec: got %d, want 0 (new field seeded at 'use global')", got.AdvancedScans.SMART.IntervalSec)
+	}
+}
+
+// TestMigrateSettings_V2toV3_SeedsAllSubsystemIntervalsToZero pins
+// PRD #239 user story 10: every fresh slice-2 install and every
+// upgrader lands on "use global" for all six configurable subsystems.
+func TestMigrateSettings_V2toV3_SeedsAllSubsystemIntervalsToZero(t *testing.T) {
+	raw := []byte(`{
+		"settings_version": 2,
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"smart": {"wake_drives": false, "max_age_days": 7}
+	}`)
+
+	got := migrateSettings(raw, defaultSettings())
+
+	if got.AdvancedScans.SMART.IntervalSec != 0 {
+		t.Errorf("advanced_scans.smart.interval_sec: got %d, want 0", got.AdvancedScans.SMART.IntervalSec)
+	}
+	if got.AdvancedScans.Docker.IntervalSec != 0 {
+		t.Errorf("advanced_scans.docker.interval_sec: got %d, want 0", got.AdvancedScans.Docker.IntervalSec)
+	}
+	if got.AdvancedScans.Proxmox.IntervalSec != 0 {
+		t.Errorf("advanced_scans.proxmox.interval_sec: got %d, want 0", got.AdvancedScans.Proxmox.IntervalSec)
+	}
+	if got.AdvancedScans.Kubernetes.IntervalSec != 0 {
+		t.Errorf("advanced_scans.kubernetes.interval_sec: got %d, want 0", got.AdvancedScans.Kubernetes.IntervalSec)
+	}
+	if got.AdvancedScans.ZFS.IntervalSec != 0 {
+		t.Errorf("advanced_scans.zfs.interval_sec: got %d, want 0", got.AdvancedScans.ZFS.IntervalSec)
+	}
+	if got.AdvancedScans.GPU.IntervalSec != 0 {
+		t.Errorf("advanced_scans.gpu.interval_sec: got %d, want 0", got.AdvancedScans.GPU.IntervalSec)
+	}
+}
+
+// TestMigrateSettings_V1toV2toV3_ChainedIntegrity pins the
+// complete upgrade path: a v1 blob climbs through both migration rungs
+// and lands in a v3 shape with all slice-1 intent preserved.
+// Covers the user stated in PRD #239 user story 11 layered on top of
+// PRD #236 user story from slice 1.
+func TestMigrateSettings_V1toV2toV3_ChainedIntegrity(t *testing.T) {
+	raw := []byte(`{
+		"settings_version": 1,
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"wake_drives_for_smart": true
+	}`)
+
+	got := migrateSettings(raw, defaultSettings())
+	if got.SettingsVersion < currentSettingsVersion {
+		got.SettingsVersion = currentSettingsVersion
+	}
+
+	if got.SettingsVersion != 3 {
+		t.Errorf("settings_version: got %d, want 3 (full v1→v2→v3 climb)", got.SettingsVersion)
+	}
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives: got false, want true (lifted from legacy wake_drives_for_smart via v1→v2→v3 chain)")
+	}
+	if got.AdvancedScans.SMART.MaxAgeDays != 7 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 7 (seeded by v1→v2 then preserved through v2→v3)", got.AdvancedScans.SMART.MaxAgeDays)
+	}
+	if got.AdvancedScans.SMART.IntervalSec != 0 {
+		t.Errorf("advanced_scans.smart.interval_sec: got %d, want 0", got.AdvancedScans.SMART.IntervalSec)
+	}
+}
+
+// TestMigrateSettings_V3_Idempotent confirms a v3-shaped blob is
+// passed through unchanged. Every subsequent read of the persisted
+// config hits this path, so it must not mutate preserved values —
+// including edge cases like explicit user zeros.
+func TestMigrateSettings_V3_Idempotent(t *testing.T) {
+	raw := []byte(`{
+		"settings_version": 3,
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"advanced_scans": {
+			"smart":      {"wake_drives": true, "max_age_days": 14, "interval_sec": 604800},
+			"docker":     {"interval_sec": 300},
+			"proxmox":    {"interval_sec": 7200},
+			"kubernetes": {"interval_sec": 0},
+			"zfs":        {"interval_sec": 7200},
+			"gpu":        {"interval_sec": 0}
+		}
+	}`)
+
+	got := migrateSettings(raw, defaultSettings())
+
+	if got.SettingsVersion != 3 {
+		t.Errorf("settings_version: got %d, want 3 preserved", got.SettingsVersion)
+	}
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives: got false, want true (should not be clobbered)")
+	}
+	if got.AdvancedScans.SMART.MaxAgeDays != 14 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 14 (should not be reseeded)", got.AdvancedScans.SMART.MaxAgeDays)
+	}
+	if got.AdvancedScans.SMART.IntervalSec != 604800 {
+		t.Errorf("advanced_scans.smart.interval_sec: got %d, want 604800 (should not be reset)", got.AdvancedScans.SMART.IntervalSec)
+	}
+	if got.AdvancedScans.Docker.IntervalSec != 300 {
+		t.Errorf("advanced_scans.docker.interval_sec: got %d, want 300", got.AdvancedScans.Docker.IntervalSec)
+	}
+	if got.AdvancedScans.Proxmox.IntervalSec != 7200 {
+		t.Errorf("advanced_scans.proxmox.interval_sec: got %d, want 7200", got.AdvancedScans.Proxmox.IntervalSec)
+	}
+	if got.AdvancedScans.ZFS.IntervalSec != 7200 {
+		t.Errorf("advanced_scans.zfs.interval_sec: got %d, want 7200", got.AdvancedScans.ZFS.IntervalSec)
+	}
+}
+
+// TestMigrateSettings_V3_PreservesExplicitZeros is the direct
+// descendant of the #268 regression guard for slice-2. A v3 blob
+// whose user deliberately chose zero on a field (max_age_days=0 as
+// "no safety net"; interval_sec=0 everywhere as "use global") must
+// survive migrateSettings verbatim — no silent re-seeding on re-read.
+//
+// Companion to TestMigrateSettings_V2_PreservesMaxAgeDaysZero in
+// settings_smart_migration_test.go. If this test fails we're
+// re-introducing the class of data-loss bug that #268 fixed.
+func TestMigrateSettings_V3_PreservesExplicitZeros(t *testing.T) {
+	raw := []byte(`{
+		"settings_version": 3,
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"advanced_scans": {
+			"smart":      {"wake_drives": false, "max_age_days": 0, "interval_sec": 0},
+			"docker":     {"interval_sec": 0},
+			"proxmox":    {"interval_sec": 0},
+			"kubernetes": {"interval_sec": 0},
+			"zfs":        {"interval_sec": 0},
+			"gpu":        {"interval_sec": 0}
+		}
+	}`)
+
+	got := migrateSettings(raw, defaultSettings())
+
+	if got.AdvancedScans.SMART.MaxAgeDays != 0 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 0 (user explicitly disabled safety net)", got.AdvancedScans.SMART.MaxAgeDays)
+	}
+	if got.AdvancedScans.SMART.IntervalSec != 0 {
+		t.Errorf("advanced_scans.smart.interval_sec: got %d, want 0 preserved", got.AdvancedScans.SMART.IntervalSec)
+	}
+	if got.SettingsVersion != 3 {
+		t.Errorf("settings_version: got %d, want 3 preserved (must not slip back to 0 and retrigger migrations — #268 class of bug)", got.SettingsVersion)
+	}
+}
+
+// TestMigrateSettings_V3_ExplicitZeroVersionNotReClobbered pins the
+// interaction between the new v3 shape and the #273 settings_version
+// clamp. A blob whose on-disk settings_version is 0 (corrupted by a
+// pre-#273 client) but that has otherwise-explicit v3 AdvancedScans
+// fields set to zero values must NOT be silently repopulated by a
+// re-migration. The caller (getSettings) stamps version back up to
+// currentSettingsVersion after migrateSettings returns; migrateSettings
+// itself should not re-seed user-chosen zeros even when the stored
+// version looks old, provided the v3 shape is recognizable.
+func TestMigrateSettings_V3_ExplicitZeroVersionNotReClobbered(t *testing.T) {
+	// This is the post-#273 world: the client must send
+	// settings_version; the server preserves it. But defence-in-depth
+	// against future regressions — if a v3-shaped blob ever appears
+	// with settings_version=0, we should treat it as v3 (the presence
+	// of advanced_scans is the authoritative shape marker) and not
+	// silently clobber the zero-values.
+	raw := []byte(`{
+		"settings_version": 0,
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"advanced_scans": {
+			"smart":      {"wake_drives": true, "max_age_days": 0, "interval_sec": 0},
+			"docker":     {"interval_sec": 0},
+			"proxmox":    {"interval_sec": 0},
+			"kubernetes": {"interval_sec": 0},
+			"zfs":        {"interval_sec": 0},
+			"gpu":        {"interval_sec": 0}
+		}
+	}`)
+
+	got := migrateSettings(raw, defaultSettings())
+
+	// max_age_days=0 must survive even though the version looks old;
+	// the v2→v3 migration path should NOT fire because the
+	// advanced_scans object already exists in the input.
+	if got.AdvancedScans.SMART.MaxAgeDays != 0 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 0 (user explicitly disabled; must not be re-seeded)", got.AdvancedScans.SMART.MaxAgeDays)
+	}
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives: got false, want true (explicit user value must survive re-migration)")
+	}
+}
+
+// TestGetSettings_V2toV3_PersistsMigration closes the loop end-to-end
+// through the HTTP-facing getSettings() function: a stored v2 blob is
+// transparently migrated to v3 on first read, and the persisted
+// representation on the store is rewritten so subsequent reads skip
+// the migration. Mirrors the slice-1 test
+// TestGetSettings_V1toV2_PersistsMigration.
+func TestGetSettings_V2toV3_PersistsMigration(t *testing.T) {
+	srv := newSettingsTestServer()
+	if err := srv.store.SetConfig(settingsConfigKey, `{
+		"settings_version": 2,
+		"scan_interval": "30m",
+		"theme": "midnight",
+		"smart": {
+			"wake_drives": true,
+			"max_age_days": 14
+		}
+	}`); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+
+	loaded := srv.getSettings()
+	if loaded.SettingsVersion != 3 {
+		t.Errorf("loaded settings_version: got %d, want 3", loaded.SettingsVersion)
+	}
+	if !loaded.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("loaded advanced_scans.smart.wake_drives: got false, want true")
+	}
+	if loaded.AdvancedScans.SMART.MaxAgeDays != 14 {
+		t.Errorf("loaded advanced_scans.smart.max_age_days: got %d, want 14", loaded.AdvancedScans.SMART.MaxAgeDays)
+	}
+
+	// Subsequent read: the stored blob must now be v3-shaped.
+	raw, err := srv.store.GetConfig(settingsConfigKey)
+	if err != nil {
+		t.Fatalf("re-read stored settings: %v", err)
+	}
+	var persisted map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &persisted); err != nil {
+		t.Fatalf("parse persisted settings: %v", err)
+	}
+	if v, _ := persisted["settings_version"].(float64); int(v) != 3 {
+		t.Errorf("persisted settings_version: got %v, want 3 (migration must rewrite the store)", persisted["settings_version"])
+	}
+	advScans, ok := persisted["advanced_scans"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("persisted settings missing advanced_scans object: %v", persisted["advanced_scans"])
+	}
+	smartMap, ok := advScans["smart"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("persisted advanced_scans missing smart object: %v", advScans["smart"])
+	}
+	if wd, _ := smartMap["wake_drives"].(bool); !wd {
+		t.Errorf("persisted advanced_scans.smart.wake_drives: got %v, want true", smartMap["wake_drives"])
+	}
+	if mad, _ := smartMap["max_age_days"].(float64); int(mad) != 14 {
+		t.Errorf("persisted advanced_scans.smart.max_age_days: got %v, want 14", smartMap["max_age_days"])
+	}
+}
+
+// TestSettingsDefault_AdvancedScans_NestedDefaults pins the defaults
+// for the new Settings.AdvancedScans sub-struct (PRD #239). Fresh
+// installs land on IntervalSec=0 for every configurable subsystem
+// (PRD user story 10) and keep slice-1's WakeDrives=false,
+// MaxAgeDays=7 SMART defaults.
+func TestSettingsDefault_AdvancedScans_NestedDefaults(t *testing.T) {
+	d := defaultSettings()
+	if d.SettingsVersion != 3 {
+		t.Errorf("defaultSettings().SettingsVersion = %d, want 3 (bumped by slice 2 PRD #239)", d.SettingsVersion)
+	}
+	if d.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("defaultSettings().AdvancedScans.SMART.WakeDrives must be false (#198 standby-aware default)")
+	}
+	if d.AdvancedScans.SMART.MaxAgeDays != 7 {
+		t.Errorf("defaultSettings().AdvancedScans.SMART.MaxAgeDays = %d, want 7 (slice 1 default, preserved across v2→v3)", d.AdvancedScans.SMART.MaxAgeDays)
+	}
+	if d.AdvancedScans.SMART.IntervalSec != 0 {
+		t.Errorf("defaultSettings().AdvancedScans.SMART.IntervalSec = %d, want 0 (use global)", d.AdvancedScans.SMART.IntervalSec)
+	}
+	subsystems := map[string]int{
+		"docker":     d.AdvancedScans.Docker.IntervalSec,
+		"proxmox":    d.AdvancedScans.Proxmox.IntervalSec,
+		"kubernetes": d.AdvancedScans.Kubernetes.IntervalSec,
+		"zfs":        d.AdvancedScans.ZFS.IntervalSec,
+		"gpu":        d.AdvancedScans.GPU.IntervalSec,
+	}
+	for name, v := range subsystems {
+		if v != 0 {
+			t.Errorf("defaultSettings().AdvancedScans.%s.IntervalSec = %d, want 0", name, v)
+		}
+	}
+}

--- a/internal/api/settings_advanced_scans_pickers_test.go
+++ b/internal/api/settings_advanced_scans_pickers_test.go
@@ -267,6 +267,12 @@ func TestSettingsHTML_AdvancedScans_UseGlobalLabelIsDynamic(t *testing.T) {
 		"settings.scan_interval",
 		"var globalLabel = globalIntervalDisplay()",
 		`" (" + globalLabel + ")"`,
+		// Humanization plumbing — globalIntervalDisplay must pipe
+		// scan_interval through parseIntervalDurationToFields +
+		// fieldsToIntervalDuration so Go's "168h0m0s" becomes "7d",
+		// "25h" becomes "1d1h", etc. (v0.9.9-rc3 UAT feedback).
+		"parseIntervalDurationToFields(raw)",
+		"fieldsToIntervalDuration(fields)",
 	}
 	for _, sub := range mustContain {
 		if !strings.Contains(content, sub) {

--- a/internal/api/settings_advanced_scans_pickers_test.go
+++ b/internal/api/settings_advanced_scans_pickers_test.go
@@ -186,8 +186,10 @@ func TestSettingsHTML_AdvancedScans_ConfirmDialogOnMaxAgeConflict(t *testing.T) 
 }
 
 // TestSettingsHTML_AdvancedScans_PickerPresetOptions pins the preset
-// dropdown's canonical option values per PRD #239: "Use global (30m)"
-// first, then the seven time presets, plus a "Custom…" fallback.
+// dropdown's canonical option values per PRD #239: "Use global" first
+// (with a dynamic "(X)" suffix injected at render time — see
+// TestSettingsHTML_AdvancedScans_UseGlobalLabelIsDynamic), then the
+// seven time presets, plus a "Custom…" fallback.
 //
 // We can't easily match each <option> element because createIntervalPicker
 // may build them via innerHTML or DOM insertion. Instead we match the
@@ -215,6 +217,60 @@ func TestSettingsHTML_AdvancedScans_PickerPresetOptions(t *testing.T) {
 	for _, sub := range mustContain {
 		if !strings.Contains(content, sub) {
 			t.Errorf("settings.html missing preset-option marker %q inside the interval-picker helper (PRD #239 user story 7)", sub)
+		}
+	}
+}
+
+// TestSettingsHTML_AdvancedScans_UseGlobalLabelIsDynamic guards
+// against a regression where the "Use global" option in the picker
+// preset dropdown carried a hardcoded "(30m)" duration suffix.
+// v0.9.9-rc2 shipped with `label: "Use global (30m)"` in the
+// advScanPresets array; a user whose scan_interval was 7 days saw
+// every picker advertise "Use global (30m)" and reasonably thought
+// the fallback cadence was 30 minutes when it was actually 7 days.
+// The fix is twofold: (1) advScanPresets carries the bare label
+// "Use global" with NO parenthesised duration; (2) a new helper
+// globalIntervalDisplay() returns the user's configured
+// scan_interval, and createIntervalPicker appends that value to
+// the label at render time via "Use global (" + X + ")". Both
+// pieces must be present.
+func TestSettingsHTML_AdvancedScans_UseGlobalLabelIsDynamic(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.html: %v", err)
+	}
+	content := string(data)
+
+	// (1) The preset array must NOT hardcode any duration suffix on
+	// the "Use global" label. If this string appears, someone has
+	// reintroduced the rc2 bug.
+	forbidden := []string{
+		`label: "Use global (30m)"`,
+		`label: "Use global (1h)"`,
+		`label: "Use global (7d)"`,
+	}
+	for _, f := range forbidden {
+		if strings.Contains(content, f) {
+			t.Errorf("settings.html advScanPresets must NOT hardcode a duration suffix on 'Use global': found %q (reintroduces the v0.9.9-rc2 UAT regression)", f)
+		}
+	}
+
+	// (2) The dynamic-suffix helper must exist and be called from
+	// createIntervalPicker's option-rendering loop. The three markers
+	// together pin the integration: the helper reads settings.scan_interval,
+	// createIntervalPicker assigns its return to globalLabel, and
+	// the "0" option's label includes " (" + globalLabel + ")"
+	// suffix.
+	mustContain := []string{
+		"function globalIntervalDisplay",
+		"settings.scan_interval",
+		"var globalLabel = globalIntervalDisplay()",
+		`" (" + globalLabel + ")"`,
+	}
+	for _, sub := range mustContain {
+		if !strings.Contains(content, sub) {
+			t.Errorf("settings.html missing dynamic 'Use global (X)' label plumbing: expected %q to appear in the <script> block", sub)
 		}
 	}
 }

--- a/internal/api/settings_advanced_scans_pickers_test.go
+++ b/internal/api/settings_advanced_scans_pickers_test.go
@@ -1,0 +1,220 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSettingsHTML_AdvancedScans_HasCreateIntervalPickerHelper pins
+// the existence of the reusable JS helper that generates the six
+// per-subsystem interval pickers. Per PRD #239 the helper is
+// parameterised by (subsystemId, label) and returns markup wiring up
+// a preset dropdown, custom d/h/m/s panel, live preview, cron
+// visualizer, and an "edit cron" button.
+//
+// We use template-source assertions (same pattern as
+// settings_smart_version_roundtrip_test.go) — the helper's internal
+// markup can change without breaking this test, but its existence
+// as a named function with the documented signature cannot.
+func TestSettingsHTML_AdvancedScans_HasCreateIntervalPickerHelper(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.html: %v", err)
+	}
+	content := string(data)
+
+	mustContain := []string{
+		// Helper declaration. We allow either `function x(...)`
+		// syntax or `var x = function(...)` by matching the name +
+		// opening paren — both valid for the PRD contract.
+		"createIntervalPicker",
+		// Both parameter slots must appear in the signature.
+		// Matching the literal "subsystemId" keeps the assertion
+		// resilient to `(subsystemId, label)` or
+		// `(subsystemId,label)` formatting.
+		"subsystemId",
+	}
+	for _, sub := range mustContain {
+		if !strings.Contains(content, sub) {
+			t.Errorf("settings.html missing createIntervalPicker helper contract symbol: %q", sub)
+		}
+	}
+}
+
+// TestSettingsHTML_AdvancedScans_SixPickerInstantiations pins that
+// the PRD's six subsystems each get their own picker in the Advanced
+// card. Per the spec: SMART's picker sits next to the existing
+// wake-drives and max-age controls; Docker / Proxmox / Kubernetes /
+// ZFS / GPU group under a "Per-subsystem scan intervals" sub-section.
+//
+// We assert presence of a stable id per picker anchor — any shape
+// the worker chooses is fine (e.g. `scan-interval-<id>`) so long as
+// it's searchable + stable.
+func TestSettingsHTML_AdvancedScans_SixPickerInstantiations(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.html: %v", err)
+	}
+	content := string(data)
+
+	// Each picker must mount its markup against a stable per-subsystem
+	// id. We match `scan-interval-<subsystem>` as the convention —
+	// parallel to `scan-preset` for the global widget.
+	subsystems := []string{"smart", "docker", "proxmox", "kubernetes", "zfs", "gpu"}
+	for _, s := range subsystems {
+		want := "scan-interval-" + s
+		if !strings.Contains(content, want) {
+			t.Errorf("settings.html missing picker anchor %q (expected one picker per subsystem per PRD #239)", want)
+		}
+	}
+
+	// Sub-section header anchor for the non-SMART five must exist,
+	// per the PRD: "Docker / Proxmox / Kubernetes / ZFS / GPU group
+	// under a new Per-subsystem scan intervals sub-section".
+	if !strings.Contains(content, "Per-subsystem scan intervals") {
+		t.Errorf("settings.html missing the 'Per-subsystem scan intervals' sub-section header")
+	}
+}
+
+// TestSettingsHTML_AdvancedScans_PickersInsideAdvancedCard pins that
+// all six pickers live inside the single id="card-advanced" block
+// (per #256 reversal — Advanced Scan Settings is one card, not two).
+func TestSettingsHTML_AdvancedScans_PickersInsideAdvancedCard(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.html: %v", err)
+	}
+	content := string(data)
+
+	cardIdx := strings.Index(content, `id="card-advanced"`)
+	if cardIdx < 0 {
+		t.Fatalf("card-advanced block not found")
+	}
+	rel := strings.Index(content[cardIdx+1:], `<div class="card"`)
+	var cardEnd int
+	if rel < 0 {
+		cardEnd = len(content)
+	} else {
+		cardEnd = cardIdx + 1 + rel
+	}
+	body := content[cardIdx:cardEnd]
+
+	for _, s := range []string{"smart", "docker", "proxmox", "kubernetes", "zfs", "gpu"} {
+		want := "scan-interval-" + s
+		if !strings.Contains(body, want) {
+			t.Errorf("Advanced card body missing picker anchor %q — all six pickers must live inside card-advanced", want)
+		}
+	}
+
+	// SMART picker is colocated with the wake-drives/max-age group —
+	// the picker anchor must appear before the existing Hide-Docker
+	// knob (which sits at the end of the SMART group in the template).
+	smartPickerIdx := strings.Index(body, "scan-interval-smart")
+	hideDockerIdx := strings.Index(body, "Hide Docker containers from dashboard")
+	if smartPickerIdx < 0 || hideDockerIdx < 0 {
+		t.Fatalf("missing ordering markers (smartPicker=%d hideDocker=%d)", smartPickerIdx, hideDockerIdx)
+	}
+	// The Per-subsystem intervals header should appear after the SMART
+	// picker and the Hide-Docker knob is independent — but we at least
+	// pin that the sub-section header is somewhere inside this card.
+	if !strings.Contains(body, "Per-subsystem scan intervals") {
+		t.Errorf("Advanced card body missing 'Per-subsystem scan intervals' sub-section header")
+	}
+}
+
+// TestSettingsHTML_AdvancedScans_ReverseCronParserExists pins the
+// existence of the JS function that translates a simple interval
+// cron expression back into d/h/m/s fields. Per PRD #239 user story
+// 8 the function handles four supported forms (`*/Ns`, `*/N * * * *`,
+// `0 */N * * *`, `0 0 */N * *`). Complex crons must produce a UI
+// error — PRD user story 14.
+func TestSettingsHTML_AdvancedScans_ReverseCronParserExists(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.html: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "parseCronToFields") {
+		t.Errorf("settings.html missing parseCronToFields() function (PRD #239 user story 8)")
+	}
+	// The UI error for unsupported crons must mention "simple"
+	// (per PRD user story 14's recommended copy).
+	if !strings.Contains(strings.ToLower(content), "simple interval cron") {
+		t.Errorf("settings.html missing UI error copy mentioning 'simple interval cron' for unsupported cron input (PRD user story 14)")
+	}
+}
+
+// TestSettingsHTML_AdvancedScans_ConfirmDialogOnMaxAgeConflict pins
+// the client-side confirm() dialog wiring described by PRD #239 user
+// story 12: saving a config with SMART.IntervalSec > MaxAgeDays *
+// 86400 (both non-zero) triggers a confirm() explaining the
+// consequence before the PUT fires.
+//
+// We use source-level assertions: the saveSettings path (or a
+// pre-save hook it calls) must include a confirm() call whose
+// surrounding logic references both smart interval and max-age.
+func TestSettingsHTML_AdvancedScans_ConfirmDialogOnMaxAgeConflict(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.html: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "confirm(") {
+		t.Errorf("settings.html has no confirm() call; expected max-age-vs-SMART-interval confirmation dialog (PRD #239 user story 12)")
+	}
+
+	// Locate the max-age conflict guard by comment marker or the
+	// canonical helper name. The worker may choose either shape —
+	// both satisfy the PRD. If neither appears, the guard is missing.
+	lower := strings.ToLower(content)
+	if !strings.Contains(lower, "max_age") && !strings.Contains(lower, "max-age") {
+		t.Fatalf("settings.html has no max-age references; cannot locate the confirm guard")
+	}
+	// The guard must compute the 86400 multiplier (days → seconds).
+	if !strings.Contains(content, "86400") {
+		t.Errorf("settings.html missing 86400 multiplier — expected SMART.IntervalSec vs MaxAgeDays*86400 comparison (PRD user story 12)")
+	}
+}
+
+// TestSettingsHTML_AdvancedScans_PickerPresetOptions pins the preset
+// dropdown's canonical option values per PRD #239: "Use global (30m)"
+// first, then the seven time presets, plus a "Custom…" fallback.
+//
+// We can't easily match each <option> element because createIntervalPicker
+// may build them via innerHTML or DOM insertion. Instead we match the
+// string literals the helper must emit — "Use global", one of each
+// preset value, "Custom".
+func TestSettingsHTML_AdvancedScans_PickerPresetOptions(t *testing.T) {
+	path := filepath.Join("templates", "settings.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.html: %v", err)
+	}
+	content := string(data)
+
+	// These are the literal preset label-or-value markers that must
+	// appear somewhere inside the helper/picker markup.
+	mustContain := []string{
+		"Use global",
+		// Seven preset durations; we look for the distinct 7-day
+		// marker from PRD user story 3 as a sentinel.
+		"7d",
+		// Custom fallback from the general-scan-interval widget
+		// pattern; the new pickers replicate this.
+		"Custom",
+	}
+	for _, sub := range mustContain {
+		if !strings.Contains(content, sub) {
+			t.Errorf("settings.html missing preset-option marker %q inside the interval-picker helper (PRD #239 user story 7)", sub)
+		}
+	}
+}

--- a/internal/api/settings_advanced_scans_validation_test.go
+++ b/internal/api/settings_advanced_scans_validation_test.go
@@ -1,0 +1,216 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestHandleUpdateSettings_AdvancedScans_IntervalSec_RangeRejected
+// pins server-side validation for advanced_scans.*.interval_sec.
+// Valid set: {0} ∪ [30, 2678400] (0 = "use global", 30s = minimum
+// positive cadence to keep the scheduler tick sensible, 2678400 = 31
+// days = effectively-disabled ceiling). Per PRD #239 user story 13.
+//
+// The UI clamps client-side but a direct API caller could still
+// submit out-of-range values; the server must reject with 400 and a
+// clear message that names the offending field + the valid range.
+func TestHandleUpdateSettings_AdvancedScans_IntervalSec_RangeRejected(t *testing.T) {
+	cases := []struct {
+		name        string
+		subsystem   string
+		intervalSec int
+		wantStatus  int
+	}{
+		{"zero is valid (use global)", "docker", 0, http.StatusOK},
+		{"thirty is the minimum positive", "docker", 30, http.StatusOK},
+		{"five minutes", "docker", 300, http.StatusOK},
+		{"one day", "docker", 86400, http.StatusOK},
+		{"31 days (maximum)", "docker", 2678400, http.StatusOK},
+		{"one second rejected (below 30)", "docker", 1, http.StatusBadRequest},
+		{"twenty-nine seconds rejected (below 30)", "docker", 29, http.StatusBadRequest},
+		{"31 days plus one rejected", "docker", 2678401, http.StatusBadRequest},
+		{"one year rejected", "docker", 31536000, http.StatusBadRequest},
+		{"negative rejected", "docker", -1, http.StatusBadRequest},
+		// Exercise SMART (has extra fields besides IntervalSec but
+		// the IntervalSec bound check applies identically).
+		{"smart: out of range rejected", "smart", 29, http.StatusBadRequest},
+		{"smart: valid 7-day interval", "smart", 604800, http.StatusOK},
+		// Exercise all 6 subsystems at a valid value to confirm
+		// every field gets validated.
+		{"proxmox: valid 1-hour interval", "proxmox", 3600, http.StatusOK},
+		{"kubernetes: out-of-range rejected", "kubernetes", 10, http.StatusBadRequest},
+		{"zfs: valid 2-hour interval", "zfs", 7200, http.StatusOK},
+		{"gpu: out-of-range rejected", "gpu", 2678401, http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newSettingsTestServer()
+			scans := map[string]interface{}{
+				"smart":      map[string]interface{}{"wake_drives": false, "max_age_days": 7, "interval_sec": 0},
+				"docker":     map[string]interface{}{"interval_sec": 0},
+				"proxmox":    map[string]interface{}{"interval_sec": 0},
+				"kubernetes": map[string]interface{}{"interval_sec": 0},
+				"zfs":        map[string]interface{}{"interval_sec": 0},
+				"gpu":        map[string]interface{}{"interval_sec": 0},
+			}
+			// Overwrite the relevant subsystem with the test value.
+			sub := scans[tc.subsystem].(map[string]interface{})
+			sub["interval_sec"] = tc.intervalSec
+			scans[tc.subsystem] = sub
+
+			body, _ := json.Marshal(map[string]interface{}{
+				"settings_version": 3,
+				"scan_interval":    "30m",
+				"theme":            "midnight",
+				"advanced_scans":   scans,
+			})
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			srv.handleUpdateSettings(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Errorf("%s=%d returned %d, want %d; body=%s",
+					tc.subsystem, tc.intervalSec, rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if tc.wantStatus == http.StatusBadRequest {
+				lower := strings.ToLower(rec.Body.String())
+				// Error message must name the offending subsystem and
+				// the field so users know exactly which input to fix.
+				if !strings.Contains(lower, "interval_sec") {
+					t.Errorf("400 body should name interval_sec; got: %s", rec.Body.String())
+				}
+				if !strings.Contains(lower, tc.subsystem) {
+					t.Errorf("400 body should name subsystem %q; got: %s", tc.subsystem, rec.Body.String())
+				}
+			}
+		})
+	}
+}
+
+// TestHandleUpdateSettings_AdvancedScans_RoundTrip exercises PUT→GET
+// for the full AdvancedScans shape. Non-default values for every
+// subsystem must survive the round trip intact.
+func TestHandleUpdateSettings_AdvancedScans_RoundTrip(t *testing.T) {
+	srv := newSettingsTestServer()
+
+	put := map[string]interface{}{
+		"settings_version": 3,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"advanced_scans": map[string]interface{}{
+			"smart":      map[string]interface{}{"wake_drives": true, "max_age_days": 14, "interval_sec": 604800},
+			"docker":     map[string]interface{}{"interval_sec": 300},
+			"proxmox":    map[string]interface{}{"interval_sec": 3600},
+			"kubernetes": map[string]interface{}{"interval_sec": 7200},
+			"zfs":        map[string]interface{}{"interval_sec": 7200},
+			"gpu":        map[string]interface{}{"interval_sec": 0},
+		},
+	}
+	body, _ := json.Marshal(put)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.handleUpdateSettings(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PUT returned %d: %s", rr.Code, rr.Body.String())
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	rr2 := httptest.NewRecorder()
+	srv.handleGetSettings(rr2, req2)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("GET returned %d", rr2.Code)
+	}
+	var got Settings
+	if err := json.Unmarshal(rr2.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse GET response: %v", err)
+	}
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives did not round-trip")
+	}
+	if got.AdvancedScans.SMART.MaxAgeDays != 14 {
+		t.Errorf("advanced_scans.smart.max_age_days did not round-trip; got %d", got.AdvancedScans.SMART.MaxAgeDays)
+	}
+	if got.AdvancedScans.SMART.IntervalSec != 604800 {
+		t.Errorf("advanced_scans.smart.interval_sec did not round-trip; got %d", got.AdvancedScans.SMART.IntervalSec)
+	}
+	if got.AdvancedScans.Docker.IntervalSec != 300 {
+		t.Errorf("advanced_scans.docker.interval_sec did not round-trip; got %d", got.AdvancedScans.Docker.IntervalSec)
+	}
+	if got.AdvancedScans.Proxmox.IntervalSec != 3600 {
+		t.Errorf("advanced_scans.proxmox.interval_sec did not round-trip; got %d", got.AdvancedScans.Proxmox.IntervalSec)
+	}
+	if got.AdvancedScans.Kubernetes.IntervalSec != 7200 {
+		t.Errorf("advanced_scans.kubernetes.interval_sec did not round-trip; got %d", got.AdvancedScans.Kubernetes.IntervalSec)
+	}
+	if got.AdvancedScans.ZFS.IntervalSec != 7200 {
+		t.Errorf("advanced_scans.zfs.interval_sec did not round-trip; got %d", got.AdvancedScans.ZFS.IntervalSec)
+	}
+	if got.AdvancedScans.GPU.IntervalSec != 0 {
+		t.Errorf("advanced_scans.gpu.interval_sec did not round-trip; got %d", got.AdvancedScans.GPU.IntervalSec)
+	}
+}
+
+// TestHandleUpdateSettings_AdvancedScans_InvalidDoesNotPersist ensures
+// an out-of-range PUT does NOT partially persist. Subsequent GET must
+// see the pre-edit state (mirrors the SMART.MaxAgeDays equivalent).
+func TestHandleUpdateSettings_AdvancedScans_InvalidDoesNotPersist(t *testing.T) {
+	srv := newSettingsTestServer()
+
+	good, _ := json.Marshal(map[string]interface{}{
+		"settings_version": 3,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"advanced_scans": map[string]interface{}{
+			"smart":      map[string]interface{}{"wake_drives": false, "max_age_days": 7, "interval_sec": 0},
+			"docker":     map[string]interface{}{"interval_sec": 300},
+			"proxmox":    map[string]interface{}{"interval_sec": 0},
+			"kubernetes": map[string]interface{}{"interval_sec": 0},
+			"zfs":        map[string]interface{}{"interval_sec": 0},
+			"gpu":        map[string]interface{}{"interval_sec": 0},
+		},
+	})
+	rec := httptest.NewRecorder()
+	srv.handleUpdateSettings(rec, httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(good)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("seed PUT failed: %d %s", rec.Code, rec.Body.String())
+	}
+
+	bad, _ := json.Marshal(map[string]interface{}{
+		"settings_version": 3,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"advanced_scans": map[string]interface{}{
+			"smart":      map[string]interface{}{"wake_drives": false, "max_age_days": 7, "interval_sec": 0},
+			"docker":     map[string]interface{}{"interval_sec": 5},
+			"proxmox":    map[string]interface{}{"interval_sec": 0},
+			"kubernetes": map[string]interface{}{"interval_sec": 0},
+			"zfs":        map[string]interface{}{"interval_sec": 0},
+			"gpu":        map[string]interface{}{"interval_sec": 0},
+		},
+	})
+	rec2 := httptest.NewRecorder()
+	srv.handleUpdateSettings(rec2, httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(bad)))
+	if rec2.Code != http.StatusBadRequest {
+		t.Fatalf("invalid PUT must return 400, got %d: %s", rec2.Code, rec2.Body.String())
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	rec3 := httptest.NewRecorder()
+	srv.handleGetSettings(rec3, req)
+	if rec3.Code != http.StatusOK {
+		t.Fatalf("GET failed: %d", rec3.Code)
+	}
+	var got Settings
+	if err := json.Unmarshal(rec3.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse GET: %v", err)
+	}
+	if got.AdvancedScans.Docker.IntervalSec != 300 {
+		t.Errorf("docker.interval_sec leaked from rejected PUT: got %d, want 300 (seeded value)", got.AdvancedScans.Docker.IntervalSec)
+	}
+}

--- a/internal/api/settings_dispatcher_wiring_test.go
+++ b/internal/api/settings_dispatcher_wiring_test.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/collector"
+	"github.com/mcdays94/nas-doctor/internal/notifier"
+	"github.com/mcdays94/nas-doctor/internal/scheduler"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// TestHandleUpdateSettings_AdvancedScans_PushesIntervalsToScheduler
+// confirms the handler invokes SetDispatcherIntervals with the
+// user-submitted values. Without this wiring, slice 2a persists the
+// config but the scheduler never picks up the cadence change —
+// issue #260 user stories 1-6 all fail silently.
+func TestHandleUpdateSettings_AdvancedScans_PushesIntervalsToScheduler(t *testing.T) {
+	store := storage.NewFakeStore()
+	silent := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	col := collector.New(internal.HostPaths{}, silent)
+	sched := scheduler.New(col, store, &notifier.Notifier{}, nil, silent, 30*time.Minute)
+
+	srv := &Server{
+		store:     store,
+		scheduler: sched,
+		collector: col,
+		logger:    silent,
+		version:   "test",
+		startTime: time.Now(),
+	}
+
+	// Precondition: dispatcher starts with everything on global
+	// (30m). FastestInterval = 30m.
+	if got := sched.Dispatcher().FastestInterval(); got != 30*time.Minute {
+		t.Fatalf("precondition: FastestInterval = %v, want 30m", got)
+	}
+
+	// Save settings with Docker=300 (5 min override) + SMART=86400
+	// (1 day). FastestInterval should drop to 5 min after the save.
+	body, _ := json.Marshal(map[string]interface{}{
+		"settings_version": 3,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"advanced_scans": map[string]interface{}{
+			"smart":      map[string]interface{}{"wake_drives": false, "max_age_days": 7, "interval_sec": 86400},
+			"docker":     map[string]interface{}{"interval_sec": 300},
+			"proxmox":    map[string]interface{}{"interval_sec": 0},
+			"kubernetes": map[string]interface{}{"interval_sec": 0},
+			"zfs":        map[string]interface{}{"interval_sec": 0},
+			"gpu":        map[string]interface{}{"interval_sec": 0},
+		},
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.handleUpdateSettings(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT /api/v1/settings returned %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// After save, dispatcher should see Docker at 5m as fastest.
+	if got, want := sched.Dispatcher().FastestInterval(), 5*time.Minute; got != want {
+		t.Errorf("after save, FastestInterval = %v, want %v (Docker=300s should be fastest)", got, want)
+	}
+}

--- a/internal/api/settings_dispatcher_wiring_test.go
+++ b/internal/api/settings_dispatcher_wiring_test.go
@@ -43,6 +43,15 @@ func TestHandleUpdateSettings_AdvancedScans_PushesIntervalsToScheduler(t *testin
 		t.Fatalf("precondition: FastestInterval = %v, want 30m", got)
 	}
 
+	// Seed settings to provide the required default values PUT expects
+	// to find on disk (otherwise the handler's validation path for
+	// nested fields may behave unexpectedly).
+	_ = store.SetConfig(settingsConfigKey, func() string {
+		d := defaultSettings()
+		b, _ := json.Marshal(d)
+		return string(b)
+	}())
+
 	// Save settings with Docker=300 (5 min override) + SMART=86400
 	// (1 day). FastestInterval should drop to 5 min after the save.
 	body, _ := json.Marshal(map[string]interface{}{

--- a/internal/api/settings_js_parses_test.go
+++ b/internal/api/settings_js_parses_test.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestSettingsTemplate_JSBlocksParse asserts every <script> block in
+// settings.html is valid JavaScript. Shells out to `node --check` if
+// available; otherwise skips (so CI without node is not blocked).
+//
+// Why this test exists: v0.9.9-rc1 shipped with a /* */ block comment
+// containing the sequence `*/N s` (documenting cron examples), which
+// closes the JS block comment prematurely. The entire <script> block
+// failed to parse, silently breaking loadSettings(),
+// renderAdvancedScanPickers(), loadDockerHiddenContainersCheckboxes(),
+// and every onchange-driven save handler. Symptom on hardware UAT:
+// Max-age input stuck on the static HTML default (value="7"), pickers
+// not rendered, Hide-Docker list stuck on "Loading containers…", no
+// Settings-Saved toast, changes reverted on refresh.
+//
+// No existing test would have caught this because template-source
+// greps only verify that specific strings appear in the rendered
+// HTML — they do not exercise JS parseability.
+func TestSettingsTemplate_JSBlocksParse(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node binary not in PATH; skipping JS parse check (dev-time guard only)")
+	}
+
+	blocks := extractScriptBlocks(SettingsPage)
+	if len(blocks) == 0 {
+		t.Fatal("no <script>...</script> blocks found in settings.html")
+	}
+
+	for i, js := range blocks {
+		if strings.TrimSpace(js) == "" {
+			continue // external <script src="..."> tags produce empty bodies
+		}
+		cmd := exec.Command("node", "--check", "-")
+		cmd.Stdin = strings.NewReader(js)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Errorf("settings.html <script> block %d failed to parse as JS:\n%s", i, string(out))
+		}
+	}
+}
+
+// extractScriptBlocks returns the bodies of every <script>...</script>
+// pair in tpl, in document order. External <script src="..."> tags
+// have empty bodies and are returned as empty strings (the caller
+// filters those out — they're served as separate static assets and
+// not inline JS under our control).
+//
+// Intentionally naive: no attribute parsing, no nested-script
+// handling (HTML disallows nesting). Adequate for our template shape.
+func extractScriptBlocks(tpl string) []string {
+	var out []string
+	cursor := 0
+	for {
+		openStart := strings.Index(tpl[cursor:], "<script")
+		if openStart < 0 {
+			break
+		}
+		openStart += cursor
+		openEnd := strings.Index(tpl[openStart:], ">")
+		if openEnd < 0 {
+			break
+		}
+		openEnd += openStart + 1 // position after the '>'
+		closeIdx := strings.Index(tpl[openEnd:], "</script>")
+		if closeIdx < 0 {
+			break
+		}
+		closeIdx += openEnd
+		out = append(out, tpl[openEnd:closeIdx])
+		cursor = closeIdx + len("</script>")
+	}
+	return out
+}

--- a/internal/api/settings_smart_migration_test.go
+++ b/internal/api/settings_smart_migration_test.go
@@ -10,8 +10,9 @@ import (
 // is automatically preserved across the schema migration.
 //
 // Input: v1 blob with the legacy flat wake_drives_for_smart=true field.
-// Expected: v2-shape output with smart.wake_drives=true, seeded
-// smart.max_age_days=7, and settings_version bumped to 2.
+// Expected: WakeDrives=true on the target SMART sub-struct (v2 put
+// this under Settings.SMART; v3 moves it to Settings.AdvancedScans.SMART
+// via the v2→v3 ladder — see #259). Asserts the final v3 shape here.
 func TestMigrateSettings_V1toV2_LiftsWakeDrivesForSMART(t *testing.T) {
 	raw := []byte(`{
 		"settings_version": 1,
@@ -27,14 +28,14 @@ func TestMigrateSettings_V1toV2_LiftsWakeDrivesForSMART(t *testing.T) {
 		got.SettingsVersion = currentSettingsVersion
 	}
 
-	if got.SettingsVersion != 2 {
-		t.Errorf("settings_version: got %d, want 2", got.SettingsVersion)
+	if got.SettingsVersion != currentSettingsVersion {
+		t.Errorf("settings_version: got %d, want %d", got.SettingsVersion, currentSettingsVersion)
 	}
-	if !got.SMART.WakeDrives {
-		t.Errorf("smart.wake_drives: got false, want true (lifted from wake_drives_for_smart)")
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives: got false, want true (lifted from wake_drives_for_smart)")
 	}
-	if got.SMART.MaxAgeDays != 7 {
-		t.Errorf("smart.max_age_days: got %d, want 7 (PRD #236 user story 2 default)", got.SMART.MaxAgeDays)
+	if got.AdvancedScans.SMART.MaxAgeDays != 7 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 7 (PRD #236 user story 2 default)", got.AdvancedScans.SMART.MaxAgeDays)
 	}
 }
 
@@ -52,18 +53,17 @@ func TestMigrateSettings_V1toV2_SeedsMaxAgeDaysForOptedOutUpgrader(t *testing.T)
 
 	got := migrateSettings(raw, defaultSettings())
 
-	if got.SMART.WakeDrives {
-		t.Errorf("smart.wake_drives: got true, want false (no legacy opt-in present)")
+	if got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives: got true, want false (no legacy opt-in present)")
 	}
-	if got.SMART.MaxAgeDays != 7 {
-		t.Errorf("smart.max_age_days: got %d, want 7 (seeded for every upgrader)", got.SMART.MaxAgeDays)
+	if got.AdvancedScans.SMART.MaxAgeDays != 7 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 7 (seeded for every upgrader)", got.AdvancedScans.SMART.MaxAgeDays)
 	}
 }
 
 // TestMigrateSettings_V2_Idempotent confirms that a v2-shaped blob is
-// passed through unchanged. Running the migration on an already-
-// migrated blob is the code path hit on every subsequent read of the
-// persisted config, so it must not mutate preserved values.
+// passed through and lifted onto the v3 shape: WakeDrives and
+// MaxAgeDays values survive the v2→v3 relocation.
 func TestMigrateSettings_V2_Idempotent(t *testing.T) {
 	raw := []byte(`{
 		"settings_version": 2,
@@ -76,24 +76,26 @@ func TestMigrateSettings_V2_Idempotent(t *testing.T) {
 	}`)
 
 	got := migrateSettings(raw, defaultSettings())
+	if got.SettingsVersion < currentSettingsVersion {
+		got.SettingsVersion = currentSettingsVersion
+	}
 
-	if got.SettingsVersion != 2 {
-		t.Errorf("settings_version: got %d, want 2 preserved", got.SettingsVersion)
+	if got.SettingsVersion != currentSettingsVersion {
+		t.Errorf("settings_version: got %d, want %d", got.SettingsVersion, currentSettingsVersion)
 	}
-	if !got.SMART.WakeDrives {
-		t.Errorf("smart.wake_drives: got false, want true (should not be clobbered)")
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives: got false, want true (should not be clobbered by v2→v3 relocation)")
 	}
-	if got.SMART.MaxAgeDays != 14 {
-		t.Errorf("smart.max_age_days: got %d, want 14 (should not be reseeded)", got.SMART.MaxAgeDays)
+	if got.AdvancedScans.SMART.MaxAgeDays != 14 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 14 (should not be reseeded)", got.AdvancedScans.SMART.MaxAgeDays)
 	}
 }
 
 // TestMigrateSettings_V2UserTouchesSettings_DoesNotReMigrateZeroMaxAge
 // pins the combined preservation contract after issue #268: a v2 blob
 // with the full spectrum of edge-case user choices (explicit
-// max_age_days=0 AND wake_drives=true) passes through migrateSettings
-// unchanged. The v1→v2 ladder MUST NOT fire once SettingsVersion is
-// already 2, no matter what SMART values were chosen.
+// max_age_days=0 AND wake_drives=true) survives both the v1→v2 ladder
+// and the v2→v3 relocation with values intact.
 func TestMigrateSettings_V2UserTouchesSettings_DoesNotReMigrateZeroMaxAge(t *testing.T) {
 	raw := []byte(`{
 		"settings_version": 2,
@@ -106,15 +108,18 @@ func TestMigrateSettings_V2UserTouchesSettings_DoesNotReMigrateZeroMaxAge(t *tes
 	}`)
 
 	got := migrateSettings(raw, defaultSettings())
+	if got.SettingsVersion < currentSettingsVersion {
+		got.SettingsVersion = currentSettingsVersion
+	}
 
-	if got.SettingsVersion != 2 {
-		t.Errorf("settings_version: got %d, want 2 preserved", got.SettingsVersion)
+	if got.SettingsVersion != currentSettingsVersion {
+		t.Errorf("settings_version: got %d, want %d", got.SettingsVersion, currentSettingsVersion)
 	}
-	if got.SMART.MaxAgeDays != 0 {
-		t.Errorf("smart.max_age_days: got %d, want 0 (explicit user zero must survive — was the visible half of #268)", got.SMART.MaxAgeDays)
+	if got.AdvancedScans.SMART.MaxAgeDays != 0 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 0 (explicit user zero must survive — was the visible half of #268)", got.AdvancedScans.SMART.MaxAgeDays)
 	}
-	if !got.SMART.WakeDrives {
-		t.Errorf("smart.wake_drives: got false, want true (explicit user true must survive — was the silent half of #268)")
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives: got false, want true (explicit user true must survive — was the silent half of #268)")
 	}
 }
 
@@ -135,17 +140,18 @@ func TestMigrateSettings_V2_PreservesMaxAgeDaysZero(t *testing.T) {
 
 	got := migrateSettings(raw, defaultSettings())
 
-	if got.SMART.MaxAgeDays != 0 {
-		t.Errorf("smart.max_age_days: got %d, want 0 (user explicitly disabled the safety net — must be preserved)", got.SMART.MaxAgeDays)
+	if got.AdvancedScans.SMART.MaxAgeDays != 0 {
+		t.Errorf("advanced_scans.smart.max_age_days: got %d, want 0 (user explicitly disabled the safety net — must be preserved)", got.AdvancedScans.SMART.MaxAgeDays)
 	}
 }
 
 // TestGetSettings_V1toV2_PersistsMigration closes the loop end-to-end
 // through the HTTP-facing getSettings() function: a stored v1 blob is
-// transparently migrated to v2 on first read, and the persisted
-// representation on the store is rewritten so subsequent reads skip
-// the migration path. This guards against a subtle regression where
-// the migration only applies in-memory and the stored blob stays v1.
+// transparently migrated to the current version on first read, and the
+// persisted representation is rewritten so subsequent reads skip the
+// migration path. Since the current version is now v3 (#259), the end
+// state assertions target the v3 shape; slice-1 intent (WakeDrives
+// lift, MaxAgeDays seed) is preserved inside advanced_scans.smart.
 func TestGetSettings_V1toV2_PersistsMigration(t *testing.T) {
 	srv := newSettingsTestServer()
 	if err := srv.store.SetConfig(settingsConfigKey, `{
@@ -158,18 +164,17 @@ func TestGetSettings_V1toV2_PersistsMigration(t *testing.T) {
 	}
 
 	loaded := srv.getSettings()
-	if loaded.SettingsVersion != 2 {
-		t.Errorf("loaded settings_version: got %d, want 2", loaded.SettingsVersion)
+	if loaded.SettingsVersion != currentSettingsVersion {
+		t.Errorf("loaded settings_version: got %d, want %d", loaded.SettingsVersion, currentSettingsVersion)
 	}
-	if !loaded.SMART.WakeDrives {
-		t.Errorf("loaded smart.wake_drives: got false, want true")
+	if !loaded.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("loaded advanced_scans.smart.wake_drives: got false, want true")
 	}
-	if loaded.SMART.MaxAgeDays != 7 {
-		t.Errorf("loaded smart.max_age_days: got %d, want 7", loaded.SMART.MaxAgeDays)
+	if loaded.AdvancedScans.SMART.MaxAgeDays != 7 {
+		t.Errorf("loaded advanced_scans.smart.max_age_days: got %d, want 7", loaded.AdvancedScans.SMART.MaxAgeDays)
 	}
 
-	// Subsequent read: the stored blob must now be v2-shaped, so a
-	// fresh migrateSettings invocation on it is an idempotent no-op.
+	// Subsequent read: the stored blob must now be v3-shaped.
 	raw, err := srv.store.GetConfig(settingsConfigKey)
 	if err != nil {
 		t.Fatalf("re-read stored settings: %v", err)
@@ -178,17 +183,21 @@ func TestGetSettings_V1toV2_PersistsMigration(t *testing.T) {
 	if err := json.Unmarshal([]byte(raw), &persisted); err != nil {
 		t.Fatalf("parse persisted settings: %v", err)
 	}
-	if v, _ := persisted["settings_version"].(float64); int(v) != 2 {
-		t.Errorf("persisted settings_version: got %v, want 2 (migration must rewrite the store)", persisted["settings_version"])
+	if v, _ := persisted["settings_version"].(float64); int(v) != currentSettingsVersion {
+		t.Errorf("persisted settings_version: got %v, want %d (migration must rewrite the store)", persisted["settings_version"], currentSettingsVersion)
 	}
-	smartMap, ok := persisted["smart"].(map[string]interface{})
+	advScans, ok := persisted["advanced_scans"].(map[string]interface{})
 	if !ok {
-		t.Fatalf("persisted settings missing nested smart object: %v", persisted["smart"])
+		t.Fatalf("persisted settings missing advanced_scans object: %v", persisted["advanced_scans"])
+	}
+	smartMap, ok := advScans["smart"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("persisted advanced_scans missing smart object: %v", advScans["smart"])
 	}
 	if wd, _ := smartMap["wake_drives"].(bool); !wd {
-		t.Errorf("persisted smart.wake_drives: got %v, want true", smartMap["wake_drives"])
+		t.Errorf("persisted advanced_scans.smart.wake_drives: got %v, want true", smartMap["wake_drives"])
 	}
 	if mad, _ := smartMap["max_age_days"].(float64); int(mad) != 7 {
-		t.Errorf("persisted smart.max_age_days: got %v, want 7", smartMap["max_age_days"])
+		t.Errorf("persisted advanced_scans.smart.max_age_days: got %v, want 7", smartMap["max_age_days"])
 	}
 }

--- a/internal/api/settings_smart_schema_test.go
+++ b/internal/api/settings_smart_schema_test.go
@@ -10,35 +10,41 @@ import (
 )
 
 // TestSettingsDefault_SMART_NestedDefaults guards the defaults for
-// the new Settings.SMART sub-struct introduced by issue #237. Every
-// fresh install (and every upgrader via the migration in getSettings)
-// must land on these concrete defaults:
+// the SMART sub-struct. Originally introduced by issue #237 under
+// Settings.SMART; relocated to Settings.AdvancedScans.SMART by #259.
+// Every fresh install (and every upgrader via the migration in
+// getSettings) must land on these concrete defaults:
 //   - WakeDrives = false (unchanged from v0.9.5 #198 standby-aware default)
-//   - MaxAgeDays = 7     (new; safety-net threshold documented in PRD #236)
+//   - MaxAgeDays = 7     (safety-net threshold documented in PRD #236)
 func TestSettingsDefault_SMART_NestedDefaults(t *testing.T) {
 	d := defaultSettings()
-	if d.SMART.WakeDrives {
-		t.Errorf("defaultSettings().SMART.WakeDrives must be false (#198 standby-aware default)")
+	if d.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("defaultSettings().AdvancedScans.SMART.WakeDrives must be false (#198 standby-aware default)")
 	}
-	if d.SMART.MaxAgeDays != 7 {
-		t.Errorf("defaultSettings().SMART.MaxAgeDays = %d, want 7 (PRD #236)", d.SMART.MaxAgeDays)
+	if d.AdvancedScans.SMART.MaxAgeDays != 7 {
+		t.Errorf("defaultSettings().AdvancedScans.SMART.MaxAgeDays = %d, want 7 (PRD #236)", d.AdvancedScans.SMART.MaxAgeDays)
 	}
 }
 
-// TestSettingsRoundTrip_SMART_Nested exercises PUT→GET for the new
-// nested smart shape. The client sends `smart: {wake_drives: true,
-// max_age_days: 14}` and the server must return the same values on
-// the subsequent GET. No new scheduler behaviour fires in this slice
-// (that's #238's scope) — this test only pins the schema contract.
+// TestSettingsRoundTrip_SMART_Nested exercises PUT→GET for the
+// advanced_scans.smart wire shape (v3 schema, #259). The client
+// sends the nested shape; the server must return matching values
+// on the subsequent GET. No new scheduler behaviour fires in this
+// slice — this test only pins the schema contract.
 func TestSettingsRoundTrip_SMART_Nested(t *testing.T) {
 	srv := newSettingsTestServer()
 
 	putBody := map[string]interface{}{
-		"scan_interval": "30m",
-		"theme":         "midnight",
-		"smart": map[string]interface{}{
-			"wake_drives":   true,
-			"max_age_days":  14,
+		"settings_version": 3,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"advanced_scans": map[string]interface{}{
+			"smart":      map[string]interface{}{"wake_drives": true, "max_age_days": 14, "interval_sec": 0},
+			"docker":     map[string]interface{}{"interval_sec": 0},
+			"proxmox":    map[string]interface{}{"interval_sec": 0},
+			"kubernetes": map[string]interface{}{"interval_sec": 0},
+			"zfs":        map[string]interface{}{"interval_sec": 0},
+			"gpu":        map[string]interface{}{"interval_sec": 0},
 		},
 	}
 	buf, _ := json.Marshal(putBody)
@@ -61,10 +67,10 @@ func TestSettingsRoundTrip_SMART_Nested(t *testing.T) {
 	if err := json.Unmarshal(rec2.Body.Bytes(), &got); err != nil {
 		t.Fatalf("parse GET response: %v", err)
 	}
-	if !got.SMART.WakeDrives {
-		t.Errorf("smart.wake_drives did not round-trip; got false, want true")
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives did not round-trip; got false, want true")
 	}
-	if got.SMART.MaxAgeDays != 14 {
-		t.Errorf("smart.max_age_days did not round-trip; got %d, want 14", got.SMART.MaxAgeDays)
+	if got.AdvancedScans.SMART.MaxAgeDays != 14 {
+		t.Errorf("advanced_scans.smart.max_age_days did not round-trip; got %d, want 14", got.AdvancedScans.SMART.MaxAgeDays)
 	}
 }

--- a/internal/api/settings_smart_validation_test.go
+++ b/internal/api/settings_smart_validation_test.go
@@ -35,11 +35,16 @@ func TestHandleUpdateSettings_SMART_MaxAgeDays_RangeRejected(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			srv := newSettingsTestServer()
 			body, _ := json.Marshal(map[string]interface{}{
-				"scan_interval": "30m",
-				"theme":         "midnight",
-				"smart": map[string]interface{}{
-					"wake_drives":  false,
-					"max_age_days": tc.maxAgeDays,
+				"settings_version": 3,
+				"scan_interval":    "30m",
+				"theme":            "midnight",
+				"advanced_scans": map[string]interface{}{
+					"smart":      map[string]interface{}{"wake_drives": false, "max_age_days": tc.maxAgeDays, "interval_sec": 0},
+					"docker":     map[string]interface{}{"interval_sec": 0},
+					"proxmox":    map[string]interface{}{"interval_sec": 0},
+					"kubernetes": map[string]interface{}{"interval_sec": 0},
+					"zfs":        map[string]interface{}{"interval_sec": 0},
+					"gpu":        map[string]interface{}{"interval_sec": 0},
 				},
 			})
 			req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(body))
@@ -70,11 +75,16 @@ func TestHandleUpdateSettings_SMART_MaxAgeDays_InvalidDoesNotPersist(t *testing.
 
 	// First, persist a known-good state.
 	good, _ := json.Marshal(map[string]interface{}{
-		"scan_interval": "30m",
-		"theme":         "midnight",
-		"smart": map[string]interface{}{
-			"wake_drives":  true,
-			"max_age_days": 14,
+		"settings_version": 3,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"advanced_scans": map[string]interface{}{
+			"smart":      map[string]interface{}{"wake_drives": true, "max_age_days": 14, "interval_sec": 0},
+			"docker":     map[string]interface{}{"interval_sec": 0},
+			"proxmox":    map[string]interface{}{"interval_sec": 0},
+			"kubernetes": map[string]interface{}{"interval_sec": 0},
+			"zfs":        map[string]interface{}{"interval_sec": 0},
+			"gpu":        map[string]interface{}{"interval_sec": 0},
 		},
 	})
 	rec := httptest.NewRecorder()
@@ -85,11 +95,16 @@ func TestHandleUpdateSettings_SMART_MaxAgeDays_InvalidDoesNotPersist(t *testing.
 
 	// Submit invalid max_age_days=99.
 	bad, _ := json.Marshal(map[string]interface{}{
-		"scan_interval": "30m",
-		"theme":         "midnight",
-		"smart": map[string]interface{}{
-			"wake_drives":  false,
-			"max_age_days": 99,
+		"settings_version": 3,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"advanced_scans": map[string]interface{}{
+			"smart":      map[string]interface{}{"wake_drives": false, "max_age_days": 99, "interval_sec": 0},
+			"docker":     map[string]interface{}{"interval_sec": 0},
+			"proxmox":    map[string]interface{}{"interval_sec": 0},
+			"kubernetes": map[string]interface{}{"interval_sec": 0},
+			"zfs":        map[string]interface{}{"interval_sec": 0},
+			"gpu":        map[string]interface{}{"interval_sec": 0},
 		},
 	})
 	rec2 := httptest.NewRecorder()
@@ -109,10 +124,10 @@ func TestHandleUpdateSettings_SMART_MaxAgeDays_InvalidDoesNotPersist(t *testing.
 	if err := json.Unmarshal(rec3.Body.Bytes(), &got); err != nil {
 		t.Fatalf("parse GET: %v", err)
 	}
-	if got.SMART.MaxAgeDays != 14 {
-		t.Errorf("max_age_days leaked from rejected PUT: got %d, want 14 (seeded value)", got.SMART.MaxAgeDays)
+	if got.AdvancedScans.SMART.MaxAgeDays != 14 {
+		t.Errorf("max_age_days leaked from rejected PUT: got %d, want 14 (seeded value)", got.AdvancedScans.SMART.MaxAgeDays)
 	}
-	if !got.SMART.WakeDrives {
+	if !got.AdvancedScans.SMART.WakeDrives {
 		t.Errorf("wake_drives leaked from rejected PUT: got false, want true (seeded value)")
 	}
 }

--- a/internal/api/settings_smart_version_roundtrip_test.go
+++ b/internal/api/settings_smart_version_roundtrip_test.go
@@ -30,12 +30,39 @@ import (
 // drives asleep (max_age_days=0, wake_drives=true — a real
 // combination: "never wake to scan, but do wake when something else
 // wakes them").
+//
+// Writes the authentic v2 wire shape (flat "smart": {...}) rather
+// than a marshalled current-schema struct, so the v2→v3 migration
+// path gets exercised end-to-end on the first getSettings() call.
 func seedV2Settings(t *testing.T, srv *Server, maxAgeDays int, wakeDrives bool) {
 	t.Helper()
+	blob := map[string]interface{}{
+		"settings_version": 2,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"smart": map[string]interface{}{
+			"wake_drives":  wakeDrives,
+			"max_age_days": maxAgeDays,
+		},
+	}
+	data, err := json.Marshal(blob)
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	if err := srv.store.SetConfig(settingsConfigKey, string(data)); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+}
+
+// seedV3Settings writes a v3-shaped settings blob (the current
+// schema) into the store. Used by tests that want to exercise the
+// post-migration steady state directly.
+func seedV3Settings(t *testing.T, srv *Server, maxAgeDays int, wakeDrives bool) {
+	t.Helper()
 	s := defaultSettings()
-	s.SettingsVersion = 2
-	s.SMART.MaxAgeDays = maxAgeDays
-	s.SMART.WakeDrives = wakeDrives
+	s.SettingsVersion = 3
+	s.AdvancedScans.SMART.MaxAgeDays = maxAgeDays
+	s.AdvancedScans.SMART.WakeDrives = wakeDrives
 	data, err := json.Marshal(s)
 	if err != nil {
 		t.Fatalf("marshal seed: %v", err)
@@ -61,25 +88,36 @@ func readStoredSettings(t *testing.T, srv *Server) map[string]interface{} {
 	return out
 }
 
+// v3AdvancedScansPayload returns a fresh map that carries an
+// advanced_scans tree with all six subsystems seeded at IntervalSec=0
+// plus the given SMART knobs. Centralises the boilerplate so the #268
+// regression tests stay focused on version-preservation behaviour.
+func v3AdvancedScansPayload(wakeDrives bool, maxAgeDays int) map[string]any {
+	return map[string]any{
+		"smart":      map[string]any{"wake_drives": wakeDrives, "max_age_days": maxAgeDays, "interval_sec": 0},
+		"docker":     map[string]any{"interval_sec": 0},
+		"proxmox":    map[string]any{"interval_sec": 0},
+		"kubernetes": map[string]any{"interval_sec": 0},
+		"zfs":        map[string]any{"interval_sec": 0},
+		"gpu":        map[string]any{"interval_sec": 0},
+	}
+}
+
 // TestHandleUpdateSettings_PreservesStoredSettingsVersion — core
-// backend regression for #268. A v2-shaped blob is in storage. The
-// client PUTs a payload that OMITS settings_version (mimicking the
-// real v0.9.8 frontend). The server must preserve the stored version
+// backend regression for #268, re-pinned for the v3 schema. A v3-
+// shaped blob is in storage. The client PUTs a payload that OMITS
+// settings_version. The server must preserve the stored version
 // rather than persisting the zero-value from the unmarshal.
 func TestHandleUpdateSettings_PreservesStoredSettingsVersion(t *testing.T) {
 	srv := newSettingsTestServer()
-	seedV2Settings(t, srv, 0, true)
+	seedV3Settings(t, srv, 0, true)
 
-	// Client payload WITHOUT settings_version — exactly what the
-	// v0.9.8 frontend sends. Valid scan_interval + theme so the
-	// handler accepts it.
+	// Client payload WITHOUT settings_version. Valid scan_interval +
+	// theme so the handler accepts it.
 	rec := putSettings(t, srv, map[string]any{
-		"scan_interval": "30m",
-		"theme":         "midnight",
-		"smart": map[string]any{
-			"wake_drives":  true,
-			"max_age_days": 0,
-		},
+		"scan_interval":  "30m",
+		"theme":          "midnight",
+		"advanced_scans": v3AdvancedScansPayload(true, 0),
 	})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
@@ -87,27 +125,24 @@ func TestHandleUpdateSettings_PreservesStoredSettingsVersion(t *testing.T) {
 
 	stored := readStoredSettings(t, srv)
 	gotVersion, _ := stored["settings_version"].(float64)
-	if int(gotVersion) != 2 {
-		t.Errorf("stored settings_version after PUT: got %v, want 2 (server must preserve, not accept client omission as 0)", stored["settings_version"])
+	if int(gotVersion) != 3 {
+		t.Errorf("stored settings_version after PUT: got %v, want 3 (server must preserve, not accept client omission as 0)", stored["settings_version"])
 	}
 }
 
 // TestHandleUpdateSettings_ClientCannotDowngradeSettingsVersion —
 // defence-in-depth. Even an explicit client-side settings_version=0
-// in the PUT body must not overwrite the stored v2. settings_version
+// in the PUT body must not overwrite the stored v3. settings_version
 // is server-authoritative.
 func TestHandleUpdateSettings_ClientCannotDowngradeSettingsVersion(t *testing.T) {
 	srv := newSettingsTestServer()
-	seedV2Settings(t, srv, 14, false)
+	seedV3Settings(t, srv, 14, false)
 
 	rec := putSettings(t, srv, map[string]any{
 		"settings_version": 0, // malicious/buggy client tries to downgrade
 		"scan_interval":    "30m",
 		"theme":            "midnight",
-		"smart": map[string]any{
-			"wake_drives":  false,
-			"max_age_days": 14,
-		},
+		"advanced_scans":   v3AdvancedScansPayload(false, 14),
 	})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
@@ -115,8 +150,8 @@ func TestHandleUpdateSettings_ClientCannotDowngradeSettingsVersion(t *testing.T)
 
 	stored := readStoredSettings(t, srv)
 	gotVersion, _ := stored["settings_version"].(float64)
-	if int(gotVersion) != 2 {
-		t.Errorf("client-sent settings_version=0 must be ignored; stored version = %v, want 2", stored["settings_version"])
+	if int(gotVersion) != 3 {
+		t.Errorf("client-sent settings_version=0 must be ignored; stored version = %v, want 3", stored["settings_version"])
 	}
 }
 
@@ -125,27 +160,17 @@ func TestHandleUpdateSettings_ClientCannotDowngradeSettingsVersion(t *testing.T)
 // something (dashboard load, backup API, anything) triggers
 // getSettings() internally which runs migration + persist. The 0 must
 // survive that round trip.
-//
-// With only the frontend fix, settings_version=2 is included in the
-// PUT payload and reaches the store intact, so getSettings() sees an
-// already-v2 blob and the migration is skipped. With only the backend
-// fix, the server preserves settings_version from the stored blob
-// and achieves the same outcome. Either fix in isolation should make
-// this test pass.
 func TestHandleUpdateSettings_MaxAgeDaysZero_SurvivesInternalGetSettings(t *testing.T) {
 	srv := newSettingsTestServer()
-	seedV2Settings(t, srv, 7, false)
+	seedV3Settings(t, srv, 7, false)
 
-	// User edits: set max_age_days=0, payload includes settings_version=2
-	// (the state the fixed frontend will produce).
+	// User edits: set max_age_days=0, payload includes
+	// settings_version=3 (the state the fixed frontend produces).
 	rec := putSettings(t, srv, map[string]any{
-		"settings_version": 2,
+		"settings_version": 3,
 		"scan_interval":    "30m",
 		"theme":            "midnight",
-		"smart": map[string]any{
-			"wake_drives":  false,
-			"max_age_days": 0,
-		},
+		"advanced_scans":   v3AdvancedScansPayload(false, 0),
 	})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200 from PUT, got %d: %s", rec.Code, rec.Body.String())
@@ -153,56 +178,61 @@ func TestHandleUpdateSettings_MaxAgeDaysZero_SurvivesInternalGetSettings(t *test
 
 	// Force the getSettings() code path (migrate + persist back).
 	loaded := srv.getSettings()
-	if loaded.SMART.MaxAgeDays != 0 {
-		t.Errorf("after internal getSettings(): smart.max_age_days = %d, want 0 (user-chosen value must not be re-seeded by a stale migration)", loaded.SMART.MaxAgeDays)
+	if loaded.AdvancedScans.SMART.MaxAgeDays != 0 {
+		t.Errorf("after internal getSettings(): advanced_scans.smart.max_age_days = %d, want 0 (user-chosen value must not be re-seeded by a stale migration)", loaded.AdvancedScans.SMART.MaxAgeDays)
 	}
 
 	// And the stored blob too, since getSettings() persists.
 	stored := readStoredSettings(t, srv)
-	smartMap, ok := stored["smart"].(map[string]interface{})
+	advScans, ok := stored["advanced_scans"].(map[string]interface{})
 	if !ok {
-		t.Fatalf("stored settings missing smart object: %v", stored["smart"])
+		t.Fatalf("stored settings missing advanced_scans object: %v", stored["advanced_scans"])
+	}
+	smartMap, ok := advScans["smart"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("stored advanced_scans missing smart object: %v", advScans["smart"])
 	}
 	mad, _ := smartMap["max_age_days"].(float64)
 	if int(mad) != 0 {
-		t.Errorf("persisted smart.max_age_days after getSettings(): got %v, want 0", smartMap["max_age_days"])
+		t.Errorf("persisted advanced_scans.smart.max_age_days after getSettings(): got %v, want 0", smartMap["max_age_days"])
 	}
 }
 
 // TestHandleUpdateSettings_WakeDrivesTrue_SurvivesInternalGetSettings
 // — same scenario as above but for wake_drives=true. The re-migration
 // bug clobbered this field by reading the missing legacy
-// wake_drives_for_smart top-level key (absent in v2 blobs → false).
+// wake_drives_for_smart top-level key (absent in v2+ blobs → false).
 func TestHandleUpdateSettings_WakeDrivesTrue_SurvivesInternalGetSettings(t *testing.T) {
 	srv := newSettingsTestServer()
-	seedV2Settings(t, srv, 7, false)
+	seedV3Settings(t, srv, 7, false)
 
 	rec := putSettings(t, srv, map[string]any{
-		"settings_version": 2,
+		"settings_version": 3,
 		"scan_interval":    "30m",
 		"theme":            "midnight",
-		"smart": map[string]any{
-			"wake_drives":  true,
-			"max_age_days": 7,
-		},
+		"advanced_scans":   v3AdvancedScansPayload(true, 7),
 	})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200 from PUT, got %d: %s", rec.Code, rec.Body.String())
 	}
 
 	loaded := srv.getSettings()
-	if !loaded.SMART.WakeDrives {
-		t.Errorf("after internal getSettings(): smart.wake_drives = false, want true (user-chosen value must not be clobbered by a stale migration)")
+	if !loaded.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("after internal getSettings(): advanced_scans.smart.wake_drives = false, want true (user-chosen value must not be clobbered by a stale migration)")
 	}
 
 	stored := readStoredSettings(t, srv)
-	smartMap, ok := stored["smart"].(map[string]interface{})
+	advScans, ok := stored["advanced_scans"].(map[string]interface{})
 	if !ok {
-		t.Fatalf("stored settings missing smart object: %v", stored["smart"])
+		t.Fatalf("stored settings missing advanced_scans object: %v", stored["advanced_scans"])
+	}
+	smartMap, ok := advScans["smart"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("stored advanced_scans missing smart object: %v", advScans["smart"])
 	}
 	wd, _ := smartMap["wake_drives"].(bool)
 	if !wd {
-		t.Errorf("persisted smart.wake_drives after getSettings(): got %v, want true", smartMap["wake_drives"])
+		t.Errorf("persisted advanced_scans.smart.wake_drives after getSettings(): got %v, want true", smartMap["wake_drives"])
 	}
 }
 

--- a/internal/api/settings_wake_drives_for_smart_test.go
+++ b/internal/api/settings_wake_drives_for_smart_test.go
@@ -17,7 +17,8 @@ import (
 // Originally (pre-#237) the toggle lived directly inside the generic
 // Advanced card. #237 moved it out to a dedicated "Advanced Scan Settings"
 // card; #256 merged it back into the generic Advanced card (id="card-advanced")
-// after UAT flagged the two-card split as clutter.
+// after UAT flagged the two-card split as clutter. #259 relocated the
+// backing field from data.smart to data.advanced_scans.smart.
 //
 // This is a cross-reference test: it confirms the HTML mentions every
 // symbol the JS load/save wiring expects, so a future refactor that
@@ -44,10 +45,10 @@ func TestSettingsHTMLIncludesWakeDrivesForSMARTToggle(t *testing.T) {
 		{"summary element", `<summary`},
 		// The toggle control + its stable id for load/save wiring.
 		{"wake-drives toggle id", `id="wake-drives-for-smart"`},
-		// Load path reads the nested JSON field.
-		{"load binds nested field", `data.smart`},
-		// Save payload writes the nested JSON field.
-		{"save sends nested field", `smart:`},
+		// Load path reads the v3 nested JSON field.
+		{"load binds nested field", `advanced_scans`},
+		// Save payload writes the v3 nested JSON field.
+		{"save sends nested field", `advanced_scans:`},
 		// Disclaimer text must communicate the wear trade-off. We keep
 		// the assertion loose so copy can be edited, but pin the key
 		// concepts: spin-ups and opt-in intent.
@@ -64,17 +65,23 @@ func TestSettingsHTMLIncludesWakeDrivesForSMARTToggle(t *testing.T) {
 }
 
 // TestSettingsRoundTrip_WakeDrivesForSMART exercises the GET/PUT cycle for
-// the wake-drives flag using the new nested schema (Settings.SMART.WakeDrives,
-// `smart.wake_drives` on the wire) introduced in #237.
+// the wake-drives flag using the v3 nested schema
+// (Settings.AdvancedScans.SMART.WakeDrives, advanced_scans.smart.wake_drives
+// on the wire).
 func TestSettingsRoundTrip_WakeDrivesForSMART(t *testing.T) {
 	srv := newSettingsTestServer()
 
 	put := map[string]interface{}{
-		"scan_interval": "30m",
-		"theme":         "midnight",
-		"smart": map[string]interface{}{
-			"wake_drives":  true,
-			"max_age_days": 7,
+		"settings_version": 3,
+		"scan_interval":    "30m",
+		"theme":            "midnight",
+		"advanced_scans": map[string]interface{}{
+			"smart":      map[string]interface{}{"wake_drives": true, "max_age_days": 7, "interval_sec": 0},
+			"docker":     map[string]interface{}{"interval_sec": 0},
+			"proxmox":    map[string]interface{}{"interval_sec": 0},
+			"kubernetes": map[string]interface{}{"interval_sec": 0},
+			"zfs":        map[string]interface{}{"interval_sec": 0},
+			"gpu":        map[string]interface{}{"interval_sec": 0},
 		},
 	}
 	body, _ := json.Marshal(put)
@@ -97,8 +104,8 @@ func TestSettingsRoundTrip_WakeDrivesForSMART(t *testing.T) {
 	if err := json.Unmarshal(rr2.Body.Bytes(), &got); err != nil {
 		t.Fatalf("parse GET response: %v", err)
 	}
-	if !got.SMART.WakeDrives {
-		t.Errorf("smart.wake_drives did not round-trip; got false, wanted true")
+	if !got.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("advanced_scans.smart.wake_drives did not round-trip; got false, wanted true")
 	}
 }
 
@@ -107,7 +114,7 @@ func TestSettingsRoundTrip_WakeDrivesForSMART(t *testing.T) {
 // means drives in standby are NOT woken by SMART scans.
 func TestSettingsDefault_WakeDrivesForSMARTIsFalse(t *testing.T) {
 	d := defaultSettings()
-	if d.SMART.WakeDrives {
-		t.Errorf("defaultSettings().SMART.WakeDrives must be false (standby-aware by default, issue #198)")
+	if d.AdvancedScans.SMART.WakeDrives {
+		t.Errorf("defaultSettings().AdvancedScans.SMART.WakeDrives must be false (standby-aware by default, issue #198)")
 	}
 }

--- a/internal/api/snapshot_subsystem_last_ran_test.go
+++ b/internal/api/snapshot_subsystem_last_ran_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// TestHandleLatestSnapshot_ExposesSubsystemLastRan confirms that when
+// a snapshot carries the SubsystemLastRan map (populated by the
+// scheduler's RunOnce after each dispatcher tick), the field is
+// serialised as `subsystem_last_ran` on /api/v1/snapshot/latest.
+//
+// This is the API-data surface for issue #260 user story 17. UI
+// consumers (future dashboard "last scanned 4m ago" indicators) will
+// read this JSON field directly. Dashboard UI is out of scope for
+// this slice — the contract under test is the JSON shape only.
+func TestHandleLatestSnapshot_ExposesSubsystemLastRan(t *testing.T) {
+	srv := newSettingsTestServer()
+
+	// Seed a snapshot with SubsystemLastRan populated.
+	now := time.Now().UTC().Truncate(time.Second)
+	snap := &internal.Snapshot{
+		ID:        "test-lastran-snap",
+		Timestamp: now,
+		SubsystemLastRan: map[string]string{
+			"smart":  now.Add(-1 * time.Hour).Format(time.RFC3339),
+			"docker": now.Add(-5 * time.Minute).Format(time.RFC3339),
+		},
+	}
+	if err := srv.store.SaveSnapshot(snap); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshot/latest", nil)
+	rec := httptest.NewRecorder()
+	srv.handleLatestSnapshot(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/snapshot/latest returned %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Parse as generic map so we can assert on JSON key presence
+	// (the internal.Snapshot Go struct uses omitempty, so absence
+	// would look like an empty map after unmarshal).
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse snapshot JSON: %v", err)
+	}
+	raw, ok := got["subsystem_last_ran"]
+	if !ok {
+		t.Fatalf("subsystem_last_ran key missing from snapshot JSON; got %v", got)
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("subsystem_last_ran is not an object; got %T", raw)
+	}
+	if len(m) != 2 {
+		t.Errorf("subsystem_last_ran size = %d, want 2; got %+v", len(m), m)
+	}
+	if _, ok := m["smart"]; !ok {
+		t.Errorf("smart missing from subsystem_last_ran; got %+v", m)
+	}
+	if _, ok := m["docker"]; !ok {
+		t.Errorf("docker missing from subsystem_last_ran; got %+v", m)
+	}
+
+	// Verify the values are parseable RFC3339 timestamps.
+	for k, v := range m {
+		s, ok := v.(string)
+		if !ok {
+			t.Errorf("subsystem_last_ran[%q] is not a string; got %T", k, v)
+			continue
+		}
+		if _, err := time.Parse(time.RFC3339, s); err != nil {
+			t.Errorf("subsystem_last_ran[%q]=%q not valid RFC3339: %v", k, s, err)
+		}
+	}
+}
+
+// TestHandleLatestSnapshot_OmitsSubsystemLastRan_WhenEmpty ensures
+// the field does not appear on the JSON when the map is nil/empty
+// (omitempty tag). Demo-mode snapshots built synthetically by the
+// feeder don't populate this map — without omitempty, they'd render
+// a misleading "subsystem_last_ran: {}" entry that UI would have to
+// filter out.
+func TestHandleLatestSnapshot_OmitsSubsystemLastRan_WhenEmpty(t *testing.T) {
+	srv := newSettingsTestServer()
+	snap := &internal.Snapshot{
+		ID:        "test-noplastran",
+		Timestamp: time.Now().UTC(),
+	}
+	if err := srv.store.SaveSnapshot(snap); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshot/latest", nil)
+	rec := httptest.NewRecorder()
+	srv.handleLatestSnapshot(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/snapshot/latest returned %d: %s", rec.Code, rec.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse snapshot JSON: %v", err)
+	}
+	if _, present := got["subsystem_last_ran"]; present {
+		t.Errorf("subsystem_last_ran should be absent when map is nil; got %+v", got["subsystem_last_ran"])
+	}
+}

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -1255,10 +1255,27 @@ var advScanPresets = [
    if settings haven't loaded yet (first paint before loadSettings
    resolves — shouldn't happen in practice because
    renderAdvancedScanPickers runs inside loadSettings' .then, but
-   defensive). */
+   defensive).
+
+   Humanizes the raw Go duration string coming from the backend.
+   Go's time.Duration.String() represents 7 days as "168h0m0s";
+   showing "Use global (168h0m0s)" (or even "168h") in the picker
+   was misleading to users who set 7d up top — they recognise "7d"
+   but have to mentally divide 168 by 24 to understand the label.
+   Reuses the existing parseIntervalDurationToFields +
+   fieldsToIntervalDuration pair, which already do the right
+   overflow arithmetic: 168h → {days:7, h:0, m:0, s:0} → "7d".
+   Combined formats like "25h" → "1d1h" are also cleaner than
+   "25h". v0.9.9-rc3 UAT feedback. */
 function globalIntervalDisplay() {
-  if (settings && settings.scan_interval) return settings.scan_interval;
-  return "30m";
+  if (!settings || !settings.scan_interval) return "30m";
+  var raw = settings.scan_interval;
+  try {
+    var fields = parseIntervalDurationToFields(raw);
+    var out = fieldsToIntervalDuration(fields);
+    if (out && out !== "0") return out;
+  } catch (e) { /* fall through to raw below */ }
+  return raw;
 }
 
 /* Duration parser shared between the global widget's

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -1289,20 +1289,26 @@ function durationToIntervalSec(dur) {
   return f.days * 86400 + f.hours * 3600 + f.minutes * 60 + f.seconds;
 }
 
-/* parseCronToFields reverse-parses simple interval cron expressions
-   into {days, hours, minutes, seconds}. Throws on anything more
-   complex than the four supported shapes. PRD #239 user stories
-   8, 14.
-
-   Supported:
-     */N s                — every N seconds (sub-minute; our extension)
-     */N * * * *          — every N minutes (N in 1..59)
-     0 */N * * *          — every N hours (N in 1..23)
-     0 0 */N * *          — every N days (N in 1..31)
-
-   Anything else (specific weekdays, comma lists, named months,
-   per-minute granularity below */N without seconds suffix, etc.)
-   triggers a clear UI error. */
+// parseCronToFields reverse-parses simple interval cron expressions
+// into {days, hours, minutes, seconds}. Throws on anything more
+// complex than the four supported shapes. PRD #239 user stories
+// 8, 14.
+//
+// Supported:
+//   */N s                — every N seconds (sub-minute; our extension)
+//   */N * * * *          — every N minutes (N in 1..59)
+//   0 */N * * *          — every N hours (N in 1..23)
+//   0 0 */N * *          — every N days (N in 1..31)
+//
+// Anything else (specific weekdays, comma lists, named months,
+// per-minute granularity below */N without seconds suffix, etc.)
+// triggers a clear UI error.
+//
+// NOTE: line comments (not /* */ block) — any `*/` inside a block
+// comment closes it early and breaks the entire <script> parse.
+// See stage-branch UAT of v0.9.9-rc1 where this bug shipped and
+// silently stopped loadSettings, renderAdvancedScanPickers, and
+// loadDockerHiddenContainersCheckboxes from running.
 function parseCronToFields(cronStr) {
   if (!cronStr) throw new Error("empty cron");
   var s = String(cronStr).trim();

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -1227,9 +1227,17 @@ document.getElementById("scan-seconds").addEventListener("input", updateInterval
 
 /* Preset values offered by every per-subsystem interval picker.
    "0" sentinel represents "use global"; matches the AdvancedScans
-   IntervalSec=0 convention on the server side (see PRD #239). */
+   IntervalSec=0 convention on the server side (see PRD #239).
+
+   The "Use global" option's label has NO hardcoded duration suffix
+   here — createIntervalPicker appends the user's actual configured
+   scan_interval (e.g. "Use global (7d)") dynamically at render
+   time. Hardcoding "(30m)" caused a v0.9.9-rc2 UAT confusion: a
+   user with scan_interval=7d saw every picker advertise "Use
+   global (30m)" and reasonably thought the per-subsystem fallback
+   was 30 minutes when it was actually 7 days. */
 var advScanPresets = [
-  { value: "0",   label: "Use global (30m)" },
+  { value: "0",   label: "Use global"       },
   { value: "5m",  label: "Every 5 minutes"  },
   { value: "15m", label: "Every 15 minutes" },
   { value: "30m", label: "Every 30 minutes" },
@@ -1241,6 +1249,17 @@ var advScanPresets = [
   { value: "7d",  label: "Every 7 days"     },
   { value: "custom", label: "Custom..."     }
 ];
+
+/* globalIntervalDisplay returns the user's configured global
+   scan_interval formatted for picker labels. Falls back to "30m"
+   if settings haven't loaded yet (first paint before loadSettings
+   resolves — shouldn't happen in practice because
+   renderAdvancedScanPickers runs inside loadSettings' .then, but
+   defensive). */
+function globalIntervalDisplay() {
+  if (settings && settings.scan_interval) return settings.scan_interval;
+  return "30m";
+}
 
 /* Duration parser shared between the global widget's
    parseDurationToFields and the new per-subsystem helpers. Goes
@@ -1391,9 +1410,14 @@ function createIntervalPicker(subsystemId, label) {
   if (mount.getAttribute("data-inited") === "1") return mount;
 
   var presetOpts = "";
+  var globalLabel = globalIntervalDisplay();
   for (var i = 0; i < advScanPresets.length; i++) {
     var p = advScanPresets[i];
-    presetOpts += '<option value="' + p.value + '">' + p.label + '</option>';
+    // Dynamic suffix on the "Use global" option so the picker
+    // reflects the user's actual scan_interval instead of a
+    // hardcoded "(30m)". See globalIntervalDisplay notes.
+    var optLabel = p.value === "0" ? (p.label + " (" + globalLabel + ")") : p.label;
+    presetOpts += '<option value="' + p.value + '">' + optLabel + '</option>';
   }
 
   mount.innerHTML = '' +

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -931,6 +931,29 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
           </p>
         </div>
 
+        <!-- SMART scan interval picker — colocated with the other SMART
+             knobs per PRD #239. Markup is injected by createIntervalPicker
+             on page init. Inert in slice 2a (#259) — value persists but
+             scheduler ignores it until slice 2b (#260) wires it up. -->
+        <div id="scan-interval-smart" data-subsystem="smart" data-label="SMART" style="margin-top:18px"></div>
+
+        <!-- Per-subsystem scan intervals sub-section — PRD #239 slice 2a.
+             Five of the six configurable subsystems land here; SMART has
+             its own picker colocated with the wake-drives / max-age group
+             above to keep all SMART knobs together. Each picker is
+             rendered by createIntervalPicker into its div id. -->
+        <div style="margin-top:22px;padding-top:16px;border-top:1px solid var(--border)">
+          <div style="font-weight:600;font-size:13px;color:var(--text);margin-bottom:4px">Per-subsystem scan intervals</div>
+          <p style="font-size:12px;color:var(--text2);margin-top:4px;margin-bottom:14px;line-height:1.5">
+            Override the global scan cadence per subsystem. Use <strong>Use global</strong> to inherit the Diagnostic Scan Interval (most users want this). Set a positive interval only if you want that subsystem to run faster or slower than the rest of the dashboard. Values persist immediately, but no scheduler behaviour changes until the slice-2b release.
+          </p>
+          <div id="scan-interval-docker" data-subsystem="docker" data-label="Docker" style="margin-bottom:14px"></div>
+          <div id="scan-interval-proxmox" data-subsystem="proxmox" data-label="Proxmox" style="margin-bottom:14px"></div>
+          <div id="scan-interval-kubernetes" data-subsystem="kubernetes" data-label="Kubernetes" style="margin-bottom:14px"></div>
+          <div id="scan-interval-zfs" data-subsystem="zfs" data-label="ZFS" style="margin-bottom:14px"></div>
+          <div id="scan-interval-gpu" data-subsystem="gpu" data-label="GPU" style="margin-bottom:0"></div>
+        </div>
+
         <!-- Docker container visibility — unchanged from pre-#237. -->
         <div style="margin-top:22px;padding-top:16px;border-top:1px solid var(--border)">
           <div style="display:block;font-weight:600;font-size:13px;color:var(--text);margin-bottom:4px">Hide Docker containers from dashboard</div>
@@ -1180,6 +1203,390 @@ document.getElementById("scan-hours").addEventListener("input", updateIntervalPr
 document.getElementById("scan-minutes").addEventListener("input", updateIntervalPreview);
 document.getElementById("scan-seconds").addEventListener("input", updateIntervalPreview);
 
+/* ---------- Advanced Scan Settings: per-subsystem interval pickers ----------
+
+   Introduced in slice 2a (PRD #239 / issue #259). Six subsystems get
+   their own cadence picker:
+
+     - SMART (colocated with wake-drives / max-age inside card-advanced)
+     - Docker / Proxmox / Kubernetes / ZFS / GPU (grouped under the
+       "Per-subsystem scan intervals" sub-section)
+
+   In slice 2a the values are PERSISTED but INERT: the scheduler still
+   runs every subsystem on the global cadence. Slice 2b (#260) activates
+   the new ScanDispatcher that consumes these values.
+
+   The createIntervalPicker(subsystemId, label) helper generates the
+   widget markup and wires all event listeners. Mount points are
+   pre-rendered in the HTML as empty div id="scan-interval-<subsystem>".
+
+   Each picker offers the same UX as the global Diagnostic Scan
+   Interval widget: preset dropdown (Use global, 5m, 15m, 30m, 1h, 2h,
+   6h, 12h, 24h, 7d, Custom...) + custom d/h/m/s panel + live preview
+   + cron visualizer + "edit cron" button with a reverse parser. */
+
+/* Preset values offered by every per-subsystem interval picker.
+   "0" sentinel represents "use global"; matches the AdvancedScans
+   IntervalSec=0 convention on the server side (see PRD #239). */
+var advScanPresets = [
+  { value: "0",   label: "Use global (30m)" },
+  { value: "5m",  label: "Every 5 minutes"  },
+  { value: "15m", label: "Every 15 minutes" },
+  { value: "30m", label: "Every 30 minutes" },
+  { value: "1h",  label: "Every 1 hour"     },
+  { value: "2h",  label: "Every 2 hours"    },
+  { value: "6h",  label: "Every 6 hours"    },
+  { value: "12h", label: "Every 12 hours"   },
+  { value: "24h", label: "Every 24 hours"   },
+  { value: "7d",  label: "Every 7 days"     },
+  { value: "custom", label: "Custom..."     }
+];
+
+/* Duration parser shared between the global widget's
+   parseDurationToFields and the new per-subsystem helpers. Goes
+   beyond parseDurationToFields because subsystem intervals may
+   include days ("7d"). Returns {days, hours, minutes, seconds}. */
+function parseIntervalDurationToFields(dur) {
+  var days = 0, hours = 0, minutes = 0, seconds = 0;
+  if (!dur || dur === "0") return { days: 0, hours: 0, minutes: 0, seconds: 0 };
+  var m;
+  m = dur.match(/(\d+)d/);
+  if (m) days = parseInt(m[1], 10);
+  m = dur.match(/(\d+)h/);
+  if (m) { var h = parseInt(m[1], 10); days += Math.floor(h / 24); hours = h % 24; }
+  m = dur.match(/(\d+)m(?!s)/);
+  if (m) minutes = parseInt(m[1], 10);
+  m = dur.match(/(\d+)s/);
+  if (m) seconds = parseInt(m[1], 10);
+  return { days: days, hours: hours, minutes: minutes, seconds: seconds };
+}
+
+/* intervalSecToDuration converts an IntervalSec value back to a
+   duration string compatible with parseIntervalDurationToFields.
+   0 → "0" (use global sentinel). */
+function intervalSecToDuration(sec) {
+  sec = parseInt(sec, 10) || 0;
+  if (sec <= 0) return "0";
+  var days = Math.floor(sec / 86400);
+  sec -= days * 86400;
+  var hours = Math.floor(sec / 3600);
+  sec -= hours * 3600;
+  var minutes = Math.floor(sec / 60);
+  var seconds = sec % 60;
+  var out = "";
+  if (days > 0) out += days + "d";
+  if (hours > 0) out += hours + "h";
+  if (minutes > 0) out += minutes + "m";
+  if (seconds > 0) out += seconds + "s";
+  return out || "0";
+}
+
+/* durationToIntervalSec is the inverse of intervalSecToDuration.
+   Unknown/malformed inputs return 0 (= "use global"). */
+function durationToIntervalSec(dur) {
+  if (!dur || dur === "0") return 0;
+  var f = parseIntervalDurationToFields(dur);
+  return f.days * 86400 + f.hours * 3600 + f.minutes * 60 + f.seconds;
+}
+
+/* parseCronToFields reverse-parses simple interval cron expressions
+   into {days, hours, minutes, seconds}. Throws on anything more
+   complex than the four supported shapes. PRD #239 user stories
+   8, 14.
+
+   Supported:
+     */N s                — every N seconds (sub-minute; our extension)
+     */N * * * *          — every N minutes (N in 1..59)
+     0 */N * * *          — every N hours (N in 1..23)
+     0 0 */N * *          — every N days (N in 1..31)
+
+   Anything else (specific weekdays, comma lists, named months,
+   per-minute granularity below */N without seconds suffix, etc.)
+   triggers a clear UI error. */
+function parseCronToFields(cronStr) {
+  if (!cronStr) throw new Error("empty cron");
+  var s = String(cronStr).trim();
+  var m;
+  m = s.match(/^\*\/(\d+)\s*s$/i);
+  if (m) {
+    var sec = parseInt(m[1], 10);
+    if (!(sec >= 1 && sec <= 59)) throw new Error("Must be a simple interval cron (seconds out of 1..59)");
+    return { days: 0, hours: 0, minutes: 0, seconds: sec };
+  }
+  var parts = s.split(/\s+/);
+  if (parts.length !== 5) {
+    throw new Error("Must be a simple interval cron (expected 5 fields)");
+  }
+  m = parts[0].match(/^\*\/(\d+)$/);
+  if (m && parts[1] === "*" && parts[2] === "*" && parts[3] === "*" && parts[4] === "*") {
+    var mins = parseInt(m[1], 10);
+    if (!(mins >= 1 && mins <= 59)) throw new Error("Must be a simple interval cron (minutes out of 1..59)");
+    return { days: 0, hours: 0, minutes: mins, seconds: 0 };
+  }
+  if (parts[0] === "0") {
+    m = parts[1].match(/^\*\/(\d+)$/);
+    if (m && parts[2] === "*" && parts[3] === "*" && parts[4] === "*") {
+      var hrs = parseInt(m[1], 10);
+      if (!(hrs >= 1 && hrs <= 23)) throw new Error("Must be a simple interval cron (hours out of 1..23)");
+      return { days: 0, hours: hrs, minutes: 0, seconds: 0 };
+    }
+    if (parts[1] === "0") {
+      m = parts[2].match(/^\*\/(\d+)$/);
+      if (m && parts[3] === "*" && parts[4] === "*") {
+        var dd = parseInt(m[1], 10);
+        if (!(dd >= 1 && dd <= 31)) throw new Error("Must be a simple interval cron (days out of 1..31)");
+        return { days: dd, hours: 0, minutes: 0, seconds: 0 };
+      }
+    }
+  }
+  throw new Error("Must be a simple interval cron (*/Ns, */N * * * *, 0 */N * * *, or 0 0 */N * *)");
+}
+
+/* fieldsToIntervalDuration — fields object to duration string. */
+function fieldsToIntervalDuration(f) {
+  var parts = [];
+  if (f.days > 0) parts.push(f.days + "d");
+  if (f.hours > 0) parts.push(f.hours + "h");
+  if (f.minutes > 0) parts.push(f.minutes + "m");
+  if (f.seconds > 0) parts.push(f.seconds + "s");
+  return parts.length === 0 ? "0" : parts.join("");
+}
+
+/* durationToCronSimple returns a simple interval cron string for a
+   duration — mirrors durationToCron but defensively returns "" for
+   the "use global" sentinel. */
+function durationToCronSimple(dur) {
+  if (!dur || dur === "0") return "";
+  var f = parseIntervalDurationToFields(dur);
+  var totalSecs = f.days * 86400 + f.hours * 3600 + f.minutes * 60 + f.seconds;
+  if (totalSecs <= 0) return "";
+  if (totalSecs < 60) return "*/" + totalSecs + "s";
+  var totalMin = Math.floor(totalSecs / 60);
+  if (totalMin < 60 && totalSecs % 60 === 0) return "*/" + totalMin + " * * * *";
+  var totalHrs = f.days * 24 + f.hours;
+  if (f.minutes === 0 && f.seconds === 0 && totalHrs > 0) {
+    if (totalHrs < 24) return "0 */" + totalHrs + " * * *";
+    if (totalHrs % 24 === 0) return "0 0 */" + (totalHrs / 24) + " * *";
+  }
+  return "*/" + totalMin + " * * * *";
+}
+
+/* createIntervalPicker mounts a picker widget inside the pre-rendered
+   div id="scan-interval-<subsystemId>". Populates DOM children,
+   wires event handlers, returns the container element.
+
+   The same widget shape is used for all six subsystems (SMART,
+   Docker, Proxmox, Kubernetes, ZFS, GPU). Per PRD #239 the existing
+   global Diagnostic Scan Interval widget is NOT refactored to use
+   this helper — that's a v0.10.0+ cleanup candidate. */
+function createIntervalPicker(subsystemId, label) {
+  var mount = document.getElementById("scan-interval-" + subsystemId);
+  if (!mount) return null;
+  if (mount.getAttribute("data-inited") === "1") return mount;
+
+  var presetOpts = "";
+  for (var i = 0; i < advScanPresets.length; i++) {
+    var p = advScanPresets[i];
+    presetOpts += '<option value="' + p.value + '">' + p.label + '</option>';
+  }
+
+  mount.innerHTML = '' +
+    '<label for="scan-interval-' + subsystemId + '-preset" style="display:block;font-weight:600;font-size:13px;color:var(--text);margin-bottom:4px">' +
+      label + ' scan interval' +
+    '</label>' +
+    '<select id="scan-interval-' + subsystemId + '-preset" style="max-width:260px">' + presetOpts + '</select>' +
+    '<div id="scan-interval-' + subsystemId + '-custom" style="display:none;margin-top:10px;padding:12px;background:rgba(255,255,255,0.02);border:1px solid var(--border);border-radius:var(--radius)">' +
+      '<div style="display:flex;gap:10px;align-items:flex-end;flex-wrap:wrap;margin-bottom:10px">' +
+        '<div style="flex:1;min-width:60px">' +
+          '<label style="font-size:11px;margin-bottom:4px">Days</label>' +
+          '<input type="number" id="scan-interval-' + subsystemId + '-days"    min="0" max="31" value="0" style="text-align:center">' +
+        '</div>' +
+        '<div style="flex:1;min-width:60px">' +
+          '<label style="font-size:11px;margin-bottom:4px">Hours</label>' +
+          '<input type="number" id="scan-interval-' + subsystemId + '-hours"   min="0" max="23" value="0" style="text-align:center">' +
+        '</div>' +
+        '<div style="flex:1;min-width:60px">' +
+          '<label style="font-size:11px;margin-bottom:4px">Minutes</label>' +
+          '<input type="number" id="scan-interval-' + subsystemId + '-minutes" min="0" max="59" value="0" style="text-align:center">' +
+        '</div>' +
+        '<div style="flex:1;min-width:60px">' +
+          '<label style="font-size:11px;margin-bottom:4px">Seconds</label>' +
+          '<input type="number" id="scan-interval-' + subsystemId + '-seconds" min="0" max="59" value="0" style="text-align:center">' +
+        '</div>' +
+      '</div>' +
+      '<div id="scan-interval-' + subsystemId + '-preview" style="font-size:12px;color:var(--text2);margin-bottom:4px"></div>' +
+      '<div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">' +
+        '<div id="scan-interval-' + subsystemId + '-cron" style="font-size:11px;font-family:monospace;color:var(--accent);background:rgba(94,106,210,0.06);padding:4px 10px;border-radius:4px;display:inline-block"></div>' +
+        '<button type="button" class="btn btn-secondary btn-sm" id="scan-interval-' + subsystemId + '-edit-cron-btn">Edit cron</button>' +
+      '</div>' +
+      '<div id="scan-interval-' + subsystemId + '-cron-edit-wrap" style="display:none;margin-top:10px">' +
+        '<input type="text" id="scan-interval-' + subsystemId + '-cron-input" placeholder="e.g. */15 * * * *" style="width:100%;font-family:monospace">' +
+        '<div style="display:flex;gap:8px;margin-top:6px;align-items:center">' +
+          '<button type="button" class="btn btn-secondary btn-sm" id="scan-interval-' + subsystemId + '-cron-apply-btn">Apply</button>' +
+          '<button type="button" class="btn btn-secondary btn-sm" id="scan-interval-' + subsystemId + '-cron-cancel-btn">Cancel</button>' +
+          '<span id="scan-interval-' + subsystemId + '-cron-error" style="font-size:12px;color:var(--error)"></span>' +
+        '</div>' +
+      '</div>' +
+    '</div>';
+
+  var sel    = document.getElementById("scan-interval-" + subsystemId + "-preset");
+  var cust   = document.getElementById("scan-interval-" + subsystemId + "-custom");
+  var inputs = ["days","hours","minutes","seconds"].map(function(f) {
+    return document.getElementById("scan-interval-" + subsystemId + "-" + f);
+  });
+  var preview = document.getElementById("scan-interval-" + subsystemId + "-preview");
+  var cronEl  = document.getElementById("scan-interval-" + subsystemId + "-cron");
+  var editBtn = document.getElementById("scan-interval-" + subsystemId + "-edit-cron-btn");
+  var cronWrap= document.getElementById("scan-interval-" + subsystemId + "-cron-edit-wrap");
+  var cronIn  = document.getElementById("scan-interval-" + subsystemId + "-cron-input");
+  var cronErr = document.getElementById("scan-interval-" + subsystemId + "-cron-error");
+  var cronApply = document.getElementById("scan-interval-" + subsystemId + "-cron-apply-btn");
+  var cronCancel= document.getElementById("scan-interval-" + subsystemId + "-cron-cancel-btn");
+
+  function refreshPreview() {
+    var f = { days: parseInt(inputs[0].value,10)||0, hours: parseInt(inputs[1].value,10)||0,
+              minutes: parseInt(inputs[2].value,10)||0, seconds: parseInt(inputs[3].value,10)||0 };
+    var parts = [];
+    if (f.days    > 0) parts.push(f.days    + (f.days    === 1 ? " day"    : " days"));
+    if (f.hours   > 0) parts.push(f.hours   + (f.hours   === 1 ? " hour"   : " hours"));
+    if (f.minutes > 0) parts.push(f.minutes + (f.minutes === 1 ? " minute" : " minutes"));
+    if (f.seconds > 0) parts.push(f.seconds + (f.seconds === 1 ? " second" : " seconds"));
+    if (parts.length === 0) {
+      preview.textContent = "Invalid: set at least 1 second (or pick 'Use global')";
+      preview.style.color = "var(--error)";
+      cronEl.textContent = "";
+    } else {
+      preview.textContent = label + " scans every " + parts.join(", ");
+      preview.style.color = "var(--text2)";
+      var dur = fieldsToIntervalDuration(f);
+      var cron = durationToCronSimple(dur);
+      cronEl.textContent = cron ? "cron: " + cron : "";
+    }
+  }
+
+  sel.addEventListener("change", function() {
+    if (sel.value === "custom") {
+      cust.style.display = "block";
+      refreshPreview();
+    } else {
+      cust.style.display = "none";
+    }
+    saveSettings();
+  });
+  for (var j = 0; j < inputs.length; j++) {
+    inputs[j].addEventListener("input", refreshPreview);
+    inputs[j].addEventListener("change", saveSettings);
+  }
+  editBtn.addEventListener("click", function() {
+    cronWrap.style.display = (cronWrap.style.display === "none" ? "block" : "none");
+    cronErr.textContent = "";
+  });
+  cronCancel.addEventListener("click", function() {
+    cronWrap.style.display = "none";
+    cronErr.textContent = "";
+  });
+  cronApply.addEventListener("click", function() {
+    try {
+      var f = parseCronToFields(cronIn.value);
+      inputs[0].value = f.days;
+      inputs[1].value = f.hours;
+      inputs[2].value = f.minutes;
+      inputs[3].value = f.seconds;
+      sel.value = "custom";
+      cust.style.display = "block";
+      cronWrap.style.display = "none";
+      cronErr.textContent = "";
+      refreshPreview();
+      saveSettings();
+    } catch (e) {
+      cronErr.textContent = e.message || "Must be a simple interval cron";
+    }
+  });
+
+  mount.setAttribute("data-inited", "1");
+  return mount;
+}
+
+/* setPickerFromIntervalSec — populate a picker from a stored
+   IntervalSec value. Called from renderAdvancedScanPickers during
+   loadSettings. */
+function setPickerFromIntervalSec(subsystemId, intervalSec) {
+  var sel  = document.getElementById("scan-interval-" + subsystemId + "-preset");
+  var cust = document.getElementById("scan-interval-" + subsystemId + "-custom");
+  if (!sel || !cust) return;
+  var dur = intervalSecToDuration(intervalSec);
+  // Match against preset values first.
+  var matched = false;
+  for (var i = 0; i < advScanPresets.length; i++) {
+    if (advScanPresets[i].value === dur) { sel.value = dur; matched = true; break; }
+  }
+  if (matched && dur !== "custom") {
+    cust.style.display = "none";
+    return;
+  }
+  // Fall through: custom duration. Populate fields + show panel.
+  sel.value = "custom";
+  cust.style.display = "block";
+  var f = parseIntervalDurationToFields(dur);
+  var d = document.getElementById("scan-interval-" + subsystemId + "-days");
+  var h = document.getElementById("scan-interval-" + subsystemId + "-hours");
+  var m = document.getElementById("scan-interval-" + subsystemId + "-minutes");
+  var s = document.getElementById("scan-interval-" + subsystemId + "-seconds");
+  if (d) d.value = f.days;
+  if (h) h.value = f.hours;
+  if (m) m.value = f.minutes;
+  if (s) s.value = f.seconds;
+  // Trigger a preview update if the picker was already wired.
+  var sel2 = document.getElementById("scan-interval-" + subsystemId + "-preset");
+  if (sel2) sel2.dispatchEvent(new Event("input"));
+  if (d) d.dispatchEvent(new Event("input"));
+}
+
+/* readPickerIntervalSec — inverse of setPickerFromIntervalSec.
+   Reads the current picker state and returns an IntervalSec int,
+   clamped into {0} union [ScanIntervalSecMin, ScanIntervalSecMax].
+   Out-of-range values collapse to 0 ("use global") so a malformed
+   UI state never triggers a server-side 400 that blocks save of
+   unrelated settings. */
+function readPickerIntervalSec(subsystemId) {
+  var sel = document.getElementById("scan-interval-" + subsystemId + "-preset");
+  if (!sel) return 0;
+  var v = sel.value;
+  if (v === "custom") {
+    var d = parseInt(document.getElementById("scan-interval-" + subsystemId + "-days").value, 10) || 0;
+    var h = parseInt(document.getElementById("scan-interval-" + subsystemId + "-hours").value, 10) || 0;
+    var m = parseInt(document.getElementById("scan-interval-" + subsystemId + "-minutes").value, 10) || 0;
+    var s = parseInt(document.getElementById("scan-interval-" + subsystemId + "-seconds").value, 10) || 0;
+    var total = d * 86400 + h * 3600 + m * 60 + s;
+    if (total === 0) return 0;
+    if (total < 30) return 0;          // below the floor → use global
+    if (total > 2678400) return 2678400; // 31-day cap
+    return total;
+  }
+  return durationToIntervalSec(v);
+}
+
+/* renderAdvancedScanPickers — called from loadSettings. Ensures the
+   six picker widgets exist in the DOM and populates each from the
+   loaded advanced_scans tree. Idempotent: re-calls are safe. */
+function renderAdvancedScanPickers(advScans) {
+  advScans = advScans || {};
+  var subsystems = [
+    { id: "smart",      label: "SMART"      },
+    { id: "docker",     label: "Docker"     },
+    { id: "proxmox",    label: "Proxmox"    },
+    { id: "kubernetes", label: "Kubernetes" },
+    { id: "zfs",        label: "ZFS"        },
+    { id: "gpu",        label: "GPU"        }
+  ];
+  for (var i = 0; i < subsystems.length; i++) {
+    var sub = subsystems[i];
+    createIntervalPicker(sub.id, sub.label);
+    var cfg = advScans[sub.id] || {};
+    setPickerFromIntervalSec(sub.id, cfg.interval_sec || 0);
+  }
+}
+
 /* ---------- Load settings ---------- */
 function loadSettings() {
   fetch("/api/v1/settings")
@@ -1245,12 +1652,16 @@ function loadSettings() {
       /* Drive replacement cost per TB */
       var costEl = document.getElementById("cost-per-tb");
       if (costEl) costEl.value = (data.cost_per_tb && data.cost_per_tb > 0) ? data.cost_per_tb : "";
-      /* Advanced Scan Settings (#237): SMART sub-struct. Reads
-         smart.wake_drives and smart.max_age_days from the server's
-         nested schema. Falls back to the legacy flat
-         wake_drives_for_smart field if the server hasn't migrated yet
-         (defensive — getSettings migrates on first read). */
-      var smartCfg = (data && data.smart) || {};
+      /* Advanced Scan Settings. SMART knobs (WakeDrives, MaxAgeDays)
+         and per-subsystem IntervalSec values all live under
+         advanced_scans (v3 schema, #259). Legacy fallbacks:
+           - data.advanced_scans.smart.{wake_drives,max_age_days} (v3)
+           - data.smart.{wake_drives,max_age_days} (v2, pre-#259)
+           - data.wake_drives_for_smart (v1, pre-#237)
+         getSettings migrates on first read so v1/v2 paths should not
+         fire in production — they're defence-in-depth only. */
+      var advScans = (data && data.advanced_scans) || {};
+      var smartCfg = advScans.smart || (data && data.smart) || {};
       var wakeEl = document.getElementById("wake-drives-for-smart");
       if (wakeEl) {
         var wakeVal = (smartCfg.wake_drives !== undefined) ? !!smartCfg.wake_drives : !!data.wake_drives_for_smart;
@@ -1262,6 +1673,11 @@ function loadSettings() {
         if (isNaN(maxAgeVal)) maxAgeVal = 7;
         maxAgeEl.value = maxAgeVal;
       }
+      /* Per-subsystem interval pickers (slice 2a — values persist but
+         are inert server-side until #260 activates the dispatcher).
+         Picker markup is rendered here rather than at template-render
+         time so load/save round-trips use the current JSON shape. */
+      renderAdvancedScanPickers(advScans);
       /* Advanced: hide Docker containers from dashboard (#204) */
       var hidden = Array.isArray(data.docker_hidden_containers) ? data.docker_hidden_containers : [];
       loadDockerHiddenContainersCheckboxes(hidden);
@@ -1323,7 +1739,12 @@ function buildSettingsPayload() {
     // getSettings() call, silently resetting smart.max_age_days=0→7
     // and smart.wake_drives=true→false. See issue #268 + the
     // companion server-side floor in handleUpdateSettings.
-    settings_version: (base && base.settings_version) || 2,
+    //
+    // Fallback floor tracks currentSettingsVersion on the server
+    // (currently 3 after slice 2a / #259). The backend's max-of-
+    // stored-and-incoming clamp still protects against a client
+    // sending a lower value.
+    settings_version: (base && base.settings_version) || 3,
     scan_interval: getScanInterval(),
     speedtest_interval: document.getElementById("speedtest-interval").value,
     speedtest_schedule: buildSpeedTestSchedule(),
@@ -1384,16 +1805,29 @@ function buildSettingsPayload() {
     fleet: fleetServers || base.fleet || [],
     dismissed_findings: base.dismissed_findings || [],
     cost_per_tb: parseFloat(document.getElementById("cost-per-tb") && document.getElementById("cost-per-tb").value) || 0,
-    smart: {
-      wake_drives: !!(document.getElementById("wake-drives-for-smart") && document.getElementById("wake-drives-for-smart").classList.contains("on")),
-      max_age_days: (function() {
-        var el = document.getElementById("smart-max-age-days");
-        if (!el) return 7;
-        var v = parseInt(el.value, 10);
-        if (isNaN(v) || v < 0) return 0;
-        if (v > 30) return 30;
-        return v;
-      })()
+    /* Advanced Scan Settings v3 (PRD #239 / issue #259). The SMART
+       sub-struct carries the slice-1 wake-drives / max-age knobs
+       alongside the new IntervalSec. The other five configurable
+       subsystems only carry IntervalSec. IntervalSec=0 means
+       "use global" (the scheduler ignores the override). */
+    advanced_scans: {
+      smart: {
+        wake_drives: !!(document.getElementById("wake-drives-for-smart") && document.getElementById("wake-drives-for-smart").classList.contains("on")),
+        max_age_days: (function() {
+          var el = document.getElementById("smart-max-age-days");
+          if (!el) return 7;
+          var v = parseInt(el.value, 10);
+          if (isNaN(v) || v < 0) return 0;
+          if (v > 30) return 30;
+          return v;
+        })(),
+        interval_sec: readPickerIntervalSec("smart")
+      },
+      docker:     { interval_sec: readPickerIntervalSec("docker") },
+      proxmox:    { interval_sec: readPickerIntervalSec("proxmox") },
+      kubernetes: { interval_sec: readPickerIntervalSec("kubernetes") },
+      zfs:        { interval_sec: readPickerIntervalSec("zfs") },
+      gpu:        { interval_sec: readPickerIntervalSec("gpu") }
     },
     docker_hidden_containers: collectCheckedHiddenContainers()
   };
@@ -1512,8 +1946,38 @@ function collectCheckedHiddenContainers() {
   return out;
 }
 
+/* smartMaxAgeConflictConfirm — PRD #239 user story 12.
+
+   When the user configures SMART.IntervalSec > MaxAgeDays * 86400
+   (both non-zero), the slice-1 max-age safety net will force-wake
+   drives more frequently than the user's stated SMART cadence.
+   That's almost certainly not what they want; show a confirm()
+   dialog explaining the consequence and let them cancel the save.
+
+   Returns true if the save may proceed, false if the user aborted.
+   Always returns true when there is no conflict. */
+function smartMaxAgeConflictConfirm(payload) {
+  try {
+    var adv = payload && payload.advanced_scans;
+    if (!adv || !adv.smart) return true;
+    var intervalSec = parseInt(adv.smart.interval_sec, 10) || 0;
+    var maxAgeDays  = parseInt(adv.smart.max_age_days, 10) || 0;
+    if (intervalSec <= 0 || maxAgeDays <= 0) return true;
+    if (intervalSec <= maxAgeDays * 86400)  return true;
+    var msg = "Your SMART scan interval (" + intervalSec + "s) is longer than the " +
+      "max-age-days safety net (" + maxAgeDays + " days = " + (maxAgeDays * 86400) +
+      "s).\n\nThe safety net will force-wake drives on its own cadence, " +
+      "overriding the SMART interval in practice. Save anyway?";
+    return confirm(msg);
+  } catch (e) { return true; }
+}
+
 function saveSettings() {
   var payload = buildSettingsPayload();
+  if (!smartMaxAgeConflictConfirm(payload)) {
+    showToast("Save aborted", "info");
+    return;
+  }
   fetch("/api/v1/settings", {
     method: "PUT",
     headers: { "Content-Type": "application/json" },

--- a/internal/collector/collect_per_subsystem_test.go
+++ b/internal/collector/collect_per_subsystem_test.go
@@ -1,0 +1,139 @@
+package collector
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// silentLogger returns a slog.Logger that writes errors-only so tests
+// don't spew on stderr. The subsystem collectors log at Info/Warn on
+// their normal paths; we're asserting on return-value contracts here,
+// not log output.
+func silentCollectorLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// TestCollector_CollectProxmox_NotEnabled_ReturnsNil: when the
+// Proxmox config has Enabled=false (the default for installs that
+// haven't configured PVE integration), CollectProxmox returns
+// (nil, nil) — no error, no result — so the scheduler can cheaply
+// call this on its configured cadence even when there's no cluster
+// to talk to.
+func TestCollector_CollectProxmox_NotEnabled_ReturnsNil(t *testing.T) {
+	c := New(internal.HostPaths{}, silentCollectorLogger())
+	c.SetProxmoxConfig(ProxmoxConfig{Enabled: false})
+
+	info, err := c.CollectProxmox()
+	if err != nil {
+		t.Errorf("CollectProxmox should not error when disabled; got %v", err)
+	}
+	if info != nil {
+		t.Errorf("CollectProxmox should return nil when disabled; got %+v", info)
+	}
+}
+
+// TestCollector_CollectKubernetes_NotEnabled_ReturnsNil: symmetric
+// with TestCollector_CollectProxmox_NotEnabled_ReturnsNil.
+func TestCollector_CollectKubernetes_NotEnabled_ReturnsNil(t *testing.T) {
+	c := New(internal.HostPaths{}, silentCollectorLogger())
+	c.SetKubeConfig(KubeConfig{Enabled: false})
+
+	info, err := c.CollectKubernetes()
+	if err != nil {
+		t.Errorf("CollectKubernetes should not error when disabled; got %v", err)
+	}
+	if info != nil {
+		t.Errorf("CollectKubernetes should return nil when disabled; got %+v", info)
+	}
+}
+
+// TestCollector_CollectGPU_ReturnsNonNil: CollectGPU always returns
+// a non-nil *GPUInfo (whose Available flag is false on hardware
+// without a GPU). This is the contract the dispatcher relies on to
+// decide whether to merge into the snapshot.
+func TestCollector_CollectGPU_ReturnsNonNil(t *testing.T) {
+	c := New(internal.HostPaths{}, silentCollectorLogger())
+	info := c.CollectGPU()
+	if info == nil {
+		t.Fatalf("CollectGPU must return a non-nil *GPUInfo even on hardware without a GPU")
+	}
+	// On CI / test hosts without nvidia-smi / intel_gpu_top / amdgpu,
+	// info.Available will be false. We don't assert on that — just
+	// that the method is cleanly callable.
+}
+
+// TestCollector_CollectZFS_ReturnsNoPanic: CollectZFS is callable
+// on hosts without ZFS. Either returns (nil, nil) or a non-nil info
+// whose Available flag accurately reports state.
+func TestCollector_CollectZFS_ReturnsNoPanic(t *testing.T) {
+	c := New(internal.HostPaths{}, silentCollectorLogger())
+	info, _ := c.CollectZFS()
+	// On a host without ZFS, info may be a non-nil value with
+	// Available=false, or nil. Either is valid. What we're asserting
+	// is that the method doesn't panic when ZFS binaries are absent.
+	if info != nil && info.Available && len(info.Pools) == 0 {
+		t.Errorf("CollectZFS reported Available=true but no pools; contract violation: %+v", info)
+	}
+}
+
+// TestCollector_CollectDocker_ReturnsCallable: CollectDocker is the
+// same code path as CollectDockerStats — a callable method even
+// when Docker is absent.
+func TestCollector_CollectDocker_ReturnsCallable(t *testing.T) {
+	c := New(internal.HostPaths{}, silentCollectorLogger())
+	info, _ := c.CollectDocker()
+	// On a host without Docker, info.Available is false. Containers
+	// slice may be nil or empty. No panic is the contract we care
+	// about for this wrapper.
+	if info.Available && len(info.Containers) == 0 {
+		// Not a hard failure — some hosts report Available with an
+		// empty list legitimately (Docker up, no containers). Just
+		// verify the shape is legal.
+		t.Logf("CollectDocker returned Available=true with no containers")
+	}
+}
+
+// TestCollector_CollectSMART_ReturnsNoPanic_EmptyPlatform: CollectSMART
+// with an empty platform is callable. It may return (nil, nil, error)
+// when no drives are discovered — that's fine, we're asserting
+// non-panic behaviour of the wrapper itself.
+func TestCollector_CollectSMART_ReturnsNoPanic_EmptyPlatform(t *testing.T) {
+	c := New(internal.HostPaths{}, silentCollectorLogger())
+	// Intentionally no SMARTConfig — we want the default (no wake).
+	// Just verify the method is callable.
+	_, _, _ = c.CollectSMART("")
+	// Also try with platform="unraid" to exercise the ArraySlot
+	// enrichment branch without asserting on its output (which
+	// depends on /sys/block/md*/slaves/).
+	_, _, _ = c.CollectSMART("unraid")
+}
+
+// TestCollector_CollectProxmox_EnabledButUnreachable_ReturnsErrorInfo:
+// when Proxmox is enabled but the URL is bogus, the wrapper returns
+// a non-nil ProxmoxInfo with Error set and Connected=false. The
+// scheduler uses this shape to report connection failures without
+// crashing.
+func TestCollector_CollectProxmox_EnabledButUnreachable_ReturnsErrorInfo(t *testing.T) {
+	c := New(internal.HostPaths{}, silentCollectorLogger())
+	c.SetProxmoxConfig(ProxmoxConfig{
+		Enabled: true,
+		URL:     "https://127.0.0.1:1",
+		TokenID: "fake",
+		Secret:  "fake",
+		Alias:   "test-pve",
+	})
+
+	info, err := c.CollectProxmox()
+	if err != nil {
+		t.Errorf("CollectProxmox should not return a Go error for unreachable endpoints; got %v", err)
+	}
+	if info == nil {
+		t.Fatalf("CollectProxmox should return non-nil info when Enabled=true, even on failure")
+	}
+	if info.Alias != "test-pve" {
+		t.Errorf("Alias not propagated; got %q, want test-pve", info.Alias)
+	}
+}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -44,7 +44,26 @@ func New(hostPaths internal.HostPaths, logger *slog.Logger) *Collector {
 	}
 }
 
-// Collect runs all diagnostic collectors and returns a complete Snapshot.
+// Collect runs the NINE non-configurable diagnostic subsystems and
+// returns a complete Snapshot frame. The six CONFIGURABLE subsystems
+// (SMART, Docker, Proxmox, Kubernetes, ZFS, GPU) are NOT invoked here
+// — they are scheduled independently by ScanDispatcher per their
+// configured cadence and merged into the snapshot by the scheduler's
+// RunOnce tick loop (issue #260 / PRD #239 slice 2b).
+//
+// Non-configurable subsystems (always run on the global tick):
+//
+//	system, disks, network, logs, parity, UPS, update check, tunnels, backup
+//
+// These are cheap enough to run every tick and/or have no meaningful
+// cadence knob a user would want to tune. The dispatcher only manages
+// the expensive / user-sensitive subsystems.
+//
+// Docker's container list IS needed here for tunnels detection (which
+// looks for cloudflared/tailscale containers). Docker is polled via a
+// lightweight inline call for this purpose; the full Docker snapshot
+// (with container stats) is produced by the dispatcher-driven
+// CollectDocker() on its own cadence.
 func (c *Collector) Collect() (*internal.Snapshot, error) {
 	start := time.Now()
 	snap := &internal.Snapshot{
@@ -68,40 +87,14 @@ func (c *Collector) Collect() (*internal.Snapshot, error) {
 	}
 	snap.Disks = disks
 
-	// SMART data
-	c.logger.Info("collecting SMART data", "wake_drives", c.smartConfig.WakeDrives)
-	smart, standbyDevices, err := collectSMART(c.smartConfig, c.logger)
-	if err != nil {
-		c.logger.Warn("SMART collection partial failure", "error", err)
-	}
-	// Issue #238: surface standby device list to the scheduler so the
-	// StaleSMARTChecker can evaluate max-age and force-wake if overdue.
-	snap.SMARTStandbyDevices = standbyDevices
-	// Enrich SMART data with Unraid array slot mapping (md -> physical device)
-	if smart != nil && sys.Platform == "unraid" {
-		mdMap := buildMDToPhysicalMap() // "sdb" -> "1" (for /mnt/disk1)
-		for i := range smart {
-			devName := strings.TrimPrefix(smart[i].Device, "/dev/")
-			if mdNum, ok := mdMap[devName]; ok {
-				smart[i].ArraySlot = "disk" + mdNum
-			}
-		}
-	}
-	snap.SMART = smart
-
-	// Docker containers
-	c.logger.Info("collecting Docker info")
+	// Docker container list is needed for tunnel detection below.
+	// The FULL Docker snapshot (with process-attribution enrichment)
+	// is produced by the dispatcher-driven CollectDocker path — this
+	// inline call is just to give collectTunnels its input. Cheap
+	// enough (docker ps has no per-container stats cost).
 	docker, err := collectDocker()
 	if err != nil {
-		c.logger.Warn("Docker collection partial failure", "error", err)
-	}
-	snap.Docker = docker
-
-	// Enrich top processes with container attribution (requires Docker data)
-	if docker.Available && len(docker.Containers) > 0 && len(sys.TopProcesses) > 0 {
-		containerIDMap := buildContainerIDMap(docker.Containers)
-		enrichProcessContainers(sys.TopProcesses, containerIDMap, "/proc")
-		snap.System.TopProcesses = sys.TopProcesses
+		c.logger.Warn("Docker probe for tunnel detection failed", "error", err)
 	}
 
 	// Network
@@ -156,53 +149,6 @@ func (c *Collector) Collect() (*internal.Snapshot, error) {
 		snap.Tunnels = tunnelInfo
 	}
 
-	// Proxmox VE (if configured)
-	if c.proxmoxConfig.Enabled {
-		c.logger.Info("collecting Proxmox VE data")
-		pveInfo := CollectProxmox(c.proxmoxConfig)
-		if pveInfo != nil {
-			pveInfo.Alias = c.proxmoxConfig.Alias
-			snap.Proxmox = pveInfo
-			if pveInfo.Error != "" {
-				c.logger.Warn("Proxmox VE collection error", "error", pveInfo.Error)
-			} else {
-				c.logger.Info("Proxmox VE data collected", "nodes", len(pveInfo.Nodes), "guests", len(pveInfo.Guests))
-			}
-		}
-	}
-
-	// Kubernetes (if configured)
-	if c.kubeConfig.Enabled {
-		c.logger.Info("collecting Kubernetes data")
-		kubeInfo := CollectKubernetes(c.kubeConfig)
-		if kubeInfo != nil {
-			kubeInfo.Alias = c.kubeConfig.Alias
-			snap.Kubernetes = kubeInfo
-			if kubeInfo.Error != "" {
-				c.logger.Warn("Kubernetes collection error", "error", kubeInfo.Error)
-			} else {
-				c.logger.Info("Kubernetes data collected", "nodes", len(kubeInfo.Nodes), "pods", len(kubeInfo.Pods))
-			}
-		}
-	}
-
-	// GPU (Nvidia / AMD / Intel)
-	c.logger.Info("collecting GPU info")
-	gpuInfo := collectGPU()
-	if gpuInfo != nil && gpuInfo.Available {
-		snap.GPU = gpuInfo
-	}
-
-	// ZFS (if available)
-	c.logger.Info("collecting ZFS info")
-	zfsInfo, err := collectZFS()
-	if err != nil {
-		c.logger.Warn("ZFS collection partial failure", "error", err)
-	}
-	if zfsInfo != nil && zfsInfo.Available {
-		snap.ZFS = zfsInfo
-	}
-
 	// Backup monitoring (Borg, Restic, PBS, Duplicati)
 	c.logger.Info("collecting backup info")
 	backupInfo := collectBackups()
@@ -211,10 +157,14 @@ func (c *Collector) Collect() (*internal.Snapshot, error) {
 	}
 
 	// Speed test: not collected here (runs on its own schedule via scheduler)
-	// snap.SpeedTest is populated by the scheduler's speed test loop
+	// snap.SpeedTest is populated by the scheduler's speed test loop.
+	//
+	// SMART, Docker (full), Proxmox, Kubernetes, GPU, ZFS: not collected
+	// here — scheduler dispatches these via their public Collect*
+	// methods on their own cadence (issue #260).
 
 	snap.Duration = time.Since(start).Seconds()
-	c.logger.Info("collection complete", "duration", fmt.Sprintf("%.1fs", snap.Duration))
+	c.logger.Info("collection complete (non-configurable subsystems)", "duration", fmt.Sprintf("%.1fs", snap.Duration))
 	return snap, nil
 }
 

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -227,6 +227,110 @@ func (c *Collector) CollectSMARTForced(devices []string) ([]internal.SMARTInfo, 
 	return CollectSMARTForced(devices, c.logger)
 }
 
+// ---------- Per-subsystem public collect methods (issue #260) ----------
+//
+// These are the thin wrappers the scheduler's ScanDispatcher calls
+// when a given subsystem's interval elapses. They preserve the exact
+// logging + error handling of the monolithic Collect() flow, and
+// return the same types produced by the existing internal collectX
+// functions. The monolithic Collect() is retained but now only
+// invokes the 9 non-configurable subsystems; the 6 configurable ones
+// (SMART, Docker, Proxmox, Kubernetes, ZFS, GPU) are invoked
+// independently from the scheduler's main loop per their configured
+// cadence.
+
+// CollectSMART performs the SMART subsystem pass. Returns the per-
+// drive SMARTInfo list, the device names that were in standby (so
+// the scheduler's StaleSMARTChecker can evaluate max-age), and any
+// error surfaced by the underlying collector. Platform-specific
+// array-slot enrichment for Unraid is applied here so the wrapper
+// produces the same shape as the monolithic Collect() path.
+func (c *Collector) CollectSMART(platform string) ([]internal.SMARTInfo, []string, error) {
+	c.logger.Info("collecting SMART data", "wake_drives", c.smartConfig.WakeDrives)
+	smart, standbyDevices, err := collectSMART(c.smartConfig, c.logger)
+	if err != nil {
+		c.logger.Warn("SMART collection partial failure", "error", err)
+	}
+	if smart != nil && platform == "unraid" {
+		mdMap := buildMDToPhysicalMap()
+		for i := range smart {
+			devName := strings.TrimPrefix(smart[i].Device, "/dev/")
+			if mdNum, ok := mdMap[devName]; ok {
+				smart[i].ArraySlot = "disk" + mdNum
+			}
+		}
+	}
+	return smart, standbyDevices, err
+}
+
+// CollectDocker performs the Docker subsystem pass. Returns the full
+// DockerInfo as a value (matching the monolithic Collect()'s
+// snap.Docker field type).
+func (c *Collector) CollectDocker() (internal.DockerInfo, error) {
+	c.logger.Info("collecting Docker info")
+	docker, err := collectDocker()
+	if err != nil {
+		c.logger.Warn("Docker collection partial failure", "error", err)
+	}
+	return docker, err
+}
+
+// CollectProxmox performs the Proxmox subsystem pass. Returns nil
+// (and no error) when Proxmox integration is not configured — the
+// dispatcher can still fire this subsystem on its cadence without
+// producing stale data.
+func (c *Collector) CollectProxmox() (*internal.ProxmoxInfo, error) {
+	if !c.proxmoxConfig.Enabled {
+		return nil, nil
+	}
+	c.logger.Info("collecting Proxmox VE data")
+	pveInfo := CollectProxmox(c.proxmoxConfig)
+	if pveInfo != nil {
+		pveInfo.Alias = c.proxmoxConfig.Alias
+		if pveInfo.Error != "" {
+			c.logger.Warn("Proxmox VE collection error", "error", pveInfo.Error)
+		} else {
+			c.logger.Info("Proxmox VE data collected", "nodes", len(pveInfo.Nodes), "guests", len(pveInfo.Guests))
+		}
+	}
+	return pveInfo, nil
+}
+
+// CollectKubernetes performs the Kubernetes subsystem pass. Returns
+// nil when K8s integration is not configured.
+func (c *Collector) CollectKubernetes() (*internal.KubeInfo, error) {
+	if !c.kubeConfig.Enabled {
+		return nil, nil
+	}
+	c.logger.Info("collecting Kubernetes data")
+	kubeInfo := CollectKubernetes(c.kubeConfig)
+	if kubeInfo != nil {
+		kubeInfo.Alias = c.kubeConfig.Alias
+		if kubeInfo.Error != "" {
+			c.logger.Warn("Kubernetes collection error", "error", kubeInfo.Error)
+		} else {
+			c.logger.Info("Kubernetes data collected", "nodes", len(kubeInfo.Nodes), "pods", len(kubeInfo.Pods))
+		}
+	}
+	return kubeInfo, nil
+}
+
+// CollectZFS performs the ZFS subsystem pass.
+func (c *Collector) CollectZFS() (*internal.ZFSInfo, error) {
+	c.logger.Info("collecting ZFS info")
+	zfsInfo, err := collectZFS()
+	if err != nil {
+		c.logger.Warn("ZFS collection partial failure", "error", err)
+	}
+	return zfsInfo, err
+}
+
+// CollectGPU performs the GPU subsystem pass.
+func (c *Collector) CollectGPU() *internal.GPUInfo {
+	c.logger.Info("collecting GPU info")
+	return collectGPU()
+}
+
 // CollectDockerStats runs a lightweight Docker stats collection (no full scan).
 // Used by the scheduler's independent container stats loop for chart history.
 func (c *Collector) CollectDockerStats() (*internal.DockerInfo, error) {

--- a/internal/models.go
+++ b/internal/models.go
@@ -67,6 +67,17 @@ type Snapshot struct {
 	// has been exceeded. Persisted so historical snapshots retain an
 	// accurate "which drives were asleep at this point" audit trail.
 	SMARTStandbyDevices []string `json:"smart_standby_devices,omitempty"`
+
+	// SubsystemLastRan maps each configurable subsystem name (smart,
+	// docker, proxmox, kubernetes, zfs, gpu) to the RFC3339 timestamp
+	// of its most recent successful collection. Introduced by issue
+	// #260 so dashboard clients can surface "last scanned 4m ago"
+	// per subsystem and distinguish stale vs fresh data. Subsystems
+	// that have never run since scheduler start are omitted rather
+	// than reported as zero-time. Optional field; omitempty so the
+	// key disappears when the dispatcher isn't populated (e.g. demo
+	// mode with a synthetic snapshot).
+	SubsystemLastRan map[string]string `json:"subsystem_last_ran,omitempty"`
 }
 
 // ---------- Proxmox VE ----------

--- a/internal/scheduler/scan_dispatcher.go
+++ b/internal/scheduler/scan_dispatcher.go
@@ -144,19 +144,24 @@ func (d *ScanDispatcher) applyIntervalsLocked(cfg DispatcherIntervalsConfig, glo
 // the existing rawCfg against a new global. Used by the scheduler's
 // UpdateInterval path so a user's change to scan_interval propagates
 // to every "use global" subsystem.
+//
+// Note on lastRun: an earlier version of this code deleted lastRun
+// for subsystems whose effective interval changed, under the "user
+// lowers interval, sees it fire immediately" intent. That caused a
+// v0.9.9-rc2 UAT regression: clicking through a picker dropdown
+// (5m → 15m → 30m → … → back to Use global) repeatedly toggled a
+// subsystem's effective interval, each toggle deleted its lastRun,
+// and the NEXT tick after the user settled back on "Use global"
+// fired the subsystem with a zero lastRun — completely ignoring the
+// user's global cadence. The fix: keep lastRun. The natural
+// `now.Sub(lr) >= interval` check in Tick already handles both the
+// "user lowers interval" case (fires ASAP if the new interval is
+// shorter than elapsed) and the "user raises or restores interval"
+// case (waits out the original cycle). Simpler and correct.
 func (d *ScanDispatcher) SetGlobal(global time.Duration) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	prev := make(map[string]time.Duration, len(d.intervals))
-	for k, v := range d.intervals {
-		prev[k] = v
-	}
 	d.applyIntervalsLocked(d.rawCfg, global)
-	for name, newInterval := range d.intervals {
-		if prev[name] != newInterval {
-			delete(d.lastRun, name)
-		}
-	}
 }
 
 // Tick returns the names of subsystems whose effective interval has
@@ -242,27 +247,27 @@ func (d *ScanDispatcher) FastestInterval() time.Duration {
 	return fastest
 }
 
-// UpdateIntervals applies a new settings configuration. Subsystems
-// whose EFFECTIVE interval changed are treated as "never ran" so the
-// new cadence takes effect on the next tick (user-lowers-interval
-// story). Subsystems whose interval is unchanged keep their lastRun
-// state so we don't spuriously re-run them.
+// UpdateIntervals applies a new settings configuration. lastRun
+// state is preserved for every subsystem — the natural
+// `now.Sub(lr) >= interval` check in Tick decides whether a
+// subsystem is due against the NEW interval, which is the behaviour
+// the user expects:
 //
-// Called from the settings-save path in the API handler. Safe to call
-// concurrently with Tick / MarkRan.
+//   - User lowers Docker from 7d to 5m, Docker last ran 20m ago →
+//     20m ≥ 5m, fires on next tick (expected).
+//   - User raises SMART from 5m to 7d, SMART last ran 4m ago →
+//     4m < 7d, waits for next 7d cycle (expected).
+//   - User clicks through SMART picker 5m → 15m → 1h → back to
+//     "Use global" (7d), SMART last ran 20m ago → 20m < 7d, does
+//     NOT fire on next tick (the rc2 UAT regression — fixed by
+//     keeping lastRun instead of resetting on every interval change).
+//
+// Called from the settings-save path in the API handler. Safe to
+// call concurrently with Tick / MarkRan.
 func (d *ScanDispatcher) UpdateIntervals(cfg DispatcherIntervalsConfig, global time.Duration) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	prev := make(map[string]time.Duration, len(d.intervals))
-	for k, v := range d.intervals {
-		prev[k] = v
-	}
 	d.applyIntervalsLocked(cfg, global)
-	for name, newInterval := range d.intervals {
-		if prev[name] != newInterval {
-			delete(d.lastRun, name)
-		}
-	}
 }
 
 // Skipped returns the subsystems in configurableSubsystems that are

--- a/internal/scheduler/scan_dispatcher.go
+++ b/internal/scheduler/scan_dispatcher.go
@@ -88,6 +88,10 @@ type ScanDispatcher struct {
 	// global is the scan_interval fallback for subsystems whose
 	// IntervalSec is 0.
 	global time.Duration
+	// rawCfg is the last DispatcherIntervalsConfig passed in. Kept
+	// so the scheduler's UpdateInterval path can re-resolve against
+	// a new global without losing the per-subsystem overrides.
+	rawCfg DispatcherIntervalsConfig
 }
 
 // NewScanDispatcher builds a dispatcher with the given per-subsystem
@@ -132,6 +136,27 @@ func (d *ScanDispatcher) applyIntervalsLocked(cfg DispatcherIntervalsConfig, glo
 		d.intervals[name] = time.Duration(sec) * time.Second
 	}
 	d.global = global
+	d.rawCfg = cfg
+}
+
+// SetGlobal updates just the global fallback without changing any
+// per-subsystem overrides. Equivalent to calling UpdateIntervals with
+// the existing rawCfg against a new global. Used by the scheduler's
+// UpdateInterval path so a user's change to scan_interval propagates
+// to every "use global" subsystem.
+func (d *ScanDispatcher) SetGlobal(global time.Duration) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	prev := make(map[string]time.Duration, len(d.intervals))
+	for k, v := range d.intervals {
+		prev[k] = v
+	}
+	d.applyIntervalsLocked(d.rawCfg, global)
+	for name, newInterval := range d.intervals {
+		if prev[name] != newInterval {
+			delete(d.lastRun, name)
+		}
+	}
 }
 
 // Tick returns the names of subsystems whose effective interval has

--- a/internal/scheduler/scan_dispatcher.go
+++ b/internal/scheduler/scan_dispatcher.go
@@ -1,0 +1,290 @@
+// Package scheduler — scan_dispatcher.go implements the per-subsystem
+// scan dispatcher introduced in issue #260 (PRD #239 slice 2b).
+//
+// Design (agreed in the Apr 2026 grilling session recorded on #239):
+//
+//   - The dispatcher is a deep module that owns "what runs when"
+//     decisions for the six configurable subsystems: SMART, Docker,
+//     Proxmox, Kubernetes, ZFS, GPU.
+//   - Each subsystem has an IntervalSec value from
+//     Settings.AdvancedScans. 0 means "use global" — the effective
+//     interval falls back to the scheduler's global scan_interval.
+//   - The scheduler sizes its main ticker at FastestInterval(), which
+//     is min(global, all non-zero per-subsystem intervals). Each tick
+//     the scheduler calls Tick(now) to get the list of due subsystems
+//     and invokes their matching Collect* methods on the Collector.
+//   - The nine non-configurable subsystems (system, disks, network,
+//     logs, parity, UPS, update check, tunnels, backup) always run
+//     every tick via Collector.Collect() — they are not routed
+//     through the dispatcher at all.
+//   - `now` is injected via a func seam so unit tests can pin time.
+//
+// Field meaning:
+//
+//   - intervals[subsystem] is the EFFECTIVE interval (already
+//     resolved: 0 from settings collapses to global at UpdateIntervals
+//     time, so this map never contains zero).
+//   - lastRun[subsystem] records the time MarkRan was called (zero
+//     value means "never ran" — treated as always due on Tick).
+package scheduler
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// configurableSubsystems is the canonical list of subsystems the
+// dispatcher manages. Enumerated in one place so dispatcher, scheduler
+// integration code, and tests agree on ordering + membership.
+//
+// The nine non-configurable subsystems (system, disks, network, logs,
+// parity, UPS, update check, tunnels, backup) are intentionally
+// absent — they are hard-wired to the global scan interval via
+// Collector.Collect() and are out of scope for the dispatcher.
+var configurableSubsystems = []string{
+	"smart",
+	"docker",
+	"proxmox",
+	"kubernetes",
+	"zfs",
+	"gpu",
+}
+
+// DispatcherIntervalsConfig is the minimal shape ScanDispatcher needs
+// to ingest a settings update. The api package's
+// AdvancedScansSettings is converted to this shape before UpdateIntervals
+// is called so the scheduler package doesn't have to import internal/api.
+type DispatcherIntervalsConfig struct {
+	// Per-subsystem interval overrides, in seconds. 0 means "use
+	// global" — the dispatcher substitutes the global scan interval
+	// when resolving the effective cadence.
+	SMARTSec      int
+	DockerSec     int
+	ProxmoxSec    int
+	KubernetesSec int
+	ZFSSec        int
+	GPUSec        int
+}
+
+// ScanDispatcher owns per-subsystem scheduling decisions. It is safe
+// for concurrent use — all state is guarded by a single mutex, and
+// methods are short enough that contention is not a concern.
+type ScanDispatcher struct {
+	mu sync.Mutex
+	// now is the time seam. Tests pin it to a fake clock.
+	now func() time.Time
+	// intervals are the EFFECTIVE per-subsystem intervals, already
+	// resolved against global (so "0 = use global" has been replaced
+	// with the global interval at config-update time). Missing key
+	// means "never configured" and is treated as "use global" on the
+	// fly — but in practice the map is always fully populated after
+	// NewScanDispatcher or UpdateIntervals.
+	intervals map[string]time.Duration
+	// lastRun records the timestamp of the most recent MarkRan for
+	// each subsystem. Zero value means "never ran" and is treated as
+	// always due on the next Tick.
+	lastRun map[string]time.Time
+	// global is the scan_interval fallback for subsystems whose
+	// IntervalSec is 0.
+	global time.Duration
+}
+
+// NewScanDispatcher builds a dispatcher with the given per-subsystem
+// config and global fallback. nowFn may be nil in which case
+// time.Now is used. Passing a non-nil nowFn is the seam tests use to
+// simulate the passage of time.
+func NewScanDispatcher(cfg DispatcherIntervalsConfig, global time.Duration, nowFn func() time.Time) *ScanDispatcher {
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	d := &ScanDispatcher{
+		now:       nowFn,
+		intervals: make(map[string]time.Duration, len(configurableSubsystems)),
+		lastRun:   make(map[string]time.Time, len(configurableSubsystems)),
+		global:    global,
+	}
+	d.applyIntervalsLocked(cfg, global)
+	return d
+}
+
+// applyIntervalsLocked resolves per-subsystem intervals against the
+// global fallback and writes them into d.intervals. Caller must hold
+// d.mu (or must not yet have published d to other goroutines).
+func (d *ScanDispatcher) applyIntervalsLocked(cfg DispatcherIntervalsConfig, global time.Duration) {
+	if global <= 0 {
+		global = 30 * time.Minute // defensive — matches default scan interval
+	}
+	byName := map[string]int{
+		"smart":      cfg.SMARTSec,
+		"docker":     cfg.DockerSec,
+		"proxmox":    cfg.ProxmoxSec,
+		"kubernetes": cfg.KubernetesSec,
+		"zfs":        cfg.ZFSSec,
+		"gpu":        cfg.GPUSec,
+	}
+	for _, name := range configurableSubsystems {
+		sec := byName[name]
+		if sec <= 0 {
+			d.intervals[name] = global
+			continue
+		}
+		d.intervals[name] = time.Duration(sec) * time.Second
+	}
+	d.global = global
+}
+
+// Tick returns the names of subsystems whose effective interval has
+// elapsed since their last MarkRan. Returned in canonical
+// configurableSubsystems order for stable log output.
+//
+// A subsystem with zero-value lastRun (never ran) is always returned.
+// This is intentional: on first tick after startup every subsystem
+// fires, which matches the pre-slice-2 "run everything on first tick"
+// behaviour.
+func (d *ScanDispatcher) Tick(now time.Time) []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	due := make([]string, 0, len(configurableSubsystems))
+	for _, name := range configurableSubsystems {
+		interval := d.intervals[name]
+		if interval <= 0 {
+			interval = d.global
+		}
+		lr := d.lastRun[name]
+		if lr.IsZero() || now.Sub(lr) >= interval {
+			due = append(due, name)
+		}
+	}
+	return due
+}
+
+// MarkRan records the given time as the latest run for the named
+// subsystem. Names outside configurableSubsystems are silently
+// ignored so callers don't need to pre-validate — passing "system"
+// or "tunnels" here is a no-op rather than a panic.
+func (d *ScanDispatcher) MarkRan(subsystem string, when time.Time) {
+	if !isConfigurable(subsystem) {
+		return
+	}
+	d.mu.Lock()
+	d.lastRun[subsystem] = when
+	d.mu.Unlock()
+}
+
+// LastRunMap returns a copy of the per-subsystem lastRun timestamps.
+// Safe to hand to the API layer for JSON serialization. Zero-value
+// timestamps are omitted — they represent "never ran" and serialize
+// better as a missing key than as "0001-01-01T00:00:00Z". Returned
+// in configurableSubsystems order as a map[string]time.Time; callers
+// that need deterministic JSON ordering should iterate the
+// configurableSubsystems slice themselves.
+func (d *ScanDispatcher) LastRunMap() map[string]time.Time {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := make(map[string]time.Time, len(d.lastRun))
+	for name, ts := range d.lastRun {
+		if ts.IsZero() {
+			continue
+		}
+		out[name] = ts
+	}
+	return out
+}
+
+// FastestInterval returns min(global, all effective per-subsystem
+// intervals). Used by the scheduler at startup to size its ticker.
+// Guaranteed to be positive and at least 1 second (defensive clamp).
+func (d *ScanDispatcher) FastestInterval() time.Duration {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	fastest := d.global
+	for _, name := range configurableSubsystems {
+		interval := d.intervals[name]
+		if interval <= 0 {
+			continue
+		}
+		if interval < fastest {
+			fastest = interval
+		}
+	}
+	if fastest <= 0 {
+		fastest = 30 * time.Minute
+	}
+	if fastest < time.Second {
+		fastest = time.Second
+	}
+	return fastest
+}
+
+// UpdateIntervals applies a new settings configuration. Subsystems
+// whose EFFECTIVE interval changed are treated as "never ran" so the
+// new cadence takes effect on the next tick (user-lowers-interval
+// story). Subsystems whose interval is unchanged keep their lastRun
+// state so we don't spuriously re-run them.
+//
+// Called from the settings-save path in the API handler. Safe to call
+// concurrently with Tick / MarkRan.
+func (d *ScanDispatcher) UpdateIntervals(cfg DispatcherIntervalsConfig, global time.Duration) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	prev := make(map[string]time.Duration, len(d.intervals))
+	for k, v := range d.intervals {
+		prev[k] = v
+	}
+	d.applyIntervalsLocked(cfg, global)
+	for name, newInterval := range d.intervals {
+		if prev[name] != newInterval {
+			delete(d.lastRun, name)
+		}
+	}
+}
+
+// Skipped returns the subsystems in configurableSubsystems that are
+// NOT in the `due` list. Used for the per-tick INFO log summary. The
+// input `due` slice does not need to be sorted; the returned slice is
+// in canonical configurableSubsystems order.
+func Skipped(due []string) []string {
+	inDue := make(map[string]struct{}, len(due))
+	for _, name := range due {
+		inDue[name] = struct{}{}
+	}
+	out := make([]string, 0, len(configurableSubsystems)-len(due))
+	for _, name := range configurableSubsystems {
+		if _, ok := inDue[name]; !ok {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// ConfigurableSubsystems returns a defensive copy of the canonical
+// subsystem list. Exported for tests and the scheduler integration
+// layer. Do not mutate the returned slice in shared state.
+func ConfigurableSubsystems() []string {
+	out := make([]string, len(configurableSubsystems))
+	copy(out, configurableSubsystems)
+	return out
+}
+
+func isConfigurable(name string) bool {
+	for _, s := range configurableSubsystems {
+		if s == name {
+			return true
+		}
+	}
+	return false
+}
+
+// sortedDue is a helper to produce deterministic ordering when the
+// caller already has a slice but doesn't care about
+// configurableSubsystems order. Not currently used inline — the
+// dispatcher returns results in canonical order — but kept for future
+// callers (and imported by tests asserting log format).
+//
+//nolint:unused // reserved for future use
+func sortedDue(due []string) []string {
+	out := append([]string(nil), due...)
+	sort.Strings(out)
+	return out
+}

--- a/internal/scheduler/scan_dispatcher_acceptance_test.go
+++ b/internal/scheduler/scan_dispatcher_acceptance_test.go
@@ -1,0 +1,135 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+)
+
+// TestScanDispatcher_Acceptance_Docker5minSMART1dayGlobal30m pins the
+// acceptance criterion from issue #260:
+//
+//	"Setting Docker.IntervalSec = 300 and SMART.IntervalSec = 86400
+//	 + global 30m: FastestInterval returns 300s; each tick dispatcher
+//	 fires Docker and, once per day, SMART"
+//
+// This is the headline user-visible outcome of slice 2b. If this
+// test breaks, a user who configured Docker-every-5m + SMART-every-day
+// would see either the wrong cadence OR the dispatcher firing SMART
+// every 5 minutes (waking drives unnecessarily).
+func TestScanDispatcher_Acceptance_Docker5minSMART1dayGlobal30m(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	clock := start
+	nowFn := func() time.Time { return clock }
+
+	d := NewScanDispatcher(DispatcherIntervalsConfig{
+		DockerSec: 300,   // 5 min
+		SMARTSec:  86400, // 1 day
+	}, 30*time.Minute, nowFn)
+
+	// Precondition: FastestInterval = 5 min (Docker).
+	if got, want := d.FastestInterval(), 5*time.Minute; got != want {
+		t.Fatalf("FastestInterval = %v, want 5m", got)
+	}
+
+	// First tick at start: everything is due (never ran).
+	firstDue := d.Tick(start)
+	if len(firstDue) != len(configurableSubsystems) {
+		t.Errorf("first tick should fire all subsystems; got %v", firstDue)
+	}
+
+	// Mark all as ran at start.
+	for _, name := range firstDue {
+		d.MarkRan(name, start)
+	}
+
+	// Advance 5 minutes — Docker should be due; SMART should NOT be.
+	clock = start.Add(5 * time.Minute)
+	due := d.Tick(clock)
+	hasDocker, hasSmart := false, false
+	for _, name := range due {
+		if name == "docker" {
+			hasDocker = true
+		}
+		if name == "smart" {
+			hasSmart = true
+		}
+	}
+	if !hasDocker {
+		t.Errorf("Docker should be due at t+5m; got %v", due)
+	}
+	if hasSmart {
+		t.Errorf("SMART should NOT be due at t+5m (interval is 1 day); got %v", due)
+	}
+
+	// Ran Docker. Advance another 5 min.
+	d.MarkRan("docker", clock)
+	clock = start.Add(10 * time.Minute)
+	due = d.Tick(clock)
+	hasSmart = false
+	for _, name := range due {
+		if name == "smart" {
+			hasSmart = true
+		}
+	}
+	if hasSmart {
+		t.Errorf("SMART still not due at t+10m; got %v", due)
+	}
+
+	// Fast-forward to t+1day: SMART finally due.
+	clock = start.Add(24 * time.Hour)
+	due = d.Tick(clock)
+	hasSmart = false
+	for _, name := range due {
+		if name == "smart" {
+			hasSmart = true
+		}
+	}
+	if !hasSmart {
+		t.Errorf("SMART should be due at t+1d; got %v", due)
+	}
+}
+
+// TestScanDispatcher_Acceptance_SMART5minGlobal30m pins the
+// second acceptance bullet: "SMART.IntervalSec = 300 and observing
+// the logs: SMART fires every 5 min, global subsystems every 30 min".
+func TestScanDispatcher_Acceptance_SMART5minGlobal30m(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	clock := start
+	nowFn := func() time.Time { return clock }
+	d := NewScanDispatcher(DispatcherIntervalsConfig{
+		SMARTSec: 300,
+	}, 30*time.Minute, nowFn)
+
+	// FastestInterval = 5m (SMART).
+	if got := d.FastestInterval(); got != 5*time.Minute {
+		t.Fatalf("FastestInterval = %v, want 5m", got)
+	}
+
+	// Mark all as ran at start.
+	for _, name := range configurableSubsystems {
+		d.MarkRan(name, start)
+	}
+
+	// t+5m: only SMART should be due (everything else is at 30m global).
+	clock = start.Add(5 * time.Minute)
+	due := d.Tick(clock)
+	if len(due) != 1 || due[0] != "smart" {
+		t.Errorf("t+5m: expected only smart due; got %v", due)
+	}
+
+	// Mark SMART ran; advance another 5m.
+	d.MarkRan("smart", clock)
+	clock = start.Add(10 * time.Minute)
+	due = d.Tick(clock)
+	if len(due) != 1 || due[0] != "smart" {
+		t.Errorf("t+10m: expected only smart due (again); got %v", due)
+	}
+
+	// t+30m: SMART + everything else (all global subsystems hit their 30m).
+	d.MarkRan("smart", clock)
+	clock = start.Add(30 * time.Minute)
+	due = d.Tick(clock)
+	if len(due) < 5 {
+		t.Errorf("t+30m: expected all global subsystems due; got %v", due)
+	}
+}

--- a/internal/scheduler/scan_dispatcher_integration_test.go
+++ b/internal/scheduler/scan_dispatcher_integration_test.go
@@ -1,0 +1,325 @@
+package scheduler
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/collector"
+	"github.com/mcdays94/nas-doctor/internal/notifier"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// silentTestLogger returns a slog logger that discards Info/Warn and
+// surfaces only Error. Kept separate from newTestStaleChecker's logger
+// builder so tests can redirect to a buffer when they need to assert
+// on log output.
+func silentTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// TestScheduler_Dispatcher_FastestInterval_SizesTickInterval: when
+// Docker's interval is 5 minutes and the global is 30 minutes,
+// the scheduler's dispatcher.FastestInterval() returns 5 minutes —
+// which is what the main loop uses to size its ticker. This is the
+// contract the dispatcher provides to the scheduler.
+func TestScheduler_Dispatcher_FastestInterval_SizesTickInterval(t *testing.T) {
+	col := collector.New(internal.HostPaths{}, silentTestLogger())
+	fake := storage.NewFakeStore()
+	s := New(col, fake, &notifier.Notifier{}, nil, silentTestLogger(), 30*time.Minute)
+
+	s.SetDispatcherIntervals(DispatcherIntervalsConfig{
+		DockerSec: 300,
+	})
+
+	if got, want := s.dispatcher.FastestInterval(), 5*time.Minute; got != want {
+		t.Errorf("after SetDispatcherIntervals(Docker=5m), FastestInterval = %v, want %v", got, want)
+	}
+}
+
+// TestScheduler_MaxAgeFiresAfterCollectSMART_NotAfterOtherSubsystems:
+// this is the critical regression guard for the slice-1 → slice-2b
+// call-site relocation. The StaleSMARTChecker must fire immediately
+// after CollectSMART() runs, and must NOT fire when other
+// subsystems run alone (e.g. Docker-only tick).
+//
+// We exercise this by calling runSubsystem directly with names other
+// than "smart" and asserting the stale-SMART checker's callback is
+// never invoked.
+func TestScheduler_MaxAgeFiresAfterCollectSMART_NotAfterOtherSubsystems(t *testing.T) {
+	col := collector.New(internal.HostPaths{}, silentTestLogger())
+	fake := storage.NewFakeStore()
+	s := New(col, fake, &notifier.Notifier{}, nil, silentTestLogger(), 30*time.Minute)
+	s.SetSMARTMaxAgeDays(7)
+
+	snap := &internal.Snapshot{
+		Timestamp: time.Now().UTC(),
+		System:    internal.SystemInfo{Platform: "linux"},
+	}
+
+	// runSubsystem("docker", ...) does NOT touch SMART state. If the
+	// stale-SMART call site had been forgotten to be relocated and
+	// was still firing on every runSubsystem call, this would query
+	// the store for each standby device. We assert no SMART mutation
+	// happened.
+	s.runSubsystem("docker", snap)
+	if len(snap.SMART) != 0 {
+		t.Errorf("docker-only subsystem run must not populate snap.SMART; got %v", snap.SMART)
+	}
+	if len(snap.SMARTStandbyDevices) != 0 {
+		t.Errorf("docker-only subsystem run must not populate SMARTStandbyDevices; got %v", snap.SMARTStandbyDevices)
+	}
+
+	// Repeat for zfs, gpu, kubernetes, proxmox.
+	for _, name := range []string{"zfs", "gpu", "kubernetes", "proxmox"} {
+		s.runSubsystem(name, snap)
+		if len(snap.SMART) != 0 {
+			t.Errorf("%s-only subsystem run must not populate snap.SMART; got %v", name, snap.SMART)
+		}
+	}
+}
+
+// TestScheduler_MaxAgeFiresAfterCollectSMART_IntegrationSMARTOnly:
+// confirms the reverse direction — when SMART IS the subsystem
+// running, the stale-SMART checker receives a call and seeded
+// standby devices get force-woken. Uses a real storage.DB for the
+// smart_history lookup.
+func TestScheduler_MaxAgeFiresAfterCollectSMART_IntegrationSMARTOnly(t *testing.T) {
+	// Set up a DB with a 10-day-old smart_history row for /dev/sda.
+	dir := t.TempDir()
+	db, err := storage.Open(dir+"/test.db", silentTestLogger())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := db.SaveSnapshot(&internal.Snapshot{
+		ID:        "seed",
+		Timestamp: now.Add(-10 * 24 * time.Hour),
+		SMART: []internal.SMARTInfo{
+			{Device: "/dev/sda", Serial: "OLD", Model: "M"},
+		},
+	}); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	// Build scheduler with real DB. We can't let CollectSMART shell
+	// out (no real smartctl in the test env); instead, seed the
+	// snapshot with the standby list ourselves and call the
+	// stale-SMART code path directly.
+	col := collector.New(internal.HostPaths{}, silentTestLogger())
+	s := New(col, db, &notifier.Notifier{}, nil, silentTestLogger(), 30*time.Minute)
+	s.SetSMARTMaxAgeDays(7)
+
+	snap := &internal.Snapshot{
+		Timestamp:           now,
+		System:              internal.SystemInfo{Platform: "linux"},
+		SMARTStandbyDevices: []string{"/dev/sda"},
+	}
+
+	// Capture the forced-collector invocation through a seam we
+	// wrap around the scheduler's CollectSMARTForced. Since we can't
+	// easily intercept that from a test without refactoring, we
+	// instead exercise the StaleSMARTChecker directly using the
+	// same code path runSubsystem("smart") would take.
+	maxAgeDays := s.smartMaxAgeDays
+	if maxAgeDays <= 0 {
+		t.Fatalf("test precondition: SetSMARTMaxAgeDays(7) must have set the field > 0")
+	}
+	chk := NewStaleSMARTChecker(db, maxAgeDays, silentTestLogger())
+	stale := chk.Check(snap)
+	if len(stale) != 1 || stale[0] != "/dev/sda" {
+		t.Fatalf("expected Check to flag /dev/sda as stale; got %v", stale)
+	}
+}
+
+// TestScheduler_PerTickLog_Format: the per-tick INFO log must contain
+// `due`, `skipped`, and `tick_interval` attrs — the canonical format
+// documented in the PRD user story 15.
+func TestScheduler_PerTickLog_Format(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	col := collector.New(internal.HostPaths{}, silentTestLogger())
+	fake := storage.NewFakeStore()
+	s := New(col, fake, &notifier.Notifier{}, nil, logger, 30*time.Minute)
+	// Arrange: SMART and Docker already ran this tick; every other
+	// subsystem is still due. This exercises the skipped-nonempty
+	// branch of the log.
+	for _, name := range []string{"smart", "docker"} {
+		s.dispatcher.MarkRan(name, time.Now().UTC())
+	}
+
+	// RunOnce will call Collector.Collect() which shells out to real
+	// binaries — for this log-format test we only care about the
+	// early dispatcher+log pass, so we bypass that by constructing
+	// a minimal snapshot and invoking the relevant pieces directly.
+	snap := &internal.Snapshot{
+		Timestamp: time.Now().UTC(),
+		System:    internal.SystemInfo{Platform: "linux"},
+	}
+	now := snap.Timestamp
+	due := s.dispatcher.Tick(now)
+	skipped := Skipped(due)
+	logger.Info("scan tick",
+		"due", due,
+		"skipped", skipped,
+		"tick_interval", s.dispatcher.FastestInterval(),
+	)
+
+	// Assert the log record is structured as expected.
+	found := false
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var rec map[string]any
+		if json.Unmarshal([]byte(line), &rec) != nil {
+			continue
+		}
+		if rec["msg"] == "scan tick" {
+			_, hasDue := rec["due"]
+			_, hasSkipped := rec["skipped"]
+			_, hasInterval := rec["tick_interval"]
+			if !hasDue || !hasSkipped || !hasInterval {
+				t.Errorf("scan tick log missing one of due/skipped/tick_interval; got %+v", rec)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no scan tick log emitted; buf=%s", buf.String())
+	}
+}
+
+// TestScheduler_CarryForward_SkippedSubsystemsKeepPriorValues: a
+// subsystem that skipped this tick must keep its previous snapshot
+// value (from s.latest) rather than rendering as empty. This is the
+// "stale but honest" user story.
+func TestScheduler_CarryForward_SkippedSubsystemsKeepPriorValues(t *testing.T) {
+	col := collector.New(internal.HostPaths{}, silentTestLogger())
+	fake := storage.NewFakeStore()
+	s := New(col, fake, &notifier.Notifier{}, nil, silentTestLogger(), 30*time.Minute)
+
+	// Pretend a previous tick populated Docker + GPU.
+	prior := &internal.Snapshot{
+		Docker: internal.DockerInfo{
+			Available:  true,
+			Containers: []internal.ContainerInfo{{Name: "c1"}, {Name: "c2"}},
+		},
+		GPU: &internal.GPUInfo{
+			Available: true,
+			GPUs:      []internal.GPUDevice{{Name: "gpu-1"}},
+		},
+	}
+	s.SetLatest(prior)
+
+	// Fresh tick snapshot — empty.
+	snap := &internal.Snapshot{}
+	s.carryForwardSubsystems(snap, []string{"docker", "gpu"})
+
+	if !snap.Docker.Available || len(snap.Docker.Containers) != 2 {
+		t.Errorf("docker not carried forward; got %+v", snap.Docker)
+	}
+	if snap.GPU == nil || !snap.GPU.Available || len(snap.GPU.GPUs) != 1 {
+		t.Errorf("gpu not carried forward; got %+v", snap.GPU)
+	}
+}
+
+// TestScheduler_CarryForward_NoLatestIsNoop: when s.latest is nil
+// (first tick after startup), carryForwardSubsystems is a no-op —
+// snap fields remain their zero values.
+func TestScheduler_CarryForward_NoLatestIsNoop(t *testing.T) {
+	col := collector.New(internal.HostPaths{}, silentTestLogger())
+	fake := storage.NewFakeStore()
+	s := New(col, fake, &notifier.Notifier{}, nil, silentTestLogger(), 30*time.Minute)
+
+	// s.latest is nil; this should not panic.
+	snap := &internal.Snapshot{}
+	s.carryForwardSubsystems(snap, []string{"docker", "smart", "proxmox"})
+
+	if snap.Docker.Available {
+		t.Errorf("no-latest carry-forward must not populate Docker; got %+v", snap.Docker)
+	}
+	if snap.GPU != nil {
+		t.Errorf("no-latest carry-forward must not populate GPU; got %+v", snap.GPU)
+	}
+}
+
+// TestScheduler_SubsystemLastRanStamping: after a tick runs, the
+// snapshot's SubsystemLastRan map is populated with RFC3339
+// timestamps for every subsystem that was dispatched this tick.
+func TestScheduler_SubsystemLastRanStamping_AfterMarkRan(t *testing.T) {
+	col := collector.New(internal.HostPaths{}, silentTestLogger())
+	fake := storage.NewFakeStore()
+	s := New(col, fake, &notifier.Notifier{}, nil, silentTestLogger(), 30*time.Minute)
+
+	now := time.Now().UTC()
+	s.dispatcher.MarkRan("smart", now)
+	s.dispatcher.MarkRan("docker", now.Add(5*time.Minute))
+
+	lastRun := s.dispatcher.LastRunMap()
+
+	// Stamp the same way RunOnce does.
+	snap := &internal.Snapshot{}
+	if len(lastRun) > 0 {
+		snap.SubsystemLastRan = make(map[string]string, len(lastRun))
+		for name, ts := range lastRun {
+			snap.SubsystemLastRan[name] = ts.Format(time.RFC3339)
+		}
+	}
+
+	if len(snap.SubsystemLastRan) != 2 {
+		t.Errorf("SubsystemLastRan len = %d, want 2; got %v", len(snap.SubsystemLastRan), snap.SubsystemLastRan)
+	}
+	if smartTS, ok := snap.SubsystemLastRan["smart"]; !ok || smartTS == "" {
+		t.Errorf("smart timestamp missing or empty; got %v", snap.SubsystemLastRan)
+	}
+	// Verify parseability.
+	if _, err := time.Parse(time.RFC3339, snap.SubsystemLastRan["smart"]); err != nil {
+		t.Errorf("smart timestamp not RFC3339: %v", err)
+	}
+}
+
+// TestScheduler_SetDispatcherIntervals_TriggersUpdateInterval: when
+// settings-save pushes new intervals, the scheduler's main-loop
+// ticker must re-size via the restart channel. We can't observe the
+// ticker directly without running Start(), but we can observe that
+// UpdateInterval was called with the correct FastestInterval value.
+func TestScheduler_SetDispatcherIntervals_DispatcherUpdated(t *testing.T) {
+	col := collector.New(internal.HostPaths{}, silentTestLogger())
+	fake := storage.NewFakeStore()
+	s := New(col, fake, &notifier.Notifier{}, nil, silentTestLogger(), 30*time.Minute)
+
+	// Before: all subsystems use global, FastestInterval = 30m.
+	if got, want := s.dispatcher.FastestInterval(), 30*time.Minute; got != want {
+		t.Fatalf("precondition: dispatcher FastestInterval = %v, want %v", got, want)
+	}
+
+	// Push Docker=5m via settings-save path.
+	s.SetDispatcherIntervals(DispatcherIntervalsConfig{
+		DockerSec: 300,
+	})
+
+	// Dispatcher should now report 5m as fastest.
+	if got, want := s.dispatcher.FastestInterval(), 5*time.Minute; got != want {
+		t.Errorf("after SetDispatcherIntervals, FastestInterval = %v, want %v", got, want)
+	}
+
+	// Restart channel should have received the new value. Drain it
+	// non-blocking — if empty, that's a regression.
+	select {
+	case got := <-s.restart:
+		if got != 5*time.Minute {
+			t.Errorf("restart channel got %v, want 5m", got)
+		}
+	default:
+		t.Errorf("SetDispatcherIntervals did not signal restart channel")
+	}
+}

--- a/internal/scheduler/scan_dispatcher_integration_test.go
+++ b/internal/scheduler/scan_dispatcher_integration_test.go
@@ -35,7 +35,7 @@ func TestScheduler_Dispatcher_FastestInterval_SizesTickInterval(t *testing.T) {
 
 	s.SetDispatcherIntervals(DispatcherIntervalsConfig{
 		DockerSec: 300,
-	})
+	}, 30*time.Minute)
 
 	if got, want := s.dispatcher.FastestInterval(), 5*time.Minute; got != want {
 		t.Errorf("after SetDispatcherIntervals(Docker=5m), FastestInterval = %v, want %v", got, want)
@@ -305,7 +305,7 @@ func TestScheduler_SetDispatcherIntervals_DispatcherUpdated(t *testing.T) {
 	// Push Docker=5m via settings-save path.
 	s.SetDispatcherIntervals(DispatcherIntervalsConfig{
 		DockerSec: 300,
-	})
+	}, 30*time.Minute)
 
 	// Dispatcher should now report 5m as fastest.
 	if got, want := s.dispatcher.FastestInterval(), 5*time.Minute; got != want {

--- a/internal/scheduler/scan_dispatcher_test.go
+++ b/internal/scheduler/scan_dispatcher_test.go
@@ -200,11 +200,17 @@ func TestScanDispatcher_FastestInterval_PicksFromMixed(t *testing.T) {
 	}
 }
 
-// TestScanDispatcher_UpdateIntervals_ResetsLastRunForChangedOnly: when
-// Docker's interval changes from 5m to 10m, docker's lastRun is
-// cleared (so the new cadence kicks in immediately) but SMART's
-// lastRun is preserved (interval unchanged).
-func TestScanDispatcher_UpdateIntervals_ResetsLastRunForChangedOnly(t *testing.T) {
+// TestScanDispatcher_UpdateIntervals_HonorsElapsedAgainstNewInterval:
+// UpdateIntervals preserves lastRun. The natural elapsed-vs-interval
+// check in Tick decides whether a subsystem is due against the new
+// interval. Exercises both directions:
+//
+//   - Docker 5m → 10m: elapsed 1s < 10m → NOT due.
+//   - SMART 1h unchanged: elapsed 1s < 1h → NOT due.
+//
+// Advancing past the new intervals fires them naturally without
+// needing a lastRun reset.
+func TestScanDispatcher_UpdateIntervals_HonorsElapsedAgainstNewInterval(t *testing.T) {
 	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
 	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
 		DockerSec: 300,
@@ -216,15 +222,24 @@ func TestScanDispatcher_UpdateIntervals_ResetsLastRunForChangedOnly(t *testing.T
 		d.MarkRan(name, start)
 	}
 
-	// Apply new config: Docker changed to 600s, SMART unchanged.
+	// Apply new config: Docker changed to 600s (10m), SMART unchanged.
 	d.UpdateIntervals(DispatcherIntervalsConfig{
 		DockerSec: 600,
 		SMARTSec:  3600,
 	}, 30*time.Minute)
 
-	// At t=1s: docker must be due (lastRun cleared), SMART must NOT be
-	// due (lastRun preserved, 1s < 1h).
+	// At t=1s: nothing is due — elapsed 1s is well under every
+	// effective interval (10m Docker, 1h SMART, 30m everything else).
 	due := d.Tick(start.Add(time.Second))
+	for _, name := range due {
+		if name == "docker" || name == "smart" {
+			t.Errorf("%s should NOT be due 1s after UpdateIntervals; got %v", name, due)
+		}
+	}
+
+	// Advance to t=10m: Docker is due (10m ≥ 10m), SMART is not
+	// (10m < 1h).
+	due = d.Tick(start.Add(10 * time.Minute))
 	foundDocker, foundSmart := false, false
 	for _, name := range due {
 		if name == "docker" {
@@ -235,17 +250,19 @@ func TestScanDispatcher_UpdateIntervals_ResetsLastRunForChangedOnly(t *testing.T
 		}
 	}
 	if !foundDocker {
-		t.Errorf("docker should be due after UpdateIntervals changed its interval; got %v", due)
+		t.Errorf("docker should be due at t=10m with new 10m interval; got %v", due)
 	}
 	if foundSmart {
-		t.Errorf("smart should NOT be due; its interval was unchanged; got %v", due)
+		t.Errorf("smart should NOT be due at t=10m (1h interval, 10m elapsed); got %v", due)
 	}
 }
 
-// TestScanDispatcher_UpdateIntervals_GlobalChangeAffectsUseGlobalSubsystems:
-// when a subsystem is on "use global" and global changes, that
-// subsystem's effective interval changes and its lastRun resets.
-func TestScanDispatcher_UpdateIntervals_GlobalChangeAffectsUseGlobalSubsystems(t *testing.T) {
+// TestScanDispatcher_UpdateIntervals_GlobalChangePreservesLastRun:
+// when a subsystem is on "use global" and global changes, the
+// subsystem's lastRun is preserved. The new global interval is
+// checked against the original last-run timestamp — a subsystem
+// that ran X ago only fires if X ≥ new global.
+func TestScanDispatcher_UpdateIntervals_GlobalChangePreservesLastRun(t *testing.T) {
 	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
 	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
 		// all zero = use global
@@ -262,13 +279,69 @@ func TestScanDispatcher_UpdateIntervals_GlobalChangeAffectsUseGlobalSubsystems(t
 		t.Errorf("no subsystem should be due 5s after run, global=30m; got %v", due)
 	}
 
-	// Reduce global to 10s — every subsystem's effective interval
-	// changes, so all lastRun values reset.
+	// Reduce global to 10s. With lastRun preserved, the natural
+	// elapsed-vs-interval check decides.
 	d.UpdateIntervals(DispatcherIntervalsConfig{}, 10*time.Second)
 
-	// Immediately all subsystems should be due.
+	// At t+6s: 6s < 10s → nothing due yet. The old code incorrectly
+	// fired everything here because it reset lastRun on interval
+	// change.
 	due = d.Tick(start.Add(6 * time.Second))
+	if len(due) != 0 {
+		t.Errorf("nothing should be due 6s after run with 10s global; got %v", due)
+	}
+
+	// At t+11s: 11s ≥ 10s → everything naturally due.
+	due = d.Tick(start.Add(11 * time.Second))
 	assertSameSet(t, due, ConfigurableSubsystems())
+}
+
+// TestScanDispatcher_UpdateIntervals_PickerWalkBackToUseGlobal:
+// regression guard for the v0.9.9-rc2 UAT finding. User clicked
+// through a picker's preset dropdown (SMART: 1h → 2h → … → 7d →
+// back to "Use global") while global was 7 days. Previously, every
+// intermediate UpdateIntervals call deleted SMART's lastRun, so the
+// FINAL state had lastRun=zero and SMART fired on the next tick
+// despite the user being back on "Use global=7d". The fix: preserve
+// lastRun across UpdateIntervals. This test walks the same path and
+// asserts SMART is NOT due when the user settles back on "Use
+// global" 20 minutes after the original SMART run.
+func TestScanDispatcher_UpdateIntervals_PickerWalkBackToUseGlobal(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 45, 46, 0, time.UTC)
+	global := 7 * 24 * time.Hour // 7 days — user's UAT global
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
+		// all zero = use global = 7d
+	}, global, start)
+
+	// All subsystems run at startup (the dispatcher's
+	// lr.IsZero() → due path fires them, scheduler calls MarkRan).
+	for _, name := range ConfigurableSubsystems() {
+		d.MarkRan(name, start)
+	}
+
+	// User opens Settings, starts clicking through the SMART picker
+	// dropdown. Each click fires saveSettings → UpdateIntervals.
+	walk := []int{3600, 7200, 21600, 43200, 86400, 604800, 0}
+	// 1h → 2h → 6h → 12h → 24h → 7d → back to "Use global" (0)
+	for _, sec := range walk {
+		d.UpdateIntervals(DispatcherIntervalsConfig{SMARTSec: sec}, global)
+	}
+
+	// 20 minutes after the original SMART run, user settles. Global
+	// is 7d, SMART is back on use-global. Elapsed 20m << 7d → SMART
+	// must NOT be due.
+	due := d.Tick(start.Add(20 * time.Minute))
+	for _, name := range due {
+		if name == "smart" {
+			t.Errorf("smart must NOT be due 20m after last run with 7d global; got %v", due)
+		}
+	}
+
+	// At the same tick, no other subsystem should be due either —
+	// they all use global=7d.
+	if len(due) != 0 {
+		t.Errorf("no subsystem should be due 20m after last run with 7d global; got %v", due)
+	}
 }
 
 // TestScanDispatcher_LastRunMap_ExcludesNeverRan: subsystems that

--- a/internal/scheduler/scan_dispatcher_test.go
+++ b/internal/scheduler/scan_dispatcher_test.go
@@ -1,0 +1,361 @@
+package scheduler
+
+import (
+	"sort"
+	"testing"
+	"time"
+)
+
+// helper: build a fixed-clock dispatcher.
+func newFixedClockDispatcher(cfg DispatcherIntervalsConfig, global time.Duration, start time.Time) (*ScanDispatcher, *time.Time) {
+	clock := start
+	nowFn := func() time.Time { return clock }
+	d := NewScanDispatcher(cfg, global, nowFn)
+	return d, &clock
+}
+
+func assertSameSet(t *testing.T, got, want []string) {
+	t.Helper()
+	g := append([]string(nil), got...)
+	w := append([]string(nil), want...)
+	sort.Strings(g)
+	sort.Strings(w)
+	if len(g) != len(w) {
+		t.Errorf("got %v, want %v", got, want)
+		return
+	}
+	for i := range g {
+		if g[i] != w[i] {
+			t.Errorf("got %v, want %v", got, want)
+			return
+		}
+	}
+}
+
+// TestScanDispatcher_Tick_AllUseGlobal_FirstTickFiresAll: with every
+// subsystem at IntervalSec=0 (use global), the very first Tick after
+// construction must return every configurable subsystem — matching
+// the pre-slice-2 "run everything once on startup" behaviour.
+func TestScanDispatcher_Tick_AllUseGlobal_FirstTickFiresAll(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{}, 30*time.Minute, start)
+
+	due := d.Tick(start)
+	assertSameSet(t, due, ConfigurableSubsystems())
+}
+
+// TestScanDispatcher_Tick_AfterMarkRanWithinInterval_NotDue: once a
+// subsystem has MarkRan called, subsequent Ticks within the interval
+// must not return it.
+func TestScanDispatcher_Tick_AfterMarkRanWithinInterval_NotDue(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
+		DockerSec: 300, // 5 min
+	}, 30*time.Minute, start)
+
+	d.MarkRan("docker", start)
+
+	// 2 min later: not due.
+	due := d.Tick(start.Add(2 * time.Minute))
+	for _, name := range due {
+		if name == "docker" {
+			t.Errorf("docker returned as due 2m after MarkRan with 5m interval; due=%v", due)
+		}
+	}
+}
+
+// TestScanDispatcher_Tick_AfterIntervalElapsed_Due: at exactly the
+// interval boundary a subsystem is due again.
+func TestScanDispatcher_Tick_AfterIntervalElapsed_Due(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
+		DockerSec: 300,
+	}, 30*time.Minute, start)
+
+	d.MarkRan("docker", start)
+
+	due := d.Tick(start.Add(5 * time.Minute))
+	foundDocker := false
+	for _, name := range due {
+		if name == "docker" {
+			foundDocker = true
+		}
+	}
+	if !foundDocker {
+		t.Errorf("expected docker due exactly 5m after MarkRan; got %v", due)
+	}
+}
+
+// TestScanDispatcher_Tick_MixedIntervals_OnlyDueFire: Docker every 5
+// min, SMART every 1 hour, others use 30m global — at t=5m, only
+// Docker should be due (others were just run at t=0).
+func TestScanDispatcher_Tick_MixedIntervals_OnlyDueFire(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
+		DockerSec: 300,  // 5 min
+		SMARTSec:  3600, // 1 h
+	}, 30*time.Minute, start)
+
+	// Simulate first tick at start — mark everything ran.
+	for _, name := range ConfigurableSubsystems() {
+		d.MarkRan(name, start)
+	}
+
+	// 5 minutes later: only docker should be due.
+	due := d.Tick(start.Add(5 * time.Minute))
+	assertSameSet(t, due, []string{"docker"})
+}
+
+// TestScanDispatcher_Tick_UseGlobalFallback_MatchesGlobal: a subsystem
+// at IntervalSec=0 fires on the global cadence. With global=30m, SMART
+// at IntervalSec=0, marking SMART ran at start, Tick at 30m must
+// include smart.
+func TestScanDispatcher_Tick_UseGlobalFallback_MatchesGlobal(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
+		// SMARTSec=0 means use global
+	}, 30*time.Minute, start)
+
+	d.MarkRan("smart", start)
+
+	// 29 min in — not yet due.
+	due := d.Tick(start.Add(29 * time.Minute))
+	for _, name := range due {
+		if name == "smart" {
+			t.Errorf("smart due at 29m with global=30m; got %v", due)
+		}
+	}
+
+	// 30 min in — due.
+	due = d.Tick(start.Add(30 * time.Minute))
+	found := false
+	for _, name := range due {
+		if name == "smart" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("smart not due at 30m with global=30m; got %v", due)
+	}
+}
+
+// TestScanDispatcher_MarkRan_IgnoresUnknown: passing a name outside
+// the configurable list must be a no-op, not a panic.
+func TestScanDispatcher_MarkRan_IgnoresUnknown(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{}, 30*time.Minute, start)
+
+	// Must not panic. Must not affect internal state.
+	d.MarkRan("system", start)   // not configurable
+	d.MarkRan("unknown", start)  // not configurable
+	d.MarkRan("", start)         // empty
+
+	// All configurable subsystems should still be due (no MarkRan was
+	// recorded for any of them).
+	due := d.Tick(start.Add(time.Second))
+	assertSameSet(t, due, ConfigurableSubsystems())
+}
+
+// TestScanDispatcher_FastestInterval_AllGlobal_ReturnsGlobal: when no
+// subsystem has a per-subsystem override, FastestInterval is global.
+func TestScanDispatcher_FastestInterval_AllGlobal_ReturnsGlobal(t *testing.T) {
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{}, 30*time.Minute, time.Now())
+	if got, want := d.FastestInterval(), 30*time.Minute; got != want {
+		t.Errorf("FastestInterval = %v, want %v", got, want)
+	}
+}
+
+// TestScanDispatcher_FastestInterval_PicksMinimum: with Docker at 5m
+// and global at 30m, FastestInterval is 5m.
+func TestScanDispatcher_FastestInterval_PicksMinimum(t *testing.T) {
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
+		DockerSec: 300,
+	}, 30*time.Minute, time.Now())
+	if got, want := d.FastestInterval(), 5*time.Minute; got != want {
+		t.Errorf("FastestInterval = %v, want %v", got, want)
+	}
+}
+
+// TestScanDispatcher_FastestInterval_LongerSubsystemDoesNotWin: with
+// SMART at 1d but global at 30m, FastestInterval is 30m (global is
+// still faster than SMART's override).
+func TestScanDispatcher_FastestInterval_LongerSubsystemDoesNotWin(t *testing.T) {
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
+		SMARTSec: 86400, // 1 day
+	}, 30*time.Minute, time.Now())
+	if got, want := d.FastestInterval(), 30*time.Minute; got != want {
+		t.Errorf("FastestInterval = %v, want %v (SMART=1d must not beat global=30m)", got, want)
+	}
+}
+
+// TestScanDispatcher_FastestInterval_PicksFromMixed: Docker at 5m and
+// SMART at 1h, global 30m — fastest is Docker's 5m.
+func TestScanDispatcher_FastestInterval_PicksFromMixed(t *testing.T) {
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
+		DockerSec: 300,
+		SMARTSec:  3600,
+	}, 30*time.Minute, time.Now())
+	if got, want := d.FastestInterval(), 5*time.Minute; got != want {
+		t.Errorf("FastestInterval = %v, want %v", got, want)
+	}
+}
+
+// TestScanDispatcher_UpdateIntervals_ResetsLastRunForChangedOnly: when
+// Docker's interval changes from 5m to 10m, docker's lastRun is
+// cleared (so the new cadence kicks in immediately) but SMART's
+// lastRun is preserved (interval unchanged).
+func TestScanDispatcher_UpdateIntervals_ResetsLastRunForChangedOnly(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
+		DockerSec: 300,
+		SMARTSec:  3600,
+	}, 30*time.Minute, start)
+
+	// Simulate first tick at start.
+	for _, name := range ConfigurableSubsystems() {
+		d.MarkRan(name, start)
+	}
+
+	// Apply new config: Docker changed to 600s, SMART unchanged.
+	d.UpdateIntervals(DispatcherIntervalsConfig{
+		DockerSec: 600,
+		SMARTSec:  3600,
+	}, 30*time.Minute)
+
+	// At t=1s: docker must be due (lastRun cleared), SMART must NOT be
+	// due (lastRun preserved, 1s < 1h).
+	due := d.Tick(start.Add(time.Second))
+	foundDocker, foundSmart := false, false
+	for _, name := range due {
+		if name == "docker" {
+			foundDocker = true
+		}
+		if name == "smart" {
+			foundSmart = true
+		}
+	}
+	if !foundDocker {
+		t.Errorf("docker should be due after UpdateIntervals changed its interval; got %v", due)
+	}
+	if foundSmart {
+		t.Errorf("smart should NOT be due; its interval was unchanged; got %v", due)
+	}
+}
+
+// TestScanDispatcher_UpdateIntervals_GlobalChangeAffectsUseGlobalSubsystems:
+// when a subsystem is on "use global" and global changes, that
+// subsystem's effective interval changes and its lastRun resets.
+func TestScanDispatcher_UpdateIntervals_GlobalChangeAffectsUseGlobalSubsystems(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{
+		// all zero = use global
+	}, 30*time.Minute, start)
+
+	// Run everything at start.
+	for _, name := range ConfigurableSubsystems() {
+		d.MarkRan(name, start)
+	}
+
+	// Verify nothing is due at t+5s (still on 30m cadence).
+	due := d.Tick(start.Add(5 * time.Second))
+	if len(due) != 0 {
+		t.Errorf("no subsystem should be due 5s after run, global=30m; got %v", due)
+	}
+
+	// Reduce global to 10s — every subsystem's effective interval
+	// changes, so all lastRun values reset.
+	d.UpdateIntervals(DispatcherIntervalsConfig{}, 10*time.Second)
+
+	// Immediately all subsystems should be due.
+	due = d.Tick(start.Add(6 * time.Second))
+	assertSameSet(t, due, ConfigurableSubsystems())
+}
+
+// TestScanDispatcher_LastRunMap_ExcludesNeverRan: subsystems that
+// have not yet MarkRan'd are omitted from LastRunMap.
+func TestScanDispatcher_LastRunMap_ExcludesNeverRan(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{}, 30*time.Minute, start)
+
+	d.MarkRan("docker", start)
+	d.MarkRan("smart", start.Add(5*time.Minute))
+
+	m := d.LastRunMap()
+	if len(m) != 2 {
+		t.Errorf("LastRunMap size = %d, want 2 (only docker + smart recorded); got %v", len(m), m)
+	}
+	if _, ok := m["docker"]; !ok {
+		t.Errorf("docker missing from LastRunMap; got %v", m)
+	}
+	if _, ok := m["smart"]; !ok {
+		t.Errorf("smart missing from LastRunMap; got %v", m)
+	}
+	if _, ok := m["proxmox"]; ok {
+		t.Errorf("proxmox should be absent from LastRunMap; got %v", m)
+	}
+}
+
+// TestScanDispatcher_Skipped_ReturnsComplement: the Skipped helper
+// returns the configurable subsystems NOT in `due`, in canonical
+// order.
+func TestScanDispatcher_Skipped_ReturnsComplement(t *testing.T) {
+	got := Skipped([]string{"docker", "smart"})
+	want := []string{"proxmox", "kubernetes", "zfs", "gpu"}
+	if len(got) != len(want) {
+		t.Errorf("Skipped len = %d, want %d; got %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Skipped[%d] = %s, want %s (canonical order matters); got %v", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestScanDispatcher_Skipped_EmptyDue_ReturnsAll: when no subsystems
+// are due, Skipped is the full list.
+func TestScanDispatcher_Skipped_EmptyDue_ReturnsAll(t *testing.T) {
+	got := Skipped(nil)
+	want := ConfigurableSubsystems()
+	if len(got) != len(want) {
+		t.Errorf("Skipped len = %d, want %d", len(got), len(want))
+	}
+}
+
+// TestScanDispatcher_Skipped_AllDue_ReturnsEmpty: when every
+// subsystem is due, Skipped is empty.
+func TestScanDispatcher_Skipped_AllDue_ReturnsEmpty(t *testing.T) {
+	got := Skipped(ConfigurableSubsystems())
+	if len(got) != 0 {
+		t.Errorf("Skipped should be empty when all are due; got %v", got)
+	}
+}
+
+// TestScanDispatcher_TickOrdering_Canonical: Tick returns subsystems
+// in configurableSubsystems order so log output is deterministic.
+func TestScanDispatcher_TickOrdering_Canonical(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{}, 30*time.Minute, start)
+	due := d.Tick(start)
+	want := ConfigurableSubsystems()
+	if len(due) != len(want) {
+		t.Fatalf("due len = %d, want %d", len(due), len(want))
+	}
+	for i := range want {
+		if due[i] != want[i] {
+			t.Errorf("Tick order not canonical: due[%d]=%s, want %s; got %v, want %v", i, due[i], want[i], due, want)
+		}
+	}
+}
+
+// TestScanDispatcher_FastestInterval_MinimumClampGuard: if somehow
+// the dispatcher ended up with zero-or-negative intervals (e.g.
+// defensive global clamp in applyIntervalsLocked), FastestInterval
+// still returns a positive duration.
+func TestScanDispatcher_FastestInterval_NonPositiveGlobalClampsToDefault(t *testing.T) {
+	// Pass global=0 which triggers the defensive clamp to 30m.
+	d, _ := newFixedClockDispatcher(DispatcherIntervalsConfig{}, 0, time.Now())
+	got := d.FastestInterval()
+	if got <= 0 {
+		t.Errorf("FastestInterval must be positive; got %v", got)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -123,6 +123,13 @@ type Scheduler struct {
 	// when the user changes the setting. Read under s.mu.
 	smartMaxAgeDays int
 
+	// dispatcher owns per-subsystem scan scheduling for the 6
+	// configurable subsystems (issue #260 / PRD #239 slice 2b).
+	// Non-nil after New(); safe for concurrent use. Settings saves
+	// push new per-subsystem intervals via dispatcher.UpdateIntervals
+	// from the API handler.
+	dispatcher *ScanDispatcher
+
 	logForwarder *logfwd.Forwarder
 
 	mu      sync.RWMutex
@@ -170,6 +177,11 @@ func New(
 		// should call SetSMARTMaxAgeDays after construction.
 		smartMaxAgeDays: 7,
 	}
+	// Dispatcher starts with all-subsystems-on-global; callers (the
+	// API settings handler on startup) push the user's configured
+	// per-subsystem intervals via SetDispatcherIntervals once
+	// Settings.AdvancedScans is loaded.
+	s.dispatcher = NewScanDispatcher(DispatcherIntervalsConfig{}, interval, nil)
 	s.checker = NewServiceChecker(store, logger)
 	// Opt into the per-type Details map on the scheduled path too —
 	// HTTP status codes, resolved IPs, DNS records, Ping RTT, failure
@@ -188,15 +200,25 @@ func New(
 }
 
 // Start begins the periodic collection loop. It runs the first collection
-// immediately, then repeats at the configured interval.
+// immediately, then repeats at the dispatcher's FastestInterval — which
+// is min(global scan_interval, all non-zero per-subsystem intervals)
+// per issue #260 / PRD #239 slice 2b. Each tick the dispatcher decides
+// which of the 6 configurable subsystems to run; the 9 non-configurable
+// subsystems always run every tick (cheap enough and the dispatcher is
+// not responsible for them).
+//
 // Also starts an independent service check loop (30s tick) that respects
 // per-check intervals.
 func (s *Scheduler) Start() {
-	s.logger.Info("scheduler starting", "interval", s.interval)
+	tickInterval := s.dispatcher.FastestInterval()
+	s.logger.Info("scheduler starting",
+		"global_interval", s.interval,
+		"tick_interval", tickInterval,
+	)
 	// Main diagnostic collection loop
 	go func() {
 		s.RunOnce()
-		ticker := time.NewTicker(s.interval)
+		ticker := time.NewTicker(tickInterval)
 		defer ticker.Stop()
 		for {
 			select {
@@ -204,11 +226,30 @@ func (s *Scheduler) Start() {
 				s.RunOnce()
 			case newInterval := <-s.restart:
 				ticker.Stop()
+				// The `restart` channel carries a GLOBAL scan_interval
+				// change (from UpdateInterval) OR a dispatcher-driven
+				// FastestInterval refresh (from SetDispatcherIntervals
+				// — in that case the dispatcher has already been
+				// updated and we just need to rebuild the ticker).
+				// We distinguish by comparing against the dispatcher's
+				// current FastestInterval: if it equals newInterval,
+				// it's the dispatcher path (global unchanged); else
+				// it's a user global update and we push the new
+				// global through to the dispatcher.
 				s.mu.Lock()
-				s.interval = newInterval
+				if newInterval != s.dispatcher.FastestInterval() {
+					s.interval = newInterval
+					// Global changed → push through to dispatcher so
+					// "use global" subsystems pick it up.
+					s.dispatcher.SetGlobal(newInterval)
+				}
 				s.mu.Unlock()
-				ticker = time.NewTicker(newInterval)
-				s.logger.Info("scheduler interval updated", "new_interval", newInterval)
+				fresh := s.dispatcher.FastestInterval()
+				ticker = time.NewTicker(fresh)
+				s.logger.Info("scheduler interval updated",
+					"global_interval", s.interval,
+					"tick_interval", fresh,
+				)
 			case <-s.stop:
 				s.logger.Info("scheduler stopped")
 				return
@@ -362,6 +403,35 @@ func (s *Scheduler) SetSMARTMaxAgeDays(days int) {
 	s.smartMaxAgeDays = days
 }
 
+// SetDispatcherIntervals pushes updated per-subsystem intervals into
+// the ScanDispatcher. Called by the API settings handler on save so
+// the new cadences take effect without restarting the scheduler
+// (issue #260 user story 1-6). Also restarts the main scan loop
+// ticker at the new FastestInterval via UpdateInterval, since a
+// newly-faster subsystem may require the ticker to fire more often.
+func (s *Scheduler) SetDispatcherIntervals(cfg DispatcherIntervalsConfig) {
+	s.mu.RLock()
+	global := s.interval
+	s.mu.RUnlock()
+	s.dispatcher.UpdateIntervals(cfg, global)
+	// Re-size the main-loop ticker to match the new FastestInterval.
+	// If nothing actually changed, UpdateInterval's select-default
+	// short-circuits gracefully.
+	s.UpdateInterval(s.dispatcher.FastestInterval())
+	s.logger.Info("scan dispatcher intervals updated",
+		"fastest_interval", s.dispatcher.FastestInterval(),
+	)
+}
+
+// Dispatcher returns the scheduler's ScanDispatcher. Exposed so the
+// API layer can surface per-subsystem lastRun timestamps on
+// /api/v1/snapshot/latest without reaching into scheduler internals.
+// Callers should treat the returned value as read-mostly; mutate only
+// via SetDispatcherIntervals.
+func (s *Scheduler) Dispatcher() *ScanDispatcher {
+	return s.dispatcher
+}
+
 // SetSpeedTestSchedule sets specific times of day to run speed tests.
 func (s *Scheduler) SetSpeedTestSchedule(times []string, day string, freq string) {
 	s.mu.Lock()
@@ -409,30 +479,52 @@ func (s *Scheduler) RunOnce() {
 
 	s.logger.Info("starting diagnostic collection")
 
-	// Collect
+	// Phase 1: collect the 9 non-configurable subsystems (system,
+	// disks, network, logs, parity, UPS, update check, tunnels,
+	// backup). These always run every tick — they're cheap and have
+	// no user-facing cadence knob.
 	snap, err := s.collector.Collect()
 	if err != nil {
 		s.logger.Error("collection failed", "error", err)
 		return
 	}
 
-	// Stale-SMART force-wake (issue #238). After the normal SMART
-	// collect pass, any drive reported as "standby" via `-n standby`
-	// whose last recorded read exceeds Settings.SMART.MaxAgeDays is
-	// force-woken for a single SMART read and merged back into the
-	// snapshot. MaxAgeDays=0 disables the feature entirely.
-	//
-	// Runs BEFORE detectDriveReplacements so the replacement logic
-	// sees fresh SMART for force-woken drives (avoids a spurious
-	// "drive missing" interpretation if a standby drive's last
-	// snapshot reported different ArraySlot metadata).
-	s.mu.RLock()
-	maxAgeDays := s.smartMaxAgeDays
-	s.mu.RUnlock()
-	if maxAgeDays > 0 {
-		staleChecker := NewStaleSMARTChecker(s.store, maxAgeDays, s.logger)
-		if stale := staleChecker.Check(snap); len(stale) > 0 {
-			staleChecker.Apply(snap, stale, s.collector.CollectSMARTForced)
+	// Phase 2: dispatch per-subsystem collectors per their configured
+	// cadence (issue #260 / PRD #239). The dispatcher's Tick decides
+	// which of the 6 configurable subsystems (SMART, Docker, Proxmox,
+	// Kubernetes, ZFS, GPU) are due on this tick. Previously-collected
+	// values from prior ticks are carried forward on snap by merging
+	// from s.latest below.
+	now := snap.Timestamp
+	due := s.dispatcher.Tick(now)
+	skipped := Skipped(due)
+
+	// Carry forward the most recent cached values for subsystems that
+	// are NOT running this tick. A subsystem that skipped should keep
+	// its previous snapshot value rather than showing empty data.
+	s.carryForwardSubsystems(snap, skipped)
+
+	// Emit the canonical per-tick INFO log summarising dispatcher
+	// decisions (user story 15).
+	s.logger.Info("scan tick",
+		"due", due,
+		"skipped", skipped,
+		"tick_interval", s.dispatcher.FastestInterval(),
+	)
+
+	for _, subsystem := range due {
+		s.runSubsystem(subsystem, snap)
+		s.dispatcher.MarkRan(subsystem, now)
+	}
+
+	// Stamp per-subsystem last-run timestamps on the snapshot so API
+	// consumers can surface "last scanned 4m ago" style staleness
+	// indicators (issue #260 user story 17; dashboard UI deferred).
+	lastRun := s.dispatcher.LastRunMap()
+	if len(lastRun) > 0 {
+		snap.SubsystemLastRan = make(map[string]string, len(lastRun))
+		for name, ts := range lastRun {
+			snap.SubsystemLastRan[name] = ts.Format(time.RFC3339)
 		}
 	}
 
@@ -529,6 +621,99 @@ func (s *Scheduler) RunOnce() {
 
 	// Auto backup check
 	s.checkBackup()
+}
+
+// runSubsystem invokes the matching per-subsystem Collector method
+// and merges its result into snap. The stale-SMART force-wake safety
+// net fires immediately after CollectSMART (issue #260 — relocated
+// from the post-Collect() call site that slice 1 used, so max-age is
+// now scoped to SMART's cadence).
+func (s *Scheduler) runSubsystem(name string, snap *internal.Snapshot) {
+	switch name {
+	case "smart":
+		smart, standby, _ := s.collector.CollectSMART(snap.System.Platform)
+		snap.SMART = smart
+		snap.SMARTStandbyDevices = standby
+		// Stale-SMART force-wake (issue #238 / slice 1). Previously
+		// ran unconditionally after Collect(); now runs ONLY when
+		// SMART actually ran on this tick, so max-age honours the
+		// user's SMART cadence. If a user sets SMART to 30d and
+		// max-age to 7d, max-age becomes the governing cadence
+		// (force-wake fires more frequently than stated SMART
+		// interval) — the UI confirm() dialog warned them about
+		// this on save.
+		s.mu.RLock()
+		maxAgeDays := s.smartMaxAgeDays
+		s.mu.RUnlock()
+		if maxAgeDays > 0 {
+			staleChecker := NewStaleSMARTChecker(s.store, maxAgeDays, s.logger)
+			if stale := staleChecker.Check(snap); len(stale) > 0 {
+				staleChecker.Apply(snap, stale, s.collector.CollectSMARTForced)
+			}
+		}
+	case "docker":
+		docker, _ := s.collector.CollectDocker()
+		snap.Docker = docker
+		// Enrich top processes with container attribution (previously
+		// done inline in Collect(); preserved here so the full-scan
+		// snapshot still has enrichment when both Docker + system ran
+		// on the same tick).
+		if docker.Available && len(docker.Containers) > 0 && len(snap.System.TopProcesses) > 0 {
+			collector.EnrichProcessContainers(snap.System.TopProcesses, docker.Containers, "")
+		}
+	case "proxmox":
+		pve, _ := s.collector.CollectProxmox()
+		if pve != nil {
+			snap.Proxmox = pve
+		}
+	case "kubernetes":
+		kube, _ := s.collector.CollectKubernetes()
+		if kube != nil {
+			snap.Kubernetes = kube
+		}
+	case "zfs":
+		zfs, _ := s.collector.CollectZFS()
+		if zfs != nil && zfs.Available {
+			snap.ZFS = zfs
+		}
+	case "gpu":
+		gpu := s.collector.CollectGPU()
+		if gpu != nil && gpu.Available {
+			snap.GPU = gpu
+		}
+	}
+}
+
+// carryForwardSubsystems copies prior-tick values from s.latest into
+// the current snapshot for each skipped subsystem. Without this, a
+// subsystem that didn't run this tick would show empty data — which
+// is technically honest but degrades the dashboard experience
+// dramatically. Snapshot-level timestamps (surfaced via ScanLastRan)
+// tell consumers how stale each subsystem's data actually is.
+func (s *Scheduler) carryForwardSubsystems(snap *internal.Snapshot, skipped []string) {
+	s.mu.RLock()
+	prev := s.latest
+	s.mu.RUnlock()
+	if prev == nil {
+		return
+	}
+	for _, name := range skipped {
+		switch name {
+		case "smart":
+			snap.SMART = prev.SMART
+			snap.SMARTStandbyDevices = prev.SMARTStandbyDevices
+		case "docker":
+			snap.Docker = prev.Docker
+		case "proxmox":
+			snap.Proxmox = prev.Proxmox
+		case "kubernetes":
+			snap.Kubernetes = prev.Kubernetes
+		case "zfs":
+			snap.ZFS = prev.ZFS
+		case "gpu":
+			snap.GPU = prev.GPU
+		}
+	}
 }
 
 // Latest returns the most recent snapshot from the cache.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -409,10 +409,30 @@ func (s *Scheduler) SetSMARTMaxAgeDays(days int) {
 // (issue #260 user story 1-6). Also restarts the main scan loop
 // ticker at the new FastestInterval via UpdateInterval, since a
 // newly-faster subsystem may require the ticker to fire more often.
-func (s *Scheduler) SetDispatcherIntervals(cfg DispatcherIntervalsConfig) {
-	s.mu.RLock()
-	global := s.interval
-	s.mu.RUnlock()
+//
+// global is the canonical scan_interval the caller just parsed from
+// settings; passed explicitly (rather than read from s.interval) to
+// avoid a race with a concurrent UpdateInterval that may not have
+// been consumed by the main loop yet. In practice the API handler
+// calls UpdateInterval then SetDispatcherIntervals in sequence on
+// the same goroutine — passing global through makes that ordering
+// irrelevant.
+func (s *Scheduler) SetDispatcherIntervals(cfg DispatcherIntervalsConfig, global time.Duration) {
+	if global <= 0 {
+		// Defensive: if caller didn't know the global (or passed a
+		// sentinel), fall back to whatever the scheduler has cached.
+		s.mu.RLock()
+		global = s.interval
+		s.mu.RUnlock()
+	} else {
+		// Caller supplied a fresh global — also update s.interval so
+		// subsequent reads see it. If a concurrent UpdateInterval is
+		// already propagating the same value, the main loop will
+		// simply re-tick at the same interval (harmless).
+		s.mu.Lock()
+		s.interval = global
+		s.mu.Unlock()
+	}
 	s.dispatcher.UpdateIntervals(cfg, global)
 	// Re-size the main-loop ticker to match the new FastestInterval.
 	// If nothing actually changed, UpdateInterval's select-default

--- a/scripts/prometheus-smoke/.env.example
+++ b/scripts/prometheus-smoke/.env.example
@@ -1,0 +1,17 @@
+# Copy this file to `.env` and fill in real values.
+# The `.env` file is gitignored (see ../../.gitignore and ./.gitignore).
+# NEVER commit a populated .env.
+
+# Scrape target — hostname:port (no scheme). Default points at UAT.
+# For a local NAS Doctor instance use e.g. 192.168.1.10:8060 and set SCRAPE_SCHEME=http.
+SCRAPE_TARGET=nasdoctoruat.mdias.info
+SCRAPE_SCHEME=https
+
+# NAS Doctor API key — get from Settings → API in the NAS Doctor UI.
+# Required whenever the instance has an API key set (all deployments after v0.8.x).
+ND_API_KEY=nd-your-api-key-here
+
+# Cloudflare Access service-token credentials. Required when the instance is
+# behind CF Access (e.g., UAT / prod demo). Leave BLANK for a local instance.
+CF_ACCESS_CLIENT_ID=your-client-id-here.access
+CF_ACCESS_CLIENT_SECRET=your-client-secret-here

--- a/scripts/prometheus-smoke/.gitignore
+++ b/scripts/prometheus-smoke/.gitignore
@@ -1,0 +1,6 @@
+# Local credentials file — NEVER commit.
+.env
+
+# Rendered Prometheus config (recreated by the init container).
+# Anchored to this directory only — must not match provisioning/datasources/prometheus.yml.
+/prometheus.yml

--- a/scripts/prometheus-smoke/README.md
+++ b/scripts/prometheus-smoke/README.md
@@ -1,0 +1,107 @@
+# NAS Doctor — Prometheus smoke-test harness
+
+A minimal, self-contained docker-compose stack that spins up **Prometheus +
+Grafana** locally and scrapes a NAS Doctor `/metrics` endpoint. Intended for
+end-to-end validation of the Prometheus exporter against UAT (or a local NAS
+Doctor instance), per issue [#255](https://github.com/mcdays94/nas-doctor/issues/255)
+Phase 1.
+
+**This is a discovery harness, not production monitoring.** Any anomalies
+found (missing `# HELP`/`# TYPE` lines, inconsistent labels, slow scrapes,
+high-cardinality series) should be filed as separate issues.
+
+## Quick start
+
+```bash
+cd scripts/prometheus-smoke
+cp .env.example .env
+# Edit .env and fill in ND_API_KEY, CF_ACCESS_CLIENT_ID, CF_ACCESS_CLIENT_SECRET
+docker compose up -d
+
+# Wait ~60 seconds for the first two scrape cycles, then:
+open http://localhost:9090/targets        # Prometheus — NAS Doctor should be UP
+open http://localhost:3000                 # Grafana — admin/admin, dashboard in "NAS Doctor" folder
+```
+
+Tear down: `docker compose down -v` (the `-v` also wipes Prometheus TSDB +
+Grafana DB, which is what you want between runs).
+
+## What runs
+
+| Service | Purpose |
+|---|---|
+| `prometheus-config-init` | One-shot Alpine container. Runs `envsubst` on `prometheus.yml.tmpl` → `prometheus.yml` using values from `.env`. Runs before Prometheus starts; exits 0 on success. |
+| `prometheus` | prom/prometheus v3.x. Scrapes the configured NAS Doctor target every 30s plus itself. UI on `:9090`. |
+| `grafana` | grafana/grafana v11.x. Auto-provisions the Prometheus datasource and the overview dashboard on first boot. UI on `:3000`. Default creds `admin/admin`; anonymous Viewer access also enabled for quick poking. |
+
+## Configuration (via `.env`)
+
+| Var | Purpose | Example |
+|---|---|---|
+| `SCRAPE_TARGET` | NAS Doctor host:port (no scheme). Defaults to UAT. | `nasdoctoruat.mdias.info`, `192.168.1.10:8060` |
+| `SCRAPE_SCHEME` | `http` or `https`. | `https` |
+| `ND_API_KEY` | Bearer token from NAS Doctor Settings → API. | `nd-…` |
+| `CF_ACCESS_CLIENT_ID` | CF Access service-token client ID. Leave blank for local instances not behind CF Access. | `xxx.access` |
+| `CF_ACCESS_CLIENT_SECRET` | CF Access service-token client secret. Leave blank for local. | `…` |
+
+Credentials are read from `.env` only. The rendered `prometheus.yml` ends up
+inside a docker volume (`prom-config`), never on the host. **`.env` is
+gitignored — never commit it.**
+
+## Scraping a local NAS Doctor instance
+
+```bash
+# Example: a local dev instance running on the host on port 8060
+cat > .env <<EOF
+SCRAPE_TARGET=host.docker.internal:8060
+SCRAPE_SCHEME=http
+ND_API_KEY=nd-your-local-api-key
+CF_ACCESS_CLIENT_ID=
+CF_ACCESS_CLIENT_SECRET=
+EOF
+docker compose up -d
+```
+
+(Linux users who don't have `host.docker.internal` resolved by default may
+need to add `extra_hosts: ["host.docker.internal:host-gateway"]` to the
+prometheus service, or use the LAN IP of the docker host.)
+
+## Verifying the scrape
+
+After `docker compose up -d`, wait ~60s (two scrape intervals), then:
+
+```bash
+# Target status
+curl -s http://localhost:9090/api/v1/targets \
+  | jq '.data.activeTargets[] | {job: .labels.job, health, lastScrape, lastScrapeDuration}'
+
+# Full list of discovered metric names
+curl -s http://localhost:9090/api/v1/label/__name__/values \
+  | jq -r '.data[]' | grep ^nasdoctor_ | head -40
+
+# Specific metric — should return samples with instance label
+curl -s 'http://localhost:9090/api/v1/query?query=nasdoctor_system_cpu_usage_percent' | jq
+
+# Prometheus's own warnings from the scrape
+docker compose logs prometheus 2>&1 | grep -iE 'warn|error'
+```
+
+## What to look for (Phase 1 checklist)
+
+- [ ] `/targets` shows `nas-doctor` job `health: "up"`
+- [ ] `lastScrapeDuration` under 500ms (NAS Doctor's budget)
+- [ ] `curl .../label/__name__/values` returns ~110+ `nasdoctor_*` metric names
+- [ ] `docker compose logs prometheus` contains no parse warnings
+- [ ] Grafana dashboard "NAS Doctor — Overview" renders panels for every category
+- [ ] Pick one sample metric (e.g., `nasdoctor_smart_temperature_celsius`) and
+      confirm the `device` label is consistently present across scrapes
+
+Any negative result → file a separate issue. Do **not** modify NAS Doctor itself
+in this harness.
+
+## Cleanup
+
+```bash
+docker compose down -v
+rm -f .env   # if you're done
+```

--- a/scripts/prometheus-smoke/dashboards/nas-doctor-overview.json
+++ b/scripts/prometheus-smoke/dashboards/nas-doctor-overview.json
@@ -1,0 +1,274 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "graphTooltip": 0,
+  "title": "NAS Doctor — Overview (smoke test)",
+  "uid": "nas-doctor-smoke",
+  "schemaVersion": 39,
+  "version": 1,
+  "timezone": "",
+  "time": {"from": "now-1h", "to": "now"},
+  "refresh": "30s",
+  "tags": ["nas-doctor", "smoke-test"],
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "label": "Instance",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "query": "label_values(nasdoctor_system_cpu_usage_percent, instance)",
+        "refresh": 2,
+        "multi": false,
+        "includeAll": false,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "System",
+      "gridPos": {"x": 0, "y": 0, "w": 24, "h": 1},
+      "collapsed": false
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "CPU usage %",
+      "gridPos": {"x": 0, "y": 1, "w": 8, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "percent", "min": 0, "max": 100}, "overrides": []},
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "showLegend": true}},
+      "targets": [
+        {
+          "expr": "nasdoctor_system_cpu_usage_percent{instance=~\"$instance\"}",
+          "legendFormat": "cpu",
+          "refId": "A"
+        },
+        {
+          "expr": "nasdoctor_system_io_wait_percent{instance=~\"$instance\"}",
+          "legendFormat": "iowait",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Memory used (bytes)",
+      "gridPos": {"x": 8, "y": 1, "w": 8, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "bytes"}, "overrides": []},
+      "targets": [
+        {
+          "expr": "nasdoctor_system_memory_used_bytes{instance=~\"$instance\"}",
+          "legendFormat": "mem used",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Load average",
+      "gridPos": {"x": 16, "y": 1, "w": 8, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "nasdoctor_system_load_avg_1{instance=~\"$instance\"}", "legendFormat": "1m", "refId": "A"},
+        {"expr": "nasdoctor_system_load_avg_5{instance=~\"$instance\"}", "legendFormat": "5m", "refId": "B"},
+        {"expr": "nasdoctor_system_load_avg_15{instance=~\"$instance\"}", "legendFormat": "15m", "refId": "C"}
+      ]
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Drives & SMART",
+      "gridPos": {"x": 0, "y": 8, "w": 24, "h": 1},
+      "collapsed": false
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "SMART temperature °C",
+      "gridPos": {"x": 0, "y": 9, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "celsius"}, "overrides": []},
+      "targets": [
+        {
+          "expr": "nasdoctor_smart_temperature_celsius{instance=~\"$instance\"}",
+          "legendFormat": "{{device}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Disk used %",
+      "gridPos": {"x": 12, "y": 9, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "percent", "min": 0, "max": 100}, "overrides": []},
+      "targets": [
+        {
+          "expr": "nasdoctor_disk_used_percent{instance=~\"$instance\"}",
+          "legendFormat": "{{mount}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "row",
+      "title": "Docker",
+      "gridPos": {"x": 0, "y": 16, "w": 24, "h": 1},
+      "collapsed": false
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Container CPU %",
+      "gridPos": {"x": 0, "y": 17, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "percent"}, "overrides": []},
+      "targets": [
+        {
+          "expr": "topk(10, nasdoctor_docker_container_cpu_percent{instance=~\"$instance\"})",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 22,
+      "type": "stat",
+      "title": "Total containers",
+      "gridPos": {"x": 12, "y": 17, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "expr": "nasdoctor_docker_container_count{instance=~\"$instance\"}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 30,
+      "type": "row",
+      "title": "Network & Service checks",
+      "gridPos": {"x": 0, "y": 24, "w": 24, "h": 1},
+      "collapsed": false
+    },
+    {
+      "id": 31,
+      "type": "timeseries",
+      "title": "Network interfaces up",
+      "gridPos": {"x": 0, "y": 25, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "expr": "nasdoctor_network_interface_up{instance=~\"$instance\"}",
+          "legendFormat": "{{interface}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 32,
+      "type": "timeseries",
+      "title": "Service checks — up & response_ms",
+      "gridPos": {"x": 12, "y": 25, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "expr": "nasdoctor_service_up{instance=~\"$instance\"}",
+          "legendFormat": "up / {{name}}",
+          "refId": "A"
+        },
+        {
+          "expr": "nasdoctor_service_response_ms{instance=~\"$instance\"}",
+          "legendFormat": "ms / {{name}}",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 40,
+      "type": "row",
+      "title": "Speed test & Parity",
+      "gridPos": {"x": 0, "y": 32, "w": 24, "h": 1},
+      "collapsed": false
+    },
+    {
+      "id": 41,
+      "type": "timeseries",
+      "title": "Speed test (Mbps)",
+      "gridPos": {"x": 0, "y": 33, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "Mbits"}, "overrides": []},
+      "targets": [
+        {"expr": "nasdoctor_speedtest_download_mbps{instance=~\"$instance\"}", "legendFormat": "download", "refId": "A"},
+        {"expr": "nasdoctor_speedtest_upload_mbps{instance=~\"$instance\"}", "legendFormat": "upload", "refId": "B"}
+      ]
+    },
+    {
+      "id": 42,
+      "type": "timeseries",
+      "title": "Parity",
+      "gridPos": {"x": 12, "y": 33, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "nasdoctor_parity_running{instance=~\"$instance\"}", "legendFormat": "running", "refId": "A"},
+        {"expr": "nasdoctor_parity_speed_mb_per_sec{instance=~\"$instance\"}", "legendFormat": "MB/s", "refId": "B"},
+        {"expr": "nasdoctor_parity_errors{instance=~\"$instance\"}", "legendFormat": "errors", "refId": "C"}
+      ]
+    },
+    {
+      "id": 50,
+      "type": "row",
+      "title": "GPU",
+      "gridPos": {"x": 0, "y": 40, "w": 24, "h": 1},
+      "collapsed": false
+    },
+    {
+      "id": 51,
+      "type": "timeseries",
+      "title": "GPU usage & temp",
+      "gridPos": {"x": 0, "y": 41, "w": 24, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "nasdoctor_gpu_usage_percent{instance=~\"$instance\"}", "legendFormat": "usage % / {{device}}", "refId": "A"},
+        {"expr": "nasdoctor_gpu_temperature_celsius{instance=~\"$instance\"}", "legendFormat": "temp °C / {{device}}", "refId": "B"}
+      ]
+    },
+    {
+      "id": 60,
+      "type": "row",
+      "title": "Scrape hygiene",
+      "gridPos": {"x": 0, "y": 48, "w": 24, "h": 1},
+      "collapsed": false
+    },
+    {
+      "id": 61,
+      "type": "timeseries",
+      "title": "Scrape duration (s)",
+      "gridPos": {"x": 0, "y": 49, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "targets": [
+        {"expr": "scrape_duration_seconds{job=\"nas-doctor\"}", "legendFormat": "{{instance}}", "refId": "A"}
+      ]
+    },
+    {
+      "id": 62,
+      "type": "timeseries",
+      "title": "Series scraped per target",
+      "gridPos": {"x": 12, "y": 49, "w": 12, "h": 7},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "scrape_samples_scraped{job=\"nas-doctor\"}", "legendFormat": "{{instance}}", "refId": "A"}
+      ]
+    }
+  ]
+}

--- a/scripts/prometheus-smoke/docker-compose.yml
+++ b/scripts/prometheus-smoke/docker-compose.yml
@@ -1,0 +1,74 @@
+# NAS Doctor — Prometheus + Grafana smoke-test harness.
+#
+# See README.md. In brief:
+#   1. cp .env.example .env  (and fill in real credentials)
+#   2. docker compose up -d
+#   3. http://localhost:9090 (Prometheus), http://localhost:3000 (Grafana, admin/admin)
+#
+# All credentials come from .env (gitignored). No secrets live in any tracked
+# file in this directory.
+
+services:
+  # envsubst renders prometheus.yml.tmpl -> prometheus.yml inside a shared
+  # volume before Prometheus starts. We use a tiny Alpine image with envsubst
+  # (ships as part of gettext) so we don't add a hand-rolled Dockerfile.
+  prometheus-config-init:
+    image: alpine:3.20
+    command:
+      - sh
+      - -c
+      - |
+        apk add --no-cache gettext >/dev/null 2>&1
+        envsubst < /tmpl/prometheus.yml.tmpl > /out/prometheus.yml
+        echo "rendered /out/prometheus.yml from template"
+    environment:
+      SCRAPE_TARGET: ${SCRAPE_TARGET:-nasdoctoruat.mdias.info}
+      SCRAPE_SCHEME: ${SCRAPE_SCHEME:-https}
+      ND_API_KEY: ${ND_API_KEY:-}
+      CF_ACCESS_CLIENT_ID: ${CF_ACCESS_CLIENT_ID:-}
+      CF_ACCESS_CLIENT_SECRET: ${CF_ACCESS_CLIENT_SECRET:-}
+    volumes:
+      - ./prometheus.yml.tmpl:/tmpl/prometheus.yml.tmpl:ro
+      - prom-config:/out
+    restart: "no"
+
+  prometheus:
+    image: prom/prometheus:v3.1.0
+    depends_on:
+      prometheus-config-init:
+        condition: service_completed_successfully
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=24h
+      - --web.enable-lifecycle
+      - --log.level=info
+    ports:
+      - "9090:9090"
+    volumes:
+      - prom-config:/etc/prometheus:ro
+      - prom-data:/prometheus
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:11.4.0
+    depends_on:
+      - prometheus
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+      GF_USERS_DEFAULT_THEME: dark
+    volumes:
+      - ./provisioning:/etc/grafana/provisioning:ro
+      - ./dashboards:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    restart: unless-stopped
+
+volumes:
+  prom-config:
+  prom-data:
+  grafana-data:

--- a/scripts/prometheus-smoke/prometheus.yml.tmpl
+++ b/scripts/prometheus-smoke/prometheus.yml.tmpl
@@ -1,0 +1,48 @@
+# Prometheus scrape config for NAS Doctor smoke-test harness.
+#
+# Placeholders (${VAR}) are substituted at container start-time by the
+# `prometheus-config-init` service in docker-compose.yml using `envsubst`.
+# Operators DO NOT hand-edit this file with real credentials — credentials
+# live only in a gitignored `.env` next to docker-compose.yml.
+
+global:
+  scrape_interval: 30s
+  scrape_timeout: 10s
+  external_labels:
+    harness: nas-doctor-smoke
+
+scrape_configs:
+  - job_name: nas-doctor
+    metrics_path: /metrics
+    scheme: ${SCRAPE_SCHEME}
+    static_configs:
+      - targets:
+          - ${SCRAPE_TARGET}
+        labels:
+          instance: ${SCRAPE_TARGET}
+          source: smoke-harness
+
+    # NAS Doctor API key (Bearer token). Set in .env as ND_API_KEY.
+    authorization:
+      type: Bearer
+      credentials: ${ND_API_KEY}
+
+    # Cloudflare Access service-token headers. Required when scraping through
+    # a cloudflared tunnel behind CF Access (e.g., nasdoctoruat.mdias.info).
+    # For a local NAS Doctor instance not fronted by CF Access, leave the
+    # corresponding env vars empty — empty header values are sent but CF Access
+    # won't be evaluating them.
+    http_headers:
+      CF-Access-Client-Id:
+        values:
+          - ${CF_ACCESS_CLIENT_ID}
+      CF-Access-Client-Secret:
+        values:
+          - ${CF_ACCESS_CLIENT_SECRET}
+
+  # Self-scrape so operators can see Prometheus's own scrape duration stats
+  # alongside NAS Doctor's metrics — useful for comparing scrape cost.
+  - job_name: prometheus
+    static_configs:
+      - targets:
+          - localhost:9090

--- a/scripts/prometheus-smoke/provisioning/dashboards/dashboards.yml
+++ b/scripts/prometheus-smoke/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: NAS Doctor
+    orgId: 1
+    folder: NAS Doctor
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/scripts/prometheus-smoke/provisioning/datasources/prometheus.yml
+++ b/scripts/prometheus-smoke/provisioning/datasources/prometheus.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+    jsonData:
+      timeInterval: 30s


### PR DESCRIPTION
## Summary

Cuts **v0.9.9**: the complete Advanced Scan Settings slice 2 (per-subsystem scan cadence) plus a Prometheus exporter smoke-test harness, plus the already-merged SMART settings_version roundtrip fix. Bundled through 4 RC cycles on UAT hardware before merging.

## What ships

### Advanced Scan Settings slice 2 — PRD #239

**V2a (#259, PR #275)** — schema reshape + interval-picker UI
- New `Settings.AdvancedScans` umbrella with sub-structs for the 6 configurable subsystems (SMART, Docker, Proxmox, Kubernetes, ZFS, GPU), each with `IntervalSec int`
- v2→v3 migration with a shape-sentinel guard (any blob carrying `advanced_scans` is treated as v3 regardless of `settings_version`) — defence-in-depth over the #273 version clamp
- 6 interval-picker widgets in the Advanced card: preset dropdown ("Use global (X)" with dynamic humanized global, 5m, 15m, 30m, 1h, 2h, 6h, 12h, 24h, 7d, Custom) + custom d/h/m/s panel + cron visualizer + reverse cron parser
- Client-side "are you sure" dialog when `SMART.IntervalSec > MaxAgeDays × 86400`
- PUT validation: `IntervalSec ∈ {0} ∪ [30, 2678400]`

**V2b (#260, PR #276)** — ScanDispatcher + per-subsystem Collect methods
- New `ScanDispatcher` deep module (Tick / MarkRan / FastestInterval / UpdateIntervals)
- 6 new public Collect* methods on `*Collector` (thin wrappers around existing internals)
- Scheduler main loop refactored: dispatcher-driven tick, per-tick INFO log summarising `due=[...] skipped=[...]`
- `StaleSMARTChecker` relocated from every global tick to post-CollectSMART; regression-guarded
- Optional `subsystem_last_ran` map exposed on `/api/v1/snapshot/latest` (backwards-compat via omitempty)
- 9 non-configurable subsystems (system, disks, network, logs, parity, UPS, update check, tunnels, backup) remain on global tick

### Prometheus exporter smoke-test harness — #255 Phase 1

**#274** — self-contained `scripts/prometheus-smoke/` directory
- docker-compose with Prometheus v3.1.0 + Grafana v11.4.0 auto-provisioned
- Bearer auth + CF Access `http_headers` in scrape config
- 21-panel baseline Grafana dashboard
- Env-var targetable (UAT default, local override)
- UAT scrape discovery clean: 75 metric families, zero missing HELP/TYPE, zero label-set inconsistencies, 48KB in 340ms
- **Phase 2 + Phase 3 remain tracked in #255** (out of this release's scope)

### v0.9.8 regression fix — #268 (via PR #273, already on main)

Frontend's `buildSettingsPayload()` now includes `settings_version` in the PUT body; backend preserves server-authoritative version via max-of-stored-and-incoming. Existing installs with corrupted `settings_version=0` self-heal on next save. 3 end-to-end guards + 3 root-cause detectors + 1 migration idempotency test.

## RC hotfixes (in stage branch before this merge)

- **rc1 → rc2**: `*/` inside a `/* */` JS block comment in `parseCronToFields`' docstring closed the comment early, breaking the entire `<script>` parse → `loadSettings()` / `renderAdvancedScanPickers()` / `loadDockerHiddenContainersCheckboxes()` all silently failed on UAT. Converted to `//` line comments. Added `TestSettingsTemplate_JSBlocksParse` that runs `node --check` on every `<script>` block (skips if node absent).
- **rc2 → rc3**:
  - Dispatcher `UpdateIntervals` and `SetGlobal` deleted `lastRun` on any interval change, causing SMART/K8s to fire incorrectly on the next tick after a user walked a picker dropdown and settled back on "Use global". Fix: preserve `lastRun`; the natural `elapsed >= interval` check handles all cases correctly. New regression test `TestScanDispatcher_UpdateIntervals_PickerWalkBackToUseGlobal` pins the exact UAT scenario.
  - Hardcoded `"Use global (30m)"` label ignored the user's configured global. Introduced `globalIntervalDisplay()` helper that reads `settings.scan_interval`; createIntervalPicker appends dynamic `(X)` suffix at render time.
- **rc3 → rc4**: humanized `"Use global (X)"` label — `parseIntervalDurationToFields` + `fieldsToIntervalDuration` pipeline turns "168h" → "7d", "25h" → "1d1h", etc.

## Testing

- `go test ./...` — all packages green including scheduler (with race), api (V2a migration + pickers + version roundtrip), collector (per-subsystem wrappers)
- `go vet ./...` — clean
- New tests shipped: 37 in V2b, 17 in V2a, 6 in #273, 1 JS-parse guard, 3 dispatcher regression tests, 1 dynamic-label regression test — **~65 net new tests**
- 4 RC cycles UAT-validated on a real Unraid Tower against Cloudflare Access

## Closes

- #259 (V2a) — shipped
- #260 (V2b) — shipped
- #268 (SMART wake_drives / max_age_days silently reverting on save) — shipped via PR #273

## Partially closes

- #255 Phase 1 — shipped. Phase 2 (CF Worker + Analytics Engine telemetry pipeline) and Phase 3 (auto-generated metric docs) remain tracked there.

## Stats

- 15 commits (merged via individual-PR → stage → squash)
- 3 workers dispatched in parallel: V2a + Phase 1 in Wave 1, V2b in Wave 2 (off stage)
- 4 RC cycles (rc1 UAT-red, rc2 UAT-red on new issue, rc3 UAT-red on polish, rc4 UAT-green)
- 1 stale community PR (#272) closed as superseded by #273