### PR TITLE
fix(synology): detect inside containers, dedup duplicate-fs mounts, surface missing /volumeN bind mounts (#300)

### DIFF
--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -21,6 +21,7 @@ func Analyze(snap *internal.Snapshot) []internal.Finding {
 	findings = append(findings, analyzeMemory(snap.System)...)
 	findings = append(findings, analyzeIOWait(snap.System)...)
 	findings = append(findings, analyzeDiskSpace(snap.Disks)...)
+	findings = append(findings, analyzeStorageMounts(snap)...)
 	findings = append(findings, analyzeDocker(snap.Docker)...)
 	findings = append(findings, analyzeNetwork(snap.Network)...)
 	findings = append(findings, analyzeLogs(snap.Logs)...)
@@ -461,6 +462,56 @@ func analyzeDiskSpace(disks []internal.DiskInfo) []internal.Finding {
 		}
 	}
 	return findings
+}
+
+// analyzeStorageMounts surfaces missing-bind-mount configuration
+// errors that produce a misleading dashboard. Issue #300: a Synology
+// DSM container that follows part of the Synology section of the
+// README — typically /boot, /var/log, /mnt — but skips the per-volume
+// bind mounts (/volume1:/host/volume1:ro, etc.) ends up showing only
+// system partitions in the storage section. The actual user storage
+// is invisible because nothing's bind-mounted.
+//
+// The finding only fires when:
+//   - Platform was detected as Synology (requires the issue-#300
+//     platform.go change so this works without /etc bind mounts).
+//   - No disks have a mount path starting with `/volume`.
+//   - At least one disk is being reported (so we don't fire on a
+//     fully-empty disk list, which usually means df itself failed
+//     and a different finding will surface).
+//
+// Mirrors the platform-aware Unraid finding at
+// "No SSD Cache with Docker Workloads" — same pattern of using
+// snap.System.Platform to gate platform-specific advice.
+func analyzeStorageMounts(snap *internal.Snapshot) []internal.Finding {
+	if snap.System.Platform != "synology" {
+		return nil
+	}
+	if len(snap.Disks) == 0 {
+		return nil
+	}
+	for _, d := range snap.Disks {
+		if strings.HasPrefix(d.MountPoint, "/volume") {
+			return nil // at least one volume is bind-mounted; user is set up
+		}
+	}
+	// Build evidence that names the bind mounts we DID see, so the
+	// operator can compare against the README at a glance.
+	mounts := make([]string, 0, len(snap.Disks))
+	for _, d := range snap.Disks {
+		mounts = append(mounts, fmt.Sprintf("%s (%s, %.1f GB)", d.MountPoint, d.Device, d.TotalGB))
+	}
+	return []internal.Finding{{
+		Severity:    internal.SeverityWarning,
+		Category:    internal.CategoryDisk,
+		Title:       "Synology storage volumes not bind-mounted",
+		Description: "The container is running on a Synology DSM host but has no /volume* paths visible. Storage tracking is incomplete — the dashboard is showing DSM system partitions, not your actual user storage.",
+		Evidence:    append([]string{"Bind mounts currently visible:"}, mounts...),
+		Impact:      "User volumes (/volume1, /volume2, ...) are invisible to NAS Doctor. Free-space alerts, disk-space findings, and capacity tracking will not fire for the storage you actually care about.",
+		Action:      "Stop the container, add `/volume1:/host/volume1:ro` (and one line per additional volume) to your docker-compose.yml or Container Manager configuration, then restart. See the Synology DSM section of the README for the full mount list.",
+		Priority:    "short-term",
+		Cost:        "Free",
+	}}
 }
 
 // ---------- Docker Rules ----------

--- a/internal/analyzer/storage_mounts_test.go
+++ b/internal/analyzer/storage_mounts_test.go
@@ -1,0 +1,143 @@
+package analyzer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// Issue #300 — when running on a Synology DSM host but no /volume*
+// bind mounts are configured in the container, the dashboard's
+// STORAGE section silently shows only DSM system partitions
+// (/dev/md0 mounted at /boot, /log, /mnt). The user has no signal
+// telling them anything is misconfigured. analyzeStorageMounts
+// surfaces this as a Warning finding so the bind-mount gap appears
+// alongside other actionable issues.
+
+// snapshotWith is a small builder that produces a minimally-populated
+// snapshot for the storage-mount analyzer. Other analyzer rules need
+// other fields populated (SMART, Docker, etc.) but those are
+// independent — they short-circuit on empty input.
+func snapshotWith(platform string, disks []internal.DiskInfo) *internal.Snapshot {
+	return &internal.Snapshot{
+		System: internal.SystemInfo{Platform: platform},
+		Disks:  disks,
+	}
+}
+
+// TestAnalyzeStorageMounts_FiresOnSynologyWithNoVolumes is the
+// primary issue-#300 regression guard. Replays the reporter's
+// post-platform-detection-fix state: platform = "synology",
+// snap.disks contains only /boot, /log, /mnt entries — no /volume*
+// in sight. The finding must fire with Warning severity and a
+// description that names the exact bind-mount the user needs.
+func TestAnalyzeStorageMounts_FiresOnSynologyWithNoVolumes(t *testing.T) {
+	snap := snapshotWith("synology", []internal.DiskInfo{
+		{Device: "/dev/md0", MountPoint: "/boot", TotalGB: 2.3, UsedGB: 1.3, UsedPct: 62},
+		{Device: "/dev/md0", MountPoint: "/log", TotalGB: 0.2, UsedGB: 0.05, UsedPct: 28},
+	})
+
+	findings := analyzeStorageMounts(snap)
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding, got %d:\n%+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Severity != internal.SeverityWarning {
+		t.Errorf("severity = %v, want Warning", f.Severity)
+	}
+	if f.Category != internal.CategoryDisk {
+		t.Errorf("category = %v, want disk", f.Category)
+	}
+	// The Action text should mention the literal bind-mount syntax
+	// so the user can copy-paste rather than guess. Pin this loosely
+	// (substring) so future copy edits don't break the test.
+	if !strings.Contains(f.Action, "/volume1:/host/volume1:ro") {
+		t.Errorf("Action should give the user a copy-pasteable bind-mount hint; got: %q", f.Action)
+	}
+	// Evidence should list the mounts the container CAN see, so the
+	// operator immediately knows what's there vs what should be.
+	if len(f.Evidence) == 0 {
+		t.Errorf("Evidence is empty; should list visible bind mounts so the operator can compare to README")
+	}
+}
+
+// TestAnalyzeStorageMounts_DoesNotFireWhenAtLeastOneVolumeMounted
+// pins the "user has at least started setting this up" case: as
+// soon as one /volume* mount appears, the finding stops firing.
+// We don't try to detect "missing /volume2 but /volume1 is there"
+// — too much false-positive risk (the user might genuinely only
+// have one volume).
+func TestAnalyzeStorageMounts_DoesNotFireWhenAtLeastOneVolumeMounted(t *testing.T) {
+	snap := snapshotWith("synology", []internal.DiskInfo{
+		{Device: "/dev/md0", MountPoint: "/boot", TotalGB: 2.3, UsedGB: 1.3, UsedPct: 62},
+		{Device: "/dev/mapper/cachedev_0", MountPoint: "/volume1", TotalGB: 23000, UsedGB: 21000, UsedPct: 89},
+	})
+
+	findings := analyzeStorageMounts(snap)
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings (user has /volume1), got %d:\n%+v", len(findings), findings)
+	}
+}
+
+// TestAnalyzeStorageMounts_NoOpOnNonSynologyPlatforms is the
+// platform-gating guard. Unraid users WANT to see /boot (their
+// flash drive) without being told to mount /volume* (an unrelated
+// concept). Same for TrueNAS, QNAP, plain Linux. The finding is
+// strictly Synology-specific.
+func TestAnalyzeStorageMounts_NoOpOnNonSynologyPlatforms(t *testing.T) {
+	disks := []internal.DiskInfo{
+		{Device: "/dev/md0", MountPoint: "/boot", TotalGB: 2, UsedGB: 1, UsedPct: 50},
+	}
+	for _, plat := range []string{"unraid", "truenas", "qnap", "proxmox", "alpine", "linux", ""} {
+		t.Run(plat, func(t *testing.T) {
+			snap := snapshotWith(plat, disks)
+			findings := analyzeStorageMounts(snap)
+			if len(findings) != 0 {
+				t.Errorf("platform %q should not emit Synology-specific finding; got: %+v", plat, findings)
+			}
+		})
+	}
+}
+
+// TestAnalyzeStorageMounts_NoOpWhenDiskCollectionFailed pins the
+// "df itself failed" case. An empty disk list usually means a
+// different failure mode (df errored, no bind mounts at all, etc.)
+// and a separate finding will surface elsewhere. Don't pile on a
+// confusing "missing volumes" hint when we have nothing to compare
+// against.
+func TestAnalyzeStorageMounts_NoOpWhenDiskCollectionFailed(t *testing.T) {
+	snap := snapshotWith("synology", nil)
+	findings := analyzeStorageMounts(snap)
+	if len(findings) != 0 {
+		t.Errorf("empty disks list should not fire the finding (no signal to act on); got: %+v", findings)
+	}
+}
+
+// TestAnalyzeStorageMounts_FiringFindingIsPicked UpByAnalyze is the
+// integration-level guard: the new analyzer must actually be wired
+// into the top-level Analyze() call. Without the wire-up the
+// per-rule unit tests above all pass but the dashboard never sees
+// the finding. Mirrors the structural guard pattern from the
+// existing #206 tests.
+func TestAnalyze_IncludesStorageMountsFinding(t *testing.T) {
+	snap := snapshotWith("synology", []internal.DiskInfo{
+		{Device: "/dev/md0", MountPoint: "/boot", TotalGB: 2.3, UsedGB: 1.3, UsedPct: 62},
+	})
+
+	findings := Analyze(snap)
+	var saw bool
+	for _, f := range findings {
+		if strings.Contains(f.Title, "Synology storage volumes not bind-mounted") {
+			saw = true
+			break
+		}
+	}
+	if !saw {
+		titles := make([]string, 0, len(findings))
+		for _, f := range findings {
+			titles = append(titles, f.Title)
+		}
+		t.Errorf("Analyze() did not include the Synology storage-mounts finding; titles seen: %v", titles)
+	}
+}

--- a/internal/collector/disk.go
+++ b/internal/collector/disk.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -16,7 +17,7 @@ func collectDisks() ([]internal.DiskInfo, error) {
 		if err != nil {
 			return nil, err
 		}
-		return parseDFSimple(out), nil
+		return dedupSameFilesystemMounts(parseDFSimple(out)), nil
 	}
 	disks := parseDFOutput(out)
 
@@ -40,7 +41,96 @@ func collectDisks() ([]internal.DiskInfo, error) {
 		}
 	}
 
-	return disks, nil
+	return dedupSameFilesystemMounts(disks), nil
+}
+
+// dedupSameFilesystemMounts collapses entries that report the same
+// physical filesystem mounted at multiple paths. Issue #300: on
+// Synology DSM, the system root partition (/dev/md0) is visible at
+// `/`, `/boot`, AND `/mnt`. When the typical Container Manager
+// deployment bind-mounts both `/boot:/host/boot:ro` and
+// `/mnt:/host/mnt:ro`, df reports both with identical Size/Used/%
+// numbers, and the dashboard shows the same partition twice — eating
+// vertical space and obscuring real user storage.
+//
+// Two entries are considered duplicates when (Device, TotalGB, UsedGB)
+// match exactly. df reports the same numbers for any mount of the
+// same filesystem, so this is a safe equality. The mount that "wins"
+// is chosen by preferUserStoragePath: real user-storage paths
+// (/volume*, /mnt/disk*, /mnt/cache, /mnt/user) beat system paths
+// (/boot, /, /log) which beat anything else; ties are broken by
+// shortest mount path. Non-duplicate entries pass through untouched
+// and the relative ordering of survivors is preserved (no map
+// iteration in the result path) so the dashboard stays
+// deterministic across scans.
+func dedupSameFilesystemMounts(disks []internal.DiskInfo) []internal.DiskInfo {
+	if len(disks) <= 1 {
+		return disks
+	}
+	// indexByKey records, for each (Device, TotalGB, UsedGB) tuple,
+	// the index in result of the currently-winning entry. We replace
+	// the entry in place when a better-named mount comes along, so
+	// the original ordering is preserved as long as the first
+	// occurrence of a tuple keeps its slot.
+	indexByKey := make(map[string]int, len(disks))
+	result := make([]internal.DiskInfo, 0, len(disks))
+	for _, d := range disks {
+		key := dedupKey(d)
+		if idx, seen := indexByKey[key]; seen {
+			if preferUserStoragePath(d, result[idx]) {
+				result[idx] = d
+			}
+			continue
+		}
+		indexByKey[key] = len(result)
+		result = append(result, d)
+	}
+	return result
+}
+
+// dedupKey is the fingerprint used to match "same filesystem mounted
+// twice". Includes Device + TotalGB + UsedGB; matches the granularity
+// df itself reports so we never collapse two genuinely-different
+// filesystems that happen to share a device name (rare but possible
+// for loop devices).
+func dedupKey(d internal.DiskInfo) string {
+	// Use 3 decimal places — the parseSize helper rounds to that
+	// granularity already, so trailing-digit jitter from re-running df
+	// can't artificially break dedup.
+	return fmt.Sprintf("%s|%.3f|%.3f", d.Device, d.TotalGB, d.UsedGB)
+}
+
+// preferUserStoragePath returns true when `a` is a more useful mount
+// path to display than `b` for the same filesystem. The hierarchy is:
+//
+//  1. real user-storage paths (/volume*, /mnt/disk*, /mnt/cache,
+//     /mnt/user) beat anything else — these are what users want to
+//     see in the storage section.
+//  2. otherwise, shorter path wins — `/boot` is more obvious than
+//     `/mnt` on a Synology system-root partition where neither is
+//     "real" storage.
+//  3. lexicographic tie-break for determinism.
+func preferUserStoragePath(a, b internal.DiskInfo) bool {
+	aReal := isUserStorageMount(a.MountPoint)
+	bReal := isUserStorageMount(b.MountPoint)
+	if aReal != bReal {
+		return aReal
+	}
+	if len(a.MountPoint) != len(b.MountPoint) {
+		return len(a.MountPoint) < len(b.MountPoint)
+	}
+	return a.MountPoint < b.MountPoint
+}
+
+// isUserStorageMount reports whether a mount path is a "real" user
+// storage location worth highlighting in the dashboard. The patterns
+// match the same prefixes collectHostMountDisks uses to decide what
+// host bind mounts to surface, kept in sync deliberately.
+func isUserStorageMount(mount string) bool {
+	return strings.HasPrefix(mount, "/volume") ||
+		strings.HasPrefix(mount, "/mnt/disk") ||
+		strings.HasPrefix(mount, "/mnt/cache") ||
+		strings.HasPrefix(mount, "/mnt/user")
 }
 
 // collectHostMountDisks reads disk info from the host's /mnt via the bind mount at /host/mnt.

--- a/internal/collector/disk_dedup_test.go
+++ b/internal/collector/disk_dedup_test.go
@@ -1,0 +1,205 @@
+package collector
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// Issue #300 — on a Synology DS918+ Container Manager deployment with
+// the README's `/boot:/host/boot:ro`, `/var/log:/host/log:ro`, and
+// `/mnt:/host/mnt:ro` bind mounts (and no `/volumeN` bind mounts),
+// the dashboard's STORAGE section showed three entries — `/boot`,
+// `/log`, `/mnt` — all reporting the system root partition
+// `/dev/md0`. `/boot` and `/mnt` had byte-for-byte identical
+// Size/Used/Available numbers because they're the same filesystem
+// mounted at two paths.
+//
+// dedupSameFilesystemMounts collapses these duplicate entries so the
+// dashboard shows the system-root partition once, freeing vertical
+// space for actual user storage. The `/log` entry has a different
+// size (smaller, because it's a separate filesystem on the host) and
+// must NOT be folded into the system root.
+
+func TestDedupSameFilesystemMounts_CollapsesDS918SystemRootDuplicates(t *testing.T) {
+	// Verbatim shape of the issue #300 reporter's API output. /boot
+	// and /mnt are byte-identical on /dev/md0; /log is a different
+	// filesystem with much smaller size; we want 2 results, not 3.
+	in := []internal.DiskInfo{
+		{Device: "/dev/md0", MountPoint: "/boot", TotalGB: 2.3, UsedGB: 1.3, FreeGB: 0.82, UsedPct: 62},
+		{Device: "/dev/md0", MountPoint: "/log", TotalGB: 0.2, UsedGB: 0.05, FreeGB: 0.14, UsedPct: 28},
+		{Device: "/dev/md0", MountPoint: "/mnt", TotalGB: 2.3, UsedGB: 1.3, FreeGB: 0.82, UsedPct: 62},
+	}
+
+	got := dedupSameFilesystemMounts(in)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries after dedup (/boot+/log, /mnt collapsed into /boot), got %d:\n%+v", len(got), got)
+	}
+	// Surviving mounts must include /log and one of {/boot, /mnt}.
+	var saw struct{ boot, log, mnt bool }
+	for _, d := range got {
+		switch d.MountPoint {
+		case "/boot":
+			saw.boot = true
+		case "/log":
+			saw.log = true
+		case "/mnt":
+			saw.mnt = true
+		}
+	}
+	if !saw.log {
+		t.Errorf("/log entry must survive dedup (different filesystem); got: %+v", got)
+	}
+	if saw.boot && saw.mnt {
+		t.Errorf("both /boot AND /mnt survived; one should have been collapsed (they have identical Size/Used)")
+	}
+	if !saw.boot && !saw.mnt {
+		t.Errorf("both /boot AND /mnt got collapsed; at least one must survive to represent the system root")
+	}
+}
+
+func TestDedupSameFilesystemMounts_PrefersUserStoragePathOverSystemPath(t *testing.T) {
+	// When a real user-storage mount (/volume1, /mnt/disk1, etc.)
+	// shares a filesystem with a system mount, the user-storage
+	// path must win — that's what the operator wants to see in the
+	// dashboard. Synthetic but it matches the contract documented
+	// in preferUserStoragePath.
+	in := []internal.DiskInfo{
+		{Device: "/dev/sda1", MountPoint: "/host", TotalGB: 18000, UsedGB: 12000, UsedPct: 67},
+		{Device: "/dev/sda1", MountPoint: "/volume1", TotalGB: 18000, UsedGB: 12000, UsedPct: 67},
+	}
+
+	got := dedupSameFilesystemMounts(in)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(got))
+	}
+	if got[0].MountPoint != "/volume1" {
+		t.Errorf("/volume1 must beat /host (real user storage); got %q", got[0].MountPoint)
+	}
+}
+
+func TestDedupSameFilesystemMounts_TieBreakOnShortestPath(t *testing.T) {
+	// Two non-user-storage mounts on the same filesystem — neither
+	// is a "real" volume. Tie-break is the shorter path so users
+	// see /boot rather than /var/lib/something.
+	in := []internal.DiskInfo{
+		{Device: "/dev/md0", MountPoint: "/var/lib/cache", TotalGB: 2.3, UsedGB: 1.3, UsedPct: 62},
+		{Device: "/dev/md0", MountPoint: "/boot", TotalGB: 2.3, UsedGB: 1.3, UsedPct: 62},
+	}
+
+	got := dedupSameFilesystemMounts(in)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(got))
+	}
+	if got[0].MountPoint != "/boot" {
+		t.Errorf("expected shorter path /boot to win; got %q", got[0].MountPoint)
+	}
+}
+
+func TestDedupSameFilesystemMounts_DoesNotCollapseDifferentFilesystems(t *testing.T) {
+	// Two real /volume mounts on different cachedevs (typical
+	// Synology setup with multiple storage pools) must both survive.
+	// Same Device prefix isn't enough — TotalGB differs, so the
+	// dedup key differs.
+	in := []internal.DiskInfo{
+		{Device: "/dev/mapper/cachedev_0", MountPoint: "/volume1", TotalGB: 23000, UsedGB: 21000, UsedPct: 89},
+		{Device: "/dev/mapper/cachedev_1", MountPoint: "/volume2", TotalGB: 1800, UsedGB: 174, UsedPct: 10},
+	}
+
+	got := dedupSameFilesystemMounts(in)
+	if len(got) != 2 {
+		t.Errorf("expected both volumes to survive (different filesystems), got %d:\n%+v", len(got), got)
+	}
+}
+
+func TestDedupSameFilesystemMounts_PreservesOrderingForDeterministicDashboard(t *testing.T) {
+	// The dashboard renders disks in the order returned by the
+	// collector, so dedup MUST be order-preserving — otherwise the
+	// storage section would shuffle on every scan, which looks
+	// alarming and breaks the "did anything change?" eyeball test.
+	in := []internal.DiskInfo{
+		{Device: "/dev/sda1", MountPoint: "/volume1", TotalGB: 100, UsedGB: 50, UsedPct: 50},
+		{Device: "/dev/sdb1", MountPoint: "/volume2", TotalGB: 200, UsedGB: 80, UsedPct: 40},
+		{Device: "/dev/md0", MountPoint: "/boot", TotalGB: 2, UsedGB: 1, UsedPct: 50},
+	}
+
+	got := dedupSameFilesystemMounts(in)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 entries (no duplicates in input), got %d", len(got))
+	}
+	wantOrder := []string{"/volume1", "/volume2", "/boot"}
+	for i, w := range wantOrder {
+		if got[i].MountPoint != w {
+			t.Errorf("position %d: got %q, want %q (full order: %v)", i, got[i].MountPoint, w, mountPaths(got))
+		}
+	}
+}
+
+func TestDedupSameFilesystemMounts_NoOpOnSingleDisk(t *testing.T) {
+	// Edge case: single-disk input must return the same disk
+	// without any allocation overhead. Common on TrueNAS SCALE
+	// installs where the only relevant mount is the ZFS pool.
+	in := []internal.DiskInfo{
+		{Device: "tank/data", MountPoint: "/mnt/tank/data", TotalGB: 8000, UsedGB: 4500, UsedPct: 56},
+	}
+	got := dedupSameFilesystemMounts(in)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(got))
+	}
+	if got[0].MountPoint != "/mnt/tank/data" {
+		t.Errorf("entry mutated: %+v", got[0])
+	}
+}
+
+func TestDedupSameFilesystemMounts_NoOpOnEmptyInput(t *testing.T) {
+	got := dedupSameFilesystemMounts(nil)
+	if len(got) != 0 {
+		t.Errorf("expected empty slice, got %v", got)
+	}
+}
+
+func TestIsUserStorageMount_PinsKnownPrefixes(t *testing.T) {
+	cases := []struct {
+		mount string
+		want  bool
+	}{
+		// Synology DSM
+		{"/volume1", true},
+		{"/volume2", true},
+		{"/volume99", true},
+		// Unraid
+		{"/mnt/disk1", true},
+		{"/mnt/disk12", true},
+		{"/mnt/cache", true},
+		{"/mnt/cache_pool", true},
+		{"/mnt/user", true},
+		{"/mnt/user0", true},
+		// System / non-storage
+		{"/boot", false},
+		{"/log", false},
+		{"/mnt", false}, // bare /mnt isn't a real volume
+		{"/var/log", false},
+		{"/", false},
+		{"/host/boot", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.mount, func(t *testing.T) {
+			if got := isUserStorageMount(tc.mount); got != tc.want {
+				t.Errorf("isUserStorageMount(%q) = %v, want %v", tc.mount, got, tc.want)
+			}
+		})
+	}
+}
+
+// mountPaths is a small helper used by failure messages above to
+// render a disk slice as just its mount paths, joined for readability.
+func mountPaths(disks []internal.DiskInfo) string {
+	out := make([]string, 0, len(disks))
+	for _, d := range disks {
+		out = append(out, d.MountPoint)
+	}
+	return strings.Join(out, ", ")
+}

--- a/internal/collector/platform.go
+++ b/internal/collector/platform.go
@@ -42,6 +42,35 @@ var (
 	platformOnce     sync.Once
 )
 
+// synologyKernelMarkers are sysctl files exposed by every Synology DSM
+// kernel build under /proc/sys/kernel/. They survive Docker namespacing
+// (Linux exposes /proc fully into containers by default) so they're
+// visible from any container on a DSM host even when /etc isn't
+// bind-mounted. Used as a third Synology platform-detection signal
+// (issue #300) after /etc/synoinfo.conf and /proc/version.
+//
+// Stored as a package var rather than a constant so tests can swap it
+// out for files in a t.TempDir() without poking real /proc paths.
+var synologyKernelMarkers = []string{
+	"/proc/sys/kernel/syno_CPU_info_clock",
+	"/proc/sys/kernel/syno_CPU_info_core",
+	"/proc/sys/kernel/syno_ata_debug",
+}
+
+// hasSynologyKernelMarker reports whether any of the
+// synologyKernelMarkers paths exist on this filesystem. A single
+// match is sufficient — DSM kernels expose all three but only one
+// needs to survive future kernel changes for detection to keep
+// working.
+func hasSynologyKernelMarker() bool {
+	for _, p := range synologyKernelMarkers {
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
 // DetectPlatform runs OS detection and caches the result.
 // Safe to call from multiple goroutines; detection runs only once.
 func DetectPlatform(hp internal.HostPaths) Platform {
@@ -111,6 +140,18 @@ func runDetection(hp internal.HostPaths) Platform {
 				p.Name = PlatformSynology
 			}
 		}
+	}
+	// Tertiary signal (issue #300): Synology kernel sysctl markers.
+	// /proc/sys/kernel/syno_* files are baked into every DSM kernel
+	// build and visible from any container on a Synology host without
+	// requiring /etc bind mounts. Catches the typical Container Manager
+	// deployment that follows the Synology section of the README but
+	// doesn't bind-mount /etc — the previous two checks miss it
+	// (/etc/synoinfo.conf isn't there, /proc/version's banner doesn't
+	// include the literal "synology" string for kernels built on
+	// Synology's `build7` farm).
+	if p.Name == "" && hasSynologyKernelMarker() {
+		p.Name = PlatformSynology
 	}
 	if p.Name == PlatformSynology {
 		// Try to get DSM version from /etc/VERSION or /etc.defaults/VERSION

--- a/internal/collector/platform_synology_test.go
+++ b/internal/collector/platform_synology_test.go
@@ -1,0 +1,116 @@
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Issue #300 — Synology DSM was mis-detected as "alpine" inside
+// nas_doctor containers because the existing detection paths require
+// either /etc/synoinfo.conf bind mounts or a /proc/version banner
+// that mentions "synology". Neither is present in the typical
+// Container Manager deployment described in the Synology section of
+// the README. As a result, snap.System.Platform reported "alpine",
+// blocking every Synology-aware finding (including the storage-mount
+// hint added alongside this fix).
+//
+// These tests pin the new third detection signal: Synology-specific
+// kernel sysctl files exposed under /proc/sys/kernel/syno_* by every
+// DSM kernel build. Linux exposes /proc fully into containers by
+// default so these are visible without bind mounts.
+
+// swapSynologyKernelMarkers replaces the package-level
+// synologyKernelMarkers slice with `paths` for the duration of a
+// test. Returns a restore function; callers should defer restore().
+func swapSynologyKernelMarkers(paths []string) (restore func()) {
+	orig := synologyKernelMarkers
+	synologyKernelMarkers = paths
+	return func() { synologyKernelMarkers = orig }
+}
+
+func TestHasSynologyKernelMarker_DetectsExistingFile(t *testing.T) {
+	tmp := t.TempDir()
+	// Create one of the marker files. The detection only requires
+	// any single match; production has three but a future kernel
+	// dropping two of them would still detect.
+	marker := filepath.Join(tmp, "syno_CPU_info_clock")
+	if err := os.WriteFile(marker, []byte("2400\n"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	defer swapSynologyKernelMarkers([]string{marker})()
+
+	if !hasSynologyKernelMarker() {
+		t.Errorf("expected hasSynologyKernelMarker()=true when marker file exists at %s", marker)
+	}
+}
+
+func TestHasSynologyKernelMarker_DetectsAnyOfMultiple(t *testing.T) {
+	tmp := t.TempDir()
+	// Three candidate paths, only the LAST one exists. Mirrors the
+	// production behaviour where the fallback list has multiple
+	// candidates so a single kernel-rename doesn't break detection.
+	exists := filepath.Join(tmp, "syno_ata_debug")
+	if err := os.WriteFile(exists, []byte("0\n"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	defer swapSynologyKernelMarkers([]string{
+		filepath.Join(tmp, "missing-1"),
+		filepath.Join(tmp, "missing-2"),
+		exists,
+	})()
+
+	if !hasSynologyKernelMarker() {
+		t.Errorf("expected detection to succeed when ANY marker exists")
+	}
+}
+
+func TestHasSynologyKernelMarker_FalseWhenNoneExist(t *testing.T) {
+	tmp := t.TempDir()
+	// All paths reference files that don't exist. Pin that we don't
+	// false-positive on plain Linux / Alpine / Unraid hosts.
+	defer swapSynologyKernelMarkers([]string{
+		filepath.Join(tmp, "missing-1"),
+		filepath.Join(tmp, "missing-2"),
+		filepath.Join(tmp, "missing-3"),
+	})()
+
+	if hasSynologyKernelMarker() {
+		t.Errorf("expected hasSynologyKernelMarker()=false when no markers exist")
+	}
+}
+
+func TestHasSynologyKernelMarker_EmptyList(t *testing.T) {
+	// Defensive: an empty marker list (e.g. someone wipes the
+	// constants without realising) must return false rather than
+	// panic or accidentally always-true.
+	defer swapSynologyKernelMarkers([]string{})()
+
+	if hasSynologyKernelMarker() {
+		t.Errorf("expected hasSynologyKernelMarker()=false for empty marker list")
+	}
+}
+
+// TestSynologyKernelMarkers_ContainsExpectedPaths is a structural
+// guard: we want at least the three production paths in the default
+// list so the detection has redundancy across DSM kernel versions.
+// Tests should fail loudly if a refactor accidentally trims the
+// list, since the issue-#300 detection silently degrades otherwise.
+func TestSynologyKernelMarkers_ContainsExpectedPaths(t *testing.T) {
+	want := map[string]bool{
+		"/proc/sys/kernel/syno_CPU_info_clock": true,
+		"/proc/sys/kernel/syno_CPU_info_core":  true,
+		"/proc/sys/kernel/syno_ata_debug":      true,
+	}
+	got := make(map[string]bool, len(synologyKernelMarkers))
+	for _, p := range synologyKernelMarkers {
+		got[p] = true
+	}
+	for w := range want {
+		if !got[w] {
+			t.Errorf("synologyKernelMarkers missing expected path %q (full list: %v)", w, synologyKernelMarkers)
+		}
+	}
+}


### PR DESCRIPTION
Closes #300

## Summary

A typical Synology DSM Container Manager deployment of `nas_doctor` with the README's `/boot`, `/var/log`, `/mnt` bind mounts — but no `/volumeN` mounts — produced a misleading dashboard:

- **STORAGE section** showed three entries (`/boot`, `/log`, `/mnt`) all on `/dev/md0`, all with the same 2.3 GB system-partition numbers. Zero visibility into actual user storage (e.g. the reporter's `/volume1` 23 TB and `/volume2` 1.8 TB).
- **`snap.System.Platform`** reported `"alpine"` instead of `"synology"`, blocking every Synology-aware finding from firing.

This PR addresses both via three independent, narrow changes:

## 1 — Platform detection inside containers without `/etc` bind mounts

`internal/collector/platform.go` adds a third Synology detection signal. The existing two paths (`/etc/synoinfo.conf` and the literal `"synology"` string in `/proc/version`) miss the typical Container Manager deployment because:

- `/etc/synoinfo.conf` requires an `/etc` bind mount that the README example doesn't include
- The DSM kernel banner is `Linux version 4.4.302+ (root@build7) (gcc version 12.2.0 (GCC)) #72806 SMP Mon Jul 21 23:16:00 CST 2025` — no `"synology"` string

The new signal: `/proc/sys/kernel/syno_*` sysctl files (`syno_CPU_info_clock`, `syno_CPU_info_core`, `syno_ata_debug`). These are baked into every DSM kernel build and visible from any container by default — Linux exposes `/proc` fully into containers without explicit volume mounts.

```go
var synologyKernelMarkers = []string{
    "/proc/sys/kernel/syno_CPU_info_clock",
    "/proc/sys/kernel/syno_CPU_info_core",
    "/proc/sys/kernel/syno_ata_debug",
}

func hasSynologyKernelMarker() bool { /* any os.Stat(p) succeeds */ }
```

Stored as a package var so the test suite can swap it for `t.TempDir()` paths instead of poking real `/proc`.

## 2 — Disk-mount deduplication

`internal/collector/disk.go` adds `dedupSameFilesystemMounts`. On Synology DSM the system root partition (`/dev/md0`) is visible at `/`, `/boot`, AND `/mnt`. When the user bind-mounts both `/boot` and `/mnt`, df reports them with byte-identical Size/Used/% numbers and the dashboard shows the same partition twice.

Dedup key is `(Device, TotalGB, UsedGB)` — same triple = same filesystem. Tie-break prefers real user-storage prefixes (`/volume*`, `/mnt/disk*`, `/mnt/cache`, `/mnt/user`) over system paths, then shortest mount path. Order-preserving so dashboard rendering stays deterministic across scans (no map iteration in the result path).

Cross-platform safe: Unraid users with `/mnt/disk1` ≠ `/dev/sda1` and `/boot` ≠ `/dev/sdf1` won't see anything collapse — different (Device, Size) tuples, different keys.

## 3 — Actionable finding for missing `/volumeN` bind mounts

`internal/analyzer/analyzer.go` adds `analyzeStorageMounts`. Mirrors the existing platform-aware Unraid pattern at `analyzer.go:811` (`snap.System.Platform == "unraid"`).

Fires when **all three** are true:
- `snap.System.Platform == "synology"` (requires the platform-detection fix above)
- No disk has a mount path starting with `/volume`
- At least one disk is reported (so we don't pile on when df itself failed)

Finding payload:

```
Severity:    Warning
Category:    Disk
Title:       Synology storage volumes not bind-mounted
Description: The container is running on a Synology DSM host but has no /volume*
             paths visible. Storage tracking is incomplete — the dashboard is
             showing DSM system partitions, not your actual user storage.
Evidence:    Bind mounts currently visible:
             /mnt (/dev/md0, 2.3 GB)
             /log (/dev/md0, 0.2 GB)
Action:      Stop the container, add `/volume1:/host/volume1:ro` (and one line per
             additional volume) to your docker-compose.yml or Container Manager
             configuration, then restart. See the Synology DSM section of the
             README for the full mount list.
Impact:      User volumes (/volume1, /volume2, ...) are invisible to NAS Doctor.
             Free-space alerts, disk-space findings, and capacity tracking will
             not fire for the storage you actually care about.
Priority:    short-term
Cost:        Free
```

## Test count delta

**18 new tests across 3 files, all green under `-race`.**

| File | Tests | Coverage |
|------|------:|----------|
| `internal/collector/platform_synology_test.go` | 5 | Synology-marker detection: existence single-file, any-of-multiple, all-missing-false, empty-list-false, structural guard pinning the production path list |
| `internal/collector/disk_dedup_test.go` | 8 | Verbatim DS918+ output collapses 3→2; user-storage path beats system path; shortest-path tie-break; different filesystems don't collapse; ordering preserved; single-disk no-op; empty-input no-op; isUserStorageMount truth-table (16 sub-cases — Synology + Unraid + non-storage paths) |
| `internal/analyzer/storage_mounts_test.go` | 5 | Synology + no volumes → fires; Synology + at least one volume → silent; non-Synology platforms (7 sub-cases) → silent; empty disks → silent; finding propagates through top-level `Analyze()` |

Test fixtures use **verbatim captures** from the reporter's DS918+ — the disk numbers (2.3 GB at 62%, 0.2 GB at 28%) are byte-for-byte what their box produces.

## §4b status

| Check | Result |
|-------|--------|
| `go build ./...` | ✅ clean |
| `go test ./... -race -count=1` | ✅ all packages pass |
| `go vet ./...` | ✅ clean |
| `gofmt -l` (changed files) | ✅ clean |

## Local smoke evidence

Cross-compiled `GOOS=linux GOARCH=amd64 go build -o /tmp/nas-doctor-issue300 ./cmd/nas-doctor` and ran inside an `alpine:3.21` container on the reporter's DS918+ with the **exact same bind mounts** as the reporter's `nas_doctor` container:

```
docker run --rm \
  -v /boot:/host/boot:ro \
  -v /var/log:/host/log:ro \
  -v /mnt:/host/mnt:ro \
  -v /tmp/nas-doctor-issue300:/nas-doctor:ro \
  alpine:3.21 \
  /nas-doctor -listen 0.0.0.0:8062 -interval 1m -data /tmp/nasdoc
```

(`/etc` not bind-mounted, no `/volumeN` mounts — exactly the scenario that produced the bug.)

### Snapshot output after one scan tick

```
platform: synology              ← was: alpine

disks:
  /mnt   /dev/md0    2.3 GB / 62%        ← was: /boot + /log + /mnt (3 entries)
  /log   /dev/md0    0.2 GB / 28%

findings:
  [warning] Synology storage volumes not bind-mounted
    The container is running on a Synology DSM host but has no /volume* paths
    visible. Storage tracking is incomplete — the dashboard is showing DSM
    system partitions, not your actual user storage.
    Action: Stop the container, add `/volume1:/host/volume1:ro`...
    Evidence:
      Bind mounts currently visible:
      /mnt (/dev/md0, 2.3 GB)
      /log (/dev/md0, 0.2 GB)
```

End-to-end: all three improvements visible. Once the user follows the Action text and adds `/volume1:/host/volume1:ro`, the finding stops firing and `/volume1` shows up properly with its 23 TB capacity.

## Out of scope

- Detecting "user has /volume1 but missing /volume2" — too much false-positive risk (the user might genuinely only have one volume). The current finding only fires when ZERO `/volume*` mounts exist, which is the unambiguous "user forgot to set this up" case.
- README updates — the existing Synology DSM section already documents the required `/volumeN` mounts. The Action text in the new finding points users back to it.
- Unraid `/boot` flash drive — explicitly not collapsed (different device than `/mnt/diskN`, so dedup never matches).