### PR TITLE
docs(readme): add maintainer-context note welcoming non-Unraid bug reports (#266)

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,6 +730,12 @@ nasdoctor_collection_duration_seconds / _last_collection_timestamp
 
 > Tested on **Unraid** daily. Synology, Proxmox, and Kubernetes have community reports / fleet-peer dogfooding. Other platforms should work but may have edge cases with disk detection, SMART access, or platform-specific features. [Report issues here.](https://github.com/mcdays94/nas-doctor/issues)
 
+### A note from the maintainer
+
+NAS Doctor is maintained by one person, and the only platform I have hands-on every day is **Unraid**. Synology DSM, TrueNAS SCALE, Proxmox VE, Kubernetes/k3s, and Docker-on-Linux are all supported and tested via emulation, captured-snapshot replay, and a couple of community fleet peers — but bugs that would be obvious to me on a box I can poke with my hands tend to surface only when a non-Unraid user reports them.
+
+**If you're running NAS Doctor on Synology, TrueNAS, Proxmox, Kubernetes, or any other non-Unraid host and something looks off — please [open an issue](https://github.com/mcdays94/nas-doctor/issues/new/choose).** Even small UX oddities are useful: "the drive merge view lists my volume twice", "the Proxmox containers widget shows VMs instead of LXCs", "the UPS section is empty even though apcupsd is running". Your reports are how this project stays honest across platforms — they're appreciated, not a burden.
+
 ---
 
 ## File Structure & Data Locations


### PR DESCRIPTION
## Summary

Adds a short "A note from the maintainer" subsection right after the existing **Supported Platforms** table in `README.md`. Makes it explicit that the project is dogfooded on Unraid daily and that bug reports from Synology / TrueNAS / Proxmox / Kubernetes / generic-Linux users are explicitly welcome and appreciated.

Tone is appreciative, not apologetic ("your reports are how this project stays honest across platforms — they're appreciated, not a burden"). Adapted from the issue body's draft copy and tuned to match the existing README voice (terse, second-person where useful, no over-formality).

Closes #266.

## Placement choice

Placed as a `### A note from the maintainer` subsection nested under `## Supported Platforms`, immediately after the existing table + advisory blockquote. This keeps it visually anchored to the platform context (not floating somewhere earlier in the README) and avoids disrupting the existing TOC entries. The subsection heading style matches the README's other H3 usage.

## Rendered prose

> ### A note from the maintainer
>
> NAS Doctor is maintained by one person, and the only platform I have hands-on every day is **Unraid**. Synology DSM, TrueNAS SCALE, Proxmox VE, Kubernetes/k3s, and Docker-on-Linux are all supported and tested via emulation, captured-snapshot replay, and a couple of community fleet peers — but bugs that would be obvious to me on a box I can poke with my hands tend to surface only when a non-Unraid user reports them.
>
> **If you're running NAS Doctor on Synology, TrueNAS, Proxmox, Kubernetes, or any other non-Unraid host and something looks off — please [open an issue](https://github.com/mcdays94/nas-doctor/issues/new/choose).** Even small UX oddities are useful: "the drive merge view lists my volume twice", "the Proxmox containers widget shows VMs instead of LXCs", "the UPS section is empty even though apcupsd is running". Your reports are how this project stays honest across platforms — they're appreciated, not a burden.

## Acceptance checklist

- [x] New subsection added to README.md, placed near the Supported Platforms table.
- [x] Tone is appreciative, not apologetic.
- [x] Mentions Unraid as the maintainer's primary daily-driver explicitly.
- [x] Names the other supported platforms (Synology, TrueNAS, Proxmox, Kubernetes, Docker-on-Linux) that benefit from user reports.
- [x] Links to https://github.com/mcdays94/nas-doctor/issues/new/choose.
- [x] Includes example of small UX oddities ("drive merge view lists my volume twice", "Proxmox containers widget shows VMs instead of LXCs", "UPS section empty even though apcupsd is running") to lower the bar for "is this worth reporting?".

## §4b checks

- [x] `go build ./...` passes (smoke test — no Go code touched).
- [x] Markdown diff visually clean — single contiguous insertion, no formatting drift.
- [x] No new dependencies, no Dockerfile changes, no template changes.
- [x] Issue template / new labels intentionally NOT added (out of scope per issue's "Optional follow-on").

## Out of scope (deferred)

- `.github/ISSUE_TEMPLATE/platform-specific-bug.yaml` with platform dropdown — separate ticket if/when desired.
- Per-platform labels (`platform:synology`, etc.) — separate ticket.