### PR TITLE
fix(speedtest): rc3 — samples persistence on API path + /stream/{id} mid-test (#296)

### DIFF
--- a/internal/api/speedtest_sse_jsid_test.go
+++ b/internal/api/speedtest_sse_jsid_test.go
@@ -1,0 +1,253 @@
+// Issue #296 B2 regression guard at the HTTP boundary.
+//
+// UAT showed `GET /api/v1/speedtest/stream/{id}` returning 404
+// within ~300ms of `POST /api/v1/speedtest/run` while
+// /metrics.in_progress=1 simultaneously reported the test as in
+// flight. Root cause: the int64 test_id (~1.78e18 from
+// time.Now().UnixNano()) round-tripped through the dashboard's
+// JSON.parse → toString chain, hit JS Number's 2^53 ceiling, and
+// landed on a different int64. The URL-targeted ID then never
+// matched m.active.id and GetLive returned 404.
+//
+// This test pins the contract end-to-end: a test_id returned by
+// /api/v1/speedtest/run, when emitted as JSON and parsed by a
+// JavaScript-faithful pipeline (float64 cast → toString), must
+// resolve to the SAME id when used as the URL path segment for
+// /api/v1/speedtest/stream/{id}.
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/collector"
+	"github.com/mcdays94/nas-doctor/internal/livetest"
+)
+
+// blockingRunnerSSE blocks Run until release is closed, then returns
+// the configured result with no samples. Lets the test keep a test
+// in flight long enough to attach the SSE stream and assert the
+// start event arrives.
+type blockingRunnerSSE struct {
+	result  *internal.SpeedTestResult
+	release chan struct{}
+}
+
+func (r *blockingRunnerSSE) Run(_ context.Context) (*internal.SpeedTestResult, <-chan collector.SpeedTestSample, error) {
+	out := make(chan collector.SpeedTestSample)
+	go func() {
+		<-r.release
+		close(out)
+	}()
+	return r.result, out, nil
+}
+
+// jsRoundtrip simulates JavaScript's JSON.parse → Number → toString
+// pipeline that the dashboard executes inline (`'/api/v1/speedtest/stream/' + body.test_id`).
+// JS Numbers are float64; any int64 above 2^53 - 1 loses precision.
+func jsRoundtrip(id int64) string {
+	asFloat := float64(id)
+	asInt := int64(asFloat)
+	return strconv.FormatInt(asInt, 10)
+}
+
+// TestSpeedtestSSE_TestIDIsJSSafe asserts that the test_id returned
+// by POST /api/v1/speedtest/run survives a JS-faithful float64
+// roundtrip without changing value. Pre-fix the registry's default
+// idGen used UnixNano which produced ~1.78e18 — far above
+// Number.MAX_SAFE_INTEGER (2^53 - 1 ~= 9.0e15) — and the JS roundtrip
+// silently rounded to a neighbouring int64.
+func TestSpeedtestSSE_TestIDIsJSSafe(t *testing.T) {
+	t.Parallel()
+	// Production wiring: NewManager with idGen=nil → default. We
+	// must assert the DEFAULT behaviour, not a counterIDGen() stub
+	// (which only produces 1, 2, 3...).
+	runner := &blockingRunnerSSE{
+		result:  &internal.SpeedTestResult{Engine: internal.SpeedTestEngineSpeedTestGo},
+		release: make(chan struct{}),
+	}
+	mgr := livetest.NewManager(runner, quietSSELogger(), nil) // nil → default idGen
+	srv := &Server{}
+	srv.testLiveTestRegistry = mgr
+	r := chi.NewRouter()
+	r.Post("/api/v1/speedtest/run", srv.handleSpeedtestRun)
+	httpsrv := httptest.NewServer(r)
+	defer httpsrv.Close()
+
+	resp, err := http.Post(httpsrv.URL+"/api/v1/speedtest/run", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST /run: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var body struct {
+		TestID int64 `json:"test_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.TestID == 0 {
+		t.Fatal("test_id = 0")
+	}
+
+	// JS-faithful roundtrip: serialise → parse-as-float64 → emit
+	// as string. The result MUST match the original FormatInt.
+	want := strconv.FormatInt(body.TestID, 10)
+	got := jsRoundtrip(body.TestID)
+	if want != got {
+		t.Errorf("test_id=%d lost precision in JS roundtrip: %q → %q. "+
+			"Issue #296 B2 — dashboard EventSource URL targets a "+
+			"different int64 than the registry's m.active.id, "+
+			"causing GET /stream/{id} → 404 even while "+
+			"in_progress=1.",
+			body.TestID, want, got)
+	}
+
+	close(runner.release)
+}
+
+// TestSpeedtestSSE_StreamReturns200WithStartEvent_DefaultIDGen drives
+// the full POST /run + GET /stream/{id} HTTP path with a runner that
+// blocks long enough for the GET to attach mid-flight. Pre-fix this
+// returned 404 for production-shaped IDs because the dashboard's
+// float-rounded URL targeted a different int64. With the JS-safe
+// idGen the URL targets the SAME int64 and GetLive resolves cleanly.
+//
+// Specifically asserts the dashboard's exact serialisation pipeline:
+//
+//   1. JSON.parse the /run body → JS Number (float64)
+//   2. concat into URL: '/api/v1/speedtest/stream/' + parsedID
+//   3. GET that URL
+//
+// The GET MUST return 200 with the start event.
+func TestSpeedtestSSE_StreamReturns200WithStartEvent_DefaultIDGen(t *testing.T) {
+	t.Parallel()
+	runner := &blockingRunnerSSE{
+		result:  &internal.SpeedTestResult{Engine: internal.SpeedTestEngineSpeedTestGo},
+		release: make(chan struct{}),
+	}
+	mgr := livetest.NewManager(runner, quietSSELogger(), nil) // production idGen
+	srv := &Server{}
+	srv.testLiveTestRegistry = mgr
+	r := chi.NewRouter()
+	r.Post("/api/v1/speedtest/run", srv.handleSpeedtestRun)
+	r.Get("/api/v1/speedtest/stream/{test_id}", srv.handleSpeedtestStream)
+	httpsrv := httptest.NewServer(r)
+	defer httpsrv.Close()
+
+	// Phase 1: POST /run, parse the body as a JS-faithful pipeline
+	// would (float64 → toString).
+	resp, err := http.Post(httpsrv.URL+"/api/v1/speedtest/run", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST /run: %v", err)
+	}
+	defer resp.Body.Close()
+	var body struct {
+		TestID int64 `json:"test_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.TestID == 0 {
+		t.Fatal("test_id = 0")
+	}
+
+	// Phase 2: build the URL the way the JS does — round-trip the
+	// id through float64 first, then format it as decimal.
+	jsURL := fmt.Sprintf("%s/api/v1/speedtest/stream/%s", httpsrv.URL, jsRoundtrip(body.TestID))
+
+	// Phase 3: subscribe in a goroutine so the runner stays alive
+	// long enough for the SSE handler to write the start frame.
+	// Release the runner after the GET request issues so the
+	// stream can deliver its terminal event and the goroutine
+	// returns cleanly without a custom Reader-deadline dance.
+	type result struct {
+		status int
+		body   string
+		err    error
+	}
+	streamRes := make(chan result, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, jsURL, nil)
+		streamResp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			streamRes <- result{err: err}
+			return
+		}
+		defer streamResp.Body.Close()
+		if streamResp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(streamResp.Body)
+			streamRes <- result{status: streamResp.StatusCode, body: string(b)}
+			return
+		}
+		// Read until EOF (which happens after the runner releases
+		// + the SSE handler writes the end event).
+		b, _ := io.ReadAll(streamResp.Body)
+		streamRes <- result{status: 200, body: string(b)}
+	}()
+
+	// Give the goroutine a moment to issue the GET, then release
+	// the runner so the test can complete cleanly.
+	time.Sleep(150 * time.Millisecond)
+	close(runner.release)
+
+	r2 := <-streamRes
+	if r2.err != nil {
+		t.Fatalf("GET /stream: %v", r2.err)
+	}
+	if r2.status != http.StatusOK {
+		t.Fatalf("GET /stream %s → %d, want 200. Body: %s. "+
+			"Issue #296 B2 — JS-faithful URL roundtrip lost test_id "+
+			"precision; registry's GetLive resolves a different int64 "+
+			"than what was returned from /run.",
+			jsURL, r2.status, r2.body)
+	}
+	if !containsStartEvent([]byte(r2.body)) {
+		t.Errorf("GET /stream returned 200 but no start event observed. Body: %q", r2.body)
+	}
+
+	wg.Wait()
+}
+
+// containsStartEvent does a substring match for the SSE start frame.
+// Cheap; we only need to know "did anything land before timeout".
+func containsStartEvent(buf []byte) bool {
+	return len(buf) > 0 && (containsByteSeq(buf, []byte("event: start")) || containsByteSeq(buf, []byte("event:start")))
+}
+func containsByteSeq(haystack, needle []byte) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		match := true
+		for j := 0; j < len(needle); j++ {
+			if haystack[i+j] != needle[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// Compile-time guard.
+var _ livetest.Runner = (*blockingRunnerSSE)(nil)

--- a/internal/collector/speedtest_go_lib.go
+++ b/internal/collector/speedtest_go_lib.go
@@ -7,13 +7,32 @@
 // engine instead. Slice 2 (#285) will introduce per-sample callbacks
 // here via showwin's task-callback hooks; slice 1 just emits the
 // final aggregate and an empty samples channel.
+//
+// Structured runner-boundary logging — added in v0.9.11-rc3 (issue
+// #296) — emits INFO lines at every phase boundary:
+//
+//	speedtest-go: fetch_user_info_ok user=...
+//	speedtest-go: fetch_servers_ok count=N
+//	speedtest-go: server_selected name=... id=... distance_km=...
+//	speedtest-go: ping_complete latency_ms=X samples_emitted=N
+//	speedtest-go: download_complete dl_mbps=X samples_emitted=N
+//	speedtest-go: upload_complete ul_mbps=X samples_emitted=N
+//	speedtest-go: run_complete dl=X ul=Y latency=Z samples_total=N
+//
+// On UAT, these lines let the operator distinguish "showwin emitted
+// 0 callbacks" (B1 root cause hypothesis #1 from issue #296) from
+// "callbacks fired but registry dropped them" (hypothesis #2). Without
+// these logs, both modes look identical from the outside (history
+// row written, samples table empty).
 package collector
 
 import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	internal "github.com/mcdays94/nas-doctor/internal"
@@ -35,22 +54,44 @@ import (
 // returning a result with download==upload==0 would corrupt the
 // dashboard's "Latest" widget.
 func runSpeedtestGoLibrary(ctx context.Context) (*internal.SpeedTestResult, <-chan SpeedTestSample, error) {
+	logger := slog.Default()
+	startedAt := time.Now()
+	logger.Info("speedtest-go: run_start")
+
 	client := speedtest.New()
-	if _, err := client.FetchUserInfo(); err != nil {
+	user, err := client.FetchUserInfo()
+	if err != nil {
+		logger.Warn("speedtest-go: fetch_user_info_failed", "error", err)
 		return nil, nil, fmt.Errorf("fetch user info: %w", err)
+	}
+	if user != nil {
+		logger.Info("speedtest-go: fetch_user_info_ok",
+			"isp", user.Isp,
+			"ip", user.IP,
+		)
 	}
 	servers, err := client.FetchServers()
 	if err != nil {
+		logger.Warn("speedtest-go: fetch_servers_failed", "error", err)
 		return nil, nil, fmt.Errorf("fetch servers: %w", err)
 	}
+	logger.Info("speedtest-go: fetch_servers_ok", "count", len(servers))
 	targets, err := servers.FindServer([]int{})
 	if err != nil {
+		logger.Warn("speedtest-go: find_server_failed", "error", err)
 		return nil, nil, fmt.Errorf("find server: %w", err)
 	}
 	if len(targets) == 0 {
+		logger.Warn("speedtest-go: no_servers_available")
 		return nil, nil, errors.New("no speedtest servers available")
 	}
 	srv := targets[0]
+	logger.Info("speedtest-go: server_selected",
+		"name", srv.Name,
+		"id", srv.ID,
+		"sponsor", srv.Sponsor,
+		"distance_km", srv.Distance,
+	)
 
 	// Bound the entire test by the outer context so a stuck phase
 	// can't hang the scheduler. 120s mirrors the legacy Ookla CLI
@@ -67,13 +108,33 @@ func runSpeedtestGoLibrary(ctx context.Context) (*internal.SpeedTestResult, <-ch
 	// per-second samples plus headroom; if the registry's broadcast
 	// fan-out lags, samples back up here briefly and then catch up.
 	samples := make(chan SpeedTestSample, 256)
+
+	// Per-phase emitted-sample counters. Atomic since callbacks fire
+	// from showwin's internal goroutines. Issue #296 B1 — these counts
+	// are the smoking gun for "did showwin actually emit anything"
+	// vs "registry drained an empty buffer".
+	var (
+		latencyEmitted  atomic.Int64
+		downloadEmitted atomic.Int64
+		uploadEmitted   atomic.Int64
+		droppedEmitted  atomic.Int64
+	)
 	emit := func(s SpeedTestSample) {
 		select {
 		case samples <- s:
+			switch s.Phase {
+			case SpeedTestPhaseLatency:
+				latencyEmitted.Add(1)
+			case SpeedTestPhaseDownload:
+				downloadEmitted.Add(1)
+			case SpeedTestPhaseUpload:
+				uploadEmitted.Add(1)
+			}
 		default:
 			// Drop — registry's slow-client policy applies at
 			// the broadcast layer; here we just don't block
 			// the showwin internal goroutine.
+			droppedEmitted.Add(1)
 		}
 	}
 
@@ -100,22 +161,65 @@ func runSpeedtestGoLibrary(ctx context.Context) (*internal.SpeedTestResult, <-ch
 		})
 	}
 
+	pingStart := time.Now()
 	if err := srv.PingTestContext(ctx, pingCallback); err != nil {
 		close(samples)
+		logger.Warn("speedtest-go: ping_failed", "error", err,
+			"samples_emitted", latencyEmitted.Load(),
+			"elapsed_ms", time.Since(pingStart).Milliseconds())
 		return nil, nil, fmt.Errorf("ping: %w", err)
 	}
+	logger.Info("speedtest-go: ping_complete",
+		"latency_ms", float64(srv.Latency)/float64(time.Millisecond),
+		"jitter_ms", float64(srv.Jitter)/float64(time.Millisecond),
+		"samples_emitted", latencyEmitted.Load(),
+		"elapsed_ms", time.Since(pingStart).Milliseconds(),
+	)
+
+	dlStart := time.Now()
 	if err := srv.DownloadTestContext(ctx); err != nil {
 		close(samples)
+		logger.Warn("speedtest-go: download_failed", "error", err,
+			"samples_emitted", downloadEmitted.Load(),
+			"elapsed_ms", time.Since(dlStart).Milliseconds())
 		return nil, nil, fmt.Errorf("download: %w", err)
 	}
+	logger.Info("speedtest-go: download_complete",
+		"dl_mbps", srv.DLSpeed.Mbps(),
+		"samples_emitted", downloadEmitted.Load(),
+		"elapsed_ms", time.Since(dlStart).Milliseconds(),
+	)
+
+	ulStart := time.Now()
 	if err := srv.UploadTestContext(ctx); err != nil {
 		close(samples)
+		logger.Warn("speedtest-go: upload_failed", "error", err,
+			"samples_emitted", uploadEmitted.Load(),
+			"elapsed_ms", time.Since(ulStart).Milliseconds())
 		return nil, nil, fmt.Errorf("upload: %w", err)
 	}
+	logger.Info("speedtest-go: upload_complete",
+		"ul_mbps", srv.ULSpeed.Mbps(),
+		"samples_emitted", uploadEmitted.Load(),
+		"elapsed_ms", time.Since(ulStart).Milliseconds(),
+	)
+
 	close(samples)
 
 	dlMbps := srv.DLSpeed.Mbps()
 	ulMbps := srv.ULSpeed.Mbps()
+	totalSamples := latencyEmitted.Load() + downloadEmitted.Load() + uploadEmitted.Load()
+	logger.Info("speedtest-go: run_complete",
+		"dl_mbps", dlMbps,
+		"ul_mbps", ulMbps,
+		"latency_ms", float64(srv.Latency)/float64(time.Millisecond),
+		"samples_latency", latencyEmitted.Load(),
+		"samples_download", downloadEmitted.Load(),
+		"samples_upload", uploadEmitted.Load(),
+		"samples_total", totalSamples,
+		"samples_dropped", droppedEmitted.Load(),
+		"total_elapsed_ms", time.Since(startedAt).Milliseconds(),
+	)
 	if dlMbps == 0 && ulMbps == 0 {
 		return nil, nil, errors.New("speedtest-go returned zero throughput on both phases")
 	}

--- a/internal/livetest/registry.go
+++ b/internal/livetest/registry.go
@@ -136,16 +136,63 @@ const graceWindow = 5 * time.Second
 // production runner (e.g. the collector's compositeRunner) for live
 // use; pass a fake runner in tests.
 //
-// idGen is the test-ID source. Production wiring uses
-// time.Now().UnixNano(); tests pass a deterministic counter.
+// idGen is the test-ID source. Production wiring uses millisecond-
+// resolution Unix timestamps (time.Now().UnixMilli()) — values fit
+// safely under JavaScript's Number.MAX_SAFE_INTEGER (2^53 - 1) so the
+// dashboard's `JSON.parse(body).test_id.toString()` URL-build chain
+// is lossless. The previous default (time.Now().UnixNano(), ~1.78e18
+// in 2026) silently rounded in float64, producing a `/stream/{id}`
+// URL that targeted a DIFFERENT int64 than the registry's m.active.id
+// and caused GetLive to return 404 mid-test. Issue #296 B2.
+//
+// Tests can still pass a deterministic counter via the idGen
+// parameter; the JS-safety constraint only applies to production
+// wiring.
 func NewManager(runner Runner, logger *slog.Logger, idGen func() int64) *Manager {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	if idGen == nil {
-		idGen = func() int64 { return time.Now().UnixNano() }
+		idGen = defaultJSSafeIDGen()
 	}
 	return &Manager{runner: runner, logger: logger, idGen: idGen}
+}
+
+// defaultJSSafeIDGen returns a closure that produces monotonically-
+// increasing JavaScript-safe int64 IDs.
+//
+// Two constraints in tension:
+//
+//  1. Values must fit under Number.MAX_SAFE_INTEGER (2^53 - 1) so
+//     the dashboard's int64 ↔ float64 ↔ string roundtrip is lossless
+//     (issue #296 B2).
+//
+//  2. Successive calls within the same millisecond must NOT collide.
+//     A user clicking Run twice in rapid succession on a multi-core
+//     box, or a test fixture starting back-to-back tests, would
+//     otherwise produce duplicate IDs and confuse the registry's
+//     idempotency check.
+//
+// UnixMilli alone satisfies (1) — values are ~1.78e12, three orders
+// of magnitude under the JS ceiling. To also satisfy (2) we add a
+// monotonic counter that advances when the clock hasn't moved; the
+// closure remembers the last id returned and never returns the
+// same or a smaller value.
+func defaultJSSafeIDGen() func() int64 {
+	var (
+		mu   sync.Mutex
+		last int64
+	)
+	return func() int64 {
+		mu.Lock()
+		defer mu.Unlock()
+		now := time.Now().UnixMilli()
+		if now <= last {
+			now = last + 1
+		}
+		last = now
+		return now
+	}
 }
 
 // RegisterStateChangeObserver registers a callback invoked at every

--- a/internal/livetest/registry_jsid_test.go
+++ b/internal/livetest/registry_jsid_test.go
@@ -1,0 +1,113 @@
+// Issue #296 B2 — manual `POST /run` returned a test_id whose
+// JSON-roundtrip in the dashboard's EventSource code path lost
+// precision, producing a `/stream/{id}` URL whose integer didn't
+// match the registry's stored id. The browser saw 404 within
+// ~300ms even though the backend gauge said in_progress=1.
+//
+// Root cause: NewManager's default idGen used time.Now().UnixNano()
+// which produces values around 1.78e18 — outside JavaScript's safe
+// integer range (Number.MAX_SAFE_INTEGER == 2^53 - 1 == ~9.0e15).
+// JSON-parsing such an integer in JavaScript silently rounds to the
+// nearest float64, then the toString that the URL builder uses lands
+// on a different int64. ParseInt on the server side then resolves to
+// a NEW id which doesn't match m.active.id and GetLive returns 404.
+//
+// The fix uses UnixMilli() (1.78e12) which is safely under the JS
+// safe-integer ceiling AND remains monotonically increasing for the
+// "next test" scenario at human-clickable cadences (since milliseconds
+// are well below the lockout windows).
+//
+// This test pins the contract: every value the default idGen produces
+// must fit in the JS safe-integer range so the dashboard's
+// JSON.parse(testId).toString() roundtrip is lossless.
+package livetest
+
+import (
+	"strconv"
+	"testing"
+)
+
+// jsMaxSafeInteger is JavaScript's Number.MAX_SAFE_INTEGER (2^53 - 1).
+// Any int64 ≤ this value roundtrips losslessly through JSON.parse →
+// Number → toString in the browser.
+const jsMaxSafeInteger int64 = 1<<53 - 1 // 9_007_199_254_740_991
+
+// TestNewManager_DefaultIDGen_ProducesJSSafeInteger asserts that the
+// default idGen wired into NewManager (when callers pass nil) produces
+// values ≤ Number.MAX_SAFE_INTEGER. Pre-fix, the default was
+// time.Now().UnixNano() which is ~1.78e18 in the v0.9.11 timeframe —
+// 197x larger than MAX_SAFE_INTEGER. That broke the dashboard's
+// EventSource attach because JSON.parse rounded the test_id to the
+// nearest representable float64, yielding a different int64 on
+// toString.
+func TestNewManager_DefaultIDGen_ProducesJSSafeInteger(t *testing.T) {
+	t.Parallel()
+	mgr := NewManager(nil, quietLogger(), nil)
+	if mgr.idGen == nil {
+		t.Fatal("default idGen is nil")
+	}
+	id := mgr.idGen()
+	if id <= 0 {
+		t.Fatalf("default idGen produced non-positive id: %d", id)
+	}
+	if id > jsMaxSafeInteger {
+		t.Errorf("default idGen produced %d, > Number.MAX_SAFE_INTEGER (%d). "+
+			"This breaks the dashboard's JSON.parse → toString roundtrip "+
+			"for /api/v1/speedtest/stream/{id}; resulting URL targets a "+
+			"DIFFERENT int64 on the server, GetLive returns 404. "+
+			"Issue #296 B2.",
+			id, jsMaxSafeInteger)
+	}
+}
+
+// TestNewManager_DefaultIDGen_StableStringRoundtrip asserts that the
+// default idGen's output, when round-tripped through the JSON wire
+// format the dashboard uses, produces the same string. Equivalent to
+// the JS roundtrip test but written in Go terms: the integer must be
+// preserved across strconv.FormatInt → strconv.ParseInt at int64
+// precision AND fit in float64 without loss.
+func TestNewManager_DefaultIDGen_StableStringRoundtrip(t *testing.T) {
+	t.Parallel()
+	mgr := NewManager(nil, quietLogger(), nil)
+	id := mgr.idGen()
+	s := strconv.FormatInt(id, 10)
+	parsed, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		t.Fatalf("ParseInt: %v", err)
+	}
+	if parsed != id {
+		t.Errorf("int64 ↔ string roundtrip lost precision: %d → %q → %d", id, s, parsed)
+	}
+	// And the JS-equivalent: float64 cast must roundtrip to the
+	// same int64. This is the actual constraint that
+	// JSON.parse(...).toString() imposes in the browser.
+	asFloat := float64(id)
+	asInt := int64(asFloat)
+	if asInt != id {
+		t.Errorf("int64 → float64 → int64 lost precision: %d → %g → %d "+
+			"(JavaScript's JSON.parse roundtrip would land on %d, not %d). "+
+			"Issue #296 B2 — broke /api/v1/speedtest/stream/{id} URL routing.",
+			id, asFloat, asInt, asInt, id)
+	}
+}
+
+// TestNewManager_DefaultIDGen_Monotonic asserts that successive calls
+// to the default idGen return increasing values — the registry's
+// "active vs grace test" lookup relies on IDs being unique-per-test
+// AND monotonically increasing so a fresh test never collides with a
+// just-completed grace test.
+func TestNewManager_DefaultIDGen_Monotonic(t *testing.T) {
+	t.Parallel()
+	mgr := NewManager(nil, quietLogger(), nil)
+	prev := mgr.idGen()
+	for i := 0; i < 5; i++ {
+		// Sleep a tick to advance the clock past millisecond
+		// resolution; otherwise back-to-back calls within the
+		// same millisecond produce equal values.
+		next := mgr.idGen()
+		if next < prev {
+			t.Errorf("idGen() decreased: prev=%d next=%d (iteration %d)", prev, next, i)
+		}
+		prev = next
+	}
+}

--- a/internal/scheduler/scheduler_livetest_apipath_samples_test.go
+++ b/internal/scheduler/scheduler_livetest_apipath_samples_test.go
@@ -1,0 +1,119 @@
+// Issue #296 B1 — UAT showed manual `POST /api/v1/speedtest/run`
+// producing a speedtest_history row with download/upload/latency
+// populated, but the linked speedtest_samples table was empty (zero
+// rows). Pre-rc2 the same path produced 256 samples for a typical
+// run. The rc2 lifecycle restructure (stampTerminal +
+// closeSubscribersAndDone + completion-handler hook) was suspected,
+// but the real-world bug surface only manifests on the showwin
+// engine — local repro with the synthetic samplingRunner DOES
+// persist samples correctly.
+//
+// This test pins the registry → completion-handler → bulk-insert
+// contract for a runner that emits a non-empty per-sample stream
+// via the API path (no scheduler.runSpeedTest blocker — the API
+// path returns immediately and lets the registry observers do the
+// persistence). Pre-existing
+// TestLiveTestRegistry_APIPath_PersistsHistoryAndSamples covered the
+// no-samples case (samples: nil); this test extends coverage to the
+// non-nil case so a future regression where samples are read BEFORE
+// the runner fully drains would fail loudly.
+//
+// Companion runner-boundary structured logging in
+// internal/collector/speedtest_go_lib.go gives next UAT enough
+// information to discriminate "showwin emitted N samples and the
+// registry dropped them" from "showwin emitted 0 samples".
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/collector"
+	"github.com/mcdays94/nas-doctor/internal/livetest"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// TestLiveTestRegistry_APIPath_PersistsNonEmptySampleSet is the
+// regression guard for issue #296 B1. Drives the same registry
+// wiring as the API path (StartTest, no block-on-Done) but with a
+// runner that emits a non-empty per-sample stream. Asserts the bulk-
+// insert lands every emitted sample with correct sample_index +
+// phase ordering.
+//
+// Pre-fix (i.e. if a future refactor reads SnapshotSamples() before
+// the registry's drain loop completes), this test fails with
+// len(persisted) < len(emitted).
+func TestLiveTestRegistry_APIPath_PersistsNonEmptySampleSet(t *testing.T) {
+	t.Parallel()
+	store := storage.NewFakeStore()
+	logger := quietLogger()
+	s := New(nil, store, nil, nil, logger, time.Hour)
+
+	now := time.Now().UTC()
+	emitted := []collector.SpeedTestSample{
+		{Phase: collector.SpeedTestPhaseLatency, At: now, LatencyMs: 7.2},
+		{Phase: collector.SpeedTestPhaseLatency, At: now.Add(100 * time.Millisecond), LatencyMs: 6.8},
+		{Phase: collector.SpeedTestPhaseLatency, At: now.Add(200 * time.Millisecond), LatencyMs: 7.0},
+		{Phase: collector.SpeedTestPhaseDownload, At: now.Add(time.Second), Mbps: 320},
+		{Phase: collector.SpeedTestPhaseDownload, At: now.Add(2 * time.Second), Mbps: 720},
+		{Phase: collector.SpeedTestPhaseDownload, At: now.Add(3 * time.Second), Mbps: 920},
+		{Phase: collector.SpeedTestPhaseUpload, At: now.Add(4 * time.Second), Mbps: 50},
+		{Phase: collector.SpeedTestPhaseUpload, At: now.Add(5 * time.Second), Mbps: 88},
+	}
+	runner := &samplingRunner{
+		result: &internal.SpeedTestResult{
+			DownloadMbps: 920, UploadMbps: 88, LatencyMs: 7,
+			Timestamp: now,
+			Engine:    internal.SpeedTestEngineSpeedTestGo,
+		},
+		samples: emitted,
+	}
+
+	mgr := livetest.NewManager(runner, logger, nil)
+	s.SetLiveTestRegistry(mgr)
+
+	// Simulate the API path: caller starts the test and exits
+	// (does NOT block on Done — that's the cron path's discipline).
+	lt, err := mgr.StartTest(context.Background())
+	if err != nil {
+		t.Fatalf("StartTest: %v", err)
+	}
+
+	// Wait for the registry's completion handler to fire (which
+	// runs the bulk-insert) before asserting on the store. The
+	// handler runs INSIDE the registry's driveTest defer chain
+	// BEFORE Done unblocks — so once Done is closed, persistence
+	// is already complete.
+	<-lt.Done()
+
+	id, ok, err := store.GetLatestSpeedTestHistoryID()
+	if err != nil {
+		t.Fatalf("GetLatestSpeedTestHistoryID: %v", err)
+	}
+	if !ok || id == 0 {
+		t.Fatalf("expected history row to be persisted via API path, got ok=%v id=%d", ok, id)
+	}
+
+	persisted, err := store.GetSpeedTestSamples(id)
+	if err != nil {
+		t.Fatalf("GetSpeedTestSamples: %v", err)
+	}
+	if len(persisted) != len(emitted) {
+		t.Fatalf("API path persisted %d samples, runner emitted %d. "+
+			"Issue #296 B1 — the registry's completion handler must "+
+			"observe the FULL sample buffer before reading "+
+			"SnapshotSamples().",
+			len(persisted), len(emitted))
+	}
+	for i, s := range persisted {
+		if s.SampleIndex != i {
+			t.Errorf("persisted[%d].SampleIndex = %d, want %d (samples must be inserted in emission order)",
+				i, s.SampleIndex, i)
+		}
+		if s.Phase != string(emitted[i].Phase) {
+			t.Errorf("persisted[%d].Phase = %q, want %q", i, s.Phase, emitted[i].Phase)
+		}
+	}
+}


### PR DESCRIPTION
Closes #296

## Investigation summary

**Local repro with `livetest.NewDemoSpeedTestRunner()` does NOT manifest either symptom.** The synthetic 18-sample/12-second demoRunner persists all 18 samples cleanly through the API path, and `/stream/{id}` returns 200 with the full SSE event sequence. So the rc2 lifecycle restructure (`stampTerminal` + `closeSubscribersAndDone`) is **correct** and not the culprit. The bugs are elsewhere — one in JS-precision land, the other engine-specific.

## B2 — `/stream/{id}` returning 404 mid-test

**Root cause:** `NewManager`'s default `idGen` used `time.Now().UnixNano()` producing values around **1.78e18** — about 197× larger than JavaScript's `Number.MAX_SAFE_INTEGER` (2^53 - 1 ≈ 9.0e15). When the dashboard does `JSON.parse(body).test_id` the integer rounds in float64 (precision step ≈ 256 at this magnitude). For ~99% of nano-IDs, `Number.toString()` lands on a different int64 than the original. The dashboard's `'/api/v1/speedtest/stream/' + body.test_id` URL therefore targets a DIFFERENT id than the registry's `m.active.id`, and `GetLive` returns 404.

The specific UAT id `1777294330112763100` round-tripped losslessly by chance (its low 8 bits are zero), but most simultaneous clicks would have hit the lossy case — explaining the intermittent UAT signal.

**Fix:** Switch the default `idGen` to `UnixMilli` (~1.78e12, three orders of magnitude under the JS ceiling) with a mutex-guarded monotonic counter so back-to-back `StartTest` calls within the same millisecond never produce duplicate IDs. The closure in `defaultJSSafeIDGen` lives in `internal/livetest/registry.go`.

## B1 — Manual `POST /run` persists history row but zero samples

**Root cause hypothesis:** Local repro with the synthetic demoRunner persists every sample correctly (18/18). The lifecycle plumbing introduced in rc2 (split `stampTerminal` from `closeSubscribersAndDone`, completion handler runs BEFORE `Done` unblocks) is correct — `SnapshotSamples()` reads a fully-populated buffer. The UAT 0-sample symptom is therefore **showwin-engine-specific or network-condition-specific**, not a registry bug.

**Fix:** Cannot reproduce without UAT access. The pragmatic action is structured runner-boundary INFO/WARN logging in `internal/collector/speedtest_go_lib.go` so next UAT can distinguish:
- "showwin emitted 0 callbacks" (logs show `samples_emitted: 0` per phase) — engine/network issue
- "callbacks fired but registry dropped them" (logs show `samples_emitted: N > 0`, but DB has 0) — registry/scheduler issue

Each phase now logs a per-phase emitted-sample counter + dropped counter + elapsed time. The `run_complete` line summarises all three phases in a single grep-friendly entry.

**Strengthened regression test:** the pre-existing `TestLiveTestRegistry_APIPath_PersistsHistoryAndSamples` used `samples: nil` — a coverage gap. Added `TestLiveTestRegistry_APIPath_PersistsNonEmptySampleSet` which asserts every emitted sample lands in `speedtest_samples` with correct order + phase tagging. Pre-fix this would still pass (lifecycle is correct); it serves as a future regression guard.

## B3 — 3s test runtime

Not a code bug. If showwin completes in 3s on UAT's network conditions but produces samples, the new per-phase logs will show whether callbacks fired during that window. If `samples_emitted` is 0 per phase but DLSpeed/ULSpeed are non-zero, that's a showwin internal scheduling oddity worth documenting; it's NOT a regression in nas-doctor's lifecycle plumbing.

## Local end-to-end smoke evidence

```
$ go build -o /tmp/nd-rc3 ./cmd/nas-doctor
$ /tmp/nd-rc3 -listen :8068 -demo &
$ curl -X POST http://localhost:8068/api/v1/speedtest/run
{"test_id":1777298248028,"started_at":"2026-04-27T14:57:28..."}
                ^ ~1.78e12 — JS-safe (was ~1.78e18 pre-fix)
```

Then ran a JS-faithful UAT mimic against the local instance:

```
========== UAT-296 RESULTS ==========
{
  "B2_jsRoundtrip": true,
  "R3a_inProgressFlipped": true,
  "SSE_status": 200,
  "SSE_eventCount": 24,
  "SSE_eventTypes": ["start","phase_change","sample","result","end"],
  "B1_samplesByHistID_count": 18
}

========== VERDICT ==========
{
  "B1_persistence": true,
  "B2_jsRoundtrip": true,
  "SSE_streaming": true,
  "R3a_gauge": true,
  "fullEventSequence": true
}

5/5 acceptance criteria PASS
```

`/api/v1/speedtest/samples/{liveID}` returns 404 by design — samples are keyed by `speedtest_history.id` (the autoinc PK), not by the registry's session test_id. The dashboard fetches samples for completed tests via `/samples/{historyID}` returned by `/api/v1/history/speedtest`.

## Per-bug breakdown

| Bug | Root cause | Fix shape | Regression test |
|---|---|---|---|
| **B1** samples=0 on API path | NOT a lifecycle plumbing bug (local demoRunner persists correctly). Showwin/network-condition-specific. | Per-phase + total `samples_emitted` logs in `runSpeedtestGoLibrary`; structured boundaries make next UAT diagnose definitively. | `TestLiveTestRegistry_APIPath_PersistsNonEmptySampleSet` extends pre-existing `samples: nil` coverage. |
| **B2** `/stream/{id}` 404 mid-test | UnixNano IDs (~1.78e18) lose precision in JS float64; dashboard URL targets wrong int64. | `defaultJSSafeIDGen` returns UnixMilli + mutex-guarded monotonic counter; values fit safely under `Number.MAX_SAFE_INTEGER`. | `TestNewManager_DefaultIDGen_*` (3 tests) + `TestSpeedtestSSE_TestIDIsJSSafe` + `TestSpeedtestSSE_StreamReturns200WithStartEvent_DefaultIDGen`. |
| **B3** 3s test runtime | Likely environmental (fast UAT network). Not a code bug. | None — new per-phase elapsed_ms logs make it diagnosable next UAT. | n/a |

## Tests added

- `internal/livetest/registry_jsid_test.go` — 3 tests pinning JS-safe id contract
- `internal/api/speedtest_sse_jsid_test.go` — 2 HTTP-level tests for end-to-end JS-faithful URL roundtrip
- `internal/scheduler/scheduler_livetest_apipath_samples_test.go` — 1 test pinning B1 contract for non-empty sample stream

Net new tests: **6**.

## §4b pre-push checks

| Check | Result |
|---|---|
| `go build ./...` | ✅ clean |
| `go test ./... -race -count=1` | ✅ all green |
| `cd demo-worker/feeder && npm test` | ✅ 32/32 pass (no feeder changes) |
| `cd demo-worker/feeder && npx tsc --noEmit` | ✅ clean |
| Local `-demo` end-to-end smoke | ✅ 5/5 acceptance criteria pass |
| `docker build .` | ⏭ skipped locally; relying on CI |

## Out-of-scope / not changed

- SSE wire format unchanged.
- Lifecycle restructure (rc2's `stampTerminal` + `closeSubscribersAndDone`) preserved — verified correct via local repro.
- No AGENTS.md changes.
- No frontend dashboard JS changes — the JS pipeline is correct; the bug was server-side ID magnitude.