### PR TITLE
feat(system): CPU temp + mainboard temp in dashboard header (#269)

### DIFF
--- a/demo-worker/feeder/src/index.ts
+++ b/demo-worker/feeder/src/index.ts
@@ -53,6 +53,15 @@ export interface PlatformProfile {
   hasKubernetes: boolean;
   hasTunnels: boolean;
   hasGPU: boolean;
+  // Issue #269 — base CPU and mainboard temperatures in °C used to
+  // synthesise demo dashboard-header gauges. When undefined, the
+  // feeder omits the field from snapshot.system, which lets the
+  // dashboard hide the gauge entirely (graceful fallback for
+  // platforms without /sys/class/hwmon — Synology, Kubernetes pods,
+  // virtualised hosts). Production collectors return 0; the demo
+  // mirrors that by simply leaving the field unset.
+  cpuTempC?: number;
+  moboTempC?: number;
   drives: { device: string; model: string; serial: string; sizeGB: number; type: string; mount: string; label: string; usedPct: number; temp: number; poh: number }[];
   containers: { name: string; image: string; state: string; cpu: number; mem: number }[];
   // Speed-test profile: realistic per-platform throughput. Feeds
@@ -118,6 +127,9 @@ export const PROFILES: Record<Platform, PlatformProfile> = {
   unraid: {
     hostname: "unraid-tower", platformName: "Unraid 7.0.1", cpuModel: "AMD Ryzen 9 5950X", cpuCores: 16, ramGB: 64, uptimeDays: 30,
     hasZFS: false, hasUPS: true, hasParity: true, hasProxmox: false, hasKubernetes: false, hasTunnels: true, hasGPU: true,
+    // Realistic Unraid bare-metal: Ryzen idle is ~50-60°C, mobo
+    // ~38-44°C with average airflow. Issue #269.
+    cpuTempC: 58, moboTempC: 42,
     drives: [
       { device: "sda", model: "WDC WD180EDGZ", serial: "WD-WX12345678", sizeGB: 18000, type: "hdd", mount: "/mnt/disk1", label: "Disk 1", usedPct: 72, temp: 35, poh: 28000 },
       { device: "sdb", model: "WDC WD180EDGZ", serial: "WD-WX23456789", sizeGB: 18000, type: "hdd", mount: "/mnt/disk2", label: "Disk 2", usedPct: 65, temp: 34, poh: 28000 },
@@ -175,6 +187,9 @@ export const PROFILES: Record<Platform, PlatformProfile> = {
   truenas: {
     hostname: "truenas-scale", platformName: "TrueNAS SCALE 24.10", cpuModel: "Intel Xeon E-2278G", cpuCores: 8, ramGB: 64, uptimeDays: 120,
     hasZFS: true, hasUPS: true, hasParity: false, hasProxmox: false, hasKubernetes: false, hasTunnels: false, hasGPU: false,
+    // Server-grade Xeon, well-cooled chassis: ~50°C CPU / ~38°C
+    // mobo. Issue #269.
+    cpuTempC: 51, moboTempC: 38,
     drives: [
       { device: "sda", model: "WDC WD120EMFZ", serial: "WD-WMC540123456", sizeGB: 12000, type: "hdd", mount: "/mnt/tank", label: "tank (raidz2)", usedPct: 68, temp: 34, poh: 38000 },
       { device: "sdb", model: "WDC WD120EMFZ", serial: "WD-WMC540234567", sizeGB: 12000, type: "hdd", mount: "/mnt/tank", label: "tank (raidz2)", usedPct: 68, temp: 35, poh: 38000 },
@@ -202,6 +217,10 @@ export const PROFILES: Record<Platform, PlatformProfile> = {
   proxmox: {
     hostname: "pve-node01", platformName: "Proxmox VE 8.3.2", cpuModel: "Intel Xeon E-2388G", cpuCores: 8, ramGB: 128, uptimeDays: 45,
     hasZFS: true, hasUPS: true, hasParity: false, hasProxmox: true, hasKubernetes: false, hasTunnels: true, hasGPU: true,
+    // Proxmox host running VMs + GPU passthrough: warmer than idle
+    // NAS workloads. Sits in the amber band so the demo shows the
+    // colour change. Issue #269.
+    cpuTempC: 63, moboTempC: 44,
     drives: [
       { device: "sda", model: "Samsung PM893 960GB", serial: "S6XNNS0T567890", sizeGB: 960, type: "ssd", mount: "/", label: "Boot SSD", usedPct: 18, temp: 32, poh: 15000 },
       { device: "sdb", model: "Samsung PM893 960GB", serial: "S6XNNS0T678901", sizeGB: 960, type: "ssd", mount: "/", label: "Boot Mirror", usedPct: 18, temp: 33, poh: 15000 },
@@ -393,6 +412,20 @@ export function transformSnapshot(d: Record<string, unknown>, p: PlatformProfile
   sys.mem_percent = round2(((sys.mem_used_gb as number) / p.ramGB) * 100);
   sys.cpu_usage = round2(clamp(jitter(22 * df, 20, hashStr(platform) + 2), 3, 85));
   sys.uptime_seconds = p.uptimeDays * 86400 + Math.floor(Date.now() / 1000) % 86400;
+
+  // Issue #269 — CPU + mainboard temperature gauges in the dashboard
+  // header. Per-platform realistic values with a small jitter so the
+  // demo telemetry looks alive between feeder ticks. Synology and
+  // Kubernetes (containers / pods without /sys/class/hwmon) showcase
+  // the graceful-fallback path: omitting the field makes the
+  // dashboard hide the gauge entirely (no "—" placeholder), matching
+  // what real users see on those platforms.
+  if (p.cpuTempC !== undefined) {
+    sys.cpu_temp_c = Math.round(clamp(jitter(p.cpuTempC, 8, hashStr(platform) + 3), 30, 95));
+  }
+  if (p.moboTempC !== undefined) {
+    sys.mobo_temp_c = Math.round(clamp(jitter(p.moboTempC, 8, hashStr(platform) + 4), 25, 70));
+  }
 
   // Disks
   const disks = p.drives.map((dr, i) => ({

--- a/demo-worker/feeder/src/widget-coverage.test.ts
+++ b/demo-worker/feeder/src/widget-coverage.test.ts
@@ -295,6 +295,44 @@ describe("demo feeder widget coverage", () => {
   // engine fields. Without these, the demo never showcases the
   // engine-aware UX.
 
+  // ── Header CPU + mainboard temperature gauges (#269) ─────────────
+  // The dashboard header renders cpu_temp_c and mobo_temp_c when the
+  // snapshot reports them; platforms without a sensor (Synology
+  // Celeron without hwmon-exposed coretemp; Kubernetes pods without
+  // /sys/class/hwmon) MUST omit the field so the gauge hides
+  // gracefully rather than rendering "0°" or "—". These tests pin
+  // both surfaces of the contract — present-when-supported,
+  // absent-when-not-supported.
+
+  it("emits cpu_temp_c + mobo_temp_c on platforms with hwmon sensors", () => {
+    for (const platform of ["unraid", "truenas", "proxmox"] as Platform[]) {
+      const snap = transformSnapshot(SEED, PROFILES[platform], platform);
+      const cpuTemp = getPath(snap, "system.cpu_temp_c");
+      const moboTemp = getPath(snap, "system.mobo_temp_c");
+      expect(typeof cpuTemp, `${platform} system.cpu_temp_c must be a number`).toBe("number");
+      expect(typeof moboTemp, `${platform} system.mobo_temp_c must be a number`).toBe("number");
+      expect(cpuTemp as number, `${platform} cpu_temp_c plausibility (>=30, <=95)`).toBeGreaterThanOrEqual(30);
+      expect(cpuTemp as number, `${platform} cpu_temp_c plausibility (>=30, <=95)`).toBeLessThanOrEqual(95);
+      expect(moboTemp as number, `${platform} mobo_temp_c plausibility (>=25, <=70)`).toBeGreaterThanOrEqual(25);
+      expect(moboTemp as number, `${platform} mobo_temp_c plausibility (>=25, <=70)`).toBeLessThanOrEqual(70);
+    }
+  });
+
+  it("omits cpu_temp_c + mobo_temp_c on platforms without hwmon sensors (graceful fallback)", () => {
+    // Synology and Kubernetes pods don't expose /sys/class/hwmon
+    // CPU/mobo temps in the production collector — the demo mirrors
+    // that by leaving the profile values undefined so the feeder
+    // omits the fields. Without this, the dashboard header would
+    // render a misleading "0°" gauge on those platforms.
+    for (const platform of ["synology", "kubernetes"] as Platform[]) {
+      const snap = transformSnapshot(SEED, PROFILES[platform], platform);
+      const cpuTemp = getPath(snap, "system.cpu_temp_c");
+      const moboTemp = getPath(snap, "system.mobo_temp_c");
+      expect(cpuTemp, `${platform} system.cpu_temp_c MUST be undefined to hide the gauge`).toBeUndefined();
+      expect(moboTemp, `${platform} system.mobo_temp_c MUST be undefined to hide the gauge`).toBeUndefined();
+    }
+  });
+
   it("emits engine='speedtest_go' on snapshot.speed_test.latest for all platforms", () => {
     for (const platform of ["unraid", "synology", "truenas", "proxmox", "kubernetes"] as Platform[]) {
       const snap = transformSnapshot(SEED, PROFILES[platform], platform);

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-chi/cors v1.2.2
 	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/showwin/speedtest-go v1.7.10
 	modernc.org/sqlite v1.48.1
 )
@@ -19,7 +20,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -79,6 +79,21 @@ util.classForPct = function(pct) {
   return "text-green";
 };
 
+/* Issue #269 — colour mapping for CPU and mainboard temperature
+   gauges in the dashboard header. Thresholds:
+       <  60 deg C : green   (cool)
+     60-75 deg C : amber   (warm)
+       >  75 deg C : red     (hot)
+   Reuses the existing text-red/text-amber/text-green classes that
+   are inlined in BOTH theme templates (midnight.html L240 and
+   clean.html L283-285). No new CSS class added — theme-template
+   parity is automatic. */
+util.classForTemp = function(degC) {
+  if (degC > 75) return "text-red";
+  if (degC >= 60) return "text-amber";
+  return "text-green";
+};
+
 util.severityClass = function(sev) {
   if (sev === "critical") return "td-crit";
   if (sev === "warning") return "td-warn";

--- a/internal/api/dashboard_header_temps_test.go
+++ b/internal/api/dashboard_header_temps_test.go
@@ -1,0 +1,195 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #269 — CPU + mainboard temperature gauges in the dashboard
+// header stats row. The render lives INSIDE the theme templates'
+// inline <script> blocks (NOT in DashboardJS), because the header
+// is theme-specific markup. midnight.html uses .stat-item-label /
+// .stat-item-value; clean.html uses .stat-label / .stat-val.
+//
+// These tests assert that:
+//   1. classForTemp helper exists in DashboardJS and applies the
+//      <60 / 60-75 / >75 thresholds documented in the issue.
+//   2. Both theme templates render conditional cpu_temp_c and
+//      mobo_temp_c stat-item divs gated on a truthy value (so
+//      sensors-missing → no gauge, NOT empty placeholder).
+//   3. Both theme templates inline the conditional, with no new
+//      CSS class names (theme-template parity rule).
+
+// TestDashboardJS_ClassForTemp_Thresholds pins the colour-mapping
+// boundaries against the issue acceptance criteria item 2:
+// "Values colour-coded by threshold (green < 60°C, yellow 60-75°C,
+// red > 75°C)".
+func TestDashboardJS_ClassForTemp_HelperPresent(t *testing.T) {
+	js := DashboardJS
+	if !strings.Contains(js, "util.classForTemp") {
+		t.Fatal("DashboardJS: util.classForTemp helper is missing — issue #269 needs a temperature → colour mapping helper")
+	}
+	// Pin the thresholds. We don't pin exact comparison operators
+	// because the helper might use `>=` vs `>`, but the numeric
+	// values 60 and 75 MUST appear inside the helper body so a
+	// future refactor that moves the boundaries (and breaks the
+	// documented green/amber/red thresholds) is caught.
+	start := strings.Index(js, "util.classForTemp")
+	if start < 0 {
+		t.Fatal("classForTemp not found")
+	}
+	body := js[start:]
+	end := strings.Index(body, "};")
+	if end < 0 {
+		t.Fatal("classForTemp body terminator not found")
+	}
+	helper := body[:end]
+	if !strings.Contains(helper, "75") {
+		t.Error("classForTemp does not reference 75 (the >75°C red threshold per issue #269)")
+	}
+	if !strings.Contains(helper, "60") {
+		t.Error("classForTemp does not reference 60 (the 60-75°C amber threshold per issue #269)")
+	}
+}
+
+// TestDashboardJS_ClassForTemp_Values exercises the helper through
+// the JS source (we can't actually evaluate JS in a Go test, so we
+// pin the textual mapping instead). Each colour MUST be referenced.
+func TestDashboardJS_ClassForTemp_Values(t *testing.T) {
+	js := DashboardJS
+	start := strings.Index(js, "util.classForTemp")
+	if start < 0 {
+		t.Fatal("classForTemp not found")
+	}
+	body := js[start:]
+	end := strings.Index(body, "};")
+	if end < 0 {
+		t.Fatal("classForTemp body terminator not found")
+	}
+	helper := body[:end]
+
+	for _, want := range []string{"text-red", "text-amber", "text-green"} {
+		if !strings.Contains(helper, want) {
+			t.Errorf("classForTemp does not return %q — palette must use the existing inlined classes (theme-template parity)", want)
+		}
+	}
+}
+
+// TestThemeTemplates_RenderTempStatItems asserts that BOTH theme
+// templates emit stat-item markup for cpu_temp_c and mobo_temp_c,
+// gated on a truthy value. This is the core acceptance criteria
+// item 1 (header stats row adds CPU + Mobo temp).
+func TestThemeTemplates_RenderTempStatItems(t *testing.T) {
+	cases := []struct {
+		name    string
+		tmpl    string
+		needles []string
+	}{
+		{
+			name: "midnight",
+			tmpl: DashboardMidnight,
+			needles: []string{
+				"sys.cpu_temp_c",
+				"sys.mobo_temp_c",
+				"classForTemp",
+				// Conditional render — the gauge should ONLY appear
+				// when value is non-zero. Look for a guard pattern.
+				"cpuTemp > 0",
+				"moboTemp > 0",
+			},
+		},
+		{
+			name: "clean",
+			tmpl: DashboardClean,
+			needles: []string{
+				"sys.cpu_temp_c",
+				"sys.mobo_temp_c",
+				"classForTemp",
+				"cpuTemp > 0",
+				"moboTemp > 0",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, n := range tc.needles {
+				if !strings.Contains(tc.tmpl, n) {
+					t.Errorf("%s.html: missing %q — issue #269 expects cpu_temp_c and mobo_temp_c rendered with a conditional guard", tc.name, n)
+				}
+			}
+		})
+	}
+}
+
+// TestThemeTemplates_GracefulFallback regression-guards the most
+// important UX bit: when the sensors are missing (sys.cpu_temp_c
+// is zero/undefined), the stat-item must NOT render at all.
+//
+// We can't execute the JS, but we CAN check that the temperature
+// markup is INSIDE the `if (cpuTemp > 0)` / `if (moboTemp > 0)`
+// guards rather than unconditionally appended. The simplest
+// invariant: for each template, the literal string
+//
+//   if (cpuTemp > 0)
+//
+// must appear BEFORE the literal `CPU \u00b0C` / `cpu_temp_c`
+// rendering line. Same for mobo.
+func TestThemeTemplates_GracefulFallback(t *testing.T) {
+	cases := []struct {
+		name string
+		tmpl string
+	}{
+		{name: "midnight", tmpl: DashboardMidnight},
+		{name: "clean", tmpl: DashboardClean},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cpuGuard := strings.Index(tc.tmpl, "cpuTemp > 0")
+			cpuRender := strings.Index(tc.tmpl, "CPU \\u00b0C")
+			if cpuGuard < 0 || cpuRender < 0 {
+				t.Fatalf("%s.html: missing CPU temp guard or render — guard=%d render=%d", tc.name, cpuGuard, cpuRender)
+			}
+			if cpuGuard >= cpuRender {
+				t.Errorf("%s.html: 'cpuTemp > 0' guard at offset %d must precede the CPU temp render at offset %d", tc.name, cpuGuard, cpuRender)
+			}
+			moboGuard := strings.Index(tc.tmpl, "moboTemp > 0")
+			moboRender := strings.Index(tc.tmpl, "Mobo \\u00b0C")
+			if moboGuard < 0 || moboRender < 0 {
+				t.Fatalf("%s.html: missing Mobo temp guard or render — guard=%d render=%d", tc.name, moboGuard, moboRender)
+			}
+			if moboGuard >= moboRender {
+				t.Errorf("%s.html: 'moboTemp > 0' guard at offset %d must precede the Mobo temp render at offset %d", tc.name, moboGuard, moboRender)
+			}
+		})
+	}
+}
+
+// TestThemeTemplates_NoNewCSSClasses — AGENTS.md theme-parity rule:
+// the theme templates do NOT link /css/shared.css, so any new
+// CSS class would silently not apply. This feature uses the
+// existing text-red/text-amber/text-green classes (already inlined
+// in both templates). Pin the absence of the obvious naive class
+// names so a future patch can't accidentally regress.
+func TestThemeTemplates_NoNewTempClasses(t *testing.T) {
+	disallowed := []string{
+		`class="temp-hot"`,
+		`class="temp-warm"`,
+		`class="temp-cool"`,
+		`class="cpu-temp"`,
+		`class="mobo-temp"`,
+	}
+	for _, tmpl := range []struct {
+		name string
+		src  string
+	}{
+		{"midnight", DashboardMidnight},
+		{"clean", DashboardClean},
+		{"DashboardJS", DashboardJS},
+	} {
+		for _, tok := range disallowed {
+			if strings.Contains(tmpl.src, tok) {
+				t.Errorf("%s introduces CSS class token %q — theme templates do NOT link shared.css. Reuse text-red/text-amber/text-green via classForTemp instead", tmpl.name, tok)
+			}
+		}
+	}
+}

--- a/internal/api/dashboard_themes_js_parse_test.go
+++ b/internal/api/dashboard_themes_js_parse_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestDashboardThemes_JSBlocksParse extends the v0.9.9 rc1
+// regression guard (see settings_js_parses_test.go for the full
+// backstory) to the two dashboard theme templates.
+//
+// midnight.html and clean.html each contain a sizeable inline
+// <script> block that renders the entire dashboard. A `*/` inside
+// a `/* */` block comment, or a stray backtick inside a JS comment,
+// would silently abort parsing and leave the dashboard a blank
+// page in browsers — exactly the v0.9.9-rc1 class of failure but
+// affecting the dashboard rather than settings.
+//
+// Issue #269 introduces new inline JS in BOTH theme templates
+// (the conditional cpu_temp_c / mobo_temp_c stat-item rendering),
+// which is high-risk for this footgun. Hence this guard.
+func TestDashboardThemes_JSBlocksParse(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node binary not in PATH; skipping JS parse check (dev-time guard only)")
+	}
+
+	cases := []struct {
+		name string
+		tmpl string
+	}{
+		{"midnight.html", DashboardMidnight},
+		{"clean.html", DashboardClean},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			blocks := extractScriptBlocks(tc.tmpl)
+			if len(blocks) == 0 {
+				t.Fatalf("no <script>...</script> blocks found in %s", tc.name)
+			}
+			for i, js := range blocks {
+				if strings.TrimSpace(js) == "" {
+					continue
+				}
+				cmd := exec.Command("node", "--check", "-")
+				cmd.Stdin = strings.NewReader(js)
+				out, err := cmd.CombinedOutput()
+				if err != nil {
+					t.Errorf("%s <script> block %d failed to parse as JS:\n%s", tc.name, i, string(out))
+				}
+			}
+		})
+	}
+}

--- a/internal/api/templates/clean.html
+++ b/internal/api/templates/clean.html
@@ -121,7 +121,7 @@ body{min-height:100vh;background:#fff}
 .sb-handle:hover::after{background:rgba(0,0,0,0.3)}
 .sb-handle:active::after{background:#171717}
 
-@media(max-width:900px){.two-col{grid-template-columns:1fr}.top-bar{flex-wrap:wrap;max-height:none}.col-left > .section{max-height:600px}}
+@media(max-width:900px){.two-col{grid-template-columns:1fr}.top-bar{flex-wrap:wrap;max-height:none}.col-left > .section{max-height:600px}.top-bar-right{flex-wrap:wrap;white-space:normal;row-gap:4px}}
 .section{margin-top:28px}
 .section:first-child{margin-top:0}
 .section-title{font-size:12px;font-weight:500;color:#808080;text-transform:uppercase;letter-spacing:0.5px;margin-bottom:12px}
@@ -385,6 +385,21 @@ tbody tr:hover{background:rgba(0,0,0,0.03)}
       h += '<span class="stat-item"><span class="stat-label">Mem</span> <span class="stat-val">' + mem.toFixed(1) + '%</span><canvas id="spark-mem" width="40" height="18" style="margin-left:3px;vertical-align:middle"></canvas></span>';
       h += '<span class="dot-sep">&middot;</span>';
       h += '<span class="stat-item"><span class="stat-label">I/O</span> <span class="stat-val">' + io.toFixed(1) + '%</span></span>';
+      // Issue #269 — CPU + mainboard temperature gauges. Same
+      // graceful-fallback pattern as midnight.html: render only
+      // when the snapshot reports a non-zero value, so platforms
+      // without thermal sensors (Synology, K8s pods, virtualised
+      // hosts) show no gauge at all rather than a "—" placeholder.
+      var cpuTemp = sys.cpu_temp_c || 0;
+      var moboTemp = sys.mobo_temp_c || 0;
+      if (cpuTemp > 0) {
+        h += '<span class="dot-sep">&middot;</span>';
+        h += '<span class="stat-item"><span class="stat-label">CPU \u00b0C</span> <span class="stat-val ' + NasDashboard.util.classForTemp(cpuTemp) + '">' + cpuTemp + '\u00b0</span></span>';
+      }
+      if (moboTemp > 0) {
+        h += '<span class="dot-sep">&middot;</span>';
+        h += '<span class="stat-item"><span class="stat-label">Mobo \u00b0C</span> <span class="stat-val ' + NasDashboard.util.classForTemp(moboTemp) + '">' + moboTemp + '\u00b0</span></span>';
+      }
       h += '<span class="dot-sep">&middot;</span>';
       h += '<span class="stat-item"><span class="stat-label">Up</span> <span class="stat-val">' + esc(uptime) + '</span></span>';
     }

--- a/internal/api/templates/midnight.html
+++ b/internal/api/templates/midnight.html
@@ -331,6 +331,22 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
       h += '<div class="stat-item"><span class="stat-item-label">CPU</span><span class="stat-item-value ' + classForPct(cpu) + '">' + cpu.toFixed(1) + '%</span><canvas id="spark-cpu" width="48" height="20" style="margin-left:4px;vertical-align:middle"></canvas></div>';
       h += '<div class="stat-item"><span class="stat-item-label">Mem</span><span class="stat-item-value ' + classForPct(mem) + '">' + mem.toFixed(1) + '%</span><canvas id="spark-mem" width="48" height="20" style="margin-left:4px;vertical-align:middle"></canvas></div>';
       h += '<div class="stat-item"><span class="stat-item-label">I/O</span><span class="stat-item-value ' + classForPct(io > 20 ? 90 : io > 10 ? 75 : 0) + '">' + io.toFixed(1) + '%</span><canvas id="spark-io" width="48" height="20" style="margin-left:4px;vertical-align:middle"></canvas></div>';
+      // Issue #269 — CPU + mainboard temperature gauges. Rendered
+      // ONLY when sys.cpu_temp_c / sys.mobo_temp_c is non-zero, so
+      // platforms without /sys/class/hwmon (Synology, K8s pods,
+      // virtualised environments) hide the gauge entirely instead
+      // of showing an empty "—" placeholder. Server-side omitempty
+      // on SystemInfo.CPUTempC / MoboTempC ensures the field is
+      // missing (not just 0) in that case, so a `truthy` JS check
+      // is all that's needed here.
+      var cpuTemp = sys.cpu_temp_c || 0;
+      var moboTemp = sys.mobo_temp_c || 0;
+      if (cpuTemp > 0) {
+        h += '<div class="stat-item"><span class="stat-item-label">CPU \u00b0C</span><span class="stat-item-value ' + NasDashboard.util.classForTemp(cpuTemp) + '">' + cpuTemp + '\u00b0</span></div>';
+      }
+      if (moboTemp > 0) {
+        h += '<div class="stat-item"><span class="stat-item-label">Mobo \u00b0C</span><span class="stat-item-value ' + NasDashboard.util.classForTemp(moboTemp) + '">' + moboTemp + '\u00b0</span></div>';
+      }
       h += '<div class="stat-item"><span class="stat-item-label">Up</span><span class="stat-item-value" style="color:var(--text-primary)">' + esc(uptime) + '</span></div>';
     }
     h += '</div></div>';

--- a/internal/collector/system.go
+++ b/internal/collector/system.go
@@ -116,6 +116,12 @@ func collectSystem(hp internal.HostPaths) (internal.SystemInfo, error) {
 		}
 	}
 
+	// CPU + mainboard temperature (issue #269). Best-effort: returns
+	// (0, 0) on platforms without /sys/class/hwmon (Synology, K8s
+	// pods, ...). The dashboard header hides the gauge when the
+	// value is 0 — JSON tags use omitempty for the same reason.
+	info.CPUTempC, info.MoboTempC = collectCPUMoboTemps()
+
 	// Top processes by CPU
 	info.TopProcesses = collectTopProcesses(10)
 

--- a/internal/collector/temps.go
+++ b/internal/collector/temps.go
@@ -1,0 +1,144 @@
+// CPU + mainboard temperature collection for the dashboard header
+// stats row. Issue #269.
+//
+// Detection strategy (all paths read from sysClassBase, which defaults
+// to /sys/class but is redirected to a tempdir in tests):
+//
+//   CPU temp:
+//     1. {sysClassBase}/thermal/thermal_zone*/type == "x86_pkg_temp"
+//        — canonical Intel package temp (preferred).
+//     2. hwmon name == "coretemp" → temp{N}_input where label == "Package id 0",
+//        else fall back to temp1_input.
+//     3. hwmon name == "k10temp" → temp1_input (Tctl/Tdie on AMD).
+//
+//   Mobo temp:
+//     1. hwmon name == "acpitz" → temp1_input.
+//     2. {sysClassBase}/thermal/thermal_zone*/type == "acpitz" → temp.
+//
+// Anything outside (0, 120]°C is rejected as a disconnected/glitched
+// reading. Returning (0, 0) is the documented "no sensor available"
+// signal for callers — the dashboard header hides the gauge entirely
+// in that case rather than rendering an "—" placeholder, per the
+// acceptance criteria on issue #269.
+//
+// NOTE: we deliberately do NOT skip the acpitz thermal zone for the
+// mobo temp reading the way readThermalZoneTemp() does for CPU temp.
+// That helper avoided acpitz because the underlying sensor is often
+// the ACPI critical trip-point (98°C) reported as "current temperature"
+// — meaningless for a CPU reading. For mainboard temp the acpitz
+// reading is the *intended* source: it's literally the system's ACPI
+// thermal zone. Boards with broken ACPI tables will simply report
+// implausible values that our 0<t<=120 filter rejects.
+package collector
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// collectCPUMoboTemps returns the package-level CPU temperature and
+// mainboard temperature in degrees Celsius. Either or both can be 0
+// to indicate "no sensor available" — callers must treat 0 as missing
+// rather than as 0°C (no real CPU runs at 0°C anyway).
+func collectCPUMoboTemps() (cpu int, mobo int) {
+	cpu = readCPUTemp()
+	mobo = readMoboTemp()
+	return cpu, mobo
+}
+
+// readCPUTemp implements the three-tier CPU detection strategy
+// described at the top of this file.
+func readCPUTemp() int {
+	// 1. x86_pkg_temp thermal zone — Intel canonical.
+	zones, _ := filepath.Glob(filepath.Join(sysClassBase, "thermal", "thermal_zone*", "type"))
+	for _, typePath := range zones {
+		zoneType := strings.TrimSpace(readSysfs(typePath))
+		if zoneType == "x86_pkg_temp" {
+			if t := parseInt(readSysfs(filepath.Join(filepath.Dir(typePath), "temp"))) / 1000; isPlausibleTemp(t) {
+				return t
+			}
+		}
+	}
+
+	// 2. coretemp hwmon — Intel via lm_sensors.
+	if dir := findHwmonByName("coretemp"); dir != "" {
+		if t := readPackageOrFirstTemp(dir); isPlausibleTemp(t) {
+			return t
+		}
+	}
+
+	// 3. k10temp hwmon — AMD.
+	if dir := findHwmonByName("k10temp"); dir != "" {
+		if t := parseInt(readSysfs(filepath.Join(dir, "temp1_input"))) / 1000; isPlausibleTemp(t) {
+			return t
+		}
+	}
+
+	return 0
+}
+
+// readMoboTemp implements the two-tier mainboard / system temp
+// detection strategy.
+func readMoboTemp() int {
+	// 1. acpitz hwmon — most common path on x86 boards.
+	if dir := findHwmonByName("acpitz"); dir != "" {
+		if t := parseInt(readSysfs(filepath.Join(dir, "temp1_input"))) / 1000; isPlausibleTemp(t) {
+			return t
+		}
+	}
+
+	// 2. acpitz thermal zone — fallback on systems where the hwmon
+	//    interface isn't registered but the thermal subsystem is.
+	zones, _ := filepath.Glob(filepath.Join(sysClassBase, "thermal", "thermal_zone*", "type"))
+	for _, typePath := range zones {
+		zoneType := strings.TrimSpace(readSysfs(typePath))
+		if zoneType == "acpitz" {
+			if t := parseInt(readSysfs(filepath.Join(filepath.Dir(typePath), "temp"))) / 1000; isPlausibleTemp(t) {
+				return t
+			}
+		}
+	}
+
+	return 0
+}
+
+// readPackageOrFirstTemp scans a coretemp hwmon directory for a temp*
+// entry labelled "Package..." (Intel coretemp's package-level sensor)
+// and falls back to temp1_input (the conventional package sensor when
+// no labels are exposed).
+func readPackageOrFirstTemp(dir string) int {
+	tempInputs, _ := filepath.Glob(filepath.Join(dir, "temp*_input"))
+	for _, tempPath := range tempInputs {
+		base := strings.TrimSuffix(filepath.Base(tempPath), "_input")
+		labelPath := filepath.Join(dir, base+"_label")
+		label := strings.ToLower(readSysfs(labelPath))
+		if strings.HasPrefix(label, "package") {
+			return parseInt(readSysfs(tempPath)) / 1000
+		}
+	}
+	return parseInt(readSysfs(filepath.Join(dir, "temp1_input"))) / 1000
+}
+
+// findHwmonByName scans every {sysClassBase}/hwmon/hwmon*/name entry
+// and returns the absolute path to the hwmon directory whose name
+// matches. Returns "" when no match is found. Used by readCPUTemp /
+// readMoboTemp to locate the right hwmon among the typical 4-8
+// devices a modern board exposes (nvme, coretemp, acpitz, nct6798, ...).
+func findHwmonByName(name string) string {
+	matches, _ := filepath.Glob(filepath.Join(sysClassBase, "hwmon", "hwmon*", "name"))
+	for _, namePath := range matches {
+		if strings.TrimSpace(readSysfs(namePath)) == name {
+			return filepath.Dir(namePath)
+		}
+	}
+	return ""
+}
+
+// isPlausibleTemp filters out 0°C (sensor disconnected / never
+// initialised) and absurd values like 250°C (sensor glitch or wrong
+// scale). The dashboard renders the gauge only when the reading is
+// both non-zero and plausible — this guard centralises the "is this
+// value safe to surface" check.
+func isPlausibleTemp(t int) bool {
+	return t > 0 && t <= 120
+}

--- a/internal/collector/temps_test.go
+++ b/internal/collector/temps_test.go
@@ -1,0 +1,217 @@
+package collector
+
+import (
+	"testing"
+)
+
+// Issue #269 — CPU + mainboard temperature collector for the dashboard
+// header. These tests cover the hwmon-name detection paths used in
+// collectCPUMoboTemps. They reuse the seedHwmon / seedThermalZone /
+// withSysClassBase helpers already defined in gpu_test.go.
+
+// TestCollectCPUMoboTemps_Coretemp covers the canonical Intel path:
+// hwmon name == "coretemp", with a temp1 entry labelled "Package id 0".
+// We expect milli-Celsius -> Celsius conversion (58000 -> 58).
+func TestCollectCPUMoboTemps_CoretempPackageLabel(t *testing.T) {
+	base := t.TempDir()
+	withSysClassBase(t, base)
+
+	seedHwmon(t, base, 1, "coretemp", map[string]struct {
+		label    string
+		millidec int
+	}{
+		"temp1": {"Package id 0", 58000},
+		"temp2": {"Core 0", 57000},
+		"temp3": {"Core 1", 59000},
+	})
+
+	cpu, mobo := collectCPUMoboTemps()
+	if cpu != 58 {
+		t.Errorf("collectCPUMoboTemps() cpu = %d, want 58 (coretemp Package id 0)", cpu)
+	}
+	if mobo != 0 {
+		t.Errorf("collectCPUMoboTemps() mobo = %d, want 0 (no acpitz seeded)", mobo)
+	}
+}
+
+// TestCollectCPUMoboTemps_CoretempWithoutPackageLabel falls back to
+// temp1_input when no Package label is defined.
+func TestCollectCPUMoboTemps_CoretempWithoutPackageLabel(t *testing.T) {
+	base := t.TempDir()
+	withSysClassBase(t, base)
+
+	seedHwmon(t, base, 0, "coretemp", map[string]struct {
+		label    string
+		millidec int
+	}{
+		"temp1": {"", 55000},
+	})
+
+	cpu, _ := collectCPUMoboTemps()
+	if cpu != 55 {
+		t.Errorf("collectCPUMoboTemps() cpu = %d, want 55 (temp1_input on coretemp without label)", cpu)
+	}
+}
+
+// TestCollectCPUMoboTemps_K10Temp covers AMD CPUs: hwmon name == "k10temp",
+// temp1_input is Tctl/Tdie.
+func TestCollectCPUMoboTemps_K10Temp(t *testing.T) {
+	base := t.TempDir()
+	withSysClassBase(t, base)
+
+	seedHwmon(t, base, 0, "k10temp", map[string]struct {
+		label    string
+		millidec int
+	}{
+		"temp1": {"Tctl", 62000},
+	})
+
+	cpu, _ := collectCPUMoboTemps()
+	if cpu != 62 {
+		t.Errorf("collectCPUMoboTemps() cpu = %d, want 62 (k10temp Tctl)", cpu)
+	}
+}
+
+// TestCollectCPUMoboTemps_ThermalZoneFallback simulates the case where
+// the kernel exposes x86_pkg_temp via /sys/class/thermal but coretemp
+// is not present (some lightweight kernels).
+func TestCollectCPUMoboTemps_ThermalZoneFallback(t *testing.T) {
+	base := t.TempDir()
+	withSysClassBase(t, base)
+
+	seedThermalZone(t, base, 0, "acpitz", 41000)       // mobo
+	seedThermalZone(t, base, 1, "x86_pkg_temp", 64000) // CPU
+
+	cpu, mobo := collectCPUMoboTemps()
+	if cpu != 64 {
+		t.Errorf("collectCPUMoboTemps() cpu = %d, want 64 (x86_pkg_temp thermal zone)", cpu)
+	}
+	if mobo != 41 {
+		t.Errorf("collectCPUMoboTemps() mobo = %d, want 41 (acpitz thermal zone)", mobo)
+	}
+}
+
+// TestCollectCPUMoboTemps_AcpitzHwmon — mainboard temp comes from acpitz
+// hwmon when no thermal_zone exposes it.
+func TestCollectCPUMoboTemps_AcpitzHwmon(t *testing.T) {
+	base := t.TempDir()
+	withSysClassBase(t, base)
+
+	seedHwmon(t, base, 0, "coretemp", map[string]struct {
+		label    string
+		millidec int
+	}{
+		"temp1": {"Package id 0", 60000},
+	})
+	seedHwmon(t, base, 1, "acpitz", map[string]struct {
+		label    string
+		millidec int
+	}{
+		"temp1": {"", 42000},
+	})
+
+	cpu, mobo := collectCPUMoboTemps()
+	if cpu != 60 {
+		t.Errorf("collectCPUMoboTemps() cpu = %d, want 60 (coretemp Package id 0)", cpu)
+	}
+	if mobo != 42 {
+		t.Errorf("collectCPUMoboTemps() mobo = %d, want 42 (acpitz hwmon)", mobo)
+	}
+}
+
+// TestCollectCPUMoboTemps_NothingAvailable — Synology, K8s pods, and
+// other environments without /sys/class/hwmon must return (0, 0). The
+// dashboard header renders no gauge in that case (graceful fallback,
+// per acceptance criteria item 3).
+func TestCollectCPUMoboTemps_NothingAvailable(t *testing.T) {
+	base := t.TempDir()
+	withSysClassBase(t, base)
+	// Empty tree.
+
+	cpu, mobo := collectCPUMoboTemps()
+	if cpu != 0 || mobo != 0 {
+		t.Errorf("collectCPUMoboTemps() = (%d, %d), want (0, 0) on empty /sys", cpu, mobo)
+	}
+}
+
+// TestCollectCPUMoboTemps_ImplausibleReadingsFiltered — sensors
+// occasionally report nonsense (e.g. 0, negative, or 250°C from a
+// disconnected probe). Anything outside (0, 120] must be treated as
+// "not available" rather than surfaced. Same defence applied to
+// readThermalZoneTemp; mirror it for the new collector to avoid
+// shipping 250°C readings to the header.
+func TestCollectCPUMoboTemps_ImplausibleReadingsFiltered(t *testing.T) {
+	base := t.TempDir()
+	withSysClassBase(t, base)
+
+	seedHwmon(t, base, 0, "coretemp", map[string]struct {
+		label    string
+		millidec int
+	}{
+		"temp1": {"Package id 0", 250000}, // 250°C — impossible
+	})
+	seedHwmon(t, base, 1, "acpitz", map[string]struct {
+		label    string
+		millidec int
+	}{
+		"temp1": {"", 0}, // 0°C — sensor disconnected
+	})
+
+	cpu, mobo := collectCPUMoboTemps()
+	if cpu != 0 {
+		t.Errorf("collectCPUMoboTemps() cpu = %d, want 0 (250°C must be rejected)", cpu)
+	}
+	if mobo != 0 {
+		t.Errorf("collectCPUMoboTemps() mobo = %d, want 0 (0°C must be rejected)", mobo)
+	}
+}
+
+// TestFindHwmonByName verifies the helper that scans every
+// /sys/class/hwmon/hwmon*/name entry and returns the directory whose
+// name matches. Multiple hwmon devices are common (coretemp +
+// nvme + acpitz + nct6798 ...), so the helper must scan them all,
+// not just hwmon0.
+func TestFindHwmonByName_FindsByName(t *testing.T) {
+	base := t.TempDir()
+	withSysClassBase(t, base)
+
+	seedHwmon(t, base, 0, "nvme", map[string]struct {
+		label    string
+		millidec int
+	}{"temp1": {"", 35000}})
+	seedHwmon(t, base, 1, "coretemp", map[string]struct {
+		label    string
+		millidec int
+	}{"temp1": {"Package id 0", 58000}})
+	seedHwmon(t, base, 2, "acpitz", map[string]struct {
+		label    string
+		millidec int
+	}{"temp1": {"", 42000}})
+
+	got := findHwmonByName("coretemp")
+	if got == "" {
+		t.Fatal("findHwmonByName('coretemp') returned empty; expected hwmon1 directory")
+	}
+	// The returned path should END with /hwmon1 — not hwmon0 (nvme) or
+	// hwmon2 (acpitz).
+	if want := "/hwmon1"; !endsWith(got, want) {
+		t.Errorf("findHwmonByName('coretemp') = %q, expected suffix %q", got, want)
+	}
+
+	if got := findHwmonByName("acpitz"); !endsWith(got, "/hwmon2") {
+		t.Errorf("findHwmonByName('acpitz') = %q, expected suffix /hwmon2", got)
+	}
+
+	if got := findHwmonByName("nonexistent"); got != "" {
+		t.Errorf("findHwmonByName('nonexistent') = %q, want empty string", got)
+	}
+}
+
+// endsWith is a tiny helper to keep the assertion readable; we don't
+// want to depend on strings just for this.
+func endsWith(s, suffix string) bool {
+	if len(suffix) > len(s) {
+		return false
+	}
+	return s[len(s)-len(suffix):] == suffix
+}

--- a/internal/models.go
+++ b/internal/models.go
@@ -346,6 +346,16 @@ type SystemInfo struct {
 	IOWait       float64       `json:"io_wait_percent"`
 	UptimeSecs   int64         `json:"uptime_seconds"`
 	Motherboard  string        `json:"motherboard"`
+	// CPUTempC is the package-level CPU temperature in °C, or 0 when no
+	// reliable sensor is available (e.g. Synology, K8s pods, virtualised
+	// environments without /sys/class/hwmon). Zero values are omitted from
+	// the JSON snapshot so the dashboard header gauge can hide gracefully
+	// rather than rendering an "—" placeholder. Issue #269.
+	CPUTempC int `json:"cpu_temp_c,omitempty"`
+	// MoboTempC is the mainboard / system / ACPI thermal-zone temperature
+	// in °C, or 0 when no reliable sensor is available. Same omitempty
+	// semantics as CPUTempC. Issue #269.
+	MoboTempC    int           `json:"mobo_temp_c,omitempty"`
 	TopProcesses []ProcessInfo `json:"top_processes"`
 }
 

--- a/internal/notifier/prometheus.go
+++ b/internal/notifier/prometheus.go
@@ -24,6 +24,14 @@ type Metrics struct {
 	ioWait     prometheus.Gauge
 	uptime     prometheus.Gauge
 	cpuCores   prometheus.Gauge
+	// Issue #269 — package-level CPU and mainboard temperatures from
+	// /sys/class/hwmon. Plain gauges that emit 0 when no sensor is
+	// available (Synology, K8s pods, virtualised environments). The
+	// dashboard header hides the value entirely on graceful fallback;
+	// Prometheus consumers should filter with `> 0` to exclude
+	// platforms without thermal probes.
+	cpuTempC  prometheus.Gauge
+	moboTempC prometheus.Gauge
 
 	// ── Disk ──
 	diskUsedBytes  *prometheus.GaugeVec
@@ -217,6 +225,8 @@ func NewMetrics() *Metrics {
 	m.ioWait = gauge(ns, "system", "io_wait_percent", "CPU I/O wait percentage")
 	m.uptime = gauge(ns, "system", "uptime_seconds", "System uptime in seconds")
 	m.cpuCores = gauge(ns, "system", "cpu_cores", "Number of CPU cores")
+	m.cpuTempC = gauge(ns, "system", "cpu_temp_celsius", "CPU package temperature in Celsius (0 when no sensor available)")
+	m.moboTempC = gauge(ns, "system", "mobo_temp_celsius", "Mainboard / system temperature in Celsius (0 when no sensor available)")
 
 	// ── Disk ──
 	diskLabels := []string{"device", "mountpoint", "label"}
@@ -379,6 +389,7 @@ func NewMetrics() *Metrics {
 	collectors := []prometheus.Collector{
 		m.cpuUsage, m.memUsed, m.memTotal, m.memPercent, m.swapUsed, m.swapTotal,
 		m.loadAvg1, m.loadAvg5, m.loadAvg15, m.ioWait, m.uptime, m.cpuCores,
+		m.cpuTempC, m.moboTempC,
 		m.diskUsedBytes, m.diskTotalBytes, m.diskUsedPct,
 		m.smartHealthy, m.smartTemp, m.smartTempMax, m.smartReallocated, m.smartPending,
 		m.smartOffline, m.smartUDMACRC, m.smartCmdTimeout, m.smartSpinRetry,
@@ -439,6 +450,8 @@ func (m *Metrics) Update(snap *internal.Snapshot) {
 	m.ioWait.Set(snap.System.IOWait)
 	m.uptime.Set(float64(snap.System.UptimeSecs))
 	m.cpuCores.Set(float64(snap.System.CPUCores))
+	m.cpuTempC.Set(float64(snap.System.CPUTempC))
+	m.moboTempC.Set(float64(snap.System.MoboTempC))
 
 	// Reset label-based metrics to clear stale entries
 	m.diskUsedBytes.Reset()

--- a/internal/notifier/prometheus_temps_test.go
+++ b/internal/notifier/prometheus_temps_test.go
@@ -1,0 +1,105 @@
+package notifier
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// Issue #269 — CPU + mainboard temperature gauges. These are plain
+// gauges (not GaugeVec) under the system subsystem, mirroring the
+// pattern used for cpu_usage_percent / io_wait_percent. They MUST be
+// registered and updated on Snapshot.System.{CPUTempC, MoboTempC}.
+
+// TestPrometheus_SystemTempGauges_Registered asserts the metric
+// names appear in the registry's exposition output, regardless of
+// value. Catches a future refactor that drops the gauge from the
+// collector list (the v0.9.5-era class of bug).
+func TestPrometheus_SystemTempGauges_Registered(t *testing.T) {
+	m := NewMetrics()
+	out, err := gatherText(m.Registry())
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, name := range []string{
+		"nasdoctor_system_cpu_temp_celsius",
+		"nasdoctor_system_mobo_temp_celsius",
+	} {
+		if !strings.Contains(out, name) {
+			t.Errorf("metric %s missing from /metrics exposition; expected registration in NewMetrics()", name)
+		}
+	}
+}
+
+// TestPrometheus_SystemTempGauges_UpdatedFromSnapshot pins the
+// snapshot.System.{CPUTempC,MoboTempC} → gauge plumbing. Without
+// this Update wiring the metric exists but always reads 0.
+func TestPrometheus_SystemTempGauges_UpdatedFromSnapshot(t *testing.T) {
+	m := NewMetrics()
+	snap := &internal.Snapshot{
+		System: internal.SystemInfo{
+			CPUTempC:  58,
+			MoboTempC: 42,
+		},
+	}
+	m.Update(snap)
+
+	if got := gaugeValue(t, m.cpuTempC); got != 58 {
+		t.Errorf("nasdoctor_system_cpu_temp_celsius = %v, want 58 after Update", got)
+	}
+	if got := gaugeValue(t, m.moboTempC); got != 42 {
+		t.Errorf("nasdoctor_system_mobo_temp_celsius = %v, want 42 after Update", got)
+	}
+}
+
+// TestPrometheus_SystemTempGauges_ZeroOnGracefulFallback covers the
+// platforms where /sys/class/hwmon doesn't expose a CPU/mobo sensor
+// (Synology, K8s pods). The collector returns (0, 0); the gauge must
+// reflect that as 0, not omit the metric. Prometheus consumers
+// filter with `> 0` to drop platforms without sensors.
+func TestPrometheus_SystemTempGauges_ZeroOnGracefulFallback(t *testing.T) {
+	m := NewMetrics()
+	snap := &internal.Snapshot{
+		System: internal.SystemInfo{CPUTempC: 0, MoboTempC: 0},
+	}
+	m.Update(snap)
+
+	if got := gaugeValue(t, m.cpuTempC); got != 0 {
+		t.Errorf("nasdoctor_system_cpu_temp_celsius = %v, want 0 on graceful fallback", got)
+	}
+	if got := gaugeValue(t, m.moboTempC); got != 0 {
+		t.Errorf("nasdoctor_system_mobo_temp_celsius = %v, want 0 on graceful fallback", got)
+	}
+}
+
+// gaugeValue extracts the current numeric value of a prometheus.Gauge
+// without depending on the testutil package (which would pull godebug
+// into go.mod). Mirrors testutil.ToFloat64 for a single Gauge.
+func gaugeValue(t *testing.T, g prometheus.Gauge) float64 {
+	t.Helper()
+	var dtoMetric dto.Metric
+	if err := g.Write(&dtoMetric); err != nil {
+		t.Fatalf("gauge Write: %v", err)
+	}
+	if dtoMetric.Gauge == nil {
+		t.Fatal("gauge has no Gauge dto field")
+	}
+	return dtoMetric.Gauge.GetValue()
+}
+
+// gatherText renders a registry's metrics in text-exposition format.
+func gatherText(reg *prometheus.Registry) (string, error) {
+	mfs, err := reg.Gather()
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	for _, mf := range mfs {
+		b.WriteString(mf.GetName())
+		b.WriteString("\n")
+	}
+	return b.String(), nil
+}

--- a/internal/system_temp_json_test.go
+++ b/internal/system_temp_json_test.go
@@ -1,0 +1,62 @@
+package internal
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Issue #269 — JSON serialisation contract for the new SystemInfo
+// temperature fields. The dashboard header and demo feeder both rely
+// on the omitempty semantic: a zero value must not appear in the
+// marshalled output, so the dashboard's `if (sys.cpu_temp_c)` guard
+// can hide the gauge entirely on platforms without thermal sensors.
+
+func TestSystemInfo_TempFields_OmittedWhenZero(t *testing.T) {
+	s := SystemInfo{Hostname: "test"} // CPUTempC and MoboTempC default to 0
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	out := string(b)
+	if strings.Contains(out, "cpu_temp_c") {
+		t.Errorf("expected cpu_temp_c to be omitted when zero, got: %s", out)
+	}
+	if strings.Contains(out, "mobo_temp_c") {
+		t.Errorf("expected mobo_temp_c to be omitted when zero, got: %s", out)
+	}
+}
+
+func TestSystemInfo_TempFields_PresentWhenNonZero(t *testing.T) {
+	s := SystemInfo{CPUTempC: 58, MoboTempC: 42}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	out := string(b)
+	if !strings.Contains(out, `"cpu_temp_c":58`) {
+		t.Errorf("expected cpu_temp_c=58 in JSON, got: %s", out)
+	}
+	if !strings.Contains(out, `"mobo_temp_c":42`) {
+		t.Errorf("expected mobo_temp_c=42 in JSON, got: %s", out)
+	}
+}
+
+// Round-trip check: a marshal → unmarshal cycle must preserve the
+// integer values (no float rounding, no string conversion). Catches
+// a future "let's switch to float64 for finer resolution" refactor
+// that would silently break the dashboard's classForTemp guard.
+func TestSystemInfo_TempFields_RoundTrip(t *testing.T) {
+	in := SystemInfo{CPUTempC: 73, MoboTempC: 35}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out SystemInfo
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.CPUTempC != 73 || out.MoboTempC != 35 {
+		t.Errorf("round-trip lost values: in=%+v out=%+v", in, out)
+	}
+}


### PR DESCRIPTION
Closes #269.

## Summary

Adds two new gauges to the dashboard header stats row — **CPU temp** and **Mobo / System temp** — sourced from `/sys/class/hwmon`. Values colour-coded by threshold (green < 60 °C, amber 60-75 °C, red > 75 °C). Graceful fallback: when no sensor is available (Synology, Kubernetes pods, virtualised hosts), the gauge is hidden entirely — no "—" / "0°" placeholder.

## Acceptance criteria (from #269)

- [x] Header stats row adds CPU temp + Mobo/System temp after I/O, before Up-time
- [x] Values colour-coded by threshold (< 60 green / 60-75 amber / > 75 red)
- [x] Graceful fallback when sensor data is absent (gauge hidden, not "—")
- [x] Mobile layout handles the extra two gauges (clean.html media query adds `flex-wrap` on `.top-bar-right`; midnight.html already had `flex-wrap` on `.top-bar-stats`)

## hwmon detection strategy

**CPU temp** (three-tier):
1. `/sys/class/thermal/thermal_zone*/type == "x86_pkg_temp"` — canonical Intel package temp.
2. `hwmon name == "coretemp"` → `temp{N}_input` where label starts with "Package", else `temp1_input`.
3. `hwmon name == "k10temp"` → `temp1_input` (AMD Tctl/Tdie).

**Mobo temp** (two-tier):
1. `hwmon name == "acpitz"` → `temp1_input`.
2. `/sys/class/thermal/thermal_zone*/type == "acpitz"` → `temp`.

A `0 < t <= 120` plausibility filter rejects disconnected probes (0 °C) and glitches (e.g. 250 °C from a wrong-scale sensor) — same defence the existing `readThermalZoneTemp` uses for CPU package temp.

The new `findHwmonByName(name)` helper scans every `/sys/class/hwmon/hwmon*/name` and returns the matching directory — needed because modern boards expose 4-8 hwmon devices (nvme, coretemp, acpitz, nct6798, ...) and the existing GPU-side `findHwmon` returns only the first.

## Platform-specific caveats

- **Synology**: Celeron J4125 typically does NOT expose `coretemp` to userspace; demo feeder mirrors this by leaving the values undefined (graceful-fallback showcase).
- **Kubernetes pods**: no `/sys/class/hwmon` access by default; demo feeder same as Synology.
- **Unraid / TrueNAS / Proxmox**: bare-metal coretemp + acpitz expected; demo feeder produces realistic values per platform (Unraid 58/42, TrueNAS 51/38, Proxmox 63/44 — Proxmox sits in the amber band so the demo showcases the colour change).

## Implementation

- `internal/models.go` — `SystemInfo.{CPUTempC,MoboTempC}` (`int`, `omitempty`).
- `internal/collector/temps.go` — `collectCPUMoboTemps`, `findHwmonByName`, `isPlausibleTemp`. Wired into `collectSystem`.
- `internal/notifier/prometheus.go` — `nasdoctor_system_{cpu,mobo}_temp_celsius` plain Gauges. Emit 0 on graceful fallback (consumers filter with `> 0`).
- `internal/api/dashboard.go` — `util.classForTemp` helper (reuses existing `text-{red,amber,green}` classes inlined in both themes — no new CSS class).
- `internal/api/templates/{midnight,clean}.html` — conditional render in the inline header `<script>` block. Mobile media query in clean.html updated to allow wrap.
- `demo-worker/feeder/src/index.ts` — `PlatformProfile.{cpuTempC,moboTempC}` with per-platform values + `transformSnapshot` synthesises `system.cpu_temp_c` / `system.mobo_temp_c` with jitter.

## Test coverage

- **Collector** (`internal/collector/temps_test.go`): 7 cases — coretemp Package label, coretemp temp1_input fallback, k10temp, x86_pkg_temp thermal zone, acpitz hwmon, nothing-available (returns 0,0), implausible-readings filter (250 °C / 0 °C rejected), `findHwmonByName` direct test.
- **Prometheus** (`internal/notifier/prometheus_temps_test.go`): 3 cases — gauges registered in `/metrics`, Update wires snapshot→gauge, zero on graceful fallback.
- **Model JSON** (`internal/system_temp_json_test.go`): 3 cases — omitempty when zero, present when non-zero, integer round-trip.
- **Dashboard** (`internal/api/dashboard_header_temps_test.go`): 4 cases — `classForTemp` helper present, threshold values 60/75 + palette `text-red/amber/green` referenced, both themes render gated stat-items, no new CSS classes accidentally introduced.
- **JS-parse guard** (`internal/api/dashboard_themes_js_parse_test.go`): NEW — extends the v0.9.9-rc1 settings-page guard to the dashboard themes (`node --check` every `<script>` block). Regression guard against `*/` inside `/* */` and stray backticks in JS comments — exactly the class of footgun this slice's inline-JS edits are most exposed to.
- **Feeder** (`demo-worker/feeder/src/widget-coverage.test.ts`): 2 cases — `cpu_temp_c` + `mobo_temp_c` present + plausible on Unraid/TrueNAS/Proxmox, omitted on Synology + Kubernetes (graceful-fallback contract).

All §4b checks pass: `go build ./...`, `go test ./... -race`, `go vet ./...`, `cd demo-worker/feeder && npm test`, `npx tsc --noEmit`. Docker daemon was unavailable locally; no Dockerfile changes in this PR so CI will validate the image build.

## Out of scope

Per the issue body — sparklines for the new temp gauges (issue says "first-cut without sparklines is also fine"), per-core breakdown, GPU/drive temp surfaces (already exist).