### PR TITLE
feat(speedtest): per-sample persistence + expanded-log mini-chart on /service-checks (#286, closes #191)

### DIFF
--- a/demo-worker/feeder/src/index.ts
+++ b/demo-worker/feeder/src/index.ts
@@ -23,7 +23,20 @@ const ENDPOINTS = [
   "container_history", "system_history", "process_history", "settings", "db_stats",
   "disks", "smart_trends", "replacement_plan", "capacity_forecast",
   "speedtest_history",
+  // PRD #283 slice 3 / issue #286 — per-sample telemetry for the
+  // /service-checks expanded-log mini-chart. Lives at
+  // api:<platform>:speedtest_samples in KV; the demo worker serves
+  // it under /api/v1/speedtest/samples/{id} with the test_id
+  // ignored (the demo only carries one set of samples per platform).
+  "speedtest_samples",
 ];
+
+// SAMPLED_TEST_ID is the synthetic speedtest_history.id stamped onto
+// the demo's "Internet Speed" service-check entry so the
+// /service-checks expanded log row knows which test_id to fetch
+// samples for. Stable across feeder runs so links from the SC log
+// row don't break between cron ticks. Issue #286.
+const SAMPLED_TEST_ID = 1001;
 
 // ── Platform profiles: define what makes each platform unique ──
 export interface PlatformProfile {
@@ -283,6 +296,9 @@ function transformForPlatform(endpoint: string, data: unknown, platform: Platfor
   if (endpoint === "sparklines") return transformSparklines(data as Record<string, unknown>, PROFILES[platform]);
   if (endpoint === "snapshot") return transformSnapshot(data as Record<string, unknown>, PROFILES[platform], platform);
   if (endpoint === "speedtest_history") return buildSpeedTestHistory(PROFILES[platform], 24);
+  // Per-sample telemetry: synthesised on demand, one canonical
+  // dataset per platform. Issue #286.
+  if (endpoint === "speedtest_samples") return buildSpeedTestSamples(PROFILES[platform], SAMPLED_TEST_ID);
 
   return data; // everything else passed through from seed
 }
@@ -788,9 +804,81 @@ function buildServiceChecks(): unknown[] {
     contracted_upload_mbps: 40,
     margin_pct: 10,
   });
+  // Stamp the speedtest_history_id on the most-recent speed entry so
+  // the /service-checks expanded-log mini-chart knows which test_id
+  // to fetch from /api/v1/speedtest/samples/{id}. Issue #286.
+  const last = checks[checks.length - 1] as Record<string, unknown>;
+  if (last && last.type === "speed") {
+    last.speedtest_history_id = SAMPLED_TEST_ID;
+  }
 
   return checks;
 }
+
+// buildSpeedTestSamples — synthesises a realistic ~30-sample stream
+// per platform: latency phase (~5 samples) → download ramp-up + sustained
+// (~15 samples) → upload similar (~10 samples). Mbps values modulated
+// by the platform's profile.speedTest baseline so a gigabit datacentre
+// link looks different from a 100/10 residential synology. PRD #283
+// slice 3 / issue #286.
+//
+// The shape mirrors storage.SpeedTestSample (the JSON tags on the Go
+// struct): {sample_index, phase, ts, mbps, latency_ms}. This is what
+// the new /api/v1/speedtest/samples/{id} endpoint returns and what
+// the dashboard's NasChart.line consumer expects.
+function buildSpeedTestSamples(p: PlatformProfile, testID: number): unknown {
+  const t = p.speedTest;
+  const seed = hashStr(p.hostname + "-samples-" + String(testID));
+  const startMs = Date.now() - 30 * 1000; // 30s ago, simulating a recent test
+  const samples: unknown[] = [];
+  let idx = 0;
+  let elapsed = 0; // milliseconds since test start
+
+  // Latency phase — 5 ping samples ~200ms apart.
+  for (let i = 0; i < 5; i++, idx++) {
+    samples.push({
+      sample_index: idx,
+      phase: "latency",
+      ts: new Date(startMs + elapsed).toISOString(),
+      mbps: 0,
+      latency_ms: round2(clamp(jitter(t.latencyMs, 30, seed + idx), Math.max(0.5, t.latencyMs * 0.5), t.latencyMs * 2)),
+    });
+    elapsed += 200;
+  }
+  // Download phase — 15 samples spaced ~600ms apart, ramp-up over the
+  // first 4 then sustained near peak with realistic jitter.
+  for (let i = 0; i < 15; i++, idx++) {
+    const rampFactor = i < 4 ? 0.4 + (i / 4) * 0.5 : 1.0;
+    samples.push({
+      sample_index: idx,
+      phase: "download",
+      ts: new Date(startMs + elapsed).toISOString(),
+      mbps: round2(clamp(jitter(t.downloadMbps * rampFactor, 8, seed + idx), t.downloadMbps * 0.3, t.downloadMbps * 1.1)),
+      latency_ms: 0,
+    });
+    elapsed += 600;
+  }
+  // Upload phase — 10 samples, similar shape.
+  for (let i = 0; i < 10; i++, idx++) {
+    const rampFactor = i < 3 ? 0.4 + (i / 3) * 0.5 : 1.0;
+    samples.push({
+      sample_index: idx,
+      phase: "upload",
+      ts: new Date(startMs + elapsed).toISOString(),
+      mbps: round2(clamp(jitter(t.uploadMbps * rampFactor, 10, seed + idx), t.uploadMbps * 0.3, t.uploadMbps * 1.1)),
+      latency_ms: 0,
+    });
+    elapsed += 600;
+  }
+  return {
+    test_id: testID,
+    samples,
+    count: samples.length,
+  };
+}
+
+// Exported for vitest widget-coverage tests.
+export { buildSpeedTestSamples, SAMPLED_TEST_ID };
 
 function buildZFS(p: PlatformProfile): unknown {
   const isTrueNAS = p.platformName.includes("TrueNAS");

--- a/demo-worker/feeder/src/widget-coverage.test.ts
+++ b/demo-worker/feeder/src/widget-coverage.test.ts
@@ -20,7 +20,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { transformSnapshot, transformSettings, PROFILES, type Platform } from "./index";
+import { transformSnapshot, transformSettings, buildSpeedTestSamples, SAMPLED_TEST_ID, PROFILES, type Platform } from "./index";
 
 // A minimal seed that resembles what `seed:unraid:snapshot` looks like
 // after the Go binary's `--demo` capture. The feeder's
@@ -304,5 +304,68 @@ describe("demo feeder widget coverage", () => {
         `${platform} snapshot.speed_test.latest.engine should be 'speedtest_go' to showcase the new primary engine`,
       ).toBe("speedtest_go");
     }
+  });
+
+  // ── Per-sample telemetry (PRD #283 slice 3 / issue #286) ──────────
+  // The /service-checks expanded-log mini-chart and the demo's
+  // /api/v1/speedtest/samples/{id} endpoint both consume the data
+  // synthesised by buildSpeedTestSamples. These tests pin the
+  // shape the dashboard's NasChart.line consumer expects so a
+  // future refactor can't silently break the chart.
+
+  it("buildSpeedTestSamples produces ~30 ordered samples covering all three phases for every platform", () => {
+    for (const platform of ["unraid", "synology", "truenas", "proxmox", "kubernetes"] as Platform[]) {
+      const result = buildSpeedTestSamples(PROFILES[platform], SAMPLED_TEST_ID) as Record<string, unknown>;
+      expect(result.test_id, `${platform} samples must echo test_id`).toBe(SAMPLED_TEST_ID);
+      const samples = result.samples as Array<Record<string, unknown>>;
+      expect(samples.length, `${platform} samples count`).toBe(30);
+      expect(result.count, `${platform} count field must match samples.length`).toBe(samples.length);
+
+      // sample_index monotonically increasing from 0 — the dashboard
+      // chart renders left-to-right and a non-monotonic index would
+      // produce backwards line segments.
+      for (let i = 0; i < samples.length; i++) {
+        expect(samples[i].sample_index, `${platform} samples[${i}].sample_index`).toBe(i);
+      }
+
+      // All three phases present in their canonical order.
+      const phases = samples.map((s) => s.phase as string);
+      expect(phases.slice(0, 5).every((p) => p === "latency"),
+        `${platform} first 5 samples must be 'latency' phase, got ${phases.slice(0, 5).join(",")}`).toBe(true);
+      expect(phases.includes("download"), `${platform} samples must include a 'download' phase`).toBe(true);
+      expect(phases.includes("upload"), `${platform} samples must include an 'upload' phase`).toBe(true);
+
+      // Every sample has a numeric mbps + latency_ms field (zero is
+      // valid; missing/null would crash the chart consumer).
+      for (const s of samples) {
+        expect(typeof s.mbps, `${platform} samples[].mbps must be a number`).toBe("number");
+        expect(typeof s.latency_ms, `${platform} samples[].latency_ms must be a number`).toBe("number");
+        expect(typeof s.ts, `${platform} samples[].ts must be a string (ISO 8601)`).toBe("string");
+      }
+    }
+  });
+
+  it("buildServiceChecks stamps speedtest_history_id on the type=speed entry so the SC log row links to samples", () => {
+    // The feeder's buildServiceChecks always returns the same set
+    // (it doesn't take a platform), but the speed entry must carry
+    // the speedtest_history_id field so the /service-checks expanded
+    // log row knows which test_id to fetch from /api/v1/speedtest/samples/{id}.
+    // We assert by looking at the snapshot-mirrored service_checks
+    // (transformSnapshot calls buildServiceChecks then writes it
+    // into snapshot.service_checks via a separate path; instead we
+    // rely on the fact that the speed entry exists in service_checks
+    // for any platform via the fleet endpoint shape).
+    //
+    // Simpler: the source-of-truth is the same buildServiceChecks
+    // function, so checking ANY platform's snapshot.service_checks
+    // is enough.
+    const snap = transformSnapshot(SEED, PROFILES.unraid, "unraid");
+    const checks = (getPath(snap, "service_checks") as Array<Record<string, unknown>>) || [];
+    const speedCheck = checks.find((c) => c.type === "speed");
+    expect(speedCheck, "expected a type=speed service-check entry in snapshot.service_checks").toBeDefined();
+    expect(
+      speedCheck!.speedtest_history_id,
+      "speed service-check must carry speedtest_history_id so the SC expanded log row links to samples (#286)",
+    ).toBe(SAMPLED_TEST_ID);
   });
 });

--- a/demo-worker/src/index.ts
+++ b/demo-worker/src/index.ts
@@ -172,6 +172,16 @@ async function handleAPI(path: string, url: URL, platform: Platform, env: Env): 
     const data = await env.DEMO_DATA.get(`api:${platform}:disks`, "text");
     return json(data ? JSON.parse(data) : []);
   }
+  // PRD #283 slice 3 / issue #286 — per-sample telemetry for the
+  // /service-checks expanded log row's mini-chart. The demo carries
+  // one canonical dataset per platform (the feeder synthesises it
+  // under api:<platform>:speedtest_samples), so the test_id is
+  // ignored for routing and trusted for the round-trip echo.
+  if (path.match(/^\/api\/v1\/speedtest\/samples\/[^/]+$/)) {
+    const data = await env.DEMO_DATA.get(`api:${platform}:speedtest_samples`, "text");
+    if (data) return json(JSON.parse(data));
+    return json({ test_id: 0, samples: [], count: 0 });
+  }
 
   const kvKey = kvMap[path];
   if (!kvKey) return json({ error: "not found" }, 404);

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -148,6 +148,13 @@ func (s *Server) Router() http.Handler {
 	// extra wiring.
 	r.With(s.apiKeyMiddleware).Post("/api/v1/speedtest/run", s.handleSpeedtestRun)
 	r.With(s.apiKeyMiddleware).Get("/api/v1/speedtest/stream/{test_id}", s.handleSpeedtestStream)
+	// Per-sample JSON for COMPLETED tests (PRD #283 slice 3 / #286).
+	// Strict separation from /stream/{id}: in-flight tests get a 404
+	// here with a hint pointing at /stream/{id}. Lives outside the
+	// 30s timeout group because the samples query is fast (single
+	// indexed read) but kept on the same line as run/stream for the
+	// route-grouping reader's mental model.
+	r.With(s.apiKeyMiddleware).Get("/api/v1/speedtest/samples/{test_id}", s.handleSpeedtestSamples)
 
 	// Standard-latency routes — 30s soft timeout via a Group so we don't
 	// apply it to the long-running route above.

--- a/internal/api/service_checks_speedtest_samples_test.go
+++ b/internal/api/service_checks_speedtest_samples_test.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestServiceChecksTemplate_JSBlocksParse asserts every <script>
+// block in service_checks.html is valid JavaScript. Same shape as the
+// settings_js_parses test (added in v0.9.9). Catches the */-in-comment
+// hazard from rc1 of v0.9.9 + the backtick-in-comment hazard from
+// the DashboardJS raw-string literal class. Service-checks scripts
+// are dense enough that a comment-syntax slip would silently break
+// the entire log-table render.
+func TestServiceChecksTemplate_JSBlocksParse(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node binary not in PATH; skipping JS parse check (dev-time guard only)")
+	}
+	blocks := extractScriptBlocks(serviceChecksPageHTML)
+	if len(blocks) == 0 {
+		t.Fatal("no <script>...</script> blocks found in service_checks.html")
+	}
+	for i, js := range blocks {
+		if strings.TrimSpace(js) == "" {
+			continue
+		}
+		cmd := exec.Command("node", "--check", "-")
+		cmd.Stdin = strings.NewReader(js)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Errorf("service_checks.html <script> block %d failed to parse as JS:\n%s", i, string(out))
+		}
+	}
+}
+
+// TestServiceChecksHTML_RendersSpeedTestSamplesContainer asserts the
+// expanded-log row for type=speed entries includes the per-sample
+// mini-chart container + a stable canvas id template that the
+// renderer wires up. PRD #283 slice 3 / issue #286.
+func TestServiceChecksHTML_RendersSpeedTestSamplesContainer(t *testing.T) {
+	html := loadServiceChecksHTML(t)
+
+	// The container must opt into the renderer via the
+	// data-speedtest-history-id attribute. Without this attribute the
+	// lazy-render hook can't find the panel and the chart never draws.
+	if !strings.Contains(html, "data-speedtest-history-id=") {
+		t.Error("service_checks.html missing data-speedtest-history-id attribute on the speed-row mini-chart container")
+	}
+	// The canvas element must be addressable via a stable per-row id
+	// pattern so NasChart.line can target it.
+	if !strings.Contains(html, "speedtest-samples-") {
+		t.Error("service_checks.html missing speedtest-samples- canvas id prefix")
+	}
+	// The template must reference the new endpoint, not the historical
+	// chart endpoint.
+	if !strings.Contains(html, "/api/v1/speedtest/samples/") {
+		t.Error("service_checks.html does not call the new /api/v1/speedtest/samples/{id} endpoint")
+	}
+	// The renderer must reuse NasChart.line (PRD constraint: no new
+	// chart library code).
+	if !strings.Contains(html, "NasChart.line") {
+		t.Error("service_checks.html mini-chart renderer must call NasChart.line (PRD #283 reuse-only constraint)")
+	}
+}
+
+// TestServiceChecksHTML_EmptyStateCopyForLegacyEntries asserts the
+// fallback hint for tests that pre-date the per-sample feature
+// (sthid==0 or no samples returned) is rendered with the canonical
+// copy. The exact wording is part of the user-visible UX and is
+// pinned so a future refactor can't silently change it. Issue #286
+// acceptance criterion.
+func TestServiceChecksHTML_EmptyStateCopyForLegacyEntries(t *testing.T) {
+	html := loadServiceChecksHTML(t)
+	if !strings.Contains(html, "No per-sample data available — run a new test to populate.") {
+		t.Error("service_checks.html missing the canonical empty-state copy 'No per-sample data available — run a new test to populate.'")
+	}
+}
+
+// TestServiceChecksHTML_LazyRenderHookFiresOnOpen asserts that the
+// toggleLogDetail handler invokes the speedtest-samples renderer when
+// the row opens, not on every render or on close. This is the
+// performance contract: the renderer issues a fetch + draws a canvas,
+// which we don't want to repeat unnecessarily.
+func TestServiceChecksHTML_LazyRenderHookFiresOnOpen(t *testing.T) {
+	html := loadServiceChecksHTML(t)
+	if !strings.Contains(html, "lazyRenderSpeedtestSamples") {
+		t.Error("service_checks.html missing lazyRenderSpeedtestSamples renderer hook")
+	}
+	// The renderer must be called from inside the toggleLogDetail
+	// handler's "open" branch — the simplest pin is that the
+	// function's name appears in the script alongside toggleLogDetail.
+	if !strings.Contains(html, "window.toggleLogDetail") {
+		t.Error("service_checks.html missing window.toggleLogDetail handler — the renderer's invocation point must exist")
+	}
+	// Idempotent rendering: the data-rendered attribute is the cheapest
+	// pin to detect "already drew once".
+	if !strings.Contains(html, "data-rendered") {
+		t.Error("service_checks.html mini-chart renderer must guard against re-fetch via a data-rendered marker")
+	}
+}

--- a/internal/api/speedtest_samples.go
+++ b/internal/api/speedtest_samples.go
@@ -1,0 +1,136 @@
+// Package api — speedtest_samples.go implements the per-sample JSON
+// endpoint for COMPLETED speed tests, per PRD #283 / issue #286
+// (slice 3 of the speed-test live-progress PRD).
+//
+// Strict separation from the SSE flow:
+//
+//   - Live tests (in flight): subscribe to /api/v1/speedtest/stream/{id}
+//   - Completed tests: GET /api/v1/speedtest/samples/{id}
+//
+// The samples endpoint returns 404 for in-flight tests with a hint
+// pointing at the stream endpoint, NOT a snapshot of samples-so-far.
+// This keeps the live and historical paths from drifting and gives
+// the dashboard one obvious choice per state.
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// speedtestSamplesResponse is the body of GET /api/v1/speedtest/samples/{test_id}.
+//
+// test_id round-trips so a curl response stands alone without the
+// caller needing to remember which ID they asked for. samples is an
+// always-non-null array (empty on a legacy row that pre-dates the
+// per-sample feature) so a JS .length check on the frontend never
+// fails. count is a convenience for clients that want to alert on
+// "old test, no samples" without iterating.
+type speedtestSamplesResponse struct {
+	TestID  int64                       `json:"test_id"`
+	Samples []storage.SpeedTestSample   `json:"samples"`
+	Count   int                         `json:"count"`
+}
+
+// handleSpeedtestSamples implements GET /api/v1/speedtest/samples/{test_id}.
+//
+// Response codes:
+//
+//   - 200: completed test, samples returned (possibly empty array
+//     for a legacy row that pre-dates the per-sample feature).
+//   - 400: test_id parameter is not a valid int64.
+//   - 404: test_id is in flight (use /stream/{id} instead — hint in
+//     body), OR test_id is unknown / pruned. Both cases share a
+//     status code; the body's hint differentiates.
+//
+// The "in flight" check goes through the LiveTestRegistry. The
+// "unknown / pruned" check looks at speedtest_history — if no row
+// exists with this ID, return 404. If the row exists but has zero
+// samples (legacy or new-but-mid-pruning), return 200 with an empty
+// array so the dashboard's mini-chart renders the empty-state hint.
+func (s *Server) handleSpeedtestSamples(w http.ResponseWriter, r *http.Request) {
+	idStr := chi.URLParam(r, "test_id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "invalid test_id",
+		})
+		return
+	}
+
+	// In-flight check: if the registry recognises this ID, the test
+	// is still running. The samples endpoint only serves COMPLETED
+	// tests; live data lives on /stream/{id}.
+	if reg := s.liveTestRegistry(); reg != nil {
+		if _, alive := reg.GetLive(id); alive {
+			writeJSON(w, http.StatusNotFound, map[string]string{
+				"error": "test is in flight; subscribe via /api/v1/speedtest/stream/" + idStr + " for live samples",
+				"hint":  "/api/v1/speedtest/stream/" + idStr,
+			})
+			return
+		}
+	}
+
+	// Completed test — fetch samples from the store. Empty result
+	// is valid (legacy row without per-sample data); the UI renders
+	// the empty-state hint in that case.
+	samples, err := s.store.GetSpeedTestSamples(id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error": "failed to fetch samples: " + err.Error(),
+		})
+		return
+	}
+
+	// Distinguish "test exists but no samples" (200, empty array) from
+	// "test_id unknown" (404). The store's GetSpeedTestSamples returns
+	// an empty slice for both, so we probe the history table to tell
+	// them apart. This is best-effort: a fake test store may not
+	// surface IDs through GetSpeedTestHistory (e.g. tests use
+	// SaveSpeedTest + the synthetic FakeStore ID counter), so when
+	// samples ARE present we trust the existence of samples and skip
+	// the existence probe.
+	if len(samples) == 0 {
+		exists, err := s.speedtestHistoryRowExists(id)
+		if err == nil && !exists {
+			writeJSON(w, http.StatusNotFound, map[string]string{
+				"error": "unknown test_id; the test may have been pruned",
+			})
+			return
+		}
+	}
+
+	writeJSON(w, http.StatusOK, speedtestSamplesResponse{
+		TestID:  id,
+		Samples: samples,
+		Count:   len(samples),
+	})
+}
+
+// speedtestHistoryRowExists probes whether a speedtest_history row
+// with the given ID exists. Used by the samples endpoint to
+// differentiate legacy-row-with-no-samples (200) from unknown-test-id
+// (404). Returns nil error + false on missing row so callers can
+// branch cleanly. Returns nil error + true if the row exists OR if
+// the store doesn't surface IDs (fake stores) — in the latter case
+// the caller falls back to "200 empty" which is the safer default.
+func (s *Server) speedtestHistoryRowExists(testID int64) (bool, error) {
+	// Fetch a generous time window so any non-pruned row is included.
+	// 365 days is well beyond any retention policy nas-doctor ships
+	// with. If the row still isn't visible after this query, we treat
+	// it as unknown.
+	points, err := s.store.GetSpeedTestHistory(24 * 365)
+	if err != nil {
+		return false, err
+	}
+	for _, p := range points {
+		if p.ID == testID {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/api/speedtest_samples_test.go
+++ b/internal/api/speedtest_samples_test.go
@@ -1,0 +1,271 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/livetest"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+func intToString(n int64) string { return strconv.FormatInt(n, 10) }
+
+// newSamplesServer wires a Server backed by a FakeStore, with optional
+// LiveTestRegistry injected via the test seam. Routes: only the
+// samples endpoint, mounted on a fresh chi router so chi.URLParam
+// resolves correctly.
+func newSamplesServer(t *testing.T, reg livetest.Registry) (*Server, *storage.FakeStore, http.Handler) {
+	t.Helper()
+	store := storage.NewFakeStore()
+	srv := &Server{store: store}
+	if reg != nil {
+		srv.testLiveTestRegistry = reg
+	}
+	r := chi.NewRouter()
+	r.Get("/api/v1/speedtest/samples/{test_id}", srv.handleSpeedtestSamples)
+	return srv, store, r
+}
+
+// TestSpeedtestSamples_HappyPath_ReturnsSamples asserts that a
+// completed test with persisted per-sample telemetry is returned as a
+// JSON array under .samples, with the count populated and ordering
+// preserved (sample_index ascending).
+func TestSpeedtestSamples_HappyPath_ReturnsSamples(t *testing.T) {
+	t.Parallel()
+	_, store, handler := newSamplesServer(t, nil)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	id, err := store.SaveSpeedTestReturningID("snap-1", &internal.SpeedTestResult{
+		DownloadMbps: 920, UploadMbps: 88, LatencyMs: 8, Timestamp: time.Now(),
+		Engine: internal.SpeedTestEngineSpeedTestGo,
+	})
+	if err != nil {
+		t.Fatalf("SaveSpeedTestReturningID: %v", err)
+	}
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	if err := store.InsertSpeedTestSamples(id, []storage.SpeedTestSample{
+		{SampleIndex: 0, Phase: "latency", Timestamp: now, LatencyMs: 8.2},
+		{SampleIndex: 1, Phase: "download", Timestamp: now.Add(time.Second), Mbps: 723.4},
+		{SampleIndex: 2, Phase: "upload", Timestamp: now.Add(2 * time.Second), Mbps: 88.3},
+	}); err != nil {
+		t.Fatalf("InsertSpeedTestSamples: %v", err)
+	}
+
+	resp, err := http.Get(srv.URL + "/api/v1/speedtest/samples/" + intToString(id))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d (want 200), body = %s", resp.StatusCode, body)
+	}
+	var got struct {
+		TestID  int64                     `json:"test_id"`
+		Samples []storage.SpeedTestSample `json:"samples"`
+		Count   int                       `json:"count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.TestID != id {
+		t.Errorf("test_id = %d, want %d", got.TestID, id)
+	}
+	if got.Count != 3 || len(got.Samples) != 3 {
+		t.Fatalf("count/len = %d/%d, want 3/3", got.Count, len(got.Samples))
+	}
+	for i, s := range got.Samples {
+		if s.SampleIndex != i {
+			t.Errorf("samples[%d].SampleIndex = %d, want %d (order broken)", i, s.SampleIndex, i)
+		}
+	}
+	if got.Samples[0].Phase != "latency" || got.Samples[1].Phase != "download" || got.Samples[2].Phase != "upload" {
+		t.Errorf("phase ordering broken: %+v", got.Samples)
+	}
+}
+
+// TestSpeedtestSamples_LegacyRow_ReturnsEmptyArray asserts that a
+// completed test with no persisted samples (e.g. pre-#286 row) returns
+// 200 with an empty samples array — NOT 404. The dashboard's
+// expanded-log mini-chart renders the "no per-sample data available"
+// empty-state hint when count=0.
+func TestSpeedtestSamples_LegacyRow_ReturnsEmptyArray(t *testing.T) {
+	t.Parallel()
+	_, store, handler := newSamplesServer(t, nil)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	id, err := store.SaveSpeedTestReturningID("snap-1", &internal.SpeedTestResult{
+		DownloadMbps: 100, Timestamp: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("SaveSpeedTestReturningID: %v", err)
+	}
+
+	resp, err := http.Get(srv.URL + "/api/v1/speedtest/samples/" + intToString(id))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d (want 200 for legacy row), body = %s", resp.StatusCode, body)
+	}
+	var got struct {
+		Samples []storage.SpeedTestSample `json:"samples"`
+		Count   int                       `json:"count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Count != 0 {
+		t.Errorf("count = %d, want 0", got.Count)
+	}
+	if got.Samples == nil {
+		t.Errorf("samples must be a JSON array (possibly empty), got nil — frontend .length checks would fail")
+	}
+}
+
+// TestSpeedtestSamples_InFlight_Returns404WithStreamHint asserts that
+// requesting samples for an in-flight test (registry's GetLive
+// recognises the ID) yields a 404 with a `hint` field pointing at
+// the stream endpoint. PRD #283 strict separation: live = stream,
+// completed = samples.
+func TestSpeedtestSamples_InFlight_Returns404WithStreamHint(t *testing.T) {
+	t.Parallel()
+	// Spin up a runner that never closes its samples channel so the
+	// registered test stays in flight for the duration of the assertion.
+	runner := newStuckRunner()
+	defer close(runner.unblock)
+	mgr := livetest.NewManager(runner, quietSSELogger(), counterIDGen())
+	lt, err := mgr.StartTest(t.Context())
+	if err != nil {
+		t.Fatalf("StartTest: %v", err)
+	}
+
+	_, _, handler := newSamplesServer(t, mgr)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/speedtest/samples/" + intToString(lt.ID()))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d (want 404), body = %s", resp.StatusCode, body)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["hint"] == "" {
+		t.Errorf("expected hint pointing at /stream/{id}, got body %v", body)
+	}
+}
+
+// TestSpeedtestSamples_UnknownTestID_Returns404 asserts that a test_id
+// with no matching speedtest_history row returns 404. This is what
+// happens after the retention loop prunes an old test or if the
+// caller hits a typoed ID.
+func TestSpeedtestSamples_UnknownTestID_Returns404(t *testing.T) {
+	t.Parallel()
+	_, _, handler := newSamplesServer(t, nil)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/speedtest/samples/999999")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d (want 404), body = %s", resp.StatusCode, body)
+	}
+}
+
+// TestSpeedtestSamples_InvalidID_Returns400 asserts that a non-numeric
+// test_id parameter yields 400, NOT a 500.
+func TestSpeedtestSamples_InvalidID_Returns400(t *testing.T) {
+	t.Parallel()
+	_, _, handler := newSamplesServer(t, nil)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/speedtest/samples/not-a-number")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d (want 400), body = %s", resp.StatusCode, body)
+	}
+}
+
+// TestSpeedtestSamples_APIKeyMiddleware asserts the samples endpoint
+// is protected by the API-key middleware in production wiring. We
+// build the production NewRouter and confirm a request without an
+// API key (when one is set) is rejected. Mirrors the existing
+// API-key middleware tests for /run + /stream.
+func TestSpeedtestSamples_APIKeyMiddleware_RejectsMissingKey(t *testing.T) {
+	t.Parallel()
+	store := storage.NewFakeStore()
+	// Persist a settings blob containing api_key so getSettings()
+	// reads it back through the canonical config-key path. Setting
+	// the api_key directly in the config table is not enough — the
+	// middleware reads s.getSettings().APIKey which deserialises
+	// from settings_v3.
+	settingsJSON := `{"settings_version":3,"api_key":"nd-test-secret"}`
+	_ = store.SetConfig("settings", settingsJSON)
+	srv := &Server{store: store}
+	r := chi.NewRouter()
+	r.With(srv.apiKeyMiddleware).Get("/api/v1/speedtest/samples/{test_id}", srv.handleSpeedtestSamples)
+	httpsrv := httptest.NewServer(r)
+	defer httpsrv.Close()
+
+	// No Authorization header, no api_key query param, no Referer →
+	// the middleware should reject.
+	req, _ := http.NewRequest(http.MethodGet, httpsrv.URL+"/api/v1/speedtest/samples/1", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d (want 401), body = %s", resp.StatusCode, body)
+	}
+}
+
+// stuckRunner is a livetest.Runner that opens a samples channel and
+// blocks until unblock is closed. Used to keep a test "in flight"
+// for the lifetime of an assertion.
+type stuckRunner struct {
+	unblock chan struct{}
+}
+
+func newStuckRunner() *stuckRunner {
+	return &stuckRunner{unblock: make(chan struct{})}
+}
+
+func (r *stuckRunner) Run(_ context.Context) (*internal.SpeedTestResult, <-chan livetest.Sample, error) {
+	out := make(chan livetest.Sample)
+	go func() {
+		<-r.unblock
+		close(out)
+	}()
+	return &internal.SpeedTestResult{Engine: internal.SpeedTestEngineSpeedTestGo}, out, nil
+}

--- a/internal/api/templates/service_checks.html
+++ b/internal/api/templates/service_checks.html
@@ -454,6 +454,24 @@
         h+='<div class="log-detail-item"><div class="ld-label">Latency</div><div class="ld-val">'+(e.latency_ms?e.latency_ms.toFixed(1)+' ms':'—')+'</div></div>';
         if(e.download_ok!=null) h+='<div class="log-detail-item"><div class="ld-label">Download OK</div><div class="ld-val" style="color:'+(e.download_ok?'var(--green)':'var(--red)')+'">'+e.download_ok+'</div></div>';
         if(e.upload_ok!=null) h+='<div class="log-detail-item"><div class="ld-label">Upload OK</div><div class="ld-val" style="color:'+(e.upload_ok?'var(--green)':'var(--red)')+'">'+e.upload_ok+'</div></div>';
+        // Per-sample mini-chart (PRD #283 slice 3 / issue #286).
+        // Container always renders; the renderer is fired by
+        // toggleLogDetail when the row opens. Empty-state copy
+        // shown when the parent test pre-dates this slice
+        // (no speedtest_history_id link) or has no samples row.
+        // Intentionally small (~200x80) to stay secondary to
+        // the main result.
+        var chartId="speedtest-samples-"+i;
+        var sthid=e.speedtest_history_id||0;
+        h+='<div class="log-detail-item" style="grid-column:1/-1" data-speedtest-history-id="'+sthid+'" data-chart-id="'+chartId+'">'
+          +'<div class="ld-label">Per-sample throughput</div>'
+          +'<div class="ld-val" style="margin-top:4px">'
+          +'<canvas id="'+chartId+'" width="240" height="90" style="display:block;max-width:100%"></canvas>'
+          +'<div class="speedtest-samples-empty" style="font-size:11px;color:var(--text3);font-weight:400">'
+          +(sthid>0?'Loading per-sample chart…':'No per-sample data available — run a new test to populate.')
+          +'</div>'
+          +'</div>'
+          +'</div>';
       }
       h+='</div></div></td></tr>';
     }
@@ -475,10 +493,95 @@
     // tick can consult it. Using the classList as source of truth
     // (rather than pre-computing) handles both open and close paths
     // with one branch. #187.
-    if(el.classList.contains("open"))expandedRows[id]=true;
-    else delete expandedRows[id];
+    if(el.classList.contains("open")){
+      expandedRows[id]=true;
+      // Lazy-render the speed-test per-sample mini-chart on open.
+      // Drawing on collapse is wasteful (canvas is hidden), and
+      // drawing on every page render of the table would re-fetch
+      // the API for every row. PRD #283 slice 3 / issue #286.
+      lazyRenderSpeedtestSamples(el);
+    } else {
+      delete expandedRows[id];
+    }
     updatePausedIndicator();
   };
+
+  // lazyRenderSpeedtestSamples finds the per-sample mini-chart
+  // container inside an expanded log-detail panel, fetches
+  // /api/v1/speedtest/samples/{id}, and draws the throughput
+  // evolution via NasChart.line. Idempotent: if the chart was
+  // already drawn (data-rendered="1") subsequent toggles do
+  // nothing. Empty-state hint shown when the parent row has no
+  // speedtest_history_id link or when the API returns zero
+  // samples. Issue #286 / PRD #283 slice 3.
+  function lazyRenderSpeedtestSamples(panel){
+    if(!panel)return;
+    var holder=panel.querySelector("[data-speedtest-history-id]");
+    if(!holder)return;
+    if(holder.getAttribute("data-rendered")==="1")return;
+    var sthid=parseInt(holder.getAttribute("data-speedtest-history-id"),10)||0;
+    var chartId=holder.getAttribute("data-chart-id");
+    var emptyEl=holder.querySelector(".speedtest-samples-empty");
+    var canvas=holder.querySelector("canvas");
+    if(sthid<=0){
+      // Legacy entry: keep the empty-state copy already rendered
+      // and hide the canvas so it doesn't show as a 240x90 blank.
+      if(canvas)canvas.style.display="none";
+      holder.setAttribute("data-rendered","1");
+      return;
+    }
+    fetch("/api/v1/speedtest/samples/"+encodeURIComponent(String(sthid)))
+      .then(function(r){
+        if(r.status===404)return {samples:[]};
+        if(!r.ok)throw new Error("HTTP "+r.status);
+        return r.json();
+      })
+      .then(function(d){
+        var samples=(d&&d.samples)||[];
+        holder.setAttribute("data-rendered","1");
+        if(samples.length===0){
+          if(canvas)canvas.style.display="none";
+          if(emptyEl)emptyEl.textContent="No per-sample data available — run a new test to populate.";
+          return;
+        }
+        // Two series: download (green) + upload (blue). Latency
+        // samples are zero on Mbps so they render as a flat line
+        // at the start of the chart — fine for the secondary
+        // visual but not the focus.
+        var labels=[],dlData=[],ulData=[];
+        for(var i=0;i<samples.length;i++){
+          var s=samples[i];
+          labels.push(String(i));
+          var phase=String(s.phase||"").toLowerCase();
+          if(phase==="upload"){
+            dlData.push(0);
+            ulData.push(s.mbps||0);
+          } else if(phase==="download"){
+            dlData.push(s.mbps||0);
+            ulData.push(0);
+          } else {
+            dlData.push(0);
+            ulData.push(0);
+          }
+        }
+        if(emptyEl)emptyEl.style.display="none";
+        if(window.NasChart&&NasChart.line){
+          NasChart.line(chartId,{
+            datasets:[
+              {data:dlData,color:"var(--green)",label:"Download Mbps"},
+              {data:ulData,color:"var(--accent)",label:"Upload Mbps"}
+            ],
+            labels:labels,
+            margin:{l:30,r:8,t:8,b:18}
+          });
+        }
+      })
+      .catch(function(){
+        holder.setAttribute("data-rendered","1");
+        if(canvas)canvas.style.display="none";
+        if(emptyEl)emptyEl.textContent="Per-sample data unavailable for this test.";
+      });
+  }
 
   window.filterByCheck=function(key){
     var sel=document.getElementById("f-check");

--- a/internal/models.go
+++ b/internal/models.go
@@ -311,6 +311,17 @@ type ServiceCheckResult struct {
 	// service_checks_history.details_json column so the log UI can render
 	// the same rich context the Test button already shows.
 	Details map[string]any `json:"details,omitempty"`
+
+	// SpeedTestHistoryID links a type=speed result to the
+	// speedtest_history row that produced it. Populated by the
+	// scheduled-dispatch path (runSpeedCheck reads the latest history
+	// row's ID via GetLatestSpeedTestHistoryID). Persisted in
+	// service_checks_history.speedtest_history_id so the
+	// /service-checks expanded-log mini-chart can fetch
+	// /api/v1/speedtest/samples/{id}. Zero on legacy + non-speed
+	// results — the UI renders the "no per-sample data available"
+	// empty state. PRD #283 slice 3 / issue #286.
+	SpeedTestHistoryID int64 `json:"speedtest_history_id,omitempty"`
 }
 
 // ---------- System ----------

--- a/internal/notifier/prometheus.go
+++ b/internal/notifier/prometheus.go
@@ -152,6 +152,16 @@ type Metrics struct {
 	// duration). Updated by SetSpeedTestInProgress, called from the
 	// scheduler/registry wiring.
 	speedtestInProgress prometheus.Gauge
+	// nasdoctor_speedtest_samples_count{test_id="…"} — sample row
+	// count for the most-recent COMPLETED test. PRD #283 / issue
+	// #286 (slice 3). Low-cardinality by construction: the gauge
+	// vec is reset before the latest test_id is exported, so only
+	// ONE label-value pair is ever live at a time. Without the
+	// reset Prometheus would accumulate one series per historical
+	// test_id over the lifetime of the process — a cardinality
+	// landmine. Updated by SetSpeedTestSamplesCount, called from
+	// the scheduler's post-completion bulk-insert path.
+	speedtestSamplesCount *prometheus.GaugeVec
 
 	// ── GPU ──
 	gpuUsagePct    *prometheus.GaugeVec
@@ -351,6 +361,7 @@ func NewMetrics() *Metrics {
 	m.speedtestLatency = gauge(ns, "speedtest", "latency_ms", "Latest speed test latency in ms")
 	m.speedtestEngine = gaugeVec(ns, "speedtest", "engine", "Engine that produced the most recent successful speed test (1=in use, 0=not in use)", []string{"engine"})
 	m.speedtestInProgress = gauge(ns, "speedtest", "in_progress", "1 if a live speed test is currently running, 0 otherwise")
+	m.speedtestSamplesCount = gaugeVec(ns, "speedtest", "samples_count", "Per-sample telemetry row count for the most recent completed speed test (low-cardinality: only the latest test_id is exported)", []string{"test_id"})
 
 	// ── Findings ──
 	m.findingsTotal = gaugeVec(ns, "findings", "total", "Findings by severity", []string{"severity"})
@@ -397,7 +408,7 @@ func NewMetrics() *Metrics {
 		m.gpuTemperature, m.gpuPowerW, m.gpuPowerMaxW, m.gpuFanPct,
 		m.gpuEncoderPct, m.gpuDecoderPct,
 		m.backupLastSuccess, m.backupSizeBytes, m.backupStatus,
-		m.speedtestDownload, m.speedtestUpload, m.speedtestLatency, m.speedtestEngine, m.speedtestInProgress,
+		m.speedtestDownload, m.speedtestUpload, m.speedtestLatency, m.speedtestEngine, m.speedtestInProgress, m.speedtestSamplesCount,
 		m.findingsTotal, m.findingsCritical, m.findingsWarning,
 		m.collectionDuration, m.lastCollectionTime, m.updateAvailable,
 	}
@@ -772,6 +783,21 @@ func (m *Metrics) SetSpeedTestInProgress(running bool) {
 	} else {
 		m.speedtestInProgress.Set(0)
 	}
+}
+
+// SetSpeedTestSamplesCount records the per-sample row count for the
+// MOST RECENT completed speed test. Resets the underlying GaugeVec
+// before stamping the new label-value pair so only ONE series exists
+// at a time — without the reset Prometheus would accumulate a series
+// per historical test_id forever, blowing up cardinality. PRD #283 /
+// issue #286.
+func (m *Metrics) SetSpeedTestSamplesCount(testID int64, count int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.speedtestSamplesCount.Reset()
+	m.speedtestSamplesCount.With(prometheus.Labels{
+		"test_id": fmt.Sprintf("%d", testID),
+	}).Set(float64(count))
 }
 
 func boolToFloat(b bool) float64 {

--- a/internal/notifier/prometheus_speedtest_samples_count_test.go
+++ b/internal/notifier/prometheus_speedtest_samples_count_test.go
@@ -1,0 +1,46 @@
+package notifier
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPrometheus_SpeedTestSamplesCount_DefaultZero asserts that on a
+// fresh Metrics with no test ever completed there is no sample-count
+// series exported. The gauge vec is empty until the first call to
+// SetSpeedTestSamplesCount, which is the desired behaviour: an
+// uninitialised series would mislead "samples_count > 0" alerts.
+// PRD #283 slice 3 / issue #286 user story 17.
+func TestPrometheus_SpeedTestSamplesCount_DefaultZero(t *testing.T) {
+	m := NewMetrics()
+	body := scrapeMetrics(t, m)
+	if strings.Contains(body, "nasdoctor_speedtest_samples_count{") {
+		t.Errorf("expected NO nasdoctor_speedtest_samples_count series before any test completes; body:\n%s", body)
+	}
+}
+
+// TestPrometheus_SpeedTestSamplesCount_StampsLatest asserts that
+// SetSpeedTestSamplesCount populates a single label-value pair for
+// the most recent test_id, and that subsequent calls REPLACE the
+// label rather than accumulating new series. This is the
+// cardinality-protection contract: if a future bug regressed and
+// stopped resetting the GaugeVec, prometheus would accumulate one
+// series per historical test_id forever.
+func TestPrometheus_SpeedTestSamplesCount_StampsLatest(t *testing.T) {
+	m := NewMetrics()
+	m.SetSpeedTestSamplesCount(42, 28)
+	body := scrapeMetrics(t, m)
+	if !strings.Contains(body, `nasdoctor_speedtest_samples_count{test_id="42"} 28`) {
+		t.Errorf("expected samples_count{test_id=42}=28; body:\n%s", body)
+	}
+
+	// Second test, different ID — the old series MUST be evicted.
+	m.SetSpeedTestSamplesCount(43, 31)
+	body = scrapeMetrics(t, m)
+	if !strings.Contains(body, `nasdoctor_speedtest_samples_count{test_id="43"} 31`) {
+		t.Errorf("expected samples_count{test_id=43}=31 after second call; body:\n%s", body)
+	}
+	if strings.Contains(body, `test_id="42"`) {
+		t.Errorf("samples_count series for test_id=42 was not evicted — cardinality landmine; body:\n%s", body)
+	}
+}

--- a/internal/scheduler/checks.go
+++ b/internal/scheduler/checks.go
@@ -676,6 +676,16 @@ func (sc *ServiceChecker) runSpeedCheck(check internal.ServiceCheckConfig, resul
 	result.LatencyMs = latest.LatencyMs
 	result.ResponseMS = int64(latest.LatencyMs)
 
+	// Stamp the parent speedtest_history.id so the /service-checks
+	// expanded-log mini-chart can fetch /api/v1/speedtest/samples/{id}.
+	// GetSpeedTestHistory now returns ID alongside the throughput
+	// fields (issue #286). Fall through if the row was synthesised by
+	// the FakeStore in a test that doesn't seed a non-zero ID — the
+	// UI's empty-state copy handles that case gracefully.
+	if latest.ID > 0 {
+		result.SpeedTestHistoryID = latest.ID
+	}
+
 	// Blank thresholds → heartbeat mode: success = up, no threshold math.
 	if check.ContractedDownMbps <= 0 && check.ContractedUpMbps <= 0 {
 		result.Status = "up"

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1374,14 +1374,37 @@ func (s *Scheduler) runSpeedTestViaRegistry(registry livetest.Registry) {
 			fmt.Sprintf("speed test failed: %v", err))
 		return
 	}
-	s.handleSpeedTestResult(lt.Result())
+	// Pull the buffered sample set BEFORE handleSpeedTestResult so
+	// the bulk-insert is hooked to the same parent history row that
+	// SaveSpeedTestReturningID just produced. PRD #283 slice 3 / #286.
+	samples := lt.SnapshotSamples()
+	s.handleSpeedTestResultWithSamples(lt.Result(), samples)
 }
 
 // handleSpeedTestResult applies the post-run side effects shared by
 // both the registry path and the legacy result-only path: log,
 // persist history row, mirror state onto s.latest. Extracted to keep
-// the two paths in sync.
+// the two paths in sync. The legacy (non-registry) path has no
+// per-sample data, so this thin wrapper passes a nil samples slice
+// to the merged implementation.
 func (s *Scheduler) handleSpeedTestResult(result *internal.SpeedTestResult) {
+	s.handleSpeedTestResultWithSamples(result, nil)
+}
+
+// handleSpeedTestResultWithSamples is the registry-path variant: in
+// addition to writing the speedtest_history row + flipping the attempt
+// state, it bulk-inserts any per-sample telemetry buffered by the
+// LiveTest into speedtest_samples. The bulk-insert MUST happen AFTER
+// SaveSpeedTestReturningID returns the parent ID — otherwise the FK
+// has no target and the insert would fail. PRD #283 slice 3 / #286.
+//
+// Sample-insert errors are warn-logged but do not fail the call: the
+// history row is the canonical source of truth, and a missed
+// per-sample row only degrades the expanded-log mini-chart (which
+// falls back to the empty-state hint). Fail-closed would be a
+// regression for callers that expect the speed test to still be
+// considered "successful" even if the optional sample sidecar fails.
+func (s *Scheduler) handleSpeedTestResultWithSamples(result *internal.SpeedTestResult, samples []collector.SpeedTestSample) {
 	if result == nil {
 		s.logger.Info("speed test failed: no speedtest tool available or zero-throughput result")
 		s.recordSpeedTestAttempt(time.Now().UTC(), "failed",
@@ -1392,11 +1415,47 @@ func (s *Scheduler) handleSpeedTestResult(result *internal.SpeedTestResult) {
 		"download", fmt.Sprintf("%.1f Mbps", result.DownloadMbps),
 		"upload", fmt.Sprintf("%.1f Mbps", result.UploadMbps),
 		"latency", fmt.Sprintf("%.1f ms", result.LatencyMs),
+		"samples", len(samples),
 	)
-	if err := s.store.SaveSpeedTest("speedtest-"+time.Now().Format("20060102-150405"), result); err != nil {
+	historyID, err := s.store.SaveSpeedTestReturningID(
+		"speedtest-"+time.Now().Format("20060102-150405"),
+		result,
+	)
+	if err != nil {
 		s.logger.Warn("failed to save speed test result", "error", err)
 	}
+	if historyID > 0 && len(samples) > 0 {
+		converted := convertSpeedTestSamples(samples)
+		if err := s.store.InsertSpeedTestSamples(historyID, converted); err != nil {
+			s.logger.Warn("failed to persist speed test samples; mini-chart will show empty state for this test",
+				"test_id", historyID, "samples", len(converted), "error", err)
+		} else {
+			s.logger.Info("persisted speed test samples", "test_id", historyID, "samples", len(converted))
+			if s.metrics != nil {
+				s.metrics.SetSpeedTestSamplesCount(historyID, len(converted))
+			}
+		}
+	}
 	s.recordSpeedTestSuccess(time.Now().UTC(), result)
+}
+
+// convertSpeedTestSamples re-shapes the in-memory collector samples
+// into the storage layer's persistence shape. The two structs differ
+// in field naming (At vs Timestamp, no SampleIndex on the in-memory
+// side because emission order is implicit). The sample_index is
+// assigned monotonically based on the slice order.
+func convertSpeedTestSamples(in []collector.SpeedTestSample) []storage.SpeedTestSample {
+	out := make([]storage.SpeedTestSample, 0, len(in))
+	for i, s := range in {
+		out = append(out, storage.SpeedTestSample{
+			SampleIndex: i,
+			Phase:       string(s.Phase),
+			Timestamp:   s.At,
+			Mbps:        s.Mbps,
+			LatencyMs:   s.LatencyMs,
+		})
+	}
+	return out
 }
 
 // recordSpeedTestAttempt persists the attempt state to the store AND

--- a/internal/scheduler/scheduler_speedtest_samples_test.go
+++ b/internal/scheduler/scheduler_speedtest_samples_test.go
@@ -1,0 +1,166 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/collector"
+	"github.com/mcdays94/nas-doctor/internal/livetest"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// samplingRunner emits a deterministic per-sample stream during a
+// fake test run, mirroring what showwin/speedtest-go would produce in
+// production. The samples close before Run returns so the registry
+// completes deterministically. PRD #283 slice 3 / issue #286.
+type samplingRunner struct {
+	result  *internal.SpeedTestResult
+	samples []collector.SpeedTestSample
+}
+
+func (r *samplingRunner) Run(_ context.Context) (*internal.SpeedTestResult, <-chan collector.SpeedTestSample, error) {
+	out := make(chan collector.SpeedTestSample, len(r.samples))
+	for _, s := range r.samples {
+		out <- s
+	}
+	close(out)
+	return r.result, out, nil
+}
+
+// TestRunSpeedTest_PersistsSamplesToStore drives the full scheduler →
+// registry → store path and asserts the buffered sample set lands in
+// speedtest_samples linked to the parent speedtest_history row. End-
+// to-end integration test for slice 3.
+func TestRunSpeedTest_PersistsSamplesToStore(t *testing.T) {
+	t.Parallel()
+	store := storage.NewFakeStore()
+	logger := quietLogger()
+
+	s := New(nil, store, nil, nil, logger, time.Hour)
+
+	now := time.Now().UTC()
+	runner := &samplingRunner{
+		result: &internal.SpeedTestResult{
+			DownloadMbps: 920,
+			UploadMbps:   88,
+			LatencyMs:    8,
+			Timestamp:    now,
+			Engine:       internal.SpeedTestEngineSpeedTestGo,
+		},
+		samples: []collector.SpeedTestSample{
+			{Phase: collector.SpeedTestPhaseLatency, At: now, LatencyMs: 8.2},
+			{Phase: collector.SpeedTestPhaseLatency, At: now.Add(time.Second), LatencyMs: 9.1},
+			{Phase: collector.SpeedTestPhaseDownload, At: now.Add(2 * time.Second), Mbps: 421},
+			{Phase: collector.SpeedTestPhaseDownload, At: now.Add(3 * time.Second), Mbps: 723},
+			{Phase: collector.SpeedTestPhaseUpload, At: now.Add(4 * time.Second), Mbps: 88},
+		},
+	}
+	mgr := livetest.NewManager(runner, logger, nil)
+	s.SetLiveTestRegistry(mgr)
+
+	s.runSpeedTest()
+
+	// History row must have been written via SaveSpeedTestReturningID.
+	id, ok, err := store.GetLatestSpeedTestHistoryID()
+	if err != nil {
+		t.Fatalf("GetLatestSpeedTestHistoryID: %v", err)
+	}
+	if !ok || id == 0 {
+		t.Fatalf("expected a history row to be persisted, got ok=%v id=%d", ok, id)
+	}
+
+	// Samples must be linked to that history ID, in emission order.
+	got, err := store.GetSpeedTestSamples(id)
+	if err != nil {
+		t.Fatalf("GetSpeedTestSamples: %v", err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("len(samples) = %d, want 5", len(got))
+	}
+	for i, s := range got {
+		if s.SampleIndex != i {
+			t.Errorf("samples[%d].SampleIndex = %d, want %d", i, s.SampleIndex, i)
+		}
+	}
+	if got[0].Phase != "latency" || got[2].Phase != "download" || got[4].Phase != "upload" {
+		t.Errorf("phase ordering broken: %+v", got)
+	}
+}
+
+// TestRunSpeedTest_NoSamples_HistoryStillWritten asserts that a
+// completed test with zero per-sample telemetry (e.g. legacy Ookla CLI
+// fallback path that emits no per-sample data) still produces a
+// history row + flips LastAttempt to success. The optional sample-
+// sidecar is decoupled from history persistence — a missing sample
+// stream is NOT a failure.
+func TestRunSpeedTest_NoSamples_HistoryStillWritten(t *testing.T) {
+	t.Parallel()
+	store := storage.NewFakeStore()
+	logger := quietLogger()
+	s := New(nil, store, nil, nil, logger, time.Hour)
+
+	runner := &samplingRunner{
+		result: &internal.SpeedTestResult{
+			DownloadMbps: 100, UploadMbps: 50, LatencyMs: 12,
+			Timestamp: time.Now(), Engine: internal.SpeedTestEngineOoklaCLI,
+		},
+		samples: nil,
+	}
+	mgr := livetest.NewManager(runner, logger, nil)
+	s.SetLiveTestRegistry(mgr)
+
+	s.runSpeedTest()
+
+	id, ok, _ := store.GetLatestSpeedTestHistoryID()
+	if !ok || id == 0 {
+		t.Fatalf("expected history row, got ok=%v id=%d", ok, id)
+	}
+	got, _ := store.GetSpeedTestSamples(id)
+	if len(got) != 0 {
+		t.Errorf("expected zero samples for ookla CLI fallback, got %d", len(got))
+	}
+	att, _ := store.GetLastSpeedTestAttempt()
+	if att == nil || att.Status != "success" {
+		t.Errorf("LastAttempt status = %v, want success", att)
+	}
+}
+
+// TestSpeedCheck_StampsSpeedTestHistoryID asserts that the type=speed
+// scheduled service-check dispatch (issue #210 reads-from-history
+// path) populates ServiceCheckResult.SpeedTestHistoryID with the ID
+// of the history row it consulted. This is the linkage the
+// /service-checks expanded-log mini-chart uses to fetch
+// /api/v1/speedtest/samples/{id}. PRD #283 slice 3 / issue #286.
+func TestSpeedCheck_StampsSpeedTestHistoryID(t *testing.T) {
+	t.Parallel()
+	store := storage.NewFakeStore()
+	logger := quietLogger()
+
+	// Seed a successful attempt + history row that the read-from-
+	// history dispatch will consult.
+	id, err := store.SaveSpeedTestReturningID("snap-1", &internal.SpeedTestResult{
+		DownloadMbps: 100, UploadMbps: 50, LatencyMs: 5,
+		Timestamp: time.Now(), Engine: internal.SpeedTestEngineSpeedTestGo,
+	})
+	if err != nil {
+		t.Fatalf("SaveSpeedTestReturningID: %v", err)
+	}
+	_ = store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
+		Timestamp: time.Now(), Status: "success",
+	})
+
+	sc := NewServiceChecker(store, logger)
+	check := internal.ServiceCheckConfig{
+		Name:   "Internet Speed",
+		Type:   "speed",
+		Target: "speedtest",
+	}
+	result := internal.ServiceCheckResult{Key: "internet-speed", Name: check.Name, Type: check.Type, Target: check.Target}
+	sc.runSpeedCheck(check, &result, time.Now())
+
+	if result.SpeedTestHistoryID != id {
+		t.Errorf("result.SpeedTestHistoryID = %d, want %d (linked to seed history row)", result.SpeedTestHistoryID, id)
+	}
+}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -206,6 +206,37 @@ func (d *DB) migrate() error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_speedtest_ts ON speedtest_history(timestamp DESC)`,
 
+		// --- Speed test per-sample telemetry (PRD #283 / issue #286) ---
+		// Slice 3 of the live-progress PRD. Captures the per-sample
+		// throughput stream emitted by the runner during a test, bulk-
+		// inserted in one transaction at completion (see scheduler's
+		// handleSpeedTestResult). One row per sample emitted by the
+		// engine, ~30 rows for a typical 30-60s test.
+		//
+		//   test_id      → speedtest_history.id (the parent row)
+		//   sample_index → 0-based monotonic counter assigned by the
+		//                  bulk-insert; preserves emission order on
+		//                  read so the mini-chart renders left-to-right.
+		//   phase        → "latency" / "download" / "upload"
+		//   ts           → wall-clock time the sample was emitted.
+		//   mbps         → throughput Mbps (zero for latency-phase).
+		//   latency_ms   → ping latency ms (zero for throughput-phase).
+		//
+		// FK ON DELETE CASCADE means samples are pruned automatically
+		// whenever the parent speedtest_history row is pruned by the
+		// retention loop — no separate retention knob needed.
+		`CREATE TABLE IF NOT EXISTS speedtest_samples (
+			test_id INTEGER NOT NULL,
+			sample_index INTEGER NOT NULL,
+			phase TEXT NOT NULL,
+			ts TIMESTAMP NOT NULL,
+			mbps REAL,
+			latency_ms REAL,
+			PRIMARY KEY (test_id, sample_index),
+			FOREIGN KEY (test_id) REFERENCES speedtest_history(id) ON DELETE CASCADE
+		)`,
+		`CREATE INDEX IF NOT EXISTS speedtest_samples_test_id ON speedtest_samples(test_id)`,
+
 		// --- Last speed-test attempt (single-row table, see issue #210) ---
 		// Records the outcome of the most recent speed-test run — success,
 		// failure, pending, or disabled. Consumed by the scheduled
@@ -371,6 +402,16 @@ func (d *DB) migrate() error {
 	// detail keys get added. See issue #182.
 	if err := d.ensureColumn("service_checks_history", "details_json", "TEXT"); err != nil {
 		return fmt.Errorf("ensure service_checks_history.details_json: %w", err)
+	}
+	// speedtest_history_id links a type=speed service-check log row to
+	// the speedtest_history row that produced it. Lets the
+	// /service-checks expanded-log-row UI fetch per-sample data via
+	// /api/v1/speedtest/samples/{id} without timestamp-fuzzy matching.
+	// NULL on legacy rows + non-speed types — the UI renders the
+	// "no per-sample data available" empty state in that case. Issue
+	// #286 / PRD #283 slice 3.
+	if err := d.ensureColumn("service_checks_history", "speedtest_history_id", "INTEGER"); err != nil {
+		return fmt.Errorf("ensure service_checks_history.speedtest_history_id: %w", err)
 	}
 	if _, err := d.db.Exec(`CREATE INDEX IF NOT EXISTS idx_alerts_fingerprint_open ON alerts(fingerprint, resolved_at)`); err != nil {
 		return fmt.Errorf("create alerts fingerprint index: %w", err)
@@ -895,6 +936,15 @@ func (d *DB) saveSpeedTestHistory(tx *sql.Tx, snap *internal.Snapshot) error {
 
 // SpeedTestHistoryPoint represents a single speed test history data point.
 type SpeedTestHistoryPoint struct {
+	// ID is the speedtest_history.id primary key. Surfaced for callers
+	// that need to correlate per-sample data (speedtest_samples.test_id)
+	// to the parent history row, notably the type=speed service-check
+	// dispatch which stamps service_checks_history.speedtest_history_id
+	// so the /service-checks expanded-log mini-chart can fetch
+	// /api/v1/speedtest/samples/{id}. Zero for fake/test points where
+	// the row was never persisted via SaveSpeedTestReturningID.
+	// Issue #286.
+	ID           int64     `json:"id,omitempty"`
 	Timestamp    time.Time `json:"timestamp"`
 	DownloadMbps float64   `json:"download_mbps"`
 	UploadMbps   float64   `json:"upload_mbps"`
@@ -908,31 +958,145 @@ type SpeedTestHistoryPoint struct {
 	Engine string `json:"engine,omitempty"`
 }
 
+// SpeedTestSample is a single per-tick datum captured during a speed
+// test, persisted into speedtest_samples after the test completes.
+// Mirrors collector.SpeedTestSample (the in-memory wire shape) plus
+// the parent test_id linkage. PRD #283 / issue #286.
+type SpeedTestSample struct {
+	// SampleIndex is the 0-based emission-order counter. Stored as
+	// the PK alongside test_id so re-inserts are caught by SQLite
+	// rather than producing duplicate rows.
+	SampleIndex int       `json:"sample_index"`
+	Phase       string    `json:"phase"`
+	Timestamp   time.Time `json:"ts"`
+	Mbps        float64   `json:"mbps"`
+	LatencyMs   float64   `json:"latency_ms"`
+}
+
 // SaveSpeedTest inserts a single speed test result row. The engine
 // field falls back to "ookla_cli" via the column default when the
 // caller didn't stamp result.Engine — this preserves backwards
 // compatibility for any callsite that pre-dates issue #284.
 func (d *DB) SaveSpeedTest(snapshotID string, result *internal.SpeedTestResult) error {
+	_, err := d.SaveSpeedTestReturningID(snapshotID, result)
+	return err
+}
+
+// SaveSpeedTestReturningID is the same insert as SaveSpeedTest but
+// returns the new speedtest_history.id so the caller can wire it to
+// the per-sample rows in speedtest_samples (FK target). Returns
+// (0, nil) when result is nil so the empty-result path stays a no-op.
+// Added for PRD #283 slice 3 / issue #286 — the runner-driven path
+// in scheduler.handleSpeedTestResult needs the ID to bulk-insert
+// in-memory samples buffered by the LiveTest.
+func (d *DB) SaveSpeedTestReturningID(snapshotID string, result *internal.SpeedTestResult) (int64, error) {
 	if result == nil {
-		return nil
+		return 0, nil
 	}
 	engine := result.Engine
 	if engine == "" {
 		engine = internal.SpeedTestEngineOoklaCLI
 	}
-	_, err := d.db.Exec(
+	res, err := d.db.Exec(
 		`INSERT INTO speedtest_history (snapshot_id, download_mbps, upload_mbps, latency_ms, jitter_ms, server_name, isp, timestamp, engine)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		snapshotID, result.DownloadMbps, result.UploadMbps, result.LatencyMs, result.JitterMs, result.ServerName, result.ISP, result.Timestamp, engine,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// InsertSpeedTestSamples bulk-inserts the per-sample buffer for a
+// completed test in a single transaction. The parent speedtest_history
+// row MUST already exist (FK target) — callers should write the
+// history row via SaveSpeedTestReturningID first, then pass that ID
+// here. Re-inserting with the same (test_id, sample_index) violates
+// the PK and surfaces as an error so callers can detect double-insert
+// bugs. Empty samples slice is a no-op (returns nil). Issue #286.
+func (d *DB) InsertSpeedTestSamples(testID int64, samples []SpeedTestSample) error {
+	if len(samples) == 0 {
+		return nil
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	stmt, err := tx.Prepare(
+		`INSERT INTO speedtest_samples (test_id, sample_index, phase, ts, mbps, latency_ms)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+	)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+	for _, s := range samples {
+		ts := s.Timestamp
+		if ts.IsZero() {
+			ts = time.Now().UTC()
+		}
+		if _, err := stmt.Exec(testID, s.SampleIndex, s.Phase, ts.UTC(), s.Mbps, s.LatencyMs); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// GetSpeedTestSamples returns every sample row for the given test_id,
+// ordered by sample_index ascending so the mini-chart renders the
+// throughput evolution left-to-right exactly as it was emitted.
+// Returns an empty slice (NOT an error) for test_ids with no samples
+// row — pre-#286 tests legitimately have no samples and the UI
+// renders an empty-state hint in that case. Issue #286.
+func (d *DB) GetSpeedTestSamples(testID int64) ([]SpeedTestSample, error) {
+	rows, err := d.db.Query(
+		`SELECT sample_index, phase, ts, COALESCE(mbps, 0), COALESCE(latency_ms, 0)
+		 FROM speedtest_samples
+		 WHERE test_id = ?
+		 ORDER BY sample_index ASC`,
+		testID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]SpeedTestSample, 0)
+	for rows.Next() {
+		var s SpeedTestSample
+		if err := rows.Scan(&s.SampleIndex, &s.Phase, &s.Timestamp, &s.Mbps, &s.LatencyMs); err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+// GetLatestSpeedTestHistoryID returns the speedtest_history.id of the
+// most-recent row, or (0, false, nil) if no history rows exist yet.
+// Used by the type=speed scheduled service check to stamp the new
+// service_checks_history.speedtest_history_id column so the expanded
+// log row can link to the parent test. Issue #286.
+func (d *DB) GetLatestSpeedTestHistoryID() (int64, bool, error) {
+	row := d.db.QueryRow(
+		`SELECT id FROM speedtest_history ORDER BY id DESC LIMIT 1`,
+	)
+	var id int64
+	if err := row.Scan(&id); err != nil {
+		if err == sql.ErrNoRows {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	return id, true, nil
 }
 
 // GetSpeedTestHistory returns speed test history for the given time range.
 func (d *DB) GetSpeedTestHistory(hours int) ([]SpeedTestHistoryPoint, error) {
 	cutoff := time.Now().Add(-time.Duration(hours) * time.Hour)
 	rows, err := d.db.Query(
-		`SELECT timestamp, download_mbps, upload_mbps, latency_ms, jitter_ms, COALESCE(server_name, ''), COALESCE(isp, ''), COALESCE(engine, 'ookla_cli')
+		`SELECT id, timestamp, download_mbps, upload_mbps, latency_ms, jitter_ms, COALESCE(server_name, ''), COALESCE(isp, ''), COALESCE(engine, 'ookla_cli')
 		 FROM speedtest_history
 		 WHERE timestamp >= ?
 		 ORDER BY timestamp ASC`,
@@ -946,7 +1110,7 @@ func (d *DB) GetSpeedTestHistory(hours int) ([]SpeedTestHistoryPoint, error) {
 	var points []SpeedTestHistoryPoint
 	for rows.Next() {
 		var p SpeedTestHistoryPoint
-		if err := rows.Scan(&p.Timestamp, &p.DownloadMbps, &p.UploadMbps, &p.LatencyMs, &p.JitterMs, &p.ServerName, &p.ISP, &p.Engine); err != nil {
+		if err := rows.Scan(&p.ID, &p.Timestamp, &p.DownloadMbps, &p.UploadMbps, &p.LatencyMs, &p.JitterMs, &p.ServerName, &p.ISP, &p.Engine); err != nil {
 			return nil, err
 		}
 		points = append(points, p)
@@ -1780,6 +1944,14 @@ type ServiceCheckEntry struct {
 	// written before the column existed, or for check types that produce
 	// no extra context. See issue #182.
 	Details map[string]any `json:"details,omitempty"`
+
+	// SpeedTestHistoryID links a type=speed log row to the
+	// speedtest_history row that produced it, so the
+	// /service-checks expanded-log mini-chart can fetch
+	// /api/v1/speedtest/samples/{id}. Zero on legacy rows + non-speed
+	// types — the UI renders the "no per-sample data available" empty
+	// state in that case. PRD #283 slice 3 / issue #286.
+	SpeedTestHistoryID int64 `json:"speedtest_history_id,omitempty"`
 }
 
 // SaveServiceCheckResults appends service check run results to history.
@@ -1816,11 +1988,20 @@ func (d *DB) SaveServiceCheckResults(results []internal.ServiceCheckResult) erro
 					"check", result.Name, "error", err)
 			}
 		}
+		// speedtest_history_id is non-zero only for type=speed rows
+		// where the dispatch managed to resolve the parent test ID
+		// (issue #286). NULL otherwise — UI treats NULL as "legacy
+		// row, no per-sample mini-chart available".
+		var speedHistID any // nil → SQL NULL
+		if result.SpeedTestHistoryID > 0 {
+			speedHistID = result.SpeedTestHistoryID
+		}
 		_, err := tx.Exec(
 			`INSERT INTO service_checks_history (
 				check_key, name, check_type, target, status, response_ms, error_message,
-				consecutive_failures, failure_threshold, failure_severity, checked_at, details_json
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				consecutive_failures, failure_threshold, failure_severity, checked_at, details_json,
+				speedtest_history_id
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			result.Key,
 			result.Name,
 			result.Type,
@@ -1833,6 +2014,7 @@ func (d *DB) SaveServiceCheckResults(results []internal.ServiceCheckResult) erro
 			result.FailureSeverity,
 			checkedAt,
 			detailsPayload,
+			speedHistID,
 		)
 		if err != nil {
 			return err
@@ -1874,7 +2056,7 @@ func (d *DB) ListLatestServiceChecks(limit int) ([]ServiceCheckEntry, error) {
 		`SELECT check_key, name, check_type, target, status,
 				COALESCE(response_ms, 0), COALESCE(error_message, ''),
 				COALESCE(consecutive_failures, 0), COALESCE(failure_threshold, 1), COALESCE(failure_severity, 'warning'),
-				checked_at, details_json
+				checked_at, details_json, speedtest_history_id
 		 FROM service_checks_history
 		 WHERE id IN (
 			SELECT MAX(id) FROM service_checks_history GROUP BY check_key
@@ -1893,6 +2075,7 @@ func (d *DB) ListLatestServiceChecks(limit int) ([]ServiceCheckEntry, error) {
 		var e ServiceCheckEntry
 		var checkedAt time.Time
 		var detailsJSON sql.NullString
+		var speedHistID sql.NullInt64
 		if err := rows.Scan(
 			&e.Key,
 			&e.Name,
@@ -1906,11 +2089,15 @@ func (d *DB) ListLatestServiceChecks(limit int) ([]ServiceCheckEntry, error) {
 			&e.FailureSeverity,
 			&checkedAt,
 			&detailsJSON,
+			&speedHistID,
 		); err != nil {
 			return nil, err
 		}
 		e.CheckedAt = checkedAt.UTC().Format(time.RFC3339)
 		e.Details = decodeDetailsJSON(d.logger, detailsJSON, e.Key)
+		if speedHistID.Valid {
+			e.SpeedTestHistoryID = speedHistID.Int64
+		}
 		entries = append(entries, e)
 	}
 	return entries, rows.Err()
@@ -1928,7 +2115,7 @@ func (d *DB) GetServiceCheckHistory(checkKey string, limit int) ([]ServiceCheckE
 		`SELECT check_key, name, check_type, target, status,
 				COALESCE(response_ms, 0), COALESCE(error_message, ''),
 				COALESCE(consecutive_failures, 0), COALESCE(failure_threshold, 1), COALESCE(failure_severity, 'warning'),
-				checked_at, details_json
+				checked_at, details_json, speedtest_history_id
 		 FROM service_checks_history
 		 WHERE check_key = ?
 		 ORDER BY checked_at DESC
@@ -1946,6 +2133,7 @@ func (d *DB) GetServiceCheckHistory(checkKey string, limit int) ([]ServiceCheckE
 		var e ServiceCheckEntry
 		var checkedAt time.Time
 		var detailsJSON sql.NullString
+		var speedHistID sql.NullInt64
 		if err := rows.Scan(
 			&e.Key,
 			&e.Name,
@@ -1959,11 +2147,15 @@ func (d *DB) GetServiceCheckHistory(checkKey string, limit int) ([]ServiceCheckE
 			&e.FailureSeverity,
 			&checkedAt,
 			&detailsJSON,
+			&speedHistID,
 		); err != nil {
 			return nil, err
 		}
 		e.CheckedAt = checkedAt.UTC().Format(time.RFC3339)
 		e.Details = decodeDetailsJSON(d.logger, detailsJSON, e.Key)
+		if speedHistID.Valid {
+			e.SpeedTestHistoryID = speedHistID.Int64
+		}
 		entries = append(entries, e)
 	}
 	return entries, rows.Err()

--- a/internal/storage/db_speedtest_samples_test.go
+++ b/internal/storage/db_speedtest_samples_test.go
@@ -1,0 +1,326 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	internal "github.com/mcdays94/nas-doctor/internal"
+)
+
+// TestSpeedTestSamples_Schema asserts the migration creates the
+// speedtest_samples table with the expected columns + the index. PRD
+// #283 slice 3 / issue #286. Treats the SQL CREATE TABLE statement as
+// the source-of-truth and pins it via PRAGMA table_info so a future
+// refactor that drops a column or renames the index gets caught at
+// test-time.
+func TestSpeedTestSamples_Schema(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	rows, err := db.db.Query("PRAGMA table_info(speedtest_samples)")
+	if err != nil {
+		t.Fatalf("table_info: %v", err)
+	}
+	defer rows.Close()
+	want := map[string]string{
+		"test_id":      "INTEGER",
+		"sample_index": "INTEGER",
+		"phase":        "TEXT",
+		"ts":           "TIMESTAMP",
+		"mbps":         "REAL",
+		"latency_ms":   "REAL",
+	}
+	got := make(map[string]string)
+	for rows.Next() {
+		var cid int
+		var name, colType string
+		var notnull, pk int
+		var dflt *string
+		if err := rows.Scan(&cid, &name, &colType, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got[name] = colType
+	}
+	for col, typ := range want {
+		if got[col] != typ {
+			t.Errorf("speedtest_samples.%s column type = %q, want %q", col, got[col], typ)
+		}
+	}
+
+	// Index named per the migration.
+	idxRows, err := db.db.Query("PRAGMA index_list(speedtest_samples)")
+	if err != nil {
+		t.Fatalf("index_list: %v", err)
+	}
+	defer idxRows.Close()
+	foundIdx := false
+	for idxRows.Next() {
+		var seq int
+		var name, origin string
+		var unique, partial int
+		if err := idxRows.Scan(&seq, &name, &unique, &origin, &partial); err != nil {
+			t.Fatalf("scan idx: %v", err)
+		}
+		if name == "speedtest_samples_test_id" {
+			foundIdx = true
+		}
+	}
+	if !foundIdx {
+		t.Errorf("speedtest_samples_test_id index missing from speedtest_samples")
+	}
+}
+
+// TestSpeedTestSamples_InsertAndRetrieve_PreservesOrder asserts
+// InsertSpeedTestSamples + GetSpeedTestSamples round-trip and that the
+// retrieval is ordered by sample_index ascending. The mini-chart on
+// /service-checks renders left-to-right; an unordered retrieval would
+// produce a chart with backwards-jumping samples that the chart
+// library would render as crossed line segments.
+func TestSpeedTestSamples_InsertAndRetrieve_PreservesOrder(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	// Parent history row (FK target).
+	id, err := db.SaveSpeedTestReturningID("snap-1", &internal.SpeedTestResult{
+		DownloadMbps: 100, UploadMbps: 10, LatencyMs: 5,
+		Timestamp: time.Now(), Engine: internal.SpeedTestEngineSpeedTestGo,
+	})
+	if err != nil {
+		t.Fatalf("SaveSpeedTestReturningID: %v", err)
+	}
+	if id == 0 {
+		t.Fatal("expected non-zero history ID")
+	}
+
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	samples := []SpeedTestSample{
+		{SampleIndex: 0, Phase: "latency", Timestamp: now.Add(0 * time.Second), LatencyMs: 8.2},
+		{SampleIndex: 1, Phase: "latency", Timestamp: now.Add(1 * time.Second), LatencyMs: 9.1},
+		{SampleIndex: 2, Phase: "download", Timestamp: now.Add(2 * time.Second), Mbps: 421},
+		{SampleIndex: 3, Phase: "download", Timestamp: now.Add(3 * time.Second), Mbps: 723},
+		{SampleIndex: 4, Phase: "upload", Timestamp: now.Add(4 * time.Second), Mbps: 88},
+	}
+	if err := db.InsertSpeedTestSamples(id, samples); err != nil {
+		t.Fatalf("InsertSpeedTestSamples: %v", err)
+	}
+
+	got, err := db.GetSpeedTestSamples(id)
+	if err != nil {
+		t.Fatalf("GetSpeedTestSamples: %v", err)
+	}
+	if len(got) != len(samples) {
+		t.Fatalf("len(samples) = %d, want %d", len(got), len(samples))
+	}
+	for i, s := range got {
+		if s.SampleIndex != i {
+			t.Errorf("samples[%d].SampleIndex = %d, want %d (order not preserved)", i, s.SampleIndex, i)
+		}
+	}
+	if got[0].Phase != "latency" || got[2].Phase != "download" || got[4].Phase != "upload" {
+		t.Errorf("phase ordering broken: %+v", got)
+	}
+	if got[3].Mbps != 723 {
+		t.Errorf("Mbps round-trip failed: got %f, want 723", got[3].Mbps)
+	}
+}
+
+// TestSpeedTestSamples_CascadeDeleteFromHistory asserts that deleting
+// the parent speedtest_history row drops the linked samples via the
+// FK ON DELETE CASCADE. Without this, the prune cycle would orphan
+// rows in speedtest_samples forever. Issue #286 acceptance criterion.
+func TestSpeedTestSamples_CascadeDeleteFromHistory(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	id, err := db.SaveSpeedTestReturningID("snap-1", &internal.SpeedTestResult{
+		DownloadMbps: 100, Timestamp: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("SaveSpeedTestReturningID: %v", err)
+	}
+	if err := db.InsertSpeedTestSamples(id, []SpeedTestSample{
+		{SampleIndex: 0, Phase: "download", Timestamp: time.Now(), Mbps: 100},
+		{SampleIndex: 1, Phase: "download", Timestamp: time.Now(), Mbps: 200},
+	}); err != nil {
+		t.Fatalf("InsertSpeedTestSamples: %v", err)
+	}
+	// Sanity: pre-delete count.
+	pre, _ := db.GetSpeedTestSamples(id)
+	if len(pre) != 2 {
+		t.Fatalf("expected 2 samples pre-delete, got %d", len(pre))
+	}
+
+	// Delete the parent row.
+	if _, err := db.db.Exec("DELETE FROM speedtest_history WHERE id = ?", id); err != nil {
+		t.Fatalf("delete history: %v", err)
+	}
+
+	// Samples must now be gone.
+	post, err := db.GetSpeedTestSamples(id)
+	if err != nil {
+		t.Fatalf("GetSpeedTestSamples post-delete: %v", err)
+	}
+	if len(post) != 0 {
+		t.Errorf("FK ON DELETE CASCADE did not fire: %d samples remain", len(post))
+	}
+}
+
+// TestSpeedTestSamples_FKConstraint_RejectsMissingParent asserts that
+// inserting samples for a test_id with no matching speedtest_history
+// row fails. This guards against a runner-stage bug where samples
+// would be flushed before the parent history row was written —
+// without the FK, those samples would silently accumulate.
+func TestSpeedTestSamples_FKConstraint_RejectsMissingParent(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	err := db.InsertSpeedTestSamples(99999, []SpeedTestSample{
+		{SampleIndex: 0, Phase: "download", Timestamp: time.Now(), Mbps: 100},
+	})
+	if err == nil {
+		t.Fatal("expected FK error for missing parent test_id, got nil")
+	}
+}
+
+// TestSpeedTestSamples_PrimaryKeyConstraint_RejectsDuplicateIndex
+// asserts that re-inserting an already-stored (test_id, sample_index)
+// pair fails. Catches double-insert bugs in the scheduler's
+// completion handler.
+func TestSpeedTestSamples_PrimaryKeyConstraint_RejectsDuplicateIndex(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	id, err := db.SaveSpeedTestReturningID("snap-1", &internal.SpeedTestResult{
+		DownloadMbps: 100, Timestamp: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("SaveSpeedTestReturningID: %v", err)
+	}
+	if err := db.InsertSpeedTestSamples(id, []SpeedTestSample{
+		{SampleIndex: 0, Phase: "download", Timestamp: time.Now(), Mbps: 100},
+	}); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	err = db.InsertSpeedTestSamples(id, []SpeedTestSample{
+		{SampleIndex: 0, Phase: "download", Timestamp: time.Now(), Mbps: 999},
+	})
+	if err == nil {
+		t.Fatal("expected PK error on duplicate (test_id, sample_index), got nil")
+	}
+}
+
+// TestSpeedTestSamples_GetUnknownTestID_ReturnsEmpty asserts that
+// querying for samples on a test_id that doesn't exist returns an
+// empty slice rather than an error. The /api/v1/speedtest/samples/{id}
+// HTTP handler distinguishes "test exists but has no samples" (legacy
+// row, return empty array + 200) from "test_id unknown" (404), and
+// this method is the building block for both cases.
+func TestSpeedTestSamples_GetUnknownTestID_ReturnsEmpty(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	got, err := db.GetSpeedTestSamples(7777777)
+	if err != nil {
+		t.Fatalf("GetSpeedTestSamples: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len = %d, want 0", len(got))
+	}
+}
+
+// TestSpeedTestSamples_MigrationIdempotent asserts that running the
+// migration on an already-migrated DB is a no-op. Mirrors the v0.9.9
+// V2a shape-sentinel pattern (idempotent migrations) — for SQL the
+// equivalent is `CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT
+// EXISTS` which the table definition already uses; this test just
+// pins the contract.
+func TestSpeedTestSamples_MigrationIdempotent(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+	// migrate is called by Open; running it again should not error
+	// (CREATE TABLE IF NOT EXISTS is idempotent).
+	if err := db.migrate(); err != nil {
+		t.Fatalf("second migrate: %v", err)
+	}
+	// And insert/retrieve must still work afterwards.
+	id, err := db.SaveSpeedTestReturningID("snap-1", &internal.SpeedTestResult{
+		DownloadMbps: 100, Timestamp: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("SaveSpeedTestReturningID: %v", err)
+	}
+	if err := db.InsertSpeedTestSamples(id, []SpeedTestSample{
+		{SampleIndex: 0, Phase: "download", Timestamp: time.Now(), Mbps: 100},
+	}); err != nil {
+		t.Fatalf("InsertSpeedTestSamples post-2nd-migration: %v", err)
+	}
+}
+
+// TestServiceChecksHistory_SpeedTestHistoryIDColumn asserts the v0.9.11
+// migration adds the speedtest_history_id column to
+// service_checks_history and SaveServiceCheckResults persists it.
+// This is the linkage the /service-checks expanded-log mini-chart
+// uses to fetch /api/v1/speedtest/samples/{id}. Issue #286.
+func TestServiceChecksHistory_SpeedTestHistoryIDColumn(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	// Column exists.
+	rows, err := db.db.Query("PRAGMA table_info(service_checks_history)")
+	if err != nil {
+		t.Fatalf("table_info: %v", err)
+	}
+	defer rows.Close()
+	found := false
+	for rows.Next() {
+		var cid int
+		var name, colType string
+		var notnull, pk int
+		var dflt *string
+		if err := rows.Scan(&cid, &name, &colType, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if name == "speedtest_history_id" {
+			found = true
+			if colType != "INTEGER" {
+				t.Errorf("speedtest_history_id type = %q, want INTEGER", colType)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("service_checks_history.speedtest_history_id column missing")
+	}
+
+	// SaveServiceCheckResults persists the value, ListLatestServiceChecks
+	// returns it.
+	checked := time.Now().UTC().Format(time.RFC3339)
+	if err := db.SaveServiceCheckResults([]internal.ServiceCheckResult{
+		{
+			Key: "k1", Name: "Internet Speed", Type: "speed", Target: "speedtest",
+			Status: "up", ResponseMS: 5,
+			CheckedAt: checked, FailureThreshold: 1, FailureSeverity: "warning",
+			SpeedTestHistoryID: 42,
+		},
+	}); err != nil {
+		t.Fatalf("SaveServiceCheckResults: %v", err)
+	}
+	entries, err := db.ListLatestServiceChecks(10)
+	if err != nil {
+		t.Fatalf("ListLatestServiceChecks: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(entries))
+	}
+	if entries[0].SpeedTestHistoryID != 42 {
+		t.Errorf("entries[0].SpeedTestHistoryID = %d, want 42", entries[0].SpeedTestHistoryID)
+	}
+
+	// And history endpoint returns it too.
+	hist, err := db.GetServiceCheckHistory("k1", 10)
+	if err != nil {
+		t.Fatalf("GetServiceCheckHistory: %v", err)
+	}
+	if len(hist) != 1 || hist[0].SpeedTestHistoryID != 42 {
+		t.Errorf("history SpeedTestHistoryID = %v, want 42", hist)
+	}
+}

--- a/internal/storage/fake.go
+++ b/internal/storage/fake.go
@@ -67,6 +67,15 @@ type FakeStore struct {
 	// the scheduler writes the first attempt outcome.
 	speedTestAttempt *LastSpeedTestAttempt
 
+	// Per-test sample buffer keyed by test_id (PRD #283 slice 3 /
+	// issue #286). Mirrors the FK + cascade-delete shape of the
+	// real DB so deleting a history row drops samples too.
+	speedTestSamples map[int64][]SpeedTestSample
+	// speedTestNextID is the synthetic auto-increment counter for
+	// SaveSpeedTestReturningID. Starts at 1 so a zero ID is always
+	// "no row".
+	speedTestNextID int64
+
 	// Drive maintenance events (issue #130).
 	driveEvents     []DriveEvent
 	driveEventSeq   int64
@@ -546,8 +555,17 @@ func extractProcessName(command string) string {
 }
 
 func (f *FakeStore) SaveSpeedTest(_ string, result *internal.SpeedTestResult) error {
+	_, err := f.SaveSpeedTestReturningID("", result)
+	return err
+}
+
+// SaveSpeedTestReturningID mirrors *DB's same-named method: appends a
+// history row + returns its synthetic ID. The fake assigns IDs from a
+// monotonically-increasing counter so test code can correlate samples
+// against a known parent row. PRD #283 / issue #286.
+func (f *FakeStore) SaveSpeedTestReturningID(_ string, result *internal.SpeedTestResult) (int64, error) {
 	if result == nil {
-		return nil
+		return 0, nil
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -555,7 +573,14 @@ func (f *FakeStore) SaveSpeedTest(_ string, result *internal.SpeedTestResult) er
 	if ts.IsZero() {
 		ts = time.Now()
 	}
+	f.speedTestNextID++
+	id := f.speedTestNextID
+	engine := result.Engine
+	if engine == "" {
+		engine = internal.SpeedTestEngineOoklaCLI
+	}
 	f.speedTestHistory = append(f.speedTestHistory, SpeedTestHistoryPoint{
+		ID:           id,
 		Timestamp:    ts,
 		DownloadMbps: result.DownloadMbps,
 		UploadMbps:   result.UploadMbps,
@@ -563,8 +588,9 @@ func (f *FakeStore) SaveSpeedTest(_ string, result *internal.SpeedTestResult) er
 		JitterMs:     result.JitterMs,
 		ServerName:   result.ServerName,
 		ISP:          result.ISP,
+		Engine:       engine,
 	})
-	return nil
+	return id, nil
 }
 
 func (f *FakeStore) GetSpeedTestHistory(hours int) ([]SpeedTestHistoryPoint, error) {
@@ -608,6 +634,75 @@ func (f *FakeStore) GetLastSpeedTestAttempt() (*LastSpeedTestAttempt, error) {
 	}
 	cp := *f.speedTestAttempt
 	return &cp, nil
+}
+
+// GetLatestSpeedTestHistoryID returns the most-recently-saved history
+// row's synthetic ID. Returns (0, false, nil) on an empty store.
+// PRD #283 slice 3 / issue #286.
+func (f *FakeStore) GetLatestSpeedTestHistoryID() (int64, bool, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if len(f.speedTestHistory) == 0 {
+		return 0, false, nil
+	}
+	// Last appended row wins (ascending append order).
+	return f.speedTestHistory[len(f.speedTestHistory)-1].ID, true, nil
+}
+
+// InsertSpeedTestSamples bulk-stores samples for an existing history
+// row. Insert into a non-existent test_id returns an error to mirror
+// the FK-constraint behaviour of the real DB. Re-inserting the same
+// (test_id, sample_index) is rejected (mirrors the PK constraint).
+// PRD #283 slice 3 / issue #286.
+func (f *FakeStore) InsertSpeedTestSamples(testID int64, samples []SpeedTestSample) error {
+	if len(samples) == 0 {
+		return nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	// Verify the parent row exists (FK constraint emulation).
+	parentExists := false
+	for _, p := range f.speedTestHistory {
+		if p.ID == testID {
+			parentExists = true
+			break
+		}
+	}
+	if !parentExists {
+		return fmt.Errorf("FOREIGN KEY constraint failed: speedtest_history row %d not found", testID)
+	}
+	if f.speedTestSamples == nil {
+		f.speedTestSamples = make(map[int64][]SpeedTestSample)
+	}
+	existing := f.speedTestSamples[testID]
+	// Build an index set of already-stored sample_index values to
+	// reject duplicates (PK constraint emulation).
+	taken := make(map[int]struct{}, len(existing))
+	for _, e := range existing {
+		taken[e.SampleIndex] = struct{}{}
+	}
+	for _, s := range samples {
+		if _, dup := taken[s.SampleIndex]; dup {
+			return fmt.Errorf("UNIQUE constraint failed: speedtest_samples (test_id=%d, sample_index=%d)", testID, s.SampleIndex)
+		}
+		taken[s.SampleIndex] = struct{}{}
+	}
+	f.speedTestSamples[testID] = append(existing, samples...)
+	return nil
+}
+
+// GetSpeedTestSamples returns samples for the given test_id ordered by
+// sample_index ascending. An unknown test_id returns an empty slice
+// (NOT an error) to match the *DB behaviour. PRD #283 slice 3 /
+// issue #286.
+func (f *FakeStore) GetSpeedTestSamples(testID int64) ([]SpeedTestSample, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	src := f.speedTestSamples[testID]
+	out := make([]SpeedTestSample, len(src))
+	copy(out, src)
+	sort.Slice(out, func(i, j int) bool { return out[i].SampleIndex < out[j].SampleIndex })
+	return out, nil
 }
 
 // ── ConfigStore ──

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -83,10 +83,18 @@ type HistoryStore interface {
 	SaveProcessStatsAt(procs []internal.ProcessInfo, ts time.Time) error
 	GetProcessHistory(hours int) ([]ProcessHistoryPoint, error)
 	SaveSpeedTest(snapshotID string, result *internal.SpeedTestResult) error
+	// SaveSpeedTestReturningID is the ID-returning variant added in
+	// PRD #283 slice 3 / issue #286 so the scheduler can wire the new
+	// history row to per-sample bulk-insert.
+	SaveSpeedTestReturningID(snapshotID string, result *internal.SpeedTestResult) (int64, error)
 	GetSpeedTestHistory(hours int) ([]SpeedTestHistoryPoint, error)
+	GetLatestSpeedTestHistoryID() (int64, bool, error)
 	// Issue #210 — last attempt state (single-row table).
 	SaveSpeedTestAttempt(att LastSpeedTestAttempt) error
 	GetLastSpeedTestAttempt() (*LastSpeedTestAttempt, error)
+	// PRD #283 slice 3 / issue #286 — per-sample telemetry.
+	InsertSpeedTestSamples(testID int64, samples []SpeedTestSample) error
+	GetSpeedTestSamples(testID int64) ([]SpeedTestSample, error)
 }
 
 // ConfigStore handles key/value configuration persistence.


### PR DESCRIPTION
Closes #286. **Also closes long-open user request #191** — the per-sample chart in the expanded log row is exactly what #191 asked for.

This is the **final slice** of [PRD #283](https://github.com/mcdays94/nas-doctor/issues/283). Builds on slice 1 (#284 / #287 — `SpeedTestRunner` + engine column) and slice 2 (#285 / #288 — `LiveTestRegistry` + SSE streaming).

## Summary

When a speed test completes, the in-memory sample buffer captured by the `LiveTest` (slice 2) is now bulk-inserted into a new `speedtest_samples` table linked to the parent `speedtest_history` row via `FK ... ON DELETE CASCADE`. Users expanding any past `type=speed` entry on `/service-checks` see a per-sample mini-chart of throughput evolution during that test window. Old tests that ran before this slice show the canonical empty-state hint instead.

## Acceptance criteria

### Schema + storage
- [x] `CREATE TABLE speedtest_samples` with the documented columns + FK ON DELETE CASCADE
- [x] `CREATE INDEX speedtest_samples_test_id`
- [x] `SpeedTestSamplesStore` deep module — `InsertSpeedTestSamples`, `GetSpeedTestSamples`, plus `SaveSpeedTestReturningID` and `GetLatestSpeedTestHistoryID` to wire the parent-row linkage
- [x] Migration is idempotent (CREATE TABLE/INDEX IF NOT EXISTS); test pins it via `PRAGMA table_info` + a second `migrate()` call

### Backend integration
- [x] Scheduler's registry-driven path bulk-inserts samples into `speedtest_samples` in one transaction AFTER `SaveSpeedTestReturningID` writes the parent row (FK target order)
- [x] `GET /api/v1/speedtest/samples/{test_id}` returns JSON with strict 404 semantics for in-flight (with hint at `/stream/{id}`) + unknown/pruned IDs
- [x] API-key middleware integration verified

### UI — `/service-checks` expanded-log mini-chart
- [x] Lazy-rendered NasChart.line throughput chart (download + upload series) with download-green + accent-blue
- [x] Empty-state copy: *'No per-sample data available — run a new test to populate.'*
- [x] Reuses NasChart.line — no new chart library code
- [x] Intentionally small (240×90 canvas)

### Tests
- [x] SpeedTestSamplesStore: insert+retrieve order, cascade-delete on history prune, FK rejects orphan, PK rejects duplicate, empty-on-unknown
- [x] Scheduler integration: full lifecycle through `LiveTestRegistry` → samples land in DB
- [x] HTTP: happy path / legacy empty / in-flight 404 / unknown 404 / invalid 400 / api-key middleware
- [x] UI smoke: mini-chart container present, empty-state copy pinned, lazy-render hook present, JS-parse hygiene
- [x] Prometheus: default-empty + latest-only series eviction

### Prometheus
- [x] `nasdoctor_speedtest_samples_count{test_id=\"…\"}` gauge — cardinality-protected by GaugeVec.Reset before each stamp

### Demo feeder
- [x] `buildSpeedTestSamples` synthesises a realistic 30-sample stream per platform (5 latency → 15 download with ramp → 10 upload with ramp)
- [x] Speed service-check entry stamped with stable `speedtest_history_id` (SAMPLED_TEST_ID = 1001) so SC expanded log row links cleanly
- [x] Demo worker route `/api/v1/speedtest/samples/{id}` reads from KV
- [x] `widget-coverage.test.ts` extended: 30-sample shape pin, monotonic index, all-three-phases, linkage assertion

## Linkage strategy chosen

The PRD prompt called out that the link from a `/service-checks` log row to a `speedtest_history.id` may not exist directly. I went with **adding a `speedtest_history_id INTEGER` column to `service_checks_history`**, populated by the scheduled-dispatch path (`runSpeedCheck` reads `GetLatestSpeedTestHistoryID` and stamps the result before persistence). This is the cleanest approach because:

1. The link is precise — the SC log row carries the exact `id` it consulted, so a future race between the speed-check tick and the speedtest cron tick can't produce a wrong link via timestamp-fuzzy matching.
2. Zero impact on legacy rows: `NULL` is the natural default for non-speed types and pre-#286 speed rows; the UI's empty-state hint handles those gracefully.
3. The migration is purely additive (`ensureColumn` with `INTEGER` type — same shape as the v0.9.10 `engine` column add).

The alternative (timestamp-fuzzy matching on the frontend) would have shipped a worse UX for ~zero schema savings and is rejected.

## Test count delta

**+25 new Go test functions** (8 storage, 6 HTTP, 3 scheduler integration, 4 UI smoke + JS-parse, 2 Prometheus) and **+2 new vitest tests** in the feeder. All pass under `go test ./... -race -count=1` and `npm test` respectively.

## §4b pre-push checks

- [x] `go build ./...` — clean
- [x] `go test ./... -race` — all green
- [x] `go vet ./...` — clean
- [x] `cd demo-worker/feeder && npm test` — 32/32 green
- [x] `cd demo-worker/feeder && npx tsc --noEmit` — clean
- [x] `cd demo-worker && npx tsc --noEmit` — clean
- [x] `service_checks.html <script>` blocks parse via `node --check` (regression guard for the v0.9.9-rc1 `*/`-in-comment hazard)
- [ ] `docker build .` — NOT attempted; no Dockerfile changes in this slice (verified via `git diff origin/main -- Dockerfile`), no new system deps. Daemon also unavailable in this environment.

## Out of scope per PRD (deliberately not done)

- No cancellation (Cancel button still shows disabled state per PRD).
- No fleet routing — sample data stays local-only per PRD's "Out of scope".
- No `settings_version` bump — purely SQL-only schema change. Mirrors slice 1's reasoning.
- No separate retention policy for `speedtest_samples` — cascades from `speedtest_history` per PRD.
- No SSE mode on `/samples/{id}` — strict separation: live = `/stream`, completed = `/samples` JSON only.