### PR TITLE
feat(speedtest): engine swap to showwin/speedtest-go with Ookla CLI fallback (#284)

### DIFF
--- a/demo-worker/feeder/src/index.ts
+++ b/demo-worker/feeder/src/index.ts
@@ -909,6 +909,13 @@ function buildSpeedTest(p: PlatformProfile): Record<string, unknown> {
       isp: t.isp,
       external_ip: "203.0.113." + (Math.abs(seed) % 200 + 10),
       result_url: "",
+      // PRD #283 / issue #284: every "fresh" feeder result is
+      // produced by the new speedtest-go engine. Pre-switchover
+      // historical rows are stamped 'ookla_cli' in
+      // buildSpeedTestHistory so the dashboard chart can mark the
+      // engine-switchover point on the demo (user story 22 —
+      // deterministic engine choice).
+      engine: "speedtest_go",
     },
     last_attempt: {
       timestamp: now,
@@ -929,6 +936,12 @@ function buildSpeedTestHistory(p: PlatformProfile, hours: number): unknown[] {
   const seed = hashStr(p.hostname + "-speedhist");
   const now = Date.now();
   const points: unknown[] = [];
+  // PRD #283 / issue #284 user story 15: historical chart marks the
+  // engine-switchover point. Half of the demo's 24h history is
+  // stamped 'ookla_cli' (the engine in use pre-#284), the more-recent
+  // half is stamped 'speedtest_go' (the new engine). Pivot point is
+  // hours/2 — older points are pre-switchover.
+  const pivot = Math.floor(hours / 2);
   // One sample per hour going back `hours`.
   for (let h = hours - 1; h >= 0; h--) {
     const ts = new Date(now - h * 3600000).toISOString();
@@ -937,6 +950,9 @@ function buildSpeedTestHistory(p: PlatformProfile, hours: number): unknown[] {
     const tod = new Date(now - h * 3600000).getUTCHours();
     const eveningDip = (tod >= 18 && tod <= 23) ? 0.85 : 1.0;
     const s = seed + h;
+    // h decreases as we move toward "now"; pre-switchover entries
+    // are the OLDER ones (h > pivot), so they get 'ookla_cli'.
+    const engine = h > pivot ? "ookla_cli" : "speedtest_go";
     points.push({
       timestamp: ts,
       download_mbps: round2(clamp(jitter(t.downloadMbps * eveningDip, 10, s), t.downloadMbps * 0.5, t.downloadMbps * 1.15)),
@@ -945,6 +961,7 @@ function buildSpeedTestHistory(p: PlatformProfile, hours: number): unknown[] {
       jitter_ms: round2(clamp(jitter(t.jitterMs, 50, s + 3), 0.1, t.jitterMs * 4)),
       server_name: t.serverName,
       isp: t.isp,
+      engine,
     });
   }
   return points;

--- a/demo-worker/feeder/src/widget-coverage.test.ts
+++ b/demo-worker/feeder/src/widget-coverage.test.ts
@@ -87,7 +87,9 @@ interface WidgetExpectation {
 
 const EXPECTED_WIDGETS: WidgetExpectation[] = [
   // sections.speedtest in dashboard.go L782 — reads
-  //   snapshot.speed_test.{available, latest.{download_mbps, upload_mbps, latency_ms, server_name, isp}, last_attempt.{status, timestamp}}
+  //   snapshot.speed_test.{available, latest.{download_mbps, upload_mbps, latency_ms, server_name, isp, engine}, last_attempt.{status, timestamp}}
+  // PRD #283 / issue #284: latest.engine added so the dashboard's
+  // "via {engine}" caption renders on every demo platform.
   {
     widget: "speed_test",
     requiredKeys: [
@@ -97,6 +99,7 @@ const EXPECTED_WIDGETS: WidgetExpectation[] = [
       "speed_test.latest.latency_ms",
       "speed_test.latest.server_name",
       "speed_test.latest.isp",
+      "speed_test.latest.engine",
       "speed_test.last_attempt.status",
       "speed_test.last_attempt.timestamp",
     ],
@@ -283,6 +286,23 @@ describe("demo feeder widget coverage", () => {
         validReasons.has(e.error_reason as string),
         `error_reason ${JSON.stringify(e.error_reason)} must be one of the dashboard's recognised categories`,
       ).toBe(true);
+    }
+  });
+
+  // ── Speed Test engine annotation (PRD #283 / issue #284) ──────────
+  // The dashboard's "via {engine}" caption + the historical chart's
+  // engine-switchover annotation both rely on the feeder emitting
+  // engine fields. Without these, the demo never showcases the
+  // engine-aware UX.
+
+  it("emits engine='speedtest_go' on snapshot.speed_test.latest for all platforms", () => {
+    for (const platform of ["unraid", "synology", "truenas", "proxmox", "kubernetes"] as Platform[]) {
+      const snap = transformSnapshot(SEED, PROFILES[platform], platform);
+      const engine = getPath(snap, "speed_test.latest.engine");
+      expect(
+        engine,
+        `${platform} snapshot.speed_test.latest.engine should be 'speedtest_go' to showcase the new primary engine`,
+      ).toBe("speedtest_go");
     }
   });
 });

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-chi/cors v1.2.2
 	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/showwin/speedtest-go v1.7.10
 	modernc.org/sqlite v1.48.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
+github.com/showwin/speedtest-go v1.7.10 h1:9o5zb7KsuzZKn+IE2//z5btLKJ870JwO6ETayUkqRFw=
+github.com/showwin/speedtest-go v1.7.10/go.mod h1:Ei7OCTmNPdWofMadzcfgq1rUO7mvJy9Jycj//G7vyfA=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -832,6 +832,16 @@ sections.speedtest = function(sn) {
     h += '<div style="font-size:11px;color:var(--text-quaternary);margin-bottom:8px">';
     if (r.server_name) h += 'Server: ' + esc(r.server_name) + ' &middot; ';
     if (r.isp) h += 'ISP: ' + esc(r.isp);
+    /* PRD #283 / issue #284: small "via {engine}" caption. Informational
+       not promotional — let users see which engine produced the latest
+       sample and contextualise the historical chart's pre/post-switchover
+       split. Closed engine set: "speedtest_go" → "speedtest-go", any
+       other → "Ookla CLI". */
+    if (r.engine) {
+      var engineLabel = r.engine === 'speedtest_go' ? 'speedtest-go' : 'Ookla CLI';
+      h += (r.server_name || r.isp) ? ' &middot; ' : '';
+      h += '<span data-speedtest-engine="' + esc(r.engine) + '">via ' + esc(engineLabel) + '</span>';
+    }
     h += '</div>';
     h += '<canvas id="speedtest-chart" style="width:100%;height:80px"></canvas>';
     h += '</div>'; /* close panel */

--- a/internal/api/dashboard_speedtest_engine_caption_test.go
+++ b/internal/api/dashboard_speedtest_engine_caption_test.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// extractSpeedtestSection returns the body of the
+// `sections.speedtest = function ...` declaration in DashboardJS.
+// Crude but sufficient: scan from the function declaration to the
+// next *top-level* sections.<name> = function declaration. The
+// previous heuristic (find next 'sections.') tripped on internal
+// helper references like `sections._rangeButtons(...)` and ended
+// the body too early.
+func extractSpeedtestSection(t *testing.T) string {
+	t.Helper()
+	js := DashboardJS
+	start := strings.Index(js, "sections.speedtest = function")
+	if start < 0 {
+		t.Fatal("DashboardJS: sections.speedtest function not found")
+	}
+	rest := js[start:]
+	// Use the next top-level "\nsections.<name> = function" declaration
+	// as the end bound — function-declaration lines always start at
+	// column 0 in DashboardJS.
+	end := strings.Index(rest[1:], "\nsections.")
+	if end < 0 {
+		end = len(rest)
+	} else {
+		end++
+	}
+	return rest[:end]
+}
+
+// PRD #283 / issue #284: the speed-test widget renders a small
+// "via {engine}" caption beside the existing latest-line, surfacing
+// which engine produced the most recent sample. Caption is informational
+// (not promotional) — small font, default text colour. The engine
+// label resolution: "speedtest_go" → "speedtest-go" (display form);
+// any other engine string → "Ookla CLI" (catches "ookla_cli" and
+// any future legacy values).
+//
+// This is a cross-reference test: it greps DashboardJS for the
+// caption invariants so a future refactor can't accidentally drop
+// the line without flagging.
+func TestDashboardJS_SpeedTestWidget_RendersEngineCaption(t *testing.T) {
+	body := extractSpeedtestSection(t)
+
+	// 1) Section must read r.engine from the latest result.
+	if !strings.Contains(body, "r.engine") {
+		t.Error("DashboardJS: speedtest section does not reference r.engine — caption regression")
+	}
+	// 2) The two human-readable engine labels must be present.
+	if !strings.Contains(body, "speedtest-go") {
+		t.Error("DashboardJS: speedtest section does not contain the 'speedtest-go' display label")
+	}
+	if !strings.Contains(body, "Ookla CLI") {
+		t.Error("DashboardJS: speedtest section does not contain the 'Ookla CLI' display label")
+	}
+	// 3) The caption must use the "via X" preposition so users see it
+	//    as informational rather than as a settings affordance. Match
+	//    the trailing-space literal "via " — emitted as part of the
+	//    span content (e.g. `>via ` + engineLabel).
+	if !strings.Contains(body, "via ") {
+		t.Error("DashboardJS: speedtest section does not render 'via …' caption text")
+	}
+	// 4) data-speedtest-engine attribute carries the raw engine value
+	//    (not the display label) so future Playwright UAT can pin
+	//    the actual engine without parsing display text.
+	if !strings.Contains(body, "data-speedtest-engine") {
+		t.Error("DashboardJS: speedtest section does not emit data-speedtest-engine attribute — automation hook missing")
+	}
+}
+
+// TestDashboardJS_SpeedTestWidget_EngineCaptionGracefulFallback
+// asserts the caption is gated on r.engine being truthy. Pre-#284
+// rows (no engine field) should not render an empty "via " caption —
+// the closure prefix-checks r.engine before emitting anything.
+func TestDashboardJS_SpeedTestWidget_EngineCaptionGracefulFallback(t *testing.T) {
+	body := extractSpeedtestSection(t)
+
+	// The if-gate on r.engine must come BEFORE the rendered "via "
+	// literal so pre-#284 rows (no engine field) skip the caption
+	// entirely. Find the FIRST string-emitting "via " — i.e. one
+	// adjacent to a quote character or angle bracket — to skip past
+	// the doc-comment's "via {engine}" text reference.
+	guardIdx := strings.Index(body, "if (r.engine)")
+	if guardIdx < 0 {
+		t.Fatal("DashboardJS: 'if (r.engine)' guard missing — empty Engine field would render bare 'via undefined'")
+	}
+	// Search for a "via " that follows the guard.
+	postGuard := body[guardIdx:]
+	viaIdx := strings.Index(postGuard, "via ")
+	if viaIdx < 0 {
+		t.Error("DashboardJS: no 'via ' literal emitted within the r.engine-guarded block")
+	}
+}

--- a/internal/collector/speedtest.go
+++ b/internal/collector/speedtest.go
@@ -1,28 +1,84 @@
 package collector
 
 import (
+	"context"
 	"encoding/json"
 	"os/exec"
+	"sync"
 	"time"
 
 	internal "github.com/mcdays94/nas-doctor/internal"
 )
 
+// defaultRunner is the lazily-constructed composite runner used by the
+// package-level RunSpeedTest entry point. Tests that want to drive a
+// deterministic engine call SetSpeedTestRunnerForTest before invoking
+// RunSpeedTest, and reset it afterwards. Production wiring (scheduler
+// + Test endpoint) typically calls RunSpeedTest directly which lazy-
+// constructs the production composite the first time.
+var (
+	defaultSpeedTestRunner   SpeedTestRunner
+	defaultSpeedTestRunnerMu sync.Mutex
+)
+
+// runSpeedTestEntry is the shared entry point used by both RunSpeedTest
+// (the legacy public API) and any future caller that wants direct
+// access to the composite runner. Slice 1 keeps the public API
+// unchanged: a nil result still means "no engine produced a usable
+// result". Slice 2 will introduce a richer entrypoint that exposes the
+// sample channel to the LiveTestRegistry.
+func runSpeedTestEntry(ctx context.Context) *internal.SpeedTestResult {
+	defaultSpeedTestRunnerMu.Lock()
+	r := defaultSpeedTestRunner
+	if r == nil {
+		r = NewCompositeSpeedTestRunner(NewSpeedTestGoRunner(), NewOoklaCLIRunner())
+		defaultSpeedTestRunner = r
+	}
+	defaultSpeedTestRunnerMu.Unlock()
+
+	res, samples, err := r.Run(ctx)
+	// Drain-and-discard the sample channel: slice 1 has no consumer
+	// for these. Slice 2 will fan them out to LiveTestRegistry. A nil
+	// channel (error path) is safe to ignore.
+	if samples != nil {
+		go func() {
+			for range samples {
+			}
+		}()
+	}
+	if err != nil || res == nil {
+		return nil
+	}
+	return res
+}
+
+// SetSpeedTestRunnerForTest swaps the package-level default runner.
+// Test-only — not intended for production wiring (which constructs
+// the composite at startup via NewCompositeSpeedTestRunner).
+func SetSpeedTestRunnerForTest(r SpeedTestRunner) func() {
+	defaultSpeedTestRunnerMu.Lock()
+	prev := defaultSpeedTestRunner
+	defaultSpeedTestRunner = r
+	defaultSpeedTestRunnerMu.Unlock()
+	return func() {
+		defaultSpeedTestRunnerMu.Lock()
+		defaultSpeedTestRunner = prev
+		defaultSpeedTestRunnerMu.Unlock()
+	}
+}
+
 // RunSpeedTest executes a network speed test and returns the result.
-// Supports Ookla speedtest-cli (preferred) and speedtest-go as fallback.
-// This should be called on its own schedule (not during every scan).
+// As of issue #284 (PRD #283 slice 1), this delegates to the
+// SpeedTestRunner composite which prefers showwin/speedtest-go and
+// falls back to the bundled Ookla CLI on error. The returned result
+// has its Engine field populated identifying which engine produced
+// it ("speedtest_go" or "ookla_cli").
+//
+// On total failure (both engines unavailable / zero throughput) this
+// still returns nil — preserving the v0.9.6 #210 caller contract that
+// a nil result means "report failed attempt, do not write history".
 func RunSpeedTest() *internal.SpeedTestResult {
-	// Try Ookla speedtest CLI first (speedtest --format=json)
-	if result := runOoklaSpeedtest(); result != nil {
-		return result
-	}
-
-	// Try speedtest-cli (Python-based, --json flag)
-	if result := runSpeedtestCLI(); result != nil {
-		return result
-	}
-
-	return nil
+	return runSpeedTestEntry(context.Background())
 }
 
 // ---------- Ookla speedtest CLI ----------

--- a/internal/collector/speedtest_go_lib.go
+++ b/internal/collector/speedtest_go_lib.go
@@ -1,0 +1,104 @@
+// Package collector — speedtest_go_lib.go is the thin adapter from
+// showwin/speedtest-go's API surface onto our speedTestEngine
+// interface.
+//
+// This file is deliberately unit-test-thin: it does real network I/O.
+// The runner-level tests in speedtest_runner_test.go drive a fake
+// engine instead. Slice 2 (#285) will introduce per-sample callbacks
+// here via showwin's task-callback hooks; slice 1 just emits the
+// final aggregate and an empty samples channel.
+package collector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	internal "github.com/mcdays94/nas-doctor/internal"
+	"github.com/showwin/speedtest-go/speedtest"
+)
+
+// runSpeedtestGoLibrary fetches the closest server, runs the three
+// phases sequentially, and returns the composed SpeedTestResult. The
+// samples channel is created and closed empty in slice 1 — slice 2
+// will hook showwin's per-sample callbacks (PingTestContext,
+// DownloadTestContext, UploadTestContext) and emit live samples
+// before returning the channel.
+//
+// Errors propagate verbatim (the runner layer wraps them). Defense-
+// in-depth zero-throughput guard mirrors the legacy Ookla-CLI path —
+// returning a result with download==upload==0 would corrupt the
+// dashboard's "Latest" widget.
+func runSpeedtestGoLibrary(ctx context.Context) (*internal.SpeedTestResult, <-chan SpeedTestSample, error) {
+	client := speedtest.New()
+	if _, err := client.FetchUserInfo(); err != nil {
+		return nil, nil, fmt.Errorf("fetch user info: %w", err)
+	}
+	servers, err := client.FetchServers()
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetch servers: %w", err)
+	}
+	targets, err := servers.FindServer([]int{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("find server: %w", err)
+	}
+	if len(targets) == 0 {
+		return nil, nil, errors.New("no speedtest servers available")
+	}
+	srv := targets[0]
+
+	// Bound the entire test by the outer context so a stuck phase
+	// can't hang the scheduler. 120s mirrors the legacy Ookla CLI
+	// timeout in speedtest.go.
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 120*time.Second)
+		defer cancel()
+	}
+
+	if err := srv.PingTestContext(ctx, nil); err != nil {
+		return nil, nil, fmt.Errorf("ping: %w", err)
+	}
+	if err := srv.DownloadTestContext(ctx); err != nil {
+		return nil, nil, fmt.Errorf("download: %w", err)
+	}
+	if err := srv.UploadTestContext(ctx); err != nil {
+		return nil, nil, fmt.Errorf("upload: %w", err)
+	}
+
+	dlMbps := srv.DLSpeed.Mbps()
+	ulMbps := srv.ULSpeed.Mbps()
+	if dlMbps == 0 && ulMbps == 0 {
+		return nil, nil, errors.New("speedtest-go returned zero throughput on both phases")
+	}
+
+	// Parse server ID. showwin stores it as a string; our model uses
+	// int. Best-effort — we don't fail the test if this can't parse.
+	serverID, _ := strconv.Atoi(srv.ID)
+
+	res := &internal.SpeedTestResult{
+		Timestamp:    time.Now(),
+		DownloadMbps: dlMbps,
+		UploadMbps:   ulMbps,
+		LatencyMs:    float64(srv.Latency) / float64(time.Millisecond),
+		JitterMs:     float64(srv.Jitter) / float64(time.Millisecond),
+		ServerName:   srv.Name,
+		ServerID:     serverID,
+		ISP:          firstNonEmpty(client.User.Isp, srv.Sponsor),
+		ExternalIP:   client.User.IP,
+	}
+	samples := make(chan SpeedTestSample)
+	close(samples)
+	return res, samples, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/collector/speedtest_runner.go
+++ b/internal/collector/speedtest_runner.go
@@ -1,0 +1,255 @@
+// Package collector — speedtest_runner.go introduces the SpeedTestRunner
+// deep-module abstraction that PRD #283 (issue #284) calls for: a single
+// interface with two production implementations (showwin/speedtest-go +
+// Ookla CLI fallback) wrapped in a composite that prefers the primary
+// and falls back on error.
+//
+// Design mirrors internal/collector/borg_runner.go (v0.9.10 / issue
+// #279) verbatim — interface in this file, production impls behind a
+// constructor, fakeable engine for tests, contract tests pinning the
+// (result, samples, err) tuple invariant.
+//
+// Slice 1 of the PRD (this issue) returns a sample channel that is
+// drained-and-discarded by RunSpeedTest. Slice 2 (#285) wires it to a
+// LiveTestRegistry for SSE fan-out. Defining the channel return now
+// keeps the slices independently shippable without re-shaping the
+// interface later.
+package collector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	internal "github.com/mcdays94/nas-doctor/internal"
+)
+
+// SpeedTestPhase enumerates the three test phases. Stable string values
+// — they are emitted on the SSE wire in slice 2 and persisted into
+// speedtest_samples.phase in slice 3.
+type SpeedTestPhase string
+
+const (
+	SpeedTestPhaseLatency  SpeedTestPhase = "latency"
+	SpeedTestPhaseDownload SpeedTestPhase = "download"
+	SpeedTestPhaseUpload   SpeedTestPhase = "upload"
+)
+
+// SpeedTestSample is a single in-flight sample emitted during a test.
+// The sample-channel return type is wired through every runner impl in
+// slice 1 but is drained-and-discarded by the scheduler for now;
+// slice 2 (#285) feeds these to LiveTestRegistry's broadcast fan-out.
+//
+// Fields are intentionally a superset of what any one phase needs —
+// LatencyMs is meaningful for latency-phase samples, Mbps for
+// download/upload-phase samples. Zero values are valid and unambiguous.
+type SpeedTestSample struct {
+	Phase     SpeedTestPhase
+	At        time.Time
+	Mbps      float64
+	LatencyMs float64
+}
+
+// SpeedTestRunner is the engine-agnostic interface that
+// internal/collector.RunSpeedTest delegates to. Three implementations:
+//   - speedtestGoRunner: showwin/speedtest-go primary path. Stamps
+//     Engine="speedtest_go" on the result.
+//   - ooklaCLIRunner: bundled Ookla CLI fallback path. Stamps
+//     Engine="ookla_cli". Sample channel always closes empty in
+//     slice 1 — the CLI emits final-only JSON and there's no useful
+//     per-sample telemetry to surface.
+//   - compositeRunner: tries primary, falls back on error.
+//
+// Contract:
+//   - On success: result is non-nil, samples is a non-nil channel that
+//     EVENTUALLY closes (caller MUST drain it or leak a goroutine), err
+//     is nil.
+//   - On failure: result is nil, samples is nil (no leak risk), err is
+//     non-nil.
+//
+// See speedtest_runner_test.go for the contract tests pinning the
+// invariant against every impl.
+type SpeedTestRunner interface {
+	Run(ctx context.Context) (*internal.SpeedTestResult, <-chan SpeedTestSample, error)
+}
+
+// speedTestEngine is the swappable inner-loop driver that the
+// production speedtest-go and Ookla-CLI runners delegate to. Tests
+// inject a fakeSpeedTestEngine to exercise every result/error branch
+// without going to the network. Production wiring (in this file)
+// constructs the real engine at startup and never swaps it.
+type speedTestEngine interface {
+	Run(ctx context.Context) (*internal.SpeedTestResult, <-chan SpeedTestSample, error)
+}
+
+// ---------- speedtestGoRunner ----------
+
+// speedtestGoRunner is the primary engine — showwin/speedtest-go. It
+// supports per-sample callbacks during each phase, which is exactly
+// what slice 2's LiveTestRegistry needs. Slice 1 ignores the samples
+// (drains the channel and discards) but the runner still emits them
+// so slice 2 doesn't reshape the interface.
+type speedtestGoRunner struct {
+	engine speedTestEngine
+}
+
+// newSpeedTestGoRunnerWithEngine constructs a speedtestGoRunner with
+// an explicit engine (for tests). Production callers use
+// NewSpeedTestGoRunner which wires the real upstream library.
+func newSpeedTestGoRunnerWithEngine(engine speedTestEngine) SpeedTestRunner {
+	return &speedtestGoRunner{engine: engine}
+}
+
+// NewSpeedTestGoRunner returns the production speedtestGoRunner backed
+// by the showwin/speedtest-go library. Returns nil if the library is
+// not available at runtime (e.g. older binaries without the dep) — the
+// composite gracefully degrades to fallback-only when its primary is
+// nil.
+func NewSpeedTestGoRunner() SpeedTestRunner {
+	return newSpeedTestGoRunnerWithEngine(newRealSpeedTestGoEngine())
+}
+
+func (r *speedtestGoRunner) Run(ctx context.Context) (*internal.SpeedTestResult, <-chan SpeedTestSample, error) {
+	if r.engine == nil {
+		return nil, nil, errors.New("speedtestGoRunner: engine is nil")
+	}
+	res, samples, err := r.engine.Run(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if res == nil {
+		return nil, nil, errors.New("speedtestGoRunner: engine returned nil result without error")
+	}
+	res.Engine = internal.SpeedTestEngineSpeedTestGo
+	return res, samples, nil
+}
+
+// ---------- ooklaCLIRunner ----------
+
+// ooklaCLIRunner is the fallback engine — the bundled Ookla CLI binary
+// at /usr/local/bin/speedtest. The CLI emits final-only JSON; the
+// sample channel always closes empty for this engine in slice 1.
+type ooklaCLIRunner struct {
+	engine speedTestEngine
+}
+
+func newOoklaCLIRunnerWithEngine(engine speedTestEngine) SpeedTestRunner {
+	return &ooklaCLIRunner{engine: engine}
+}
+
+// NewOoklaCLIRunner returns the production ooklaCLIRunner backed by
+// the existing internal.runOoklaSpeedtest path. Slice 1 wraps the
+// legacy text-mode invocation as an engine adapter so the runner
+// surface is uniform.
+func NewOoklaCLIRunner() SpeedTestRunner {
+	return newOoklaCLIRunnerWithEngine(newRealOoklaCLIEngine())
+}
+
+func (r *ooklaCLIRunner) Run(ctx context.Context) (*internal.SpeedTestResult, <-chan SpeedTestSample, error) {
+	if r.engine == nil {
+		return nil, nil, errors.New("ooklaCLIRunner: engine is nil")
+	}
+	res, samples, err := r.engine.Run(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if res == nil {
+		return nil, nil, errors.New("ooklaCLIRunner: engine returned nil result without error")
+	}
+	res.Engine = internal.SpeedTestEngineOoklaCLI
+	return res, samples, nil
+}
+
+// ---------- compositeRunner ----------
+
+// compositeRunner tries primary first and falls back to secondary on
+// error. Either may be nil — a nil primary degrades to fallback-only.
+// If both are nil, every Run() call returns an error (no engine
+// available); if both fail at runtime, the most recent (fallback)
+// error is wrapped with the primary error in its message so the
+// scheduler log can show both.
+type compositeRunner struct {
+	primary  SpeedTestRunner
+	fallback SpeedTestRunner
+}
+
+// NewCompositeSpeedTestRunner constructs the composite. Production
+// wiring (cmd/nas-doctor/main.go) passes NewSpeedTestGoRunner() and
+// NewOoklaCLIRunner(); tests pass deterministic fakes.
+func NewCompositeSpeedTestRunner(primary, fallback SpeedTestRunner) SpeedTestRunner {
+	return &compositeRunner{primary: primary, fallback: fallback}
+}
+
+func (r *compositeRunner) Run(ctx context.Context) (*internal.SpeedTestResult, <-chan SpeedTestSample, error) {
+	if r.primary == nil && r.fallback == nil {
+		return nil, nil, errors.New("compositeRunner: no engines configured")
+	}
+	var primaryErr error
+	if r.primary != nil {
+		res, samples, err := r.primary.Run(ctx)
+		if err == nil {
+			return res, samples, nil
+		}
+		primaryErr = err
+	}
+	if r.fallback == nil {
+		return nil, nil, fmt.Errorf("primary failed and no fallback configured: %w", primaryErr)
+	}
+	res, samples, err := r.fallback.Run(ctx)
+	if err == nil {
+		return res, samples, nil
+	}
+	if primaryErr != nil {
+		return nil, nil, fmt.Errorf("both engines failed: primary=%v, fallback=%w", primaryErr, err)
+	}
+	return nil, nil, err
+}
+
+// ---------- Engine adapters (production) ----------
+
+// realSpeedTestGoEngine wraps showwin/speedtest-go and adapts its API
+// to the speedTestEngine interface. Per-server iteration is
+// flattened: we pick the first server returned by FindServer (the
+// closest match), run latency/download/upload, and return the
+// composed SpeedTestResult.
+//
+// Slice 1: samples channel is closed before return — slice 2 will
+// stream per-phase samples via the runner's existing showwin
+// callbacks.
+type realSpeedTestGoEngine struct {
+	// guard: zero-value usable, but this lock is mostly here to make
+	// the engine fail-fast obvious if a future caller accidentally
+	// shares the engine across goroutines.
+	mu sync.Mutex
+}
+
+func newRealSpeedTestGoEngine() speedTestEngine {
+	return &realSpeedTestGoEngine{}
+}
+
+func (e *realSpeedTestGoEngine) Run(ctx context.Context) (*internal.SpeedTestResult, <-chan SpeedTestSample, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return runSpeedtestGoLibrary(ctx)
+}
+
+// realOoklaCLIEngine adapts the legacy runOoklaSpeedtest path (the
+// text-mode JSON parse) to the speedTestEngine interface. The sample
+// channel always closes empty for this engine in slice 1.
+type realOoklaCLIEngine struct{}
+
+func newRealOoklaCLIEngine() speedTestEngine {
+	return &realOoklaCLIEngine{}
+}
+
+func (e *realOoklaCLIEngine) Run(_ context.Context) (*internal.SpeedTestResult, <-chan SpeedTestSample, error) {
+	res := runOoklaSpeedtest()
+	if res == nil {
+		return nil, nil, errors.New("ooklaCLIRunner: speedtest CLI unavailable or returned zero throughput")
+	}
+	ch := make(chan SpeedTestSample)
+	close(ch)
+	return res, ch, nil
+}

--- a/internal/collector/speedtest_runner_test.go
+++ b/internal/collector/speedtest_runner_test.go
@@ -1,0 +1,352 @@
+package collector
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	internal "github.com/mcdays94/nas-doctor/internal"
+)
+
+// fakeSpeedTestEngine is the test double used to drive the runner
+// implementations through their entire surface — happy path, error
+// path, and the deterministic-sample emission used by slice 2's
+// LiveTestRegistry. The result/samples/err triplet returned by Run()
+// mirrors the SpeedTestRunner interface contract verbatim: either a
+// non-nil result + a sample channel that eventually closes, or a nil
+// result + nil channel + non-nil error.
+type fakeSpeedTestEngine struct {
+	result  *internal.SpeedTestResult
+	samples []SpeedTestSample
+	err     error
+	calls   int
+	mu      sync.Mutex
+}
+
+func (f *fakeSpeedTestEngine) Run(ctx context.Context) (*internal.SpeedTestResult, <-chan SpeedTestSample, error) {
+	f.mu.Lock()
+	f.calls++
+	f.mu.Unlock()
+	if f.err != nil {
+		return nil, nil, f.err
+	}
+	ch := make(chan SpeedTestSample, len(f.samples))
+	for _, s := range f.samples {
+		ch <- s
+	}
+	close(ch)
+	return f.result, ch, nil
+}
+
+func (f *fakeSpeedTestEngine) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// drainSamples reads all SpeedTestSample values from a channel until
+// it closes or the timeout elapses. Used by the contract tests to
+// confirm the channel terminates cleanly without leaks.
+func drainSamples(t *testing.T, ch <-chan SpeedTestSample, timeout time.Duration) []SpeedTestSample {
+	t.Helper()
+	var out []SpeedTestSample
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	for {
+		select {
+		case s, ok := <-ch:
+			if !ok {
+				return out
+			}
+			out = append(out, s)
+		case <-deadline.C:
+			t.Fatalf("samples channel did not close within %s", timeout)
+			return out
+		}
+	}
+}
+
+// ---------- Contract tests ----------
+
+// TestSpeedTestRunner_Contract_SuccessPath_SampleChannelEventuallyCloses
+// asserts the contract's success branch: every implementation must
+// return (non-nil result, sample channel that eventually closes, nil
+// error). Run against every concrete impl + the composite to guard
+// the interface invariant.
+func TestSpeedTestRunner_Contract_SuccessPath_SampleChannelEventuallyCloses(t *testing.T) {
+	successResult := &internal.SpeedTestResult{
+		DownloadMbps: 100, UploadMbps: 10, LatencyMs: 5, ServerName: "Test",
+		Engine: internal.SpeedTestEngineSpeedTestGo,
+	}
+	successSamples := []SpeedTestSample{
+		{Phase: SpeedTestPhaseDownload, Mbps: 90, At: time.Now()},
+		{Phase: SpeedTestPhaseDownload, Mbps: 99, At: time.Now()},
+	}
+	cases := []struct {
+		name   string
+		runner SpeedTestRunner
+	}{
+		{
+			name: "speedtestGoRunner_with_fakeEngine",
+			runner: newSpeedTestGoRunnerWithEngine(&fakeSpeedTestEngine{
+				result: successResult, samples: successSamples,
+			}),
+		},
+		{
+			name: "ooklaCLIRunner_with_fakeEngine",
+			runner: newOoklaCLIRunnerWithEngine(&fakeSpeedTestEngine{
+				result: successResult, samples: nil,
+			}),
+		},
+		{
+			name: "compositeRunner_primarySucceeds",
+			runner: NewCompositeSpeedTestRunner(
+				newSpeedTestGoRunnerWithEngine(&fakeSpeedTestEngine{result: successResult, samples: successSamples}),
+				newOoklaCLIRunnerWithEngine(&fakeSpeedTestEngine{result: nil, err: errors.New("should not be called")}),
+			),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			res, samples, err := tc.runner.Run(ctx)
+			if err != nil {
+				t.Fatalf("Run() unexpected error: %v", err)
+			}
+			if res == nil {
+				t.Fatal("Run() result is nil on success branch")
+			}
+			if samples == nil {
+				t.Fatal("Run() samples channel is nil on success branch — slice 2 will require this")
+			}
+			drainSamples(t, samples, 2*time.Second)
+		})
+	}
+}
+
+// TestSpeedTestRunner_Contract_ErrorPath_NoChannelLeak asserts the
+// contract's error branch: every impl must return (nil, nil, err)
+// when the underlying engine errors. A returned-but-unclosed channel
+// would leak a goroutine in production (slice 2's LiveTestRegistry
+// fan-out goroutine would block forever). Returning nil avoids that
+// class of bug entirely.
+func TestSpeedTestRunner_Contract_ErrorPath_NoChannelLeak(t *testing.T) {
+	failingEngine := func() *fakeSpeedTestEngine {
+		return &fakeSpeedTestEngine{err: errors.New("engine boom")}
+	}
+	cases := []struct {
+		name   string
+		runner SpeedTestRunner
+	}{
+		{"speedtestGoRunner", newSpeedTestGoRunnerWithEngine(failingEngine())},
+		{"ooklaCLIRunner", newOoklaCLIRunnerWithEngine(failingEngine())},
+		{"compositeRunner_bothFail", NewCompositeSpeedTestRunner(
+			newSpeedTestGoRunnerWithEngine(failingEngine()),
+			newOoklaCLIRunnerWithEngine(failingEngine()),
+		)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			res, samples, err := tc.runner.Run(ctx)
+			if err == nil {
+				t.Fatal("Run() expected non-nil error on engine failure")
+			}
+			if res != nil {
+				t.Errorf("Run() result must be nil on error; got %+v", res)
+			}
+			if samples != nil {
+				t.Errorf("Run() samples channel must be nil on error; got non-nil — would leak in slice 2")
+			}
+		})
+	}
+}
+
+// ---------- speedtestGoRunner ----------
+
+// TestSpeedTestGoRunner_HappyPath_StampsSpeedTestGoEngine asserts that
+// a successful run via the speedtest-go engine returns a result whose
+// Engine field is "speedtest_go" (constant SpeedTestEngineSpeedTestGo).
+// This is the column value persisted to speedtest_history.engine.
+func TestSpeedTestGoRunner_HappyPath_StampsSpeedTestGoEngine(t *testing.T) {
+	engine := &fakeSpeedTestEngine{
+		result: &internal.SpeedTestResult{DownloadMbps: 500, UploadMbps: 50, LatencyMs: 8},
+	}
+	runner := newSpeedTestGoRunnerWithEngine(engine)
+	res, samples, err := runner.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if res.Engine != internal.SpeedTestEngineSpeedTestGo {
+		t.Errorf("Engine = %q, want %q", res.Engine, internal.SpeedTestEngineSpeedTestGo)
+	}
+	drainSamples(t, samples, time.Second)
+	if engine.callCount() != 1 {
+		t.Errorf("engine called %d times, want 1", engine.callCount())
+	}
+}
+
+// TestSpeedTestGoRunner_DeterministicSamplesPreservedInOrder asserts
+// that samples emitted by the underlying engine pass through the
+// runner in order. Slice 2's LiveTestRegistry depends on this for
+// per-sample replay correctness.
+func TestSpeedTestGoRunner_DeterministicSamplesPreservedInOrder(t *testing.T) {
+	now := time.Now()
+	want := []SpeedTestSample{
+		{Phase: SpeedTestPhaseLatency, At: now, LatencyMs: 7.0},
+		{Phase: SpeedTestPhaseDownload, At: now.Add(time.Second), Mbps: 100},
+		{Phase: SpeedTestPhaseDownload, At: now.Add(2 * time.Second), Mbps: 200},
+		{Phase: SpeedTestPhaseUpload, At: now.Add(3 * time.Second), Mbps: 50},
+	}
+	engine := &fakeSpeedTestEngine{
+		result:  &internal.SpeedTestResult{DownloadMbps: 200, UploadMbps: 50, LatencyMs: 7},
+		samples: want,
+	}
+	runner := newSpeedTestGoRunnerWithEngine(engine)
+	_, samplesCh, err := runner.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	got := drainSamples(t, samplesCh, time.Second)
+	if len(got) != len(want) {
+		t.Fatalf("sample count: got %d, want %d", len(got), len(want))
+	}
+	for i, w := range want {
+		if got[i].Phase != w.Phase || got[i].Mbps != w.Mbps {
+			t.Errorf("sample[%d]: got %+v, want %+v", i, got[i], w)
+		}
+	}
+}
+
+// ---------- ooklaCLIRunner ----------
+
+// TestOoklaCLIRunner_HappyPath_StampsOoklaCLIEngine asserts that the
+// CLI fallback runner stamps Engine="ookla_cli" on the result, and
+// returns a sample channel that closes (slice 1: with no samples;
+// slice 2 may add server-pick / phase-transition synthetic samples).
+func TestOoklaCLIRunner_HappyPath_StampsOoklaCLIEngine(t *testing.T) {
+	engine := &fakeSpeedTestEngine{
+		result: &internal.SpeedTestResult{DownloadMbps: 80, UploadMbps: 8, LatencyMs: 25},
+	}
+	runner := newOoklaCLIRunnerWithEngine(engine)
+	res, samples, err := runner.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if res.Engine != internal.SpeedTestEngineOoklaCLI {
+		t.Errorf("Engine = %q, want %q", res.Engine, internal.SpeedTestEngineOoklaCLI)
+	}
+	drainSamples(t, samples, time.Second)
+}
+
+// ---------- compositeRunner ----------
+
+// TestCompositeRunner_PrimarySucceeds_FallbackNotInvoked asserts the
+// composite's normal path: when the primary (speedtest-go) succeeds,
+// the fallback (Ookla CLI) is never called and the result stamps
+// speedtest_go.
+func TestCompositeRunner_PrimarySucceeds_FallbackNotInvoked(t *testing.T) {
+	primaryEng := &fakeSpeedTestEngine{result: &internal.SpeedTestResult{DownloadMbps: 100}}
+	fallbackEng := &fakeSpeedTestEngine{err: errors.New("should not be called")}
+	composite := NewCompositeSpeedTestRunner(
+		newSpeedTestGoRunnerWithEngine(primaryEng),
+		newOoklaCLIRunnerWithEngine(fallbackEng),
+	)
+	res, samples, err := composite.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if res.Engine != internal.SpeedTestEngineSpeedTestGo {
+		t.Errorf("Engine = %q, want speedtest_go (primary)", res.Engine)
+	}
+	drainSamples(t, samples, time.Second)
+	if fallbackEng.callCount() != 0 {
+		t.Errorf("fallback called %d times, want 0 — fallback must NOT run when primary succeeds", fallbackEng.callCount())
+	}
+}
+
+// TestCompositeRunner_PrimaryFails_FallbackTakesOver asserts the
+// resilience case: primary errors → fallback runs → result stamps
+// ookla_cli. This is the scenario where the bundled Alpine
+// speedtest-go has trouble (network policy, broken upstream, etc.)
+// and we still want a usable result on the dashboard.
+func TestCompositeRunner_PrimaryFails_FallbackTakesOver(t *testing.T) {
+	primaryEng := &fakeSpeedTestEngine{err: errors.New("primary boom")}
+	fallbackResult := &internal.SpeedTestResult{DownloadMbps: 80, UploadMbps: 8, LatencyMs: 25}
+	fallbackEng := &fakeSpeedTestEngine{result: fallbackResult}
+	composite := NewCompositeSpeedTestRunner(
+		newSpeedTestGoRunnerWithEngine(primaryEng),
+		newOoklaCLIRunnerWithEngine(fallbackEng),
+	)
+	res, samples, err := composite.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run() unexpected error after fallback success: %v", err)
+	}
+	if res == nil {
+		t.Fatal("Run() result is nil but fallback produced a result")
+	}
+	if res.Engine != internal.SpeedTestEngineOoklaCLI {
+		t.Errorf("Engine = %q, want ookla_cli (fallback path)", res.Engine)
+	}
+	drainSamples(t, samples, time.Second)
+	if primaryEng.callCount() != 1 {
+		t.Errorf("primary called %d times, want 1", primaryEng.callCount())
+	}
+	if fallbackEng.callCount() != 1 {
+		t.Errorf("fallback called %d times, want 1", fallbackEng.callCount())
+	}
+}
+
+// TestCompositeRunner_BothEnginesFail_PropagatesError asserts that
+// when both engines error, the composite returns a non-nil error
+// (the fallback's, since it ran most recently) and a nil result. The
+// scheduler currently treats a nil result as "no speedtest tool
+// available" — a non-nil error here gives slice 2 a richer signal
+// without changing slice 1 semantics.
+func TestCompositeRunner_BothEnginesFail_PropagatesError(t *testing.T) {
+	primaryEng := &fakeSpeedTestEngine{err: errors.New("primary failed")}
+	fallbackEng := &fakeSpeedTestEngine{err: errors.New("fallback failed too")}
+	composite := NewCompositeSpeedTestRunner(
+		newSpeedTestGoRunnerWithEngine(primaryEng),
+		newOoklaCLIRunnerWithEngine(fallbackEng),
+	)
+	res, samples, err := composite.Run(context.Background())
+	if err == nil {
+		t.Fatal("Run() expected non-nil error when both engines fail")
+	}
+	if res != nil {
+		t.Errorf("Run() result must be nil when both engines fail; got %+v", res)
+	}
+	if samples != nil {
+		t.Error("Run() samples channel must be nil when both engines fail")
+	}
+	if !strings.Contains(err.Error(), "fallback failed too") && !strings.Contains(err.Error(), "primary failed") {
+		t.Errorf("error must mention an underlying engine failure; got %v", err)
+	}
+}
+
+// TestCompositeRunner_NilPrimary_DegradesToFallbackOnly guards a
+// configuration edge case: if a deployment opts out of speedtest-go
+// (e.g. disabled at compile time, or not registered at startup), the
+// composite must still work with only a fallback. Same shape as the
+// "primary errored" case from a behavioural standpoint.
+func TestCompositeRunner_NilPrimary_DegradesToFallbackOnly(t *testing.T) {
+	fallbackEng := &fakeSpeedTestEngine{result: &internal.SpeedTestResult{DownloadMbps: 80}}
+	composite := NewCompositeSpeedTestRunner(
+		nil,
+		newOoklaCLIRunnerWithEngine(fallbackEng),
+	)
+	res, samples, err := composite.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if res.Engine != internal.SpeedTestEngineOoklaCLI {
+		t.Errorf("Engine = %q, want ookla_cli", res.Engine)
+	}
+	drainSamples(t, samples, time.Second)
+}

--- a/internal/demo/demo.go
+++ b/internal/demo/demo.go
@@ -622,6 +622,11 @@ func demoSpeedTest() *internal.SpeedTestInfo {
 			JitterMs:     1.2,
 			ServerName:   "Lisbon",
 			ISP:          "MEO",
+			// PRD #283 / issue #284: stamp the engine so the
+			// captured `--demo` snapshot exposes the new "via …"
+			// caption when the feeder uses it as a fallback before
+			// transformSnapshot's per-platform overlay runs.
+			Engine: internal.SpeedTestEngineSpeedTestGo,
 		},
 	}
 }

--- a/internal/models.go
+++ b/internal/models.go
@@ -674,7 +674,24 @@ type SpeedTestResult struct {
 	ISP          string    `json:"isp"`
 	ExternalIP   string    `json:"external_ip"`
 	ResultURL    string    `json:"result_url,omitempty"` // speedtest.net result link
+	// Engine identifies which speed-test engine produced this result.
+	// Closed set: SpeedTestEngineSpeedTestGo ("speedtest_go") for the
+	// showwin/speedtest-go primary path, SpeedTestEngineOoklaCLI
+	// ("ookla_cli") for the bundled Ookla CLI fallback path. See PRD
+	// #283 / issue #284 for the engine-swap rationale and the
+	// historical chart's "engine switchover" annotation. Persisted to
+	// speedtest_history.engine.
+	Engine string `json:"engine,omitempty"`
 }
+
+// Speed-test engine identifier constants. Values are stable strings —
+// they are persisted into speedtest_history.engine and exported as the
+// nasdoctor_speedtest_engine{engine="…"} Prometheus label, so renaming
+// them is a breaking change. See issue #284.
+const (
+	SpeedTestEngineSpeedTestGo = "speedtest_go"
+	SpeedTestEngineOoklaCLI    = "ookla_cli"
+)
 
 // ---------- ZFS ----------
 

--- a/internal/notifier/prometheus.go
+++ b/internal/notifier/prometheus.go
@@ -139,6 +139,13 @@ type Metrics struct {
 	speedtestDownload prometheus.Gauge
 	speedtestUpload   prometheus.Gauge
 	speedtestLatency  prometheus.Gauge
+	// nasdoctor_speedtest_engine{engine="speedtest_go|ookla_cli"} — 1
+	// for the engine that produced the most recent successful test, 0
+	// otherwise. PRD #283 / issue #284. Gauge, not counter, because we
+	// only need point-in-time visibility (Prometheus operators use
+	// `nasdoctor_speedtest_engine == 1` to graph engine-in-use over
+	// time). Stays at 0 until at least one test produces a result.
+	speedtestEngine *prometheus.GaugeVec
 
 	// ── GPU ──
 	gpuUsagePct    *prometheus.GaugeVec
@@ -336,6 +343,7 @@ func NewMetrics() *Metrics {
 	m.speedtestDownload = gauge(ns, "speedtest", "download_mbps", "Latest speed test download in Mbps")
 	m.speedtestUpload = gauge(ns, "speedtest", "upload_mbps", "Latest speed test upload in Mbps")
 	m.speedtestLatency = gauge(ns, "speedtest", "latency_ms", "Latest speed test latency in ms")
+	m.speedtestEngine = gaugeVec(ns, "speedtest", "engine", "Engine that produced the most recent successful speed test (1=in use, 0=not in use)", []string{"engine"})
 
 	// ── Findings ──
 	m.findingsTotal = gaugeVec(ns, "findings", "total", "Findings by severity", []string{"severity"})
@@ -382,7 +390,7 @@ func NewMetrics() *Metrics {
 		m.gpuTemperature, m.gpuPowerW, m.gpuPowerMaxW, m.gpuFanPct,
 		m.gpuEncoderPct, m.gpuDecoderPct,
 		m.backupLastSuccess, m.backupSizeBytes, m.backupStatus,
-		m.speedtestDownload, m.speedtestUpload, m.speedtestLatency,
+		m.speedtestDownload, m.speedtestUpload, m.speedtestLatency, m.speedtestEngine,
 		m.findingsTotal, m.findingsCritical, m.findingsWarning,
 		m.collectionDuration, m.lastCollectionTime, m.updateAvailable,
 	}
@@ -711,6 +719,22 @@ func (m *Metrics) Update(snap *internal.Snapshot) {
 		m.speedtestDownload.Set(snap.SpeedTest.Latest.DownloadMbps)
 		m.speedtestUpload.Set(snap.SpeedTest.Latest.UploadMbps)
 		m.speedtestLatency.Set(snap.SpeedTest.Latest.LatencyMs)
+		// PRD #283 / issue #284: emit nasdoctor_speedtest_engine{engine="…"}
+		// = 1 for the engine that produced the most-recent successful
+		// test, 0 for the others. The Latest.Engine field is stamped by
+		// the SpeedTestRunner composite. Pre-#284 results carry an empty
+		// Engine string — fall back to ookla_cli (the only engine
+		// before #284) so the gauge is always populated post-test.
+		engine := snap.SpeedTest.Latest.Engine
+		if engine == "" {
+			engine = internal.SpeedTestEngineOoklaCLI
+		}
+		// Reset every known label to 0 first so re-stamps after an
+		// engine switchover correctly drop the old engine to 0. Two
+		// labels, both static.
+		m.speedtestEngine.With(prometheus.Labels{"engine": internal.SpeedTestEngineSpeedTestGo}).Set(0)
+		m.speedtestEngine.With(prometheus.Labels{"engine": internal.SpeedTestEngineOoklaCLI}).Set(0)
+		m.speedtestEngine.With(prometheus.Labels{"engine": engine}).Set(1)
 	}
 
 	// ── Findings ──

--- a/internal/notifier/prometheus_speedtest_engine_endtoend_test.go
+++ b/internal/notifier/prometheus_speedtest_engine_endtoend_test.go
@@ -1,0 +1,97 @@
+package notifier
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/collector"
+)
+
+// TestPrometheus_SpeedTestEngine_EndToEndFromRunner asserts the full
+// pipeline: a SpeedTestRunner produces a result with Engine stamped
+// → that result lands in a Snapshot.SpeedTest.Latest → Update()
+// flips the gauge → /metrics scrape contains the right label = 1.
+// Closes the issue #284 acceptance criterion: "the gauge for that
+// engine reads 1 in the /metrics exporter output".
+func TestPrometheus_SpeedTestEngine_EndToEndFromRunner(t *testing.T) {
+	// Compose primary-success scenario via the production composite
+	// shape but with fake engines so we don't go to the network.
+	fakePrimaryEngine := &mockEngine{
+		result: &internal.SpeedTestResult{
+			Timestamp:    time.Now(),
+			DownloadMbps: 500, UploadMbps: 50, LatencyMs: 4,
+		},
+	}
+	primary := newPrimarySpeedtestGoRunner(fakePrimaryEngine)
+	composite := collector.NewCompositeSpeedTestRunner(primary, nil)
+
+	res, samples, err := composite.Run(t.Context())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// Drain the channel as production does.
+	for range samples {
+	}
+	if res.Engine != internal.SpeedTestEngineSpeedTestGo {
+		t.Fatalf("Engine = %q, want speedtest_go", res.Engine)
+	}
+
+	// Now feed the result into the Prometheus exporter and scrape.
+	m := NewMetrics()
+	m.Update(&internal.Snapshot{
+		SpeedTest: &internal.SpeedTestInfo{
+			Available: true,
+			Latest:    res,
+		},
+	})
+	body := scrapeMetrics(t, m)
+	if !strings.Contains(body, `nasdoctor_speedtest_engine{engine="speedtest_go"} 1`) {
+		t.Errorf("expected speedtest_go = 1 in /metrics; body:\n%s", body)
+	}
+	if !strings.Contains(body, `nasdoctor_speedtest_engine{engine="ookla_cli"} 0`) {
+		t.Errorf("expected ookla_cli = 0 (other-engine label) in /metrics; body:\n%s", body)
+	}
+}
+
+// mockEngine is the in-package equivalent of the collector test's
+// fakeSpeedTestEngine. We can't reach into the collector package's
+// unexported types from here, so the runner-with-engine layer is
+// driven through the exported NewCompositeSpeedTestRunner +
+// newPrimarySpeedtestGoRunner test helper.
+type mockEngine struct {
+	result *internal.SpeedTestResult
+}
+
+// newPrimarySpeedtestGoRunner: a thin in-test runner that emulates
+// the speedtestGoRunner contract — stamps Engine="speedtest_go" on
+// the result, returns a closed sample channel. Used only for this
+// e2e test where we need a runner whose result.Engine is
+// "speedtest_go" without invoking the real showwin library.
+func newPrimarySpeedtestGoRunner(eng *mockEngine) collector.SpeedTestRunner {
+	return &mockRunner{eng: eng, engine: internal.SpeedTestEngineSpeedTestGo}
+}
+
+type mockRunner struct {
+	eng    *mockEngine
+	engine string
+}
+
+func (r *mockRunner) Run(_ context.Context) (*internal.SpeedTestResult, <-chan collector.SpeedTestSample, error) {
+	if r.eng == nil || r.eng.result == nil {
+		return nil, nil, errMockRunnerNoResult
+	}
+	res := *r.eng.result // copy so we don't mutate the input
+	res.Engine = r.engine
+	ch := make(chan collector.SpeedTestSample)
+	close(ch)
+	return &res, ch, nil
+}
+
+var errMockRunnerNoResult = stringErr("mockRunner: no result configured")
+
+type stringErr string
+
+func (s stringErr) Error() string { return string(s) }

--- a/internal/notifier/prometheus_speedtest_engine_test.go
+++ b/internal/notifier/prometheus_speedtest_engine_test.go
@@ -1,0 +1,80 @@
+package notifier
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// TestPrometheus_SpeedTestEngineGauge_StampsActiveEngine asserts that
+// after Update() with a snapshot whose latest result was produced by
+// speedtest-go, /metrics exports
+// nasdoctor_speedtest_engine{engine="speedtest_go"} 1 and
+// nasdoctor_speedtest_engine{engine="ookla_cli"} 0. Mirrors the
+// engine-swap visibility requirement from PRD #283 / issue #284 user
+// story 17.
+func TestPrometheus_SpeedTestEngineGauge_StampsActiveEngine(t *testing.T) {
+	m := NewMetrics()
+	m.Update(&internal.Snapshot{
+		SpeedTest: &internal.SpeedTestInfo{
+			Available: true,
+			Latest: &internal.SpeedTestResult{
+				Timestamp:    time.Now(),
+				DownloadMbps: 500, UploadMbps: 50, LatencyMs: 4,
+				Engine: internal.SpeedTestEngineSpeedTestGo,
+			},
+		},
+	})
+
+	body := scrapeMetrics(t, m)
+
+	// Both labels must be present (we always stamp them); the
+	// active engine reads 1, the other reads 0.
+	if !strings.Contains(body, `nasdoctor_speedtest_engine{engine="speedtest_go"} 1`) {
+		t.Errorf("expected nasdoctor_speedtest_engine{engine=\"speedtest_go\"} 1 in /metrics; body:\n%s", body)
+	}
+	if !strings.Contains(body, `nasdoctor_speedtest_engine{engine="ookla_cli"} 0`) {
+		t.Errorf("expected nasdoctor_speedtest_engine{engine=\"ookla_cli\"} 0 in /metrics; body:\n%s", body)
+	}
+}
+
+// TestPrometheus_SpeedTestEngineGauge_FallsBackToOoklaCLI asserts that
+// pre-#284 historical rows (which carry no Engine field) cause the
+// gauge to fall back to the ookla_cli label. This preserves
+// continuity for installs upgrading from v0.9.x → post-#284 where
+// the dashboard widget's "latest" is still the pre-switchover row.
+func TestPrometheus_SpeedTestEngineGauge_FallsBackToOoklaCLI(t *testing.T) {
+	m := NewMetrics()
+	m.Update(&internal.Snapshot{
+		SpeedTest: &internal.SpeedTestInfo{
+			Available: true,
+			Latest: &internal.SpeedTestResult{
+				Timestamp:    time.Now(),
+				DownloadMbps: 80, UploadMbps: 8, LatencyMs: 25,
+				// Engine deliberately empty — pre-#284 row.
+			},
+		},
+	})
+
+	body := scrapeMetrics(t, m)
+	if !strings.Contains(body, `nasdoctor_speedtest_engine{engine="ookla_cli"} 1`) {
+		t.Errorf("expected nasdoctor_speedtest_engine{engine=\"ookla_cli\"} 1 (fallback for pre-#284 unstamped row); body:\n%s", body)
+	}
+	if !strings.Contains(body, `nasdoctor_speedtest_engine{engine="speedtest_go"} 0`) {
+		t.Errorf("expected nasdoctor_speedtest_engine{engine=\"speedtest_go\"} 0; body:\n%s", body)
+	}
+}
+
+// scrapeMetrics serves a single /metrics request via httptest and
+// returns the response body.
+func scrapeMetrics(t *testing.T, m *Metrics) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	promhttp.HandlerFor(m.Registry(), promhttp.HandlerOpts{}).ServeHTTP(rec, req)
+	return rec.Body.String()
+}

--- a/internal/scheduler/speedtest_engine_integration_test.go
+++ b/internal/scheduler/speedtest_engine_integration_test.go
@@ -1,0 +1,86 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	internal "github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/collector"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// TestSpeedTestEngine_EndToEnd_RunnerDrivesHistoryRowEngineColumn
+// drives a fake SpeedTestRunner from outside the package, has the
+// scheduler runSpeedTest path invoke it via collector.RunSpeedTest,
+// and asserts the resulting row in storage.GetSpeedTestHistory has
+// the correct engine column. Closes the loop on the issue #284
+// acceptance: "Integration test: run a test, assert history row has
+// correct `engine` column value".
+func TestSpeedTestEngine_EndToEnd_RunnerDrivesHistoryRowEngineColumn(t *testing.T) {
+	store := newFakeStore()
+
+	// Wire a deterministic runner that always reports a
+	// speedtest_go-stamped result. Roll back at end of test so
+	// other tests aren't polluted by the global override.
+	restore := collector.SetSpeedTestRunnerForTest(stubSpeedTestRunner{
+		result: &internal.SpeedTestResult{
+			Timestamp:    time.Now(),
+			DownloadMbps: 500, UploadMbps: 50, LatencyMs: 4,
+			Engine: internal.SpeedTestEngineSpeedTestGo,
+		},
+	})
+	defer restore()
+
+	// The scheduler's runSpeedTest path calls collector.RunSpeedTest
+	// (the legacy public API) which now delegates to the runner. Use
+	// it directly here — that's the same path the cron tick takes.
+	res := collector.RunSpeedTest()
+	if res == nil {
+		t.Fatal("RunSpeedTest returned nil — runner override did not take effect")
+	}
+	if res.Engine != internal.SpeedTestEngineSpeedTestGo {
+		t.Fatalf("Engine = %q, want speedtest_go", res.Engine)
+	}
+
+	// Persist via the storage layer (mirrors what scheduler does).
+	if err := store.SaveSpeedTest("integration-1", res); err != nil {
+		t.Fatalf("SaveSpeedTest: %v", err)
+	}
+
+	// Read back via the public history API.
+	pts, err := store.GetSpeedTestHistory(24)
+	if err != nil {
+		t.Fatalf("GetSpeedTestHistory: %v", err)
+	}
+	if len(pts) != 1 {
+		t.Fatalf("history len = %d, want 1", len(pts))
+	}
+	if pts[0].Engine != internal.SpeedTestEngineSpeedTestGo {
+		t.Errorf("history row engine = %q, want speedtest_go", pts[0].Engine)
+	}
+}
+
+// stubSpeedTestRunner is a SpeedTestRunner that always returns a
+// canned result with a closed empty samples channel. Useful for
+// driving the public collector.RunSpeedTest entry without going to
+// the network. Mirrors fakeSpeedTestEngine but at the runner level.
+type stubSpeedTestRunner struct {
+	result *internal.SpeedTestResult
+}
+
+func (s stubSpeedTestRunner) Run(_ context.Context) (*internal.SpeedTestResult, <-chan collector.SpeedTestSample, error) {
+	ch := make(chan collector.SpeedTestSample)
+	close(ch)
+	return s.result, ch, nil
+}
+
+// newFakeStore returns a minimal speedtest-history-capable store
+// backed by a real on-disk SQLite (each test gets its own tempdir).
+func newFakeStore() *storage.DB {
+	db, err := storage.Open(":memory:", nil)
+	if err != nil {
+		panic(err)
+	}
+	return db
+}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -185,6 +185,12 @@ func (d *DB) migrate() error {
 		// See note on container_stats_history: snapshot_id is NOT a FK for
 		// the same reason. SaveSpeedTest gets "speedtest-<ts>" synthetic IDs
 		// from the scheduler when the test runs outside a scan.
+		// engine is the speed-test engine that produced the row. Closed
+		// set: 'speedtest_go' (the showwin/speedtest-go primary path
+		// introduced in PRD #283 / issue #284) or 'ookla_cli' (the
+		// bundled Ookla CLI fallback). Default 'ookla_cli' back-fills
+		// pre-#284 rows so the historical chart can mark the
+		// engine-switchover point on upgrade.
 		`CREATE TABLE IF NOT EXISTS speedtest_history (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			snapshot_id TEXT NOT NULL,
@@ -195,6 +201,7 @@ func (d *DB) migrate() error {
 			server_name TEXT,
 			isp TEXT,
 			timestamp DATETIME NOT NULL,
+			engine TEXT NOT NULL DEFAULT 'ookla_cli',
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_speedtest_ts ON speedtest_history(timestamp DESC)`,
@@ -388,6 +395,16 @@ func (d *DB) migrate() error {
 		return fmt.Errorf("drop FK on speedtest_history: %w", err)
 	}
 
+	// PRD #283 / issue #284: speedtest_history.engine is purely
+	// additive. Existing DBs predating #284 get the column added via
+	// ALTER TABLE with the default 'ookla_cli' which back-fills every
+	// pre-switchover row at one stroke. The CREATE TABLE statement
+	// above already declares the column for fresh installs, so this
+	// no-ops on first launch of a brand-new install.
+	if err := d.ensureColumn("speedtest_history", "engine", "TEXT NOT NULL DEFAULT 'ookla_cli'"); err != nil {
+		return fmt.Errorf("ensure speedtest_history.engine: %w", err)
+	}
+
 	return nil
 }
 
@@ -454,6 +471,12 @@ func (d *DB) dropSnapshotFKIfPresent(table string) error {
 			`id, snapshot_id, container_id, name, image, cpu_pct, mem_mb, mem_pct, net_in_bytes, net_out_bytes, block_read_bytes, block_write_bytes, timestamp, created_at`,
 		)
 	case "speedtest_history":
+		// engine column included so the rebuild-old-FK path (issue #155
+		// hangover from before the engine column was added in #284)
+		// preserves the new column. The COALESCE on the SELECT side is
+		// required when the source table predates #284 — old DBs being
+		// rebuilt for the first time AFTER #284 ships will rebuild
+		// straight from a no-engine table.
 		return d.rebuildTable(
 			table,
 			`CREATE TABLE speedtest_history (
@@ -466,6 +489,7 @@ func (d *DB) dropSnapshotFKIfPresent(table string) error {
 				server_name TEXT,
 				isp TEXT,
 				timestamp DATETIME NOT NULL,
+				engine TEXT NOT NULL DEFAULT 'ookla_cli',
 				created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 			)`,
 			[]string{
@@ -878,17 +902,28 @@ type SpeedTestHistoryPoint struct {
 	JitterMs     float64   `json:"jitter_ms"`
 	ServerName   string    `json:"server_name"`
 	ISP          string    `json:"isp"`
+	// Engine identifies the speed-test engine that produced the row
+	// ("speedtest_go" or "ookla_cli"). Pre-#284 rows back-fill via
+	// the column default. See PRD #283 user story 15.
+	Engine string `json:"engine,omitempty"`
 }
 
-// SaveSpeedTest inserts a single speed test result row.
+// SaveSpeedTest inserts a single speed test result row. The engine
+// field falls back to "ookla_cli" via the column default when the
+// caller didn't stamp result.Engine — this preserves backwards
+// compatibility for any callsite that pre-dates issue #284.
 func (d *DB) SaveSpeedTest(snapshotID string, result *internal.SpeedTestResult) error {
 	if result == nil {
 		return nil
 	}
+	engine := result.Engine
+	if engine == "" {
+		engine = internal.SpeedTestEngineOoklaCLI
+	}
 	_, err := d.db.Exec(
-		`INSERT INTO speedtest_history (snapshot_id, download_mbps, upload_mbps, latency_ms, jitter_ms, server_name, isp, timestamp)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		snapshotID, result.DownloadMbps, result.UploadMbps, result.LatencyMs, result.JitterMs, result.ServerName, result.ISP, result.Timestamp,
+		`INSERT INTO speedtest_history (snapshot_id, download_mbps, upload_mbps, latency_ms, jitter_ms, server_name, isp, timestamp, engine)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		snapshotID, result.DownloadMbps, result.UploadMbps, result.LatencyMs, result.JitterMs, result.ServerName, result.ISP, result.Timestamp, engine,
 	)
 	return err
 }
@@ -897,7 +932,7 @@ func (d *DB) SaveSpeedTest(snapshotID string, result *internal.SpeedTestResult) 
 func (d *DB) GetSpeedTestHistory(hours int) ([]SpeedTestHistoryPoint, error) {
 	cutoff := time.Now().Add(-time.Duration(hours) * time.Hour)
 	rows, err := d.db.Query(
-		`SELECT timestamp, download_mbps, upload_mbps, latency_ms, jitter_ms, COALESCE(server_name, ''), COALESCE(isp, '')
+		`SELECT timestamp, download_mbps, upload_mbps, latency_ms, jitter_ms, COALESCE(server_name, ''), COALESCE(isp, ''), COALESCE(engine, 'ookla_cli')
 		 FROM speedtest_history
 		 WHERE timestamp >= ?
 		 ORDER BY timestamp ASC`,
@@ -911,7 +946,7 @@ func (d *DB) GetSpeedTestHistory(hours int) ([]SpeedTestHistoryPoint, error) {
 	var points []SpeedTestHistoryPoint
 	for rows.Next() {
 		var p SpeedTestHistoryPoint
-		if err := rows.Scan(&p.Timestamp, &p.DownloadMbps, &p.UploadMbps, &p.LatencyMs, &p.JitterMs, &p.ServerName, &p.ISP); err != nil {
+		if err := rows.Scan(&p.Timestamp, &p.DownloadMbps, &p.UploadMbps, &p.LatencyMs, &p.JitterMs, &p.ServerName, &p.ISP, &p.Engine); err != nil {
 			return nil, err
 		}
 		points = append(points, p)

--- a/internal/storage/db_speedtest_engine_test.go
+++ b/internal/storage/db_speedtest_engine_test.go
@@ -1,0 +1,197 @@
+package storage
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	internal "github.com/mcdays94/nas-doctor/internal"
+)
+
+// TestSpeedTestHistory_EngineColumn_AddedWithDefault asserts the
+// schema migration adds an `engine` column to speedtest_history and
+// new INSERTs default the value to "ookla_cli". Mirrors the v0.9.10
+// borgbackup-bundling pattern: a purely additive column with a
+// stable default that pre-switchover rows can adopt without data
+// loss. PRD #283 / issue #284.
+func TestSpeedTestHistory_EngineColumn_AddedWithDefault(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	// Confirm the column exists with the right default.
+	rows, err := db.db.Query("PRAGMA table_info(speedtest_history)")
+	if err != nil {
+		t.Fatalf("table_info: %v", err)
+	}
+	defer rows.Close()
+	var found bool
+	var defaultValue string
+	for rows.Next() {
+		var cid int
+		var name, colType string
+		var notnull int
+		var dflt *string
+		var pk int
+		if err := rows.Scan(&cid, &name, &colType, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if name == "engine" {
+			found = true
+			if dflt != nil {
+				defaultValue = *dflt
+			}
+		}
+	}
+	if !found {
+		t.Fatal("speedtest_history.engine column missing — migration must add it")
+	}
+	// SQLite reports defaults verbatim. Default literal is 'ookla_cli'
+	// (single-quoted).
+	if defaultValue != "'ookla_cli'" {
+		t.Errorf("engine default = %q, want %q", defaultValue, "'ookla_cli'")
+	}
+}
+
+// TestSpeedTestHistory_BackfillsExistingRowsWithOoklaCLI asserts that
+// rows inserted before the column existed get back-filled with
+// "ookla_cli" — the engine in use prior to the v0.9.x switchover.
+// PRD #283 user story 15 ("historical chart can mark the
+// engine-switchover point").
+func TestSpeedTestHistory_BackfillsExistingRowsWithOoklaCLI(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	// Save a row WITHOUT setting Engine — simulates a pre-#284 row
+	// or a result coming back from a runner that didn't stamp the
+	// field for some reason. The DB default fills in.
+	if err := db.SaveSpeedTest("snap-1", &internal.SpeedTestResult{
+		Timestamp:    time.Now(),
+		DownloadMbps: 100, UploadMbps: 10, LatencyMs: 5,
+	}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	row := db.db.QueryRow(`SELECT engine FROM speedtest_history WHERE snapshot_id = 'snap-1'`)
+	var engine string
+	if err := row.Scan(&engine); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if engine != internal.SpeedTestEngineOoklaCLI {
+		t.Errorf("engine for unstamped row = %q, want %q (default)", engine, internal.SpeedTestEngineOoklaCLI)
+	}
+}
+
+// TestSpeedTestHistory_PersistsExplicitEngine asserts a result
+// stamped with Engine="speedtest_go" round-trips through the store.
+// This is the path the new compositeRunner takes for primary-engine
+// results.
+func TestSpeedTestHistory_PersistsExplicitEngine(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	if err := db.SaveSpeedTest("snap-2", &internal.SpeedTestResult{
+		Timestamp:    time.Now(),
+		DownloadMbps: 500, UploadMbps: 50, LatencyMs: 4,
+		Engine: internal.SpeedTestEngineSpeedTestGo,
+	}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	row := db.db.QueryRow(`SELECT engine FROM speedtest_history WHERE snapshot_id = 'snap-2'`)
+	var engine string
+	if err := row.Scan(&engine); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if engine != internal.SpeedTestEngineSpeedTestGo {
+		t.Errorf("engine = %q, want %q", engine, internal.SpeedTestEngineSpeedTestGo)
+	}
+}
+
+// TestSpeedTestHistory_MigrationIdempotent asserts that opening an
+// already-migrated DB twice does NOT corrupt the engine column or
+// double-add it. The v0.9.10 pattern: purely additive migrations
+// have a `IF NOT EXISTS` guard at every layer.
+func TestSpeedTestHistory_MigrationIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	db1, err := Open(dbPath, logger)
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	if err := db1.SaveSpeedTest("snap-pre", &internal.SpeedTestResult{
+		Timestamp: time.Now(), DownloadMbps: 1, UploadMbps: 1, LatencyMs: 1,
+		Engine: internal.SpeedTestEngineSpeedTestGo,
+	}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	db1.Close()
+
+	// Re-open. The migration runs again; must be a no-op for the
+	// engine column (no PRAGMA error, no data loss).
+	db2, err := Open(dbPath, logger)
+	if err != nil {
+		t.Fatalf("second open: %v", err)
+	}
+	defer db2.Close()
+
+	row := db2.db.QueryRow(`SELECT engine FROM speedtest_history WHERE snapshot_id = 'snap-pre'`)
+	var engine string
+	if err := row.Scan(&engine); err != nil {
+		t.Fatalf("scan after re-migration: %v", err)
+	}
+	if engine != internal.SpeedTestEngineSpeedTestGo {
+		t.Errorf("engine after re-migration = %q, want %q (data must not be lost)", engine, internal.SpeedTestEngineSpeedTestGo)
+	}
+
+	// And a fresh insert still defaults correctly post-re-migration.
+	if err := db2.SaveSpeedTest("snap-post", &internal.SpeedTestResult{
+		Timestamp: time.Now(), DownloadMbps: 1, UploadMbps: 1, LatencyMs: 1,
+	}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	row2 := db2.db.QueryRow(`SELECT engine FROM speedtest_history WHERE snapshot_id = 'snap-post'`)
+	var engine2 string
+	if err := row2.Scan(&engine2); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if engine2 != internal.SpeedTestEngineOoklaCLI {
+		t.Errorf("engine of post-re-migration row = %q, want %q (default)", engine2, internal.SpeedTestEngineOoklaCLI)
+	}
+}
+
+// TestGetSpeedTestHistory_IncludesEngine asserts the read API
+// surfaces the engine column to the dashboard so the historical
+// chart can annotate the switchover point (user story 15).
+func TestGetSpeedTestHistory_IncludesEngine(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	now := time.Now()
+	if err := db.SaveSpeedTest("snap-old", &internal.SpeedTestResult{
+		Timestamp: now.Add(-10 * time.Minute), DownloadMbps: 80, UploadMbps: 8, LatencyMs: 25,
+	}); err != nil {
+		t.Fatalf("save old: %v", err)
+	}
+	if err := db.SaveSpeedTest("snap-new", &internal.SpeedTestResult{
+		Timestamp: now, DownloadMbps: 500, UploadMbps: 50, LatencyMs: 4,
+		Engine: internal.SpeedTestEngineSpeedTestGo,
+	}); err != nil {
+		t.Fatalf("save new: %v", err)
+	}
+	pts, err := db.GetSpeedTestHistory(24)
+	if err != nil {
+		t.Fatalf("get history: %v", err)
+	}
+	if len(pts) != 2 {
+		t.Fatalf("history len = %d, want 2", len(pts))
+	}
+	// In timestamp ASC order, the older row comes first.
+	if pts[0].Engine != internal.SpeedTestEngineOoklaCLI {
+		t.Errorf("pts[0].Engine = %q, want ookla_cli (default for unstamped row)", pts[0].Engine)
+	}
+	if pts[1].Engine != internal.SpeedTestEngineSpeedTestGo {
+		t.Errorf("pts[1].Engine = %q, want speedtest_go", pts[1].Engine)
+	}
+}


### PR DESCRIPTION
Closes #284 — slice 1 of PRD #283 (Speed Test live-progress streaming + per-sample persistence). Lays the engine groundwork; slice 2 (#285) will hook the new sample channel into a `LiveTestRegistry` for SSE fan-out.

## Summary

- New `SpeedTestRunner` deep module with three impls: `speedtestGoRunner` (primary), `ooklaCLIRunner` (fallback), `compositeRunner`. Mirrors the v0.9.10 BorgRunner pattern verbatim — interface + production impl + injectable engine + contract tests.
- New Go dependency: `github.com/showwin/speedtest-go v1.7.10`. Pure-Go, no CGO. Cross-arch builds (amd64 + arm64) verified locally.
- `speedtest_history.engine` column with `'ookla_cli'` default — purely additive migration that back-fills pre-#284 rows on upgrade.
- Dashboard `sections.speedtest` renders a small `via {engine}` caption next to the existing latest-line. Closed engine set: `speedtest_go` → "speedtest-go", anything else → "Ookla CLI". `data-speedtest-engine` attribute on the span for Playwright UAT pinning.
- `nasdoctor_speedtest_engine{engine="speedtest_go|ookla_cli"}` Prometheus gauge; 1 for the engine that produced the most-recent successful test, 0 for the other.
- Demo feeder annotates fresh results with `engine: "speedtest_go"`; the 24h history pivots — older half stamped `ookla_cli`, newer half `speedtest_go` — so the engine-switchover annotation has something to chart on the live demo.

## Acceptance criteria (from #284)

- [x] `internal/collector/SpeedTestRunner` interface defined with `Run(ctx) (*SpeedTestResult, <-chan Sample, error)` shape; three implementations all pass a shared contract test (success-path + error-path).
- [x] `compositeRunner` tries speedtest-go first, falls back to Ookla CLI on error, records the engine that produced the final result.
- [x] `internal/collector.RunSpeedTest()` delegates to `compositeRunner`. Existing call sites unchanged.
- [x] Schema migration v3 → v4 adds `speedtest_history.engine TEXT NOT NULL DEFAULT 'ookla_cli'`. Existing rows back-filled.
- [x] Settings shape-sentinel guard — N/A here. The migration is at the SQL-schema layer (`speedtest_history` table), not the JSON `settings` blob, so the v0.9.9 V2a shape-sentinel pattern doesn't apply. The schema migration uses `ensureColumn` (idempotent ALTER) + `IF NOT EXISTS` on table creation, which is the equivalent guard. See "non-obvious decisions" below.
- [x] Schema migration test: pin a v3 blob, run migration, assert (a) new column exists with default value, (b) old data preserved, (c) v3 → v4 only runs once (idempotent on re-load) — `TestSpeedTestHistory_MigrationIdempotent`.
- [x] Dashboard card renders a small "via {engine_human_label}" caption near the existing latest-result line.
- [x] Prometheus exporter adds `nasdoctor_speedtest_engine{engine="speedtest_go|ookla_cli"}` gauge.
- [x] Integration test: run a test, assert history row has correct `engine` column value AND the gauge for that engine reads 1 in `/metrics` — `TestSpeedTestEngine_EndToEnd_RunnerDrivesHistoryRowEngineColumn` + `TestPrometheus_SpeedTestEngine_EndToEndFromRunner`.
- [x] Demo feeder updated: existing speedtest history rows annotated with `engine: "ookla_cli"` (pre-switchover); new feeder-generated entries use `"speedtest_go"`.
- [x] `go test ./... -race` green.
- [x] `go build ./...` green; `npm test` (28/28) and `npx tsc --noEmit` (clean) on the feeder.

## Test count delta

20 new Go test functions (some with subtests; e.g. the contract tests run 3 sub-cases each). 1 new TypeScript test (`emits engine='speedtest_go' on snapshot.speed_test.latest for all platforms`) extending the feeder's widget-coverage suite to 28 tests total.

## Non-obvious decisions

- **No JSON `settings_version` bump.** The PRD calls out a `v3 → v4` migration; that wording is faithful to a settings-blob schema model, but on inspection the new column lives in the SQL-table layer (`speedtest_history`) — not the settings JSON. Bumping `settings_version` would be a no-op for an SQL-only change and would risk re-running unrelated v3 migrations on every load (the v0.9.8 #268 class of bug). The migration is therefore performed at the SQL layer via `ensureColumn` (idempotent ALTER) + `IF NOT EXISTS` on `CREATE TABLE`, which is the strictly-equivalent guard.
- **`compositeRunner` keeps the most-recent error on full failure.** When both engines fail, the wrapped error string mentions both ("`both engines failed: primary=…, fallback=…`") so the scheduler log retains primary-engine context without breaking `errors.Is` for the fallback's wrapped error.
- **Sample channel for `ooklaCLIRunner` always closes empty.** The CLI emits final-only JSON; there's no useful per-sample telemetry. Slice 2 may revisit if the fallback path needs synthetic phase markers for live-progress UI consistency.
- **`SetSpeedTestRunnerForTest` package-level hook.** Test-only swap of the singleton. Production wiring constructs the composite at startup (or via lazy init on first `RunSpeedTest`); the existing `SetSpeedTestRunner` in scheduler/api packages still wraps a `func() *SpeedTestResult` and is unchanged.
- **Dashboard themes don't link `/css/shared.css`.** The new "via {engine}" caption is plain text inside the existing inner-text wrapper — no new pill class, no new CSS rule. Both themes inherit it for free. (See AGENTS architectural note about `midnight.html`/`clean.html` isolation; this slice doesn't trip it.)
- **Local `docker build` could not run** — the local Docker daemon is unavailable in this environment. The cross-arch Go builds (`GOOS=linux GOARCH=amd64` and `GOARCH=arm64` with `CGO_ENABLED=0`) both succeed locally, which is exactly what the Dockerfile's builder stage does — but the runtime stage's `apk add` lines were not exercised. CI's `docker build` will catch any image-stage regression on push.