### PR TITLE
fix(speedtest): rc2 — hydration upstream + in_progress gauge + API-path persistence (#294)

### DIFF
--- a/internal/api/speedtest_sse.go
+++ b/internal/api/speedtest_sse.go
@@ -67,8 +67,11 @@ func (s *Server) handleSpeedtestRun(w http.ResponseWriter, r *http.Request) {
 	// cancels as soon as the POST response is written, which would
 	// kill the just-started runner before the first sample arrives.
 	// The registry owns the test's lifetime; the runner needs a
-	// context that outlives this handler call.
-	lt, err := reg.StartTest(context.Background())
+	// context that outlives this handler call. Annotate with the
+	// caller tag so livetest's structured logs differentiate
+	// API-triggered tests from cron-triggered ones (issue #294
+	// debugging hint).
+	lt, err := reg.StartTest(livetest.WithCaller(context.Background(), "api"))
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
 			"error": err.Error(),

--- a/internal/api/speedtest_sse_grace_test.go
+++ b/internal/api/speedtest_sse_grace_test.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/collector"
+	"github.com/mcdays94/nas-doctor/internal/livetest"
+)
+
+// Issue #294 R3 — UAT showed GET /api/v1/speedtest/stream/{id} returning
+// 404 within ~100ms of POST /api/v1/speedtest/run on the live host.
+// Root cause: a fast-failing runner (showwin's FetchUserInfo erroring
+// before the SSE client could attach) cleared the registry slot
+// before GetLive could resolve the test_id. Pre-fix, the user saw
+// "test not found" instead of an error event in the stream.
+//
+// The grace window in livetest.Manager.GetLive (graceWindow) keeps
+// just-completed tests discoverable for 5s so late SSE clients can
+// still attach. This test pins that contract end-to-end.
+
+// fastFailRunner returns an error from Run() immediately. Mirrors
+// what showwin/speedtest-go does when FetchUserInfo or FetchServers
+// hits a transient network failure on UAT.
+type fastFailRunner struct {
+	err error
+}
+
+func (r *fastFailRunner) Run(_ context.Context) (*internal.SpeedTestResult, <-chan collector.SpeedTestSample, error) {
+	if r.err == nil {
+		r.err = errors.New("FetchUserInfo: timeout")
+	}
+	return nil, nil, r.err
+}
+
+// TestSpeedtestSSE_FastFailingRunner_StreamReturns200WithErrorEvent
+// drives the full HTTP path: POST /run with a runner that errors
+// immediately, then GET /stream/{id} ~50ms later (after the runner
+// has already cleared the registry slot but within the grace window).
+// The stream must return 200 with a clean error+end event sequence,
+// NOT 404. Pre-fix this returned 404. Issue #294 R3.
+func TestSpeedtestSSE_FastFailingRunner_StreamReturns200WithErrorEvent(t *testing.T) {
+	t.Parallel()
+	runner := &fastFailRunner{err: errors.New("FetchUserInfo: timeout")}
+	mgr := livetest.NewManager(runner, quietSSELogger(), counterIDGen())
+
+	srv := &Server{}
+	srv.testLiveTestRegistry = mgr
+	r := chi.NewRouter()
+	r.Post("/api/v1/speedtest/run", srv.handleSpeedtestRun)
+	r.Get("/api/v1/speedtest/stream/{test_id}", srv.handleSpeedtestStream)
+	httpsrv := httptest.NewServer(r)
+	defer httpsrv.Close()
+
+	// Trigger the run.
+	resp, err := http.Post(httpsrv.URL+"/api/v1/speedtest/run", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST /run: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /run status = %d, want 200", resp.StatusCode)
+	}
+	var body struct {
+		TestID int64 `json:"test_id"`
+	}
+	json.NewDecoder(resp.Body).Decode(&body)
+	if body.TestID == 0 {
+		t.Fatal("POST /run returned test_id=0")
+	}
+
+	// Wait long enough for the runner to fail + the registry slot
+	// to be cleared. 50ms is overkill but deterministic. Pre-fix
+	// the next GET /stream/{id} would 404. Post-fix the grace
+	// window keeps it discoverable.
+	time.Sleep(50 * time.Millisecond)
+
+	streamResp, err := http.Get(fmt.Sprintf("%s/api/v1/speedtest/stream/%d", httpsrv.URL, body.TestID))
+	if err != nil {
+		t.Fatalf("GET /stream: %v", err)
+	}
+	defer streamResp.Body.Close()
+	if streamResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /stream status = %d, want 200 (grace window must keep just-completed test discoverable for late SSE clients — issue #294 R3)", streamResp.StatusCode)
+	}
+
+	events, err := parseSSEStream(streamResp.Body)
+	if err != nil {
+		t.Fatalf("parseSSEStream: %v", err)
+	}
+	// We expect at least: start, error, end.
+	var seenStart, seenError, seenEnd bool
+	for _, e := range events {
+		switch e.Event {
+		case "start":
+			seenStart = true
+		case "error":
+			seenError = true
+		case "end":
+			seenEnd = true
+		}
+	}
+	if !seenStart {
+		t.Error("late stream missing 'start' event")
+	}
+	if !seenError {
+		t.Error("late stream missing 'error' event — UI cannot tell user why the test failed")
+	}
+	if !seenEnd {
+		t.Error("late stream missing 'end' event — EventSource won't close cleanly")
+	}
+}
+
+// Compile-time guard: fastFailRunner satisfies livetest.Runner.
+var _ livetest.Runner = (*fastFailRunner)(nil)

--- a/internal/livetest/lifecycle_test.go
+++ b/internal/livetest/lifecycle_test.go
@@ -1,0 +1,305 @@
+// Lifecycle observer tests for the LiveTestRegistry. Issue #294 R3.
+//
+// The registry exposes two callback hooks so production wiring can
+// reflect test state without the registry caring about Prometheus or
+// SQLite directly:
+//
+//   - StateChange(running bool) — fires synchronously at StartTest
+//     (running=true) and at completion (running=false). Wired to the
+//     nasdoctor_speedtest_in_progress Prometheus gauge so the gauge
+//     flips correctly regardless of whether the test was started by
+//     the cron loop OR a manual POST /api/v1/speedtest/run. Closes
+//     #294 R3a.
+//
+//   - Completion(*LiveTest) — fires once after the runner returns and
+//     before m.active is cleared. Wired to scheduler persistence so
+//     EVERY test (cron OR API-triggered) writes its history row +
+//     samples through the same code path. Closes #294 R3b.
+package livetest
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestRegistry_StateChangeObserver_FiresOnStartAndEnd asserts the
+// registered observer is called once with running=true at StartTest
+// and once with running=false after the test completes. This is the
+// gauge-flip contract for R3a.
+func TestRegistry_StateChangeObserver_FiresOnStartAndEnd(t *testing.T) {
+	t.Parallel()
+	runner := newFakeRunner()
+	runner.result = &Result{Engine: "speedtest_go"}
+	mgr := NewManager(runner, quietLogger(), counterIDGen())
+
+	var (
+		mu     sync.Mutex
+		states []bool
+	)
+	mgr.RegisterStateChangeObserver(func(running bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		states = append(states, running)
+	})
+
+	lt, err := mgr.StartTest(context.Background())
+	if err != nil {
+		t.Fatalf("StartTest: %v", err)
+	}
+
+	// Synchronous after StartTest: running=true must already have fired.
+	mu.Lock()
+	gotInitial := append([]bool(nil), states...)
+	mu.Unlock()
+	if len(gotInitial) != 1 || gotInitial[0] != true {
+		t.Fatalf("after StartTest: states = %v, want [true]", gotInitial)
+	}
+
+	close(runner.done)
+	<-lt.Done()
+
+	// Allow the observer goroutine to fire (defer ordering means
+	// running=false is invoked just after Done closes).
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(states)
+		mu.Unlock()
+		if n >= 2 {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	mu.Lock()
+	final := append([]bool(nil), states...)
+	mu.Unlock()
+	if len(final) != 2 {
+		t.Fatalf("states = %v, want [true false]", final)
+	}
+	if final[0] != true || final[1] != false {
+		t.Errorf("states = %v, want [true false]", final)
+	}
+}
+
+// TestRegistry_StateChange_FiresFalseEvenOnRunnerError asserts that
+// if Run returns an error immediately (no samples, no result), the
+// observer still receives running=false so the in_progress gauge
+// returns to 0. Without this, a fast-failing runner would leave the
+// gauge stuck at 1 forever.
+func TestRegistry_StateChange_FiresFalseEvenOnRunnerError(t *testing.T) {
+	t.Parallel()
+	runner := newFakeRunner()
+	runner.err = errors.New("FetchUserInfo: timeout")
+	mgr := NewManager(runner, quietLogger(), counterIDGen())
+
+	var (
+		mu     sync.Mutex
+		states []bool
+	)
+	mgr.RegisterStateChangeObserver(func(running bool) {
+		mu.Lock()
+		states = append(states, running)
+		mu.Unlock()
+	})
+
+	lt, err := mgr.StartTest(context.Background())
+	if err != nil {
+		t.Fatalf("StartTest: %v", err)
+	}
+	<-lt.Done()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(states)
+		mu.Unlock()
+		if n >= 2 {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(states) != 2 || states[0] != true || states[1] != false {
+		t.Errorf("states = %v, want [true false] even on runner error", states)
+	}
+}
+
+// TestRegistry_CompletionHandler_FiresOnSuccess asserts the registered
+// completion handler is called once with the completed *LiveTest after
+// a successful run. The handler must observe both Result() and
+// SnapshotSamples() so production wiring can persist history+samples.
+// This is the persistence contract for R3b.
+func TestRegistry_CompletionHandler_FiresOnSuccess(t *testing.T) {
+	t.Parallel()
+	runner := newFakeRunner()
+	runner.result = &Result{
+		DownloadMbps: 100, UploadMbps: 50, LatencyMs: 8,
+		Engine: "speedtest_go",
+	}
+	mgr := NewManager(runner, quietLogger(), counterIDGen())
+
+	completed := make(chan *LiveTest, 1)
+	mgr.RegisterCompletionHandler(func(lt *LiveTest) {
+		completed <- lt
+	})
+
+	lt, err := mgr.StartTest(context.Background())
+	if err != nil {
+		t.Fatalf("StartTest: %v", err)
+	}
+
+	// Push two samples so the handler can verify SnapshotSamples()
+	// is non-empty.
+	runner.samples <- Sample{Phase: "download", Mbps: 100}
+	runner.samples <- Sample{Phase: "upload", Mbps: 50}
+	close(runner.done)
+	<-lt.Done()
+
+	select {
+	case got := <-completed:
+		if got != lt {
+			t.Errorf("handler got different LiveTest pointer (got=%p, want=%p)", got, lt)
+		}
+		if got.Result() == nil {
+			t.Error("handler invoked but Result() was nil — handler ran before result stamped")
+		}
+		samples := got.SnapshotSamples()
+		if len(samples) != 2 {
+			t.Errorf("SnapshotSamples() len = %d, want 2", len(samples))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("completion handler did not fire within 1s")
+	}
+}
+
+// TestRegistry_CompletionHandler_FiresOnError asserts the handler also
+// fires when the runner returns an error — production needs this so
+// failed manual /run requests still record a "failed" attempt row,
+// matching the cron-path behaviour. lt.Err() must be non-nil when the
+// handler runs.
+func TestRegistry_CompletionHandler_FiresOnError(t *testing.T) {
+	t.Parallel()
+	runner := newFakeRunner()
+	runner.err = errors.New("network unreachable")
+	mgr := NewManager(runner, quietLogger(), counterIDGen())
+
+	completed := make(chan *LiveTest, 1)
+	mgr.RegisterCompletionHandler(func(lt *LiveTest) {
+		completed <- lt
+	})
+
+	lt, err := mgr.StartTest(context.Background())
+	if err != nil {
+		t.Fatalf("StartTest: %v", err)
+	}
+	<-lt.Done()
+
+	select {
+	case got := <-completed:
+		if got.Err() == nil {
+			t.Error("handler invoked but Err() was nil — should be non-nil for error path")
+		}
+		if got.Result() != nil {
+			t.Errorf("Result() = %+v, want nil on error path", got.Result())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("completion handler did not fire within 1s on error path")
+	}
+}
+
+// TestRegistry_GetLive_GraceWindow asserts that GetLive(testID)
+// continues to return the LiveTest for a brief window after completion
+// so a late-arriving SSE subscriber can attach, receive the full
+// replay, and see the terminal events. Without this grace window, a
+// fast-failing runner (issue #294 R3 — showwin's FetchUserInfo timing
+// out in <100ms on UAT) clears the registry slot before the browser
+// can issue GET /stream/{id}, and the user sees a 404 instead of an
+// error event in the stream.
+func TestRegistry_GetLive_GraceWindow(t *testing.T) {
+	t.Parallel()
+	runner := newFakeRunner()
+	runner.err = errors.New("fast failure")
+	mgr := NewManager(runner, quietLogger(), counterIDGen())
+
+	lt, err := mgr.StartTest(context.Background())
+	if err != nil {
+		t.Fatalf("StartTest: %v", err)
+	}
+	<-lt.Done() // runner has returned, slot has been cleared
+
+	// Even after completion, GetLive must still resolve for a
+	// brief grace window (PRD #283 alludes to this in the
+	// "subscriber attaching after completion" comment in
+	// livetest.go). Pin the contract: at least 100ms of grace.
+	got, ok := mgr.GetLive(lt.ID())
+	if !ok || got != lt {
+		t.Fatalf("GetLive immediately after Done() — ok=%v, got=%v, want the just-completed test (grace window)", ok, got)
+	}
+}
+
+// TestRegistry_StateChangeObserver_NoObserverDoesntPanic asserts the
+// observer hook is optional — if no observer is registered, StartTest
+// must not panic.
+func TestRegistry_StateChangeObserver_NoObserverDoesntPanic(t *testing.T) {
+	t.Parallel()
+	runner := newFakeRunner()
+	runner.result = &Result{Engine: "speedtest_go"}
+	mgr := NewManager(runner, quietLogger(), counterIDGen())
+	// No RegisterStateChangeObserver call.
+	lt, err := mgr.StartTest(context.Background())
+	if err != nil {
+		t.Fatalf("StartTest: %v", err)
+	}
+	close(runner.done)
+	<-lt.Done()
+}
+
+// TestRegistry_CompletionHandler_NoHandlerDoesntPanic mirrors the above
+// for the completion hook.
+func TestRegistry_CompletionHandler_NoHandlerDoesntPanic(t *testing.T) {
+	t.Parallel()
+	runner := newFakeRunner()
+	runner.result = &Result{Engine: "speedtest_go"}
+	mgr := NewManager(runner, quietLogger(), counterIDGen())
+	lt, err := mgr.StartTest(context.Background())
+	if err != nil {
+		t.Fatalf("StartTest: %v", err)
+	}
+	close(runner.done)
+	<-lt.Done()
+}
+
+// TestRegistry_StateChange_TrueIsSynchronousWithStart asserts that
+// when StartTest returns, the running=true notification has already
+// fired. Critical for the gauge: production wiring registers a
+// callback that calls metrics.SetSpeedTestInProgress(true), and a
+// metrics scrape immediately after POST /run must already see 1.
+func TestRegistry_StateChange_TrueIsSynchronousWithStart(t *testing.T) {
+	t.Parallel()
+	runner := newFakeRunner()
+	runner.result = &Result{Engine: "speedtest_go"}
+	mgr := NewManager(runner, quietLogger(), counterIDGen())
+
+	var trueFired int64
+	mgr.RegisterStateChangeObserver(func(running bool) {
+		if running {
+			atomic.StoreInt64(&trueFired, 1)
+		}
+	})
+
+	lt, err := mgr.StartTest(context.Background())
+	if err != nil {
+		t.Fatalf("StartTest: %v", err)
+	}
+	if atomic.LoadInt64(&trueFired) == 0 {
+		t.Fatal("running=true observer not invoked synchronously with StartTest — POST /run may return before in_progress gauge flips")
+	}
+	close(runner.done)
+	<-lt.Done()
+}

--- a/internal/livetest/livetest.go
+++ b/internal/livetest/livetest.go
@@ -122,43 +122,64 @@ func (t *LiveTest) emit(s Sample) {
 	}
 }
 
-// finishWithResult transitions the test to its terminal state on
-// success: stamps the result, closes every remaining subscriber
-// channel, and closes the Done channel. Idempotent — a second call
-// is a no-op (defensive against runner contract violations).
-func (t *LiveTest) finishWithResult(res *Result) {
+// stampTerminal records the terminal result/err and marks the test
+// closed so emit() ignores any late samples. The Done channel is NOT
+// yet closed — that's deferred to closeSubscribersAndDone, which runs
+// AFTER completion handlers fire. This split guarantees that a cron
+// caller blocking on <-lt.Done() observes the registry's completion
+// handler having ALREADY persisted history+samples, instead of racing
+// against it. Issue #294 R3b. Idempotent.
+func (t *LiveTest) stampTerminal(res *Result, err error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.closed {
 		return
 	}
 	t.result = res
+	t.err = err
 	t.closed = true
+}
+
+// closeSubscribersAndDone broadcasts the terminal-state signals: every
+// remaining subscriber channel is closed (their range loop exits with
+// the buffered events drained), then complete + done are closed so
+// any goroutine waiting on lt.Done() proceeds. Idempotent.
+//
+// MUST be called AFTER stampTerminal — emit() guards on t.closed so
+// stampTerminal first ensures no late sample slips into the buffer
+// after the close-broadcast.
+func (t *LiveTest) closeSubscribersAndDone() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	// Closing a closed channel panics, so check via a sentinel that
+	// rides on the same mutex. We piggyback on an unexported flag.
+	if t.subscribers == nil {
+		return
+	}
 	for ch := range t.subscribers {
 		close(ch)
 		delete(t.subscribers, ch)
 	}
+	t.subscribers = nil
 	close(t.complete)
 	close(t.done)
 }
 
-// finishWithError transitions the test to its terminal state on
-// failure. Same shape as finishWithResult except err is set instead
-// of result.
+// finishWithResult is preserved as a thin wrapper for backward compat
+// with any path that doesn't need the split-stamp behaviour. The
+// registry's driveTest deliberately does NOT use this — it calls
+// stampTerminal + completion handlers + closeSubscribersAndDone in
+// that order so persistence runs before Done unblocks.
+func (t *LiveTest) finishWithResult(res *Result) {
+	t.stampTerminal(res, nil)
+	t.closeSubscribersAndDone()
+}
+
+// finishWithError mirrors finishWithResult for the error path. Same
+// thin-wrapper semantics.
 func (t *LiveTest) finishWithError(err error) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.closed {
-		return
-	}
-	t.err = err
-	t.closed = true
-	for ch := range t.subscribers {
-		close(ch)
-		delete(t.subscribers, ch)
-	}
-	close(t.complete)
-	close(t.done)
+	t.stampTerminal(nil, err)
+	t.closeSubscribersAndDone()
 }
 
 // Done returns a channel that closes when the test has fully ended

--- a/internal/livetest/registry.go
+++ b/internal/livetest/registry.go
@@ -32,6 +32,7 @@ package livetest
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -97,14 +98,39 @@ type Registry interface {
 // LiveTest under a mutex. After completion the LiveTest is retained
 // for a short grace window so a late-arriving SSE subscriber can see
 // the final result + end events before the test is fully forgotten.
+//
+// State-change + completion observers are registered ONCE during
+// production wiring (cmd/nas-doctor/main.go) and are read on every
+// test lifecycle event without acquiring the registry mutex; the
+// observer slice is treated as effectively-immutable after registration
+// to avoid lock-ordering hazards (driveTest defer chain holds m.mu
+// briefly to clear the slot, then calls observers without it).
 type Manager struct {
 	runner Runner
 	logger *slog.Logger
 	idGen  func() int64
 
-	mu     sync.Mutex
-	active *LiveTest // nil when no test in flight
+	mu       sync.Mutex
+	active   *LiveTest // nil when no test in flight
+	graceLT  *LiveTest // last completed test, available via GetLive within graceWindow
+	graceAt  time.Time // when graceLT completed; cleared after graceWindow elapses
+
+	// Observers registered before any tests run. Production wires
+	// these in main.go; tests wire their own. No mutex protection
+	// because the registration calls happen before any StartTest
+	// in production AND before parallel goroutines exist in tests.
+	stateChangeObservers []func(running bool)
+	completionHandlers   []func(*LiveTest)
 }
+
+// graceWindow is how long a just-completed test remains discoverable
+// via GetLive. Sized so a fast-failing runner (e.g. showwin's
+// FetchUserInfo erroring in <100ms — issue #294 R3 root cause on UAT)
+// can still hand a LiveTest off to a late-arriving SSE client. The
+// client gets the full replay (including the error event) and a
+// closed channel, which is the desired UX (error visible in stream)
+// rather than a 404 (confusing "test never existed" surface).
+const graceWindow = 5 * time.Second
 
 // NewManager constructs a Registry-implementing Manager. Pass a
 // production runner (e.g. the collector's compositeRunner) for live
@@ -120,6 +146,42 @@ func NewManager(runner Runner, logger *slog.Logger, idGen func() int64) *Manager
 		idGen = func() int64 { return time.Now().UnixNano() }
 	}
 	return &Manager{runner: runner, logger: logger, idGen: idGen}
+}
+
+// RegisterStateChangeObserver registers a callback invoked at every
+// test-lifecycle transition: running=true synchronously inside
+// StartTest (BEFORE the runner goroutine launches and BEFORE
+// StartTest returns), running=false on the runner goroutine after
+// the registry slot is cleared. Issue #294 R3a — production wires
+// this to notifier.Metrics.SetSpeedTestInProgress so the gauge flips
+// regardless of whether the test was triggered by cron or by a
+// manual POST /api/v1/speedtest/run.
+//
+// Observers are called in registration order. Panic-safety: if an
+// observer panics, the panic is logged and remaining observers still
+// fire (defensive against careless production wiring).
+func (m *Manager) RegisterStateChangeObserver(fn func(running bool)) {
+	if fn == nil {
+		return
+	}
+	m.stateChangeObservers = append(m.stateChangeObservers, fn)
+}
+
+// RegisterCompletionHandler registers a callback invoked exactly once
+// after the runner returns and BEFORE the registry slot is cleared.
+// The LiveTest's Result()/Err()/SnapshotSamples() are all readable
+// at handler invocation time. Issue #294 R3b — production wires this
+// to scheduler.handleSpeedTestResultWithSamples so EVERY completed
+// test (cron OR API-triggered) writes its history row + per-sample
+// telemetry through the same code path.
+//
+// Multiple handlers are called in registration order. Panic-safety
+// matches state-change observers.
+func (m *Manager) RegisterCompletionHandler(fn func(*LiveTest)) {
+	if fn == nil {
+		return
+	}
+	m.completionHandlers = append(m.completionHandlers, fn)
 }
 
 // StartTest acquires the singleton lock and starts a new test if none
@@ -156,7 +218,25 @@ func (m *Manager) StartTest(ctx context.Context) (*LiveTest, error) {
 		complete:    make(chan struct{}),
 	}
 	m.active = t
+	// Clear any prior grace test now that a fresh one is active —
+	// the grace window only applies to the most-recently-completed
+	// test, not a stale handle.
+	m.graceLT = nil
+	m.graceAt = time.Time{}
 	m.mu.Unlock()
+
+	m.logger.Info("livetest: start",
+		"test_id", t.id,
+		"caller", callerFromContext(ctx),
+	)
+
+	// Fire running=true BEFORE the runner goroutine launches so the
+	// in_progress gauge is set to 1 synchronously with StartTest's
+	// return. A metrics scrape immediately after POST /run will
+	// observe in_progress=1 even if the runner hasn't actually
+	// started yet — the registry IS in progress from the caller's
+	// perspective.
+	m.notifyStateChange(true)
 
 	// Drive the runner asynchronously. The goroutine owns the
 	// transition to terminal state (result/error -> done channel
@@ -164,6 +244,66 @@ func (m *Manager) StartTest(ctx context.Context) (*LiveTest, error) {
 	// touches m.active.
 	go m.driveTest(ctx, t)
 	return t, nil
+}
+
+// notifyStateChange invokes every registered state-change observer
+// with the given running flag. Panic in any observer is logged and
+// recovered; remaining observers still fire.
+func (m *Manager) notifyStateChange(running bool) {
+	for _, fn := range m.stateChangeObservers {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					m.logger.Warn("livetest: state-change observer panicked",
+						"running", running, "panic", r)
+				}
+			}()
+			fn(running)
+		}()
+	}
+}
+
+// notifyCompletion invokes every registered completion handler with
+// the just-completed LiveTest. Panic in any handler is logged and
+// recovered.
+func (m *Manager) notifyCompletion(t *LiveTest) {
+	for _, fn := range m.completionHandlers {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					m.logger.Warn("livetest: completion handler panicked",
+						"test_id", t.id, "panic", r)
+				}
+			}()
+			fn(t)
+		}()
+	}
+}
+
+// callerFromContext extracts a free-form "caller" tag from the
+// context (set via WithCaller). Used purely for structured logs so
+// future UAT can tell at a glance whether a test came from cron, the
+// API, or a test fixture. Returns "" if nothing was attached.
+func callerFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if v, ok := ctx.Value(callerCtxKey{}).(string); ok {
+		return v
+	}
+	return ""
+}
+
+type callerCtxKey struct{}
+
+// WithCaller annotates the context with a caller tag. Production
+// wiring sets this to "cron" / "api" so /var/log entries from
+// livetest are filterable. Tests can leave it unset.
+func WithCaller(ctx context.Context, caller string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, callerCtxKey{}, caller)
 }
 
 // driveTest invokes the runner and broadcasts samples to subscribers.
@@ -184,8 +324,9 @@ func (m *Manager) StartTest(ctx context.Context) (*LiveTest, error) {
 // an error result so subscribers see a clean error event.
 func (m *Manager) driveTest(ctx context.Context, t *LiveTest) {
 	var (
-		res *Result
-		err error
+		res        *Result
+		err        error
+		samplesSeen int
 	)
 
 	defer func() {
@@ -193,19 +334,60 @@ func (m *Manager) driveTest(ctx context.Context, t *LiveTest) {
 			err = errFromPanic(r)
 			m.logger.Warn("livetest: runner panicked", "panic", r, "test_id", t.id)
 		}
-		// Clear the registry slot FIRST so observers waiting on
-		// Done() see InProgress()=false the moment Done closes.
+		// Stamp terminal state on the LiveTest. After this returns,
+		// Result()/Err()/SnapshotSamples() are all readable but the
+		// Done channel is NOT yet closed. This split lets the
+		// completion handler run BEFORE any goroutine waiting on
+		// <-lt.Done() proceeds — critical so the cron path observes
+		// "Done unblocked → persistence already happened" instead of
+		// racing against the registry's persistence callback.
+		// Issue #294 R3b.
+		t.stampTerminal(res, err)
+		// Fire completion handlers synchronously. Production wires
+		// this to scheduler persistence (history row + samples).
+		// Both cron- and API-triggered tests therefore produce
+		// identical persistence side effects via the SAME callback.
+		m.notifyCompletion(t)
+		// Now broadcast subscriber-channel close + Done close. SSE
+		// clients waiting on the channel get the buffered events +
+		// terminal close; cron callers waiting on Done() unblock
+		// AFTER the persistence handler has returned.
+		t.closeSubscribersAndDone()
+		// Clear the active slot + stash for the grace window so
+		// late SSE clients can still attach. GetLive checks both
+		// active and graceLT.
 		m.mu.Lock()
 		m.active = nil
+		m.graceLT = t
+		m.graceAt = time.Now()
 		m.mu.Unlock()
-		// Then transition the test to its terminal state, which
-		// closes every subscriber channel + Done.
-		if err != nil {
-			t.finishWithError(err)
+		// Broadcast running=false. By firing AFTER the slot is
+		// cleared, callers asserting "gauge==0 implies not in
+		// progress" stay correct (Prometheus scrapes during the
+		// race window will see in_progress=1 AND active==nil but
+		// the gauge clamps quickly to 0 once notify fires).
+		m.notifyStateChange(false)
+
+		var resultSummary string
+		if res != nil {
+			resultSummary = "success"
+		} else if err != nil {
+			resultSummary = "error"
 		} else {
-			t.finishWithResult(res)
+			resultSummary = "unknown"
 		}
+		m.logger.Info("livetest: end",
+			"test_id", t.id,
+			"samples_seen", samplesSeen,
+			"result", resultSummary,
+			"err", err,
+		)
 	}()
+
+	m.logger.Info("livetest: drive",
+		"test_id", t.id,
+		"runner_type", fmt.Sprintf("%T", m.runner),
+	)
 
 	var samples <-chan Sample
 	res, samples, err = m.runner.Run(ctx)
@@ -222,24 +404,35 @@ func (m *Manager) driveTest(ctx context.Context, t *LiveTest) {
 	// it does.
 	for s := range samples {
 		t.emit(s)
+		samplesSeen++
 	}
 }
 
 // GetLive returns the current in-flight LiveTest if its ID matches.
-// Returns (nil, false) if no test is in flight or the ID is for a
-// completed test (the registry forgets completed IDs once active
-// is cleared).
+// Returns (nil, false) if no test is in flight, the ID doesn't match,
+// AND no recently-completed test is within the grace window.
 //
-// Note: there's an unavoidable race window between a test completing
-// and m.active being cleared. In that window, GetLive may still
-// return the just-completed test. Callers that subscribe in that
-// window see a fully-populated replay + immediate end event, which
-// is the desired behaviour.
+// The grace window (graceWindow, currently 5s) keeps a just-completed
+// test discoverable so a late-arriving SSE subscriber can still
+// attach, receive the full replay (including the terminal event),
+// and exit cleanly. Without this, a fast-failing runner — e.g.
+// showwin's FetchUserInfo erroring in <100ms on UAT (issue #294 R3
+// root cause) — clears the registry slot before the browser can
+// issue GET /stream/{id}, and the user sees a 404 instead of the
+// error event in the stream.
 func (m *Manager) GetLive(testID int64) (*LiveTest, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.active != nil && m.active.id == testID {
 		return m.active, true
+	}
+	if m.graceLT != nil && m.graceLT.id == testID {
+		if time.Since(m.graceAt) <= graceWindow {
+			return m.graceLT, true
+		}
+		// Grace expired — clear so subsequent calls are O(1).
+		m.graceLT = nil
+		m.graceAt = time.Time{}
 	}
 	return nil, false
 }

--- a/internal/livetest/registry_test.go
+++ b/internal/livetest/registry_test.go
@@ -516,17 +516,13 @@ func TestRegistry_GetLive_Lookup(t *testing.T) {
 	close(runner.done)
 	<-lt.Done()
 
-	// After completion, GetLive may briefly still return the test
-	// (race window) — but eventually returns false. We don't pin
-	// timing; just check it eventually clears.
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		if _, ok := mgr.GetLive(lt.ID()); !ok {
-			return
-		}
-		time.Sleep(time.Millisecond)
+	// After completion, the registry retains the just-completed
+	// test for a grace window (issue #294 R3 — keeps SSE clients
+	// from getting 404 on a fast-failing runner). GetLive must
+	// still resolve immediately after Done().
+	if _, ok := mgr.GetLive(lt.ID()); !ok {
+		t.Error("GetLive returned !ok during grace window — late SSE clients would get 404")
 	}
-	t.Error("GetLive still returned the completed test after 1s")
 }
 
 // counterIDGen returns deterministic monotonically-increasing IDs

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -397,10 +397,57 @@ func (s *Scheduler) SetSpeedTestRunner(fn SpeedTestRunner) {
 // SetSpeedTestRunner to inject the legacy result-only stub — that
 // path is preserved so existing scheduler tests (#180, #210) keep
 // working unchanged. PRD #283 slice 2 / issue #285.
+//
+// If the registry implements the observable lifecycle interface
+// (livetest.Manager does), the scheduler registers two callbacks:
+//
+//   - state-change → flips notifier.Metrics.SetSpeedTestInProgress
+//     so the gauge is correct regardless of whether a test was
+//     started by the cron loop OR a manual POST /api/v1/speedtest/run.
+//     Closes #294 R3a.
+//
+//   - completion → persists the test's history row + samples through
+//     handleSpeedTestResultWithSamples. Both cron- and API-triggered
+//     tests therefore produce identical persistence side effects.
+//     Closes #294 R3b.
+//
+// Calling SetLiveTestRegistry more than once is supported but the
+// observer registrations stack — only call once per Scheduler in
+// production. Tests that need to re-wire should construct a fresh
+// registry/manager.
 func (s *Scheduler) SetLiveTestRegistry(reg livetest.Registry) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.liveTestRegistry = reg
+	s.mu.Unlock()
+
+	// Type-assert to the observable interface. *livetest.Manager
+	// satisfies it; lightweight test fakes that DON'T need
+	// completion-handling can elect not to implement it.
+	type observable interface {
+		RegisterStateChangeObserver(func(running bool))
+		RegisterCompletionHandler(func(*livetest.LiveTest))
+	}
+	if obs, ok := reg.(observable); ok {
+		obs.RegisterStateChangeObserver(func(running bool) {
+			if s.metrics != nil {
+				s.metrics.SetSpeedTestInProgress(running)
+			}
+		})
+		obs.RegisterCompletionHandler(func(lt *livetest.LiveTest) {
+			if err := lt.Err(); err != nil {
+				s.logger.Info("speed test failed via registry", "error", err, "test_id", lt.ID())
+				s.recordSpeedTestAttempt(time.Now().UTC(), "failed",
+					fmt.Sprintf("speed test failed: %v", err))
+				return
+			}
+			// Pull the buffered sample set BEFORE
+			// handleSpeedTestResult so the bulk-insert is hooked
+			// to the same parent history row that
+			// SaveSpeedTestReturningID just produced.
+			samples := lt.SnapshotSamples()
+			s.handleSpeedTestResultWithSamples(lt.Result(), samples)
+		})
+	}
 }
 
 // LiveTestRegistry returns the wired registry. Used by the API layer
@@ -623,6 +670,13 @@ func (s *Scheduler) RunOnce() {
 		}
 	}
 
+	// Hydrate snap.SpeedTest.Latest from history if the in-memory
+	// snap doesn't carry it. Mirrors what Latest() does for HTTP
+	// callers and ensures Prometheus reads the same hydrated view —
+	// otherwise post-restart /metrics shows the speedtest gauge
+	// family stuck at zero. Issue #294 R1+R2.
+	s.hydrateSpeedTestFromHistory(snap)
+
 	// Update Prometheus metrics
 	if s.metrics != nil {
 		s.metrics.Update(snap)
@@ -770,11 +824,57 @@ func (s *Scheduler) carryForwardSubsystems(snap *internal.Snapshot, skipped []st
 	}
 }
 
-// Latest returns the most recent snapshot from the cache.
+// Latest returns the most recent snapshot from the cache. The returned
+// snapshot's SpeedTest.Latest is hydrated from speedtest_history when
+// the in-memory snapshot lacks it — closes the cold-start gap where
+// /api/v1/snapshot/latest AND the Prometheus exporter would see
+// SpeedTest=nil after a fresh container start, even though historical
+// rows exist on disk. Issue #294 R1+R2.
+//
+// Hydration is a fallback: if Latest is already populated (steady
+// state, after the speed-test loop has fired), live data wins over
+// any stale history row.
 func (s *Scheduler) Latest() *internal.Snapshot {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.latest
+	snap := s.latest
+	s.mu.RUnlock()
+	if snap == nil {
+		return nil
+	}
+	s.hydrateSpeedTestFromHistory(snap)
+	return snap
+}
+
+// hydrateSpeedTestFromHistory mutates snap.SpeedTest.Latest in place
+// from the most-recent speedtest_history row IFF Latest is nil. Idempotent
+// — safe to call repeatedly. Errors during the lookup are logged and
+// swallowed: a missing speed-test card is strictly better than a
+// failure on snapshot read. Single source of truth for hydration so
+// both Prometheus's Update() (driven from RunOnce) and the API
+// handleLatestSnapshot path see the same hydrated state. Issue #294.
+func (s *Scheduler) hydrateSpeedTestFromHistory(snap *internal.Snapshot) {
+	if snap == nil {
+		return
+	}
+	if snap.SpeedTest != nil && snap.SpeedTest.Latest != nil {
+		return
+	}
+	if s.store == nil {
+		return
+	}
+	latest, ok, err := s.store.GetLatestSpeedTestResult()
+	if err != nil {
+		s.logger.Warn("hydrate speedtest from history failed", "error", err)
+		return
+	}
+	if !ok || latest == nil {
+		return
+	}
+	if snap.SpeedTest == nil {
+		snap.SpeedTest = &internal.SpeedTestInfo{}
+	}
+	snap.SpeedTest.Available = true
+	snap.SpeedTest.Latest = latest
 }
 
 // SetLatest injects a snapshot into the scheduler's cache (used by demo mode).
@@ -1346,16 +1446,17 @@ func (s *Scheduler) runSpeedTest() {
 // this cron tick, the registry's idempotency guarantees both paths
 // converge on the same in-flight test (one runner invocation).
 //
-// Sets the nasdoctor_speedtest_in_progress Prometheus gauge to 1
-// while the test runs (PRD #283). The set+unset is wrapped in a
-// defer so a panic in the runner still flips the gauge back to 0
-// — otherwise alerting on stuck tests would emit false positives.
+// State-change + persistence side effects are now driven by registry
+// observers wired in SetLiveTestRegistry, so this function is a thin
+// orchestration layer: kick off the test and block until it finishes.
+// The block is needed so the cron loop's lastRun timestamp doesn't
+// advance until the test actually completes — without it, a 30-60s
+// test could let a subsequent tick fire a parallel run before the
+// first one finishes (the registry's idempotency would collapse them
+// onto one runner, but the cron lastRun would skew). Issue #294
+// R3a/R3b moved gauge + persistence into the registry observers.
 func (s *Scheduler) runSpeedTestViaRegistry(registry livetest.Registry) {
-	if s.metrics != nil {
-		s.metrics.SetSpeedTestInProgress(true)
-		defer s.metrics.SetSpeedTestInProgress(false)
-	}
-	ctx := context.Background()
+	ctx := livetest.WithCaller(context.Background(), "cron")
 	lt, err := registry.StartTest(ctx)
 	if err != nil {
 		s.logger.Warn("speed test: registry start failed", "error", err)
@@ -1363,22 +1464,11 @@ func (s *Scheduler) runSpeedTestViaRegistry(registry livetest.Registry) {
 			fmt.Sprintf("registry start failed: %v", err))
 		return
 	}
-	// Wait for the test to fully complete (samples drained,
-	// subscribers fanned out, registry slot cleared). Don't drain
-	// samples here — that's the SSE handler's job; we only care
-	// about the terminal result.
+	// Wait for the test to fully complete. Persistence + gauge flip
+	// happen via observers inside the registry's driveTest defer
+	// chain; this goroutine only blocks so the cron loop's own
+	// lastRun cadence doesn't advance prematurely.
 	<-lt.Done()
-	if err := lt.Err(); err != nil {
-		s.logger.Info("speed test failed via registry", "error", err)
-		s.recordSpeedTestAttempt(time.Now().UTC(), "failed",
-			fmt.Sprintf("speed test failed: %v", err))
-		return
-	}
-	// Pull the buffered sample set BEFORE handleSpeedTestResult so
-	// the bulk-insert is hooked to the same parent history row that
-	// SaveSpeedTestReturningID just produced. PRD #283 slice 3 / #286.
-	samples := lt.SnapshotSamples()
-	s.handleSpeedTestResultWithSamples(lt.Result(), samples)
 }
 
 // handleSpeedTestResult applies the post-run side effects shared by

--- a/internal/scheduler/scheduler_livetest_observer_test.go
+++ b/internal/scheduler/scheduler_livetest_observer_test.go
@@ -1,0 +1,248 @@
+package scheduler
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/livetest"
+	"github.com/mcdays94/nas-doctor/internal/notifier"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// Issue #294 R3a + R3b: when SetLiveTestRegistry wires the observer
+// hooks, ANY caller of registry.StartTest (cron loop, manual API
+// path, or future fleet-driven path) gets the same persistence +
+// gauge-management side effects via the registered callbacks. These
+// tests simulate the API path by calling registry.StartTest directly
+// without going through s.runSpeedTest, asserting the result is
+// indistinguishable from the cron path.
+
+// TestLiveTestRegistry_APIPath_PersistsHistoryAndSamples drives the
+// API path's call shape: get the registry, StartTest(ctx) (no block-
+// on-Done), wait briefly, then assert the DB holds a history row +
+// samples linked to the test_id. Pre-fix this was R3b — the API path
+// returned the test_id and exited; nothing wrote to DB until the next
+// cron tick (4h later). After the fix, the registry's completion
+// observer persists synchronously inside the registry goroutine.
+func TestLiveTestRegistry_APIPath_PersistsHistoryAndSamples(t *testing.T) {
+	t.Parallel()
+	store := storage.NewFakeStore()
+	logger := quietLogger()
+	s := New(nil, store, nil, nil, logger, time.Hour)
+
+	now := time.Now().UTC()
+	runner := &samplingRunner{
+		result: &internal.SpeedTestResult{
+			DownloadMbps: 250, UploadMbps: 25, LatencyMs: 12,
+			Timestamp: now,
+			Engine:    internal.SpeedTestEngineSpeedTestGo,
+		},
+		// samplingRunner type from scheduler_speedtest_samples_test.go;
+		// per-sample stream stays empty for this test (we only care
+		// about history-row persistence on the API path).
+		samples: nil,
+	}
+
+	// Build via registry directly (mirrors what the API handler does).
+	mgr := livetest.NewManager(runner, logger, nil)
+	s.SetLiveTestRegistry(mgr)
+
+	// Simulate the API path: registry.StartTest, no scheduler
+	// block-on-Done. The registry's completion handler (wired in
+	// SetLiveTestRegistry) is responsible for persistence.
+	lt, err := mgr.StartTest(context.Background())
+	if err != nil {
+		t.Fatalf("StartTest: %v", err)
+	}
+
+	// Now wait for completion. We don't have a cron-loop blocker
+	// here — the API path returns immediately. But we need to wait
+	// to assert the side effects. This block is the test waiting,
+	// not the production code path.
+	<-lt.Done()
+
+	// At this point the production code's completion handler has
+	// run. History row must exist.
+	id, ok, err := store.GetLatestSpeedTestHistoryID()
+	if err != nil {
+		t.Fatalf("GetLatestSpeedTestHistoryID: %v", err)
+	}
+	if !ok || id == 0 {
+		t.Fatalf("expected history row to be persisted via API path, got ok=%v id=%d", ok, id)
+	}
+
+	// LastAttempt must have been flipped to success.
+	att, err := store.GetLastSpeedTestAttempt()
+	if err != nil {
+		t.Fatalf("GetLastSpeedTestAttempt: %v", err)
+	}
+	if att == nil || att.Status != "success" {
+		t.Errorf("LastAttempt = %v, want status=success", att)
+	}
+}
+
+// TestLiveTestRegistry_StateChange_FlipsInProgressGauge wires a real
+// notifier.Metrics into the scheduler and asserts that the
+// nasdoctor_speedtest_in_progress gauge is 1 while a test is in
+// flight (driven by an arbitrary caller of registry.StartTest, NOT
+// just runSpeedTest) and 0 after completion. R3a regression guard.
+func TestLiveTestRegistry_StateChange_FlipsInProgressGauge(t *testing.T) {
+	t.Parallel()
+	store := storage.NewFakeStore()
+	logger := quietLogger()
+	m := notifier.NewMetrics()
+	s := New(nil, store, nil, m, logger, time.Hour)
+
+	// Use a runner whose Run() blocks until the test releases it.
+	// This simulates a real speed test where the gauge MUST read 1
+	// during the runner's execution window.
+	release := make(chan struct{})
+	runner := &blockingRunner{
+		result:  &internal.SpeedTestResult{Engine: internal.SpeedTestEngineSpeedTestGo, DownloadMbps: 100},
+		release: release,
+	}
+	mgr := livetest.NewManager(runner, logger, nil)
+	s.SetLiveTestRegistry(mgr)
+
+	// Simulate manual /api/v1/speedtest/run path: caller invokes
+	// StartTest and exits without blocking on Done.
+	lt, err := mgr.StartTest(context.Background())
+	if err != nil {
+		t.Fatalf("StartTest: %v", err)
+	}
+
+	// Scrape /metrics — gauge must read 1 BEFORE the runner
+	// finishes. If the observer fired at StartTest time (synchronous
+	// per the contract), this scrape sees in_progress=1.
+	body := scrapeFromMetrics(t, m)
+	if !strings.Contains(body, "nasdoctor_speedtest_in_progress 1") {
+		t.Errorf("during in-flight test, /metrics did NOT show in_progress=1 — observer wiring broken; body excerpt:\n%s",
+			grepMetricsLines(body, "speedtest_in_progress"))
+	}
+
+	// Release the runner; wait for completion.
+	close(release)
+	<-lt.Done()
+
+	// Allow observer (running=false) to fire — it's invoked after
+	// closeSubscribersAndDone, which itself runs after Done closes.
+	// We need to wait for it.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		body = scrapeFromMetrics(t, m)
+		if strings.Contains(body, "nasdoctor_speedtest_in_progress 0") {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if !strings.Contains(body, "nasdoctor_speedtest_in_progress 0") {
+		t.Errorf("after test completed, /metrics did NOT return to in_progress=0; body excerpt:\n%s",
+			grepMetricsLines(body, "speedtest_in_progress"))
+	}
+}
+
+// TestLiveTestRegistry_StateChange_FailedRunStillResetsGauge asserts
+// that a runner returning an error immediately (the showwin
+// FetchUserInfo flake on UAT) still resets the gauge to 0. Without
+// this the gauge would be stuck at 1 after a failed manual run,
+// creating false positives for any future "running >5min" alerts.
+func TestLiveTestRegistry_StateChange_FailedRunStillResetsGauge(t *testing.T) {
+	t.Parallel()
+	store := storage.NewFakeStore()
+	logger := quietLogger()
+	m := notifier.NewMetrics()
+	s := New(nil, store, nil, m, logger, time.Hour)
+
+	runner := &failingRunner{}
+	mgr := livetest.NewManager(runner, logger, nil)
+	s.SetLiveTestRegistry(mgr)
+
+	lt, err := mgr.StartTest(context.Background())
+	if err != nil {
+		t.Fatalf("StartTest: %v", err)
+	}
+	<-lt.Done()
+
+	// Gauge eventually returns to 0.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		body := scrapeFromMetrics(t, m)
+		if strings.Contains(body, "nasdoctor_speedtest_in_progress 0") {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Errorf("gauge stuck after fast-failing runner — would generate false stuck-test alerts")
+}
+
+// blockingRunner blocks Run until release is closed, then returns
+// the configured result with no samples. Useful for tests that need
+// to assert metrics during a runner's window.
+type blockingRunner struct {
+	result  *internal.SpeedTestResult
+	release chan struct{}
+}
+
+func (r *blockingRunner) Run(_ context.Context) (*internal.SpeedTestResult, <-chan internalSpeedTestSample, error) {
+	out := make(chan internalSpeedTestSample)
+	go func() {
+		<-r.release
+		close(out)
+	}()
+	return r.result, out, nil
+}
+
+// failingRunner errors on Run() — simulates the showwin FetchUserInfo
+// fast-fail mode observed during UAT.
+type failingRunner struct{}
+
+func (failingRunner) Run(_ context.Context) (*internal.SpeedTestResult, <-chan internalSpeedTestSample, error) {
+	return nil, nil, errFastFail
+}
+
+var errFastFail = stringError("simulated fast failure (e.g. FetchUserInfo timeout)")
+
+type stringError string
+
+func (s stringError) Error() string { return string(s) }
+
+// scrapeFromMetrics renders /metrics from a notifier.Metrics. Local
+// helper to avoid depending on the notifier package's test exports.
+func scrapeFromMetrics(t *testing.T, m *notifier.Metrics) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	promhttp.HandlerFor(m.Registry(), promhttp.HandlerOpts{}).ServeHTTP(rec, req)
+	return rec.Body.String()
+}
+
+// grepMetricsLines filters metrics body to lines containing substr.
+func grepMetricsLines(body, substr string) string {
+	var keep []string
+	for _, line := range strings.Split(body, "\n") {
+		if strings.Contains(line, substr) {
+			keep = append(keep, line)
+		}
+	}
+	return strings.Join(keep, "\n")
+}
+
+// internalSpeedTestSample re-aliases collector.SpeedTestSample under
+// a simpler name so the test runners' Run signatures stay readable.
+// The livetest.Sample type aliases the collector type already, but
+// blockingRunner / failingRunner implement collector.SpeedTestRunner
+// directly — they need the original collector type.
+type internalSpeedTestSample = livetest.Sample
+
+// Compile-time guard: blockingRunner / failingRunner satisfy
+// livetest.Runner.
+var (
+	_ livetest.Runner = (*blockingRunner)(nil)
+	_ livetest.Runner = failingRunner{}
+)

--- a/internal/scheduler/scheduler_livetest_registry_test.go
+++ b/internal/scheduler/scheduler_livetest_registry_test.go
@@ -43,6 +43,20 @@ func (f *fakeRegistry) InProgress() bool {
 	return f.mgr.InProgress()
 }
 
+// RegisterStateChangeObserver / RegisterCompletionHandler proxy to the
+// inner livetest.Manager so the scheduler's observer wiring fires
+// even when tests pass *fakeRegistry instead of the bare manager.
+// Without these methods the type-assertion in
+// Scheduler.SetLiveTestRegistry would fall through and persistence
+// would silently skip on the cron path. Issue #294.
+func (f *fakeRegistry) RegisterStateChangeObserver(fn func(running bool)) {
+	f.mgr.RegisterStateChangeObserver(fn)
+}
+
+func (f *fakeRegistry) RegisterCompletionHandler(fn func(*livetest.LiveTest)) {
+	f.mgr.RegisterCompletionHandler(fn)
+}
+
 func (f *fakeRegistry) Calls() int64 {
 	return atomic.LoadInt64(&f.startCalls)
 }

--- a/internal/scheduler/scheduler_speedtest_hydration_test.go
+++ b/internal/scheduler/scheduler_speedtest_hydration_test.go
@@ -1,0 +1,178 @@
+package scheduler
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/notifier"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// Issue #294 R1+R2: Prometheus must see a hydrated snapshot even when
+// the scheduler's in-memory s.latest.SpeedTest is nil but a historical
+// row exists in speedtest_history. Prior to this fix the API handler
+// was the ONLY place that hydrated, leaving Prometheus stuck reading
+// 0 / missing labels after a fresh container start.
+//
+// This test pins the contract: Scheduler.Latest() returns a snapshot
+// whose SpeedTest.Latest is hydrated from history when needed, AND
+// Prometheus's Update() is fed the hydrated snapshot during RunOnce.
+
+// TestScheduler_Latest_HydratesSpeedTestFromHistory asserts that after
+// a fresh container start (s.latest populated via SetLatest with a
+// snapshot that has no SpeedTest), Latest() returns a snapshot where
+// SpeedTest.Latest has been hydrated from speedtest_history.
+func TestScheduler_Latest_HydratesSpeedTestFromHistory(t *testing.T) {
+	t.Parallel()
+	store := storage.NewFakeStore()
+
+	// Seed a historical row.
+	histTs := time.Now().Add(-2 * time.Hour).UTC()
+	if err := store.SaveSpeedTest("snap-pre-restart", &internal.SpeedTestResult{
+		Timestamp:    histTs,
+		DownloadMbps: 250, UploadMbps: 25, LatencyMs: 12,
+		Engine: internal.SpeedTestEngineSpeedTestGo,
+	}); err != nil {
+		t.Fatalf("SaveSpeedTest: %v", err)
+	}
+
+	logger := quietLogger()
+	s := New(nil, store, nil, nil, logger, time.Hour)
+
+	// Simulate post-restart: cache holds a snapshot that lacks
+	// SpeedTest (the persisted Snapshot envelope doesn't carry
+	// it forward — only the speed-test loop populates it).
+	s.SetLatest(&internal.Snapshot{
+		ID:        "post-restart",
+		Timestamp: time.Now().UTC(),
+	})
+
+	got := s.Latest()
+	if got == nil {
+		t.Fatal("Latest() returned nil")
+	}
+	if got.SpeedTest == nil || got.SpeedTest.Latest == nil {
+		t.Fatalf("Latest().SpeedTest.Latest = nil; want hydrated from history. got=%+v", got.SpeedTest)
+	}
+	if got.SpeedTest.Latest.DownloadMbps != 250 {
+		t.Errorf("DownloadMbps = %v, want 250", got.SpeedTest.Latest.DownloadMbps)
+	}
+	if got.SpeedTest.Latest.Engine != internal.SpeedTestEngineSpeedTestGo {
+		t.Errorf("Engine = %q, want speedtest_go", got.SpeedTest.Latest.Engine)
+	}
+	if !got.SpeedTest.Available {
+		t.Error("Available = false; widget happy-path gate skips")
+	}
+}
+
+// TestScheduler_Latest_PreservesExistingSpeedTest asserts hydration is
+// a fallback — when the cached snapshot already carries Latest, the
+// stored history row must not clobber it.
+func TestScheduler_Latest_PreservesExistingSpeedTest(t *testing.T) {
+	t.Parallel()
+	store := storage.NewFakeStore()
+	if err := store.SaveSpeedTest("stale", &internal.SpeedTestResult{
+		Timestamp:    time.Now().Add(-10 * time.Hour).UTC(),
+		DownloadMbps: 1, // sentinel — must NOT win
+	}); err != nil {
+		t.Fatalf("SaveSpeedTest: %v", err)
+	}
+
+	s := New(nil, store, nil, nil, quietLogger(), time.Hour)
+	s.SetLatest(&internal.Snapshot{
+		Timestamp: time.Now().UTC(),
+		SpeedTest: &internal.SpeedTestInfo{
+			Available: true,
+			Latest: &internal.SpeedTestResult{
+				Timestamp:    time.Now().Add(-1 * time.Minute).UTC(),
+				DownloadMbps: 999, // sentinel — must survive
+				Engine:       internal.SpeedTestEngineSpeedTestGo,
+			},
+		},
+	})
+
+	got := s.Latest()
+	if got.SpeedTest == nil || got.SpeedTest.Latest == nil {
+		t.Fatal("Latest dropped during hydration")
+	}
+	if got.SpeedTest.Latest.DownloadMbps != 999 {
+		t.Errorf("DownloadMbps = %v, want 999 (live data must beat stale history)", got.SpeedTest.Latest.DownloadMbps)
+	}
+}
+
+// TestScheduler_Latest_NilSnapshotReturnsNil asserts the no-cache path
+// is unaffected by the new hydration logic.
+func TestScheduler_Latest_NilSnapshotReturnsNil(t *testing.T) {
+	t.Parallel()
+	s := New(nil, storage.NewFakeStore(), nil, nil, quietLogger(), time.Hour)
+	if got := s.Latest(); got != nil {
+		t.Errorf("Latest() = %+v on empty cache, want nil", got)
+	}
+}
+
+// TestPrometheus_SeesHydratedSpeedTest_AfterRestart wires a real
+// notifier.Metrics into the Scheduler and asserts that scraping
+// /metrics after a "post-restart" SetLatest exposes the speedtest
+// gauges with values from the historical row. This is the explicit
+// regression guard for #294 R1+R2: Prometheus reads the hydrated
+// snapshot through the same code path the API handler uses.
+func TestPrometheus_SeesHydratedSpeedTest_AfterRestart(t *testing.T) {
+	t.Parallel()
+	store := storage.NewFakeStore()
+
+	// Seed history so hydration has something to find.
+	if err := store.SaveSpeedTest("pre-restart-row", &internal.SpeedTestResult{
+		Timestamp:    time.Now().Add(-3 * time.Hour).UTC(),
+		DownloadMbps: 92.10, UploadMbps: 8.50, LatencyMs: 14.2,
+		Engine: internal.SpeedTestEngineSpeedTestGo,
+	}); err != nil {
+		t.Fatalf("SaveSpeedTest: %v", err)
+	}
+
+	m := notifier.NewMetrics()
+	s := New(nil, store, nil, m, quietLogger(), time.Hour)
+
+	// Simulate post-restart: cache snapshot lacks SpeedTest.
+	postRestart := &internal.Snapshot{
+		ID:        "post-restart",
+		Timestamp: time.Now().UTC(),
+	}
+	s.SetLatest(postRestart)
+
+	// Push the hydrated snapshot through the Prometheus exporter
+	// the way RunOnce does. After this fix, Latest() returns the
+	// hydrated snapshot, so feeding that into Update() must surface
+	// the speedtest gauges.
+	m.Update(s.Latest())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	promhttp.HandlerFor(m.Registry(), promhttp.HandlerOpts{}).ServeHTTP(rec, req)
+	body := rec.Body.String()
+
+	if !strings.Contains(body, `nasdoctor_speedtest_engine{engine="speedtest_go"} 1`) {
+		t.Errorf("expected nasdoctor_speedtest_engine{engine=\"speedtest_go\"} 1 in /metrics; body excerpt:\n%s",
+			grepLines(body, "speedtest"))
+	}
+	if !strings.Contains(body, "nasdoctor_speedtest_download_mbps 92.1") {
+		t.Errorf("expected nasdoctor_speedtest_download_mbps 92.1 in /metrics; body excerpt:\n%s",
+			grepLines(body, "speedtest_download"))
+	}
+}
+
+// grepLines returns a string containing only the lines of body that
+// contain substr. Used to keep failure messages readable.
+func grepLines(body, substr string) string {
+	var keep []string
+	for _, line := range strings.Split(body, "\n") {
+		if strings.Contains(line, substr) {
+			keep = append(keep, line)
+		}
+	}
+	return strings.Join(keep, "\n")
+}


### PR DESCRIPTION
Closes #294
Refs PRD #283 · slice 1 PR #287 · slice 2 PR #288 · slice 3 PR #289 · slice-A PR #293

## Summary

Three regressions found during v0.9.11-rc1 UAT against the live host all surfaced from the manual `POST /api/v1/speedtest/run` path or the post-restart Prometheus path. This PR is the rc2 prep.

**Architectural shift**: hoist hydration into the scheduler and move test-lifecycle side effects (gauge management, persistence) onto registry observer hooks so the cron AND API paths share one persistence/state-management code path.

## Per-regression checklist

### R1 + R2 — Prometheus hydration gap
**Decision: Option A (hoist hydration into scheduler).**

- `Scheduler.Latest()` now hydrates `s.latest.SpeedTest.Latest` from `speedtest_history` if nil. Idempotent; live data wins over stale rows.
- `Scheduler.RunOnce()` hydrates the snapshot before `metrics.Update(snap)` so the Prometheus exporter reads the same hydrated view the API handler does.
- Closes the cold-start gap where `/metrics` had `nasdoctor_speedtest_*` gauges missing/zero after container restart even though historical rows existed on disk.
- API-side `hydrateSpeedTestFromHistory` kept as defensive double-hydrate for the rare `scheduler==nil` path (used by tests + transitional bare-Server states); idempotent so harmless.

### R3a — `in_progress` gauge on manual `/run`
**Decision: Observer pattern via `RegisterStateChangeObserver`.**

- New `livetest.Manager.RegisterStateChangeObserver(fn func(running bool))` hook fires synchronously at `StartTest` (true) and after `m.active` is cleared (false). Both invariants pinned by tests.
- Production wiring (in `Scheduler.SetLiveTestRegistry`) registers a callback that flips `notifier.Metrics.SetSpeedTestInProgress`.
- `runSpeedTestViaRegistry` no longer manages the gauge — the observer does. Both cron and API paths get correct `in_progress` signal automatically.

### R3b — Manual `POST /run` persistence
**Decision: Observer pattern via `RegisterCompletionHandler`.**

- New `livetest.Manager.RegisterCompletionHandler(fn func(*LiveTest))` hook fires once after the runner returns and BEFORE `Done` unblocks.
- `LiveTest.finishWith*` split into `stampTerminal` + `closeSubscribersAndDone` so the completion handler can read `Result/Err/SnapshotSamples` before subscribers and `Done` are closed. The cron caller blocking on `<-lt.Done()` now observes "persistence already happened" instead of racing the registry's persistence callback.
- Production wiring registers a handler that calls `handleSpeedTestResultWithSamples` — same code path the cron loop used to use directly. API-triggered tests now produce identical persistence side effects (history row + samples + LastAttempt flip).

### R3 — `/stream/{id}` 100ms 404 on fast-failing runner
**Decision: 5s grace window in `Manager.GetLive`.**

- Just-completed tests stay discoverable for 5 seconds via `GetLive`, so a late-arriving SSE client (e.g. when the runner errors faster than the browser can issue `GET /stream/{id}`) receives a clean `error` + `end` event sequence instead of a 404.
- Diagnoses the UAT-observed showwin `FetchUserInfo` fast-fail mode by ensuring the user sees the error in the stream, not a confusing "test not found".
- Existing `TestRegistry_GetLive_Lookup` updated to expect grace-window behaviour.

### Bonus — Structured logging at registry boundaries
- `Manager.StartTest` logs `test_id` + `caller` (`cron`|`api`).
- `Manager.driveTest` logs `runner_type` at start, `samples_seen` + `result` + `err` at end.
- API handler annotates `StartTest` context via `livetest.WithCaller(ctx, "api")`.
- Future UAT debugging gets a grep-friendly lifecycle trace per `test_id`.

## Test count delta

**16 new tests, all green under `-race`.**

| File | Tests | Coverage |
|------|------:|----------|
| `internal/livetest/lifecycle_test.go` | 8 | observer-hook contracts; state-change sync w/ Start; fires false on error too; completion handler sees Result/Err/Samples; nil-observer safety; GetLive grace window |
| `internal/scheduler/scheduler_speedtest_hydration_test.go` | 4 | Latest() hydration; preserve existing; nil-cache safety; Prometheus end-to-end post-restart |
| `internal/scheduler/scheduler_livetest_observer_test.go` | 3 | API-path persistence; gauge flip during in-flight; failed-run gauge reset |
| `internal/api/speedtest_sse_grace_test.go` | 1 | full HTTP guard for fast-fail-runner `/stream/{id}` returning 200 + error event |

Plus existing `TestRegistry_GetLive_Lookup` updated to pin the grace-window contract.

## §4b status

| Check | Result |
|-------|--------|
| `go build ./...` | ✅ clean |
| `go test ./... -race -count=1` | ✅ all packages pass |
| `cd demo-worker/feeder && npm test` | ✅ 32 passed |
| `cd demo-worker/feeder && npx tsc --noEmit` | ✅ clean |
| `docker build .` | ⚠️ docker not available in worker env — relying on CI; no new system deps |

## Local smoke evidence

`go build -o /tmp/nas-doctor-rc2 ./cmd/nas-doctor && /tmp/nas-doctor-rc2 -listen :8067 -demo -data /tmp/nasdoc-data` (synthetic 12s demo runner, 18 samples).

### R3a — `in_progress` gauge flips on manual `POST /run`
```
Before run:        nasdoctor_speedtest_in_progress 0
~100ms after POST: nasdoctor_speedtest_in_progress 1
While running:     nasdoctor_speedtest_in_progress 1
After completion:  nasdoctor_speedtest_in_progress 0
```

### R3 — `GET /stream/{id}` returns 200 with full event sequence
```
POST /run → test_id=1777293086018500000
GET /stream/{test_id} → 200 OK; Content-Type: text/event-stream
24 events: start → phase_change → 18×sample → result → end
result event engine: "speedtest_go"
```

### R3b — Manual run persists history + samples
```
/api/v1/speedtest/samples/{history_id}: test_id=79, samples=18
/api/v1/snapshot/latest .speed_test.last_attempt.status: "success"
/api/v1/snapshot/latest .speed_test.latest.engine: "speedtest_go"
```

### R1+R2 — Prometheus reads hydrated gauges (after restart with pre-existing rows)
```
nasdoctor_speedtest_engine{engine="speedtest_go"} 1
nasdoctor_speedtest_engine{engine="ookla_cli"} 0
nasdoctor_speedtest_download_mbps 940
nasdoctor_speedtest_upload_mbps 450
nasdoctor_speedtest_latency_ms 8
nasdoctor_speedtest_samples_count{test_id="79"} 18
```

### Structured logs (caller-annotated)
```
{"msg":"livetest: start","test_id":1777293151972051000,"caller":"api"}
{"msg":"livetest: drive","test_id":1777293151972051000,"runner_type":"*livetest.demoRunner"}
{"msg":"livetest: end","test_id":1777293151972051000,"samples_seen":18,"result":"success"}
```

## Caveats / notes for the orchestrator

- **R3 root cause (showwin fast-fail) was NOT reproduced locally** — `go run -demo` uses the deterministic synthetic runner. The grace-window fix is the resilience layer for whatever environment-specific failure mode hit UAT (likely transient network on the live host's egress). If rc2 UAT against the live host still 404s, that would point to a different bug. The structured logs added here will make the next round trivially diagnosable: grep the container log for `test_id` + `caller=api` and you see the full lifecycle.
- **Backward compat**: `Scheduler.SetLiveTestRegistry` only registers observers if the registry implements the `observable` interface (which `*livetest.Manager` does). Lightweight test fakes that don't implement it still work — just don't get persistence/gauge wiring, which is the existing behaviour. Pre-existing `fakeRegistry` in scheduler tests was extended to proxy through to its inner `*livetest.Manager`.
- **`finishWithResult/finishWithError` kept** for tests + non-registry code paths. They now wrap `stampTerminal` + `closeSubscribersAndDone` for backward compat. Registry's `driveTest` deliberately does NOT use them — it fires the completion handler between the two phases so persistence runs before `Done` unblocks.
- **`runSpeedTestViaRegistry` is now thin**: kicks off the test and blocks on `<-lt.Done()` only so the cron loop's `lastRun` cadence doesn't advance prematurely. All side effects flow through observers.