### PR TITLE
fix(metrics): hydrate s.latest before serving /metrics endpoint (#305)

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -84,6 +85,13 @@ type Server struct {
 	// value is the safe default — bare Servers in tests and demo mode
 	// don't scare users with a false-positive banner. See #227.
 	dataEphemeral bool
+	// ensureLatestMu serializes ensureLatestSnapshot so concurrent
+	// readers (e.g. parallel /metrics scrapes plus an API hit) do not
+	// race on the lazy-hydration path that loads from disk and
+	// populates the scheduler cache + Prometheus gauge family. See
+	// #305 for the post-restart silent-window class of bug this
+	// helper closes.
+	ensureLatestMu sync.Mutex
 }
 
 // SetDataPersistent records whether /data resolved to a real bind-mount
@@ -175,9 +183,19 @@ func (s *Server) Router() http.Handler {
 			r.Get("/report", s.handleReport)
 		})
 
-		// Prometheus metrics
+		// Prometheus metrics. Wrapped so a scrape that arrives before
+		// the first scan tick (or before any API hit) lazily hydrates
+		// s.latest from disk and populates the gauge family — closes
+		// the post-restart silent-window where /metrics returned
+		// zero/missing values for any gauge derived from s.latest
+		// until /api/v1/snapshot/latest happened to be hit. Issue
+		// #305.
 		if s.metrics != nil {
-			r.Handle("/metrics", promhttp.HandlerFor(s.metrics.Registry(), promhttp.HandlerOpts{}))
+			promHandler := promhttp.HandlerFor(s.metrics.Registry(), promhttp.HandlerOpts{})
+			r.Handle("/metrics", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				s.ensureLatestSnapshot()
+				promHandler.ServeHTTP(w, r)
+			}))
 		}
 
 		// Extended API routes (settings, disks, history, notifications)
@@ -323,13 +341,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		resp.ScanIntervalSecs = int(s.scheduler.Interval().Seconds())
 	}
 
-	var snap *internal.Snapshot
-	if s.scheduler != nil {
-		snap = s.scheduler.Latest()
-	}
-	if snap == nil {
-		snap, _ = s.store.GetLatestSnapshot()
-	}
+	snap := s.ensureLatestSnapshot()
 	if snap != nil {
 		resp.Hostname = snap.System.Hostname
 		resp.Platform = snap.System.Platform
@@ -372,18 +384,102 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-func (s *Server) handleLatestSnapshot(w http.ResponseWriter, r *http.Request) {
-	var snap *internal.Snapshot
+// ensureLatestSnapshot returns the most recent snapshot, hydrating the
+// scheduler's in-memory cache and the Prometheus gauge family from disk
+// on first access if neither has been populated yet. This is the single
+// hydration point shared by every reader of s.latest — the API
+// /snapshot/latest path, the /metrics scraper, /api/v1/status,
+// /api/v1/report, drive_events.currentPlatform, and the per-disk
+// detail endpoints.
+//
+// Why a single helper: prior to issue #305, /metrics read s.latest
+// directly with no fallback path. After a container restart, every
+// gauge derived from s.latest read zero/missing values until either a
+// full Collect tick fired (up to 7 days on installs with high
+// scan_interval) or some other endpoint coincidentally hit the
+// API-side hydration in handleLatestSnapshot. Centralising the
+// hydration here means every reader benefits from the same warm-up
+// behaviour, and any future gauge added to notifier.Metrics inherits
+// the post-restart safety net for free.
+//
+// Behaviour:
+//   - If the scheduler already holds a snapshot, return it (same path
+//     as scheduler.Latest, which also runs the speed-test history
+//     hydration so /metrics sees the same numbers as /snapshot/latest).
+//   - Otherwise load the latest persisted snapshot from storage. On a
+//     successful disk read we ALSO seed the scheduler cache via
+//     SetLatest and prime the Prometheus gauge family via Update so
+//     subsequent /metrics scrapes don't repeat the disk round-trip.
+//   - On store error or empty database (fresh install), return nil and
+//     let the caller render its own empty-state.
+//
+// Concurrency: serialised by ensureLatestMu. Multiple concurrent
+// /metrics scrapes plus an API hit will fall through to a single disk
+// read; subsequent callers see the populated cache and return without
+// re-hitting storage. Idempotent — once the scheduler cache is
+// populated, the helper short-circuits at the scheduler.Latest call.
+func (s *Server) ensureLatestSnapshot() *internal.Snapshot {
+	// Fast path: scheduler already has a snapshot. No mutex needed —
+	// scheduler.Latest is itself goroutine-safe (RWMutex protected) and
+	// re-running it on every call is cheap. Still routes through
+	// scheduler.Latest so the speed-test history hydration (#294) runs.
 	if s.scheduler != nil {
-		snap = s.scheduler.Latest()
-	}
-	if snap == nil {
-		var err error
-		snap, err = s.store.GetLatestSnapshot()
-		if err != nil || snap == nil {
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": "no snapshots available"})
-			return
+		if snap := s.scheduler.Latest(); snap != nil {
+			return snap
 		}
+	}
+
+	// Slow path: scheduler cache empty (or scheduler nil). Serialise
+	// the disk read + cache seeding so concurrent callers don't race.
+	s.ensureLatestMu.Lock()
+	defer s.ensureLatestMu.Unlock()
+
+	// Re-check under the lock — another goroutine may have populated
+	// the cache while we waited for the mutex.
+	if s.scheduler != nil {
+		if snap := s.scheduler.Latest(); snap != nil {
+			return snap
+		}
+	}
+
+	if s.store == nil {
+		return nil
+	}
+	snap, err := s.store.GetLatestSnapshot()
+	if err != nil || snap == nil {
+		return nil
+	}
+
+	// Seed the scheduler cache so subsequent readers (including the
+	// next /metrics scrape) hit the fast path. SetLatest is a simple
+	// pointer swap under the scheduler's write lock; safe to call
+	// while holding ensureLatestMu.
+	if s.scheduler != nil {
+		s.scheduler.SetLatest(snap)
+		// Re-fetch via scheduler.Latest to pick up any post-cache
+		// hydration the scheduler applies (e.g. speed-test history).
+		if hydrated := s.scheduler.Latest(); hydrated != nil {
+			snap = hydrated
+		}
+	}
+
+	// Prime the Prometheus gauge family. Without this, the very first
+	// /metrics scrape after restart would still see empty gauges even
+	// though we just hydrated s.latest — Update is what writes the
+	// snapshot's values onto the registry. Subsequent ticks of the
+	// scheduler's full scan loop call Update again with fresh data.
+	if s.metrics != nil {
+		s.metrics.Update(snap)
+	}
+
+	return snap
+}
+
+func (s *Server) handleLatestSnapshot(w http.ResponseWriter, r *http.Request) {
+	snap := s.ensureLatestSnapshot()
+	if snap == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no snapshots available"})
+		return
 	}
 	// Enrich parity checks with avg/max array temperature from smart_history
 	s.enrichParityTemps(snap)
@@ -535,13 +631,7 @@ func (s *Server) handleTriggerScan(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleReport(w http.ResponseWriter, r *http.Request) {
-	var snap *internal.Snapshot
-	if s.scheduler != nil {
-		snap = s.scheduler.Latest()
-	}
-	if snap == nil {
-		snap, _ = s.store.GetLatestSnapshot()
-	}
+	snap := s.ensureLatestSnapshot()
 	if snap == nil {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no snapshot available for report"})
 		return

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -2980,13 +2980,9 @@ func parseAlertActor(r *http.Request) (string, error) {
 }
 
 // latestSnapshot retrieves the most recent snapshot, preferring the in-memory
-// scheduler copy and falling back to the database.
+// scheduler copy and falling back to the database. Routed through
+// ensureLatestSnapshot so every reader of s.latest goes through the same
+// hydration path — see #305 for the class-of-bug this fixes.
 func (s *Server) latestSnapshot() *internal.Snapshot {
-	if s.scheduler != nil {
-		if snap := s.scheduler.Latest(); snap != nil {
-			return snap
-		}
-	}
-	snap, _ := s.store.GetLatestSnapshot()
-	return snap
+	return s.ensureLatestSnapshot()
 }

--- a/internal/api/drive_events.go
+++ b/internal/api/drive_events.go
@@ -205,13 +205,10 @@ func (s *Server) handleDeleteDriveEvent(w http.ResponseWriter, r *http.Request) 
 // currentPlatform returns the platform string captured by the latest
 // snapshot, or "" if unknown. Used to stamp drive_events rows at
 // creation time; downstream readers can filter or enrich by platform.
+// Routed through ensureLatestSnapshot so it benefits from the same
+// post-restart hydration as every other s.latest reader (#305).
 func (s *Server) currentPlatform() string {
-	if s.scheduler != nil {
-		if snap := s.scheduler.Latest(); snap != nil {
-			return snap.System.Platform
-		}
-	}
-	snap, _ := s.store.GetLatestSnapshot()
+	snap := s.ensureLatestSnapshot()
 	if snap == nil {
 		return ""
 	}

--- a/internal/api/ensure_latest_snapshot_test.go
+++ b/internal/api/ensure_latest_snapshot_test.go
@@ -1,0 +1,352 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/collector"
+	"github.com/mcdays94/nas-doctor/internal/notifier"
+	"github.com/mcdays94/nas-doctor/internal/scheduler"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// Issue #305: prior to this fix, /metrics read s.latest directly with
+// no fallback, so any gauge derived from s.latest reported zero/missing
+// values between container restart and the first /api/v1/snapshot/latest
+// hit (which lazily hydrated). The fix extracts a shared
+// ensureLatestSnapshot helper that's called by BOTH the API path AND the
+// /metrics handler, closing the post-restart silent window.
+//
+// These tests pin the helper's contract:
+//   1. Hydration from disk when scheduler cache is empty.
+//   2. Concurrent-safety under -race when N goroutines call simultaneously.
+//   3. /metrics post-restart exposes gauges that derive from s.latest
+//      WITHOUT any prior API hit.
+//   4. /metrics post-restart exposes the speedtest engine gauge family
+//      (the specific subset that originally surfaced this class of bug
+//      in v0.9.11-rc1/rc2 UAT).
+
+// quietLoggerForEnsureTest produces a logger that swallows debug noise
+// during the test runs so failures aren't buried in scheduler chatter.
+func quietLoggerForEnsureTest() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// newServerWithSchedulerForEnsureTest builds a Server wired through a
+// real Scheduler + FakeStore + (optionally) Metrics, mirroring the
+// production composition in cmd/nas-doctor/main.go. Returns the
+// Server, store, scheduler and metrics so individual tests can seed
+// pre-restart state via the store before exercising ensureLatestSnapshot.
+func newServerWithSchedulerForEnsureTest(t *testing.T, withMetrics bool) (*Server, *storage.FakeStore, *scheduler.Scheduler, *notifier.Metrics) {
+	t.Helper()
+	store := storage.NewFakeStore()
+	logger := quietLoggerForEnsureTest()
+	col := collector.New(internal.HostPaths{}, logger)
+	var m *notifier.Metrics
+	if withMetrics {
+		m = notifier.NewMetrics()
+	}
+	sched := scheduler.New(col, store, &notifier.Notifier{}, m, logger, time.Hour)
+	srv := &Server{
+		store:     store,
+		scheduler: sched,
+		collector: col,
+		metrics:   m,
+		logger:    logger,
+		version:   "test",
+		startTime: time.Now(),
+	}
+	return srv, store, sched, m
+}
+
+// TestEnsureLatestSnapshot_HydratesFromDisk: when the scheduler cache
+// is empty (post-restart) and a snapshot exists on disk, calling
+// ensureLatestSnapshot must populate s.latest from disk and return it.
+// Subsequent calls must hit the cache (don't re-read disk on every
+// scrape). #305 root cause regression guard.
+func TestEnsureLatestSnapshot_HydratesFromDisk(t *testing.T) {
+	t.Parallel()
+	srv, store, sched, _ := newServerWithSchedulerForEnsureTest(t, false)
+
+	// Persist a snapshot pre-restart.
+	preRestart := &internal.Snapshot{
+		ID:        "pre-restart",
+		Timestamp: time.Now().Add(-30 * time.Minute).UTC(),
+		System: internal.SystemInfo{
+			Hostname: "tower",
+			Platform: "unraid",
+		},
+	}
+	if err := store.SaveSnapshot(preRestart); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	// Simulate post-restart: scheduler cache is empty.
+	if got := sched.Latest(); got != nil {
+		t.Fatalf("precondition: scheduler.Latest() = %+v on fresh start, want nil", got)
+	}
+
+	got := srv.ensureLatestSnapshot()
+	if got == nil {
+		t.Fatal("ensureLatestSnapshot() returned nil after hydrating from disk")
+	}
+	if got.ID != "pre-restart" {
+		t.Errorf("ensureLatestSnapshot().ID = %q, want %q", got.ID, "pre-restart")
+	}
+	if got.System.Hostname != "tower" {
+		t.Errorf("ensureLatestSnapshot().System.Hostname = %q, want %q", got.System.Hostname, "tower")
+	}
+
+	// Cache must now be seeded — second call should hit the fast path.
+	if cached := sched.Latest(); cached == nil || cached.ID != "pre-restart" {
+		t.Errorf("scheduler cache not seeded after hydration; sched.Latest() = %+v", cached)
+	}
+}
+
+// TestEnsureLatestSnapshot_NilWhenNoSnapshot: fresh install with no
+// disk snapshot must return nil rather than a zero-value snapshot.
+// Caller-side empty-state branches depend on this.
+func TestEnsureLatestSnapshot_NilWhenNoSnapshot(t *testing.T) {
+	t.Parallel()
+	srv, _, _, _ := newServerWithSchedulerForEnsureTest(t, false)
+	if got := srv.ensureLatestSnapshot(); got != nil {
+		t.Errorf("ensureLatestSnapshot() = %+v on empty install, want nil", got)
+	}
+}
+
+// TestEnsureLatestSnapshot_PrefersSchedulerCache: when the scheduler
+// already has a snapshot (steady state — Collect tick has fired), the
+// helper must return the cached value, not re-read disk.
+func TestEnsureLatestSnapshot_PrefersSchedulerCache(t *testing.T) {
+	t.Parallel()
+	srv, store, sched, _ := newServerWithSchedulerForEnsureTest(t, false)
+
+	// Disk has an OLD snapshot.
+	if err := store.SaveSnapshot(&internal.Snapshot{ID: "stale-disk", Timestamp: time.Now().Add(-time.Hour).UTC()}); err != nil {
+		t.Fatalf("SaveSnapshot stale: %v", err)
+	}
+	// Cache has a FRESH snapshot.
+	fresh := &internal.Snapshot{ID: "fresh-cache", Timestamp: time.Now().UTC()}
+	sched.SetLatest(fresh)
+
+	got := srv.ensureLatestSnapshot()
+	if got == nil || got.ID != "fresh-cache" {
+		t.Errorf("ensureLatestSnapshot() = %+v, want fresh-cache (cache must beat disk)", got)
+	}
+}
+
+// TestEnsureLatestSnapshot_ConcurrentSafe: N goroutines calling the
+// helper simultaneously must all see the hydrated state with no data
+// race. Run under `go test -race`.
+func TestEnsureLatestSnapshot_ConcurrentSafe(t *testing.T) {
+	t.Parallel()
+	srv, store, _, _ := newServerWithSchedulerForEnsureTest(t, false)
+
+	if err := store.SaveSnapshot(&internal.Snapshot{
+		ID:        "concurrent-target",
+		Timestamp: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	const N = 64
+	var wg sync.WaitGroup
+	results := make([]*internal.Snapshot, N)
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func(i int) {
+			defer wg.Done()
+			results[i] = srv.ensureLatestSnapshot()
+		}(i)
+	}
+	wg.Wait()
+
+	for i, snap := range results {
+		if snap == nil {
+			t.Errorf("goroutine %d saw nil snapshot — hydration race lost the result", i)
+			continue
+		}
+		if snap.ID != "concurrent-target" {
+			t.Errorf("goroutine %d saw ID=%q, want concurrent-target", i, snap.ID)
+		}
+	}
+}
+
+// TestMetricsEndpoint_PostRestart_HasSpeedtestGauges is the explicit
+// regression guard for the v0.9.11-rc1/rc2 finding that originally
+// motivated #305: nasdoctor_speedtest_engine was missing from /metrics
+// after a fresh container start until /api/v1/snapshot/latest was
+// curled. After the fix, scraping /metrics WITHOUT any prior API hit
+// must surface the gauge family seeded from the persisted snapshot
+// + speedtest_history hydration.
+func TestMetricsEndpoint_PostRestart_HasSpeedtestGauges(t *testing.T) {
+	t.Parallel()
+	srv, store, _, m := newServerWithSchedulerForEnsureTest(t, true)
+
+	// Pre-restart state: a snapshot envelope on disk + a historical
+	// speedtest_history row. The Snapshot deliberately does NOT carry
+	// SpeedTest (only the speed-test loop populates it in memory; the
+	// persisted envelope drops it).
+	if err := store.SaveSnapshot(&internal.Snapshot{
+		ID:        "post-restart",
+		Timestamp: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+	if err := store.SaveSpeedTest("hist", &internal.SpeedTestResult{
+		Timestamp:    time.Now().Add(-2 * time.Hour).UTC(),
+		DownloadMbps: 142.5, UploadMbps: 12.3, LatencyMs: 18.7,
+		Engine: internal.SpeedTestEngineSpeedTestGo,
+	}); err != nil {
+		t.Fatalf("SaveSpeedTest: %v", err)
+	}
+
+	// Exercise the wrapped /metrics handler the same way the chi
+	// router serves it: ensureLatestSnapshot first, then promhttp.
+	srv.ensureLatestSnapshot()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	promhttp.HandlerFor(m.Registry(), promhttp.HandlerOpts{}).ServeHTTP(rec, req)
+	body := rec.Body.String()
+
+	if !strings.Contains(body, `nasdoctor_speedtest_engine{engine="speedtest_go"} 1`) {
+		t.Errorf("expected speedtest_go=1 gauge in /metrics post-restart with no prior API hit; speedtest lines:\n%s",
+			grepBodyLines(body, "speedtest"))
+	}
+	if !strings.Contains(body, "nasdoctor_speedtest_download_mbps 142.5") {
+		t.Errorf("expected download_mbps=142.5 in /metrics post-restart; speedtest lines:\n%s",
+			grepBodyLines(body, "speedtest_download"))
+	}
+}
+
+// TestMetricsEndpoint_PostRestart_AllSLatestGaugesPresent is the
+// generic regression guard against this class of bug. It enumerates
+// the subset of gauges that derive from s.latest and checks that
+// every one of them appears in /metrics output post-restart with NO
+// prior API hit. New gauges added to notifier.Metrics in future
+// releases that read snap fields must work transparently — if a
+// future change breaks the hydration plumbing, this test should fail
+// across multiple gauge families simultaneously, making the regression
+// loud rather than silent.
+func TestMetricsEndpoint_PostRestart_AllSLatestGaugesPresent(t *testing.T) {
+	t.Parallel()
+	srv, store, _, m := newServerWithSchedulerForEnsureTest(t, true)
+
+	// Build a richly-populated snapshot covering the major gauge
+	// families that read from s.latest: System (CPU/mem/load/temps),
+	// SMART, UPS, network, ZFS, and the Update gauge. Per-subsystem
+	// values are sentinel-distinct so a typo or wiring break shows up
+	// as a missing line rather than an unrelated coincidental match.
+	snap := &internal.Snapshot{
+		ID:        "post-restart-all-gauges",
+		Timestamp: time.Now().UTC(),
+		System: internal.SystemInfo{
+			Hostname:   "tower",
+			Platform:   "unraid",
+			CPUUsage:   17.5,
+			MemUsedMB:  8192,
+			MemTotalMB: 32768,
+			LoadAvg1:   0.55,
+			LoadAvg5:   0.42,
+			LoadAvg15:  0.31,
+			UptimeSecs: 123456,
+			CPUCores:   16,
+			CPUTempC:   49,
+			MoboTempC:  38,
+		},
+	}
+	if err := store.SaveSnapshot(snap); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	// Post-restart: scheduler cache is empty. The /metrics handler's
+	// ensureLatestSnapshot wrapper must hydrate from disk + prime the
+	// gauge family BEFORE promhttp serializes the registry.
+	srv.ensureLatestSnapshot()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	promhttp.HandlerFor(m.Registry(), promhttp.HandlerOpts{}).ServeHTTP(rec, req)
+	body := rec.Body.String()
+
+	// Subset of gauges derived from s.latest. If any are missing, the
+	// hydration plumbing is broken — surface every miss in one failure
+	// so the maintainer sees the pattern.
+	wantSubstrings := []string{
+		"nasdoctor_system_cpu_usage_percent 17.5",
+		"nasdoctor_system_load_avg_1 0.55",
+		"nasdoctor_system_load_avg_5 0.42",
+		"nasdoctor_system_load_avg_15 0.31",
+		"nasdoctor_system_uptime_seconds 123456",
+		"nasdoctor_system_cpu_cores 16",
+		"nasdoctor_system_cpu_temp_celsius 49",
+		"nasdoctor_system_mobo_temp_celsius 38",
+	}
+	var missing []string
+	for _, want := range wantSubstrings {
+		if !strings.Contains(body, want) {
+			missing = append(missing, want)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("post-restart /metrics missing %d gauge(s) derived from s.latest:\n  %s\n\nbody system lines:\n%s",
+			len(missing), strings.Join(missing, "\n  "), grepBodyLines(body, "nasdoctor_system_"))
+	}
+}
+
+// TestMetricsHandler_CallsEnsureLatestSnapshot wires the actual chi
+// router and exercises the full /metrics request path end-to-end —
+// guards against a refactor that adds a new /metrics route without
+// the hydration wrapper.
+func TestMetricsHandler_CallsEnsureLatestSnapshot(t *testing.T) {
+	t.Parallel()
+	srv, store, _, _ := newServerWithSchedulerForEnsureTest(t, true)
+
+	if err := store.SaveSnapshot(&internal.Snapshot{
+		ID:        "router-restart",
+		Timestamp: time.Now().UTC(),
+		System: internal.SystemInfo{
+			Hostname: "router-tower",
+			CPUUsage: 73.5,
+		},
+	}); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	// Use the real router so the /metrics route's middleware chain +
+	// hydration wrapper are exercised together.
+	router := srv.Router()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /metrics returned %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "nasdoctor_system_cpu_usage_percent 73.5") {
+		t.Errorf("GET /metrics did NOT surface s.latest-derived gauge; cpu lines:\n%s",
+			grepBodyLines(body, "nasdoctor_system_cpu"))
+	}
+}
+
+// grepBodyLines is a tiny helper for readable test failure output.
+func grepBodyLines(body, substr string) string {
+	var keep []string
+	for _, line := range strings.Split(body, "\n") {
+		if strings.Contains(line, substr) {
+			keep = append(keep, line)
+		}
+	}
+	return strings.Join(keep, "\n")
+}


### PR DESCRIPTION
Closes #305

## Summary

- Extract the lazy-hydration logic that lived inline in `handleLatestSnapshot` into a single shared `Server.ensureLatestSnapshot` helper. Every reader of `s.latest` (API `/snapshot/latest`, `/metrics`, `/api/v1/status`, `/api/v1/report`, `drive_events.currentPlatform`, `/api/v1/disks/:serial`, replacement-planner) now goes through it.
- Wrap the chi `/metrics` route so a scrape that arrives before the first scan tick (or before any API hit) lazily hydrates `s.latest` from disk and primes the Prometheus gauge family BEFORE `promhttp` serialises the registry.
- Mutex-serialise the slow path so concurrent `/metrics` scrapes plus an API hit fall through to a single disk read; subsequent callers hit the seeded scheduler cache.

## s.latest reader audit

| Path | Hydration before this PR | Hydration after | Test coverage |
|---|---|---|---|
| `GET /api/v1/snapshot/latest` (`handleLatestSnapshot`) | inline scheduler-cache → store fallback | `ensureLatestSnapshot` | `TestHandleLatestSnapshot_*` (existing) |
| `GET /metrics` (promhttp wrapped) | **read `s.latest` directly, no fallback (BUG)** | `ensureLatestSnapshot` then promhttp | `TestMetricsEndpoint_PostRestart_HasSpeedtestGauges`, `TestMetricsEndpoint_PostRestart_AllSLatestGaugesPresent`, `TestMetricsHandler_CallsEnsureLatestSnapshot` (new) |
| `GET /api/v1/status` (`handleStatus`) | inline scheduler-cache → store fallback | `ensureLatestSnapshot` | existing status tests still green |
| `GET /api/v1/report` (`handleReport`) | inline scheduler-cache → store fallback | `ensureLatestSnapshot` | existing report tests still green |
| `Server.latestSnapshot()` (used by `/disks/:serial` and `replacement-planner`) | scheduler-cache → store fallback | delegates to `ensureLatestSnapshot` | existing detail-page tests still green |
| `drive_events.currentPlatform()` | scheduler-cache → store fallback | `ensureLatestSnapshot` | existing drive-events tests still green |
| `Scheduler.RunOnce` → `s.latest = snap; metrics.Update(snap)` (write side) | n/a (writer, not reader) | unchanged | n/a |

The `Scheduler` package's own internal readers (`carryForwardSubsystems`, `collectContainerStats`, `collectProcessStats`, `recordSpeedTestAttempt`, etc.) are explicitly out of scope — they run inside the scheduler's own goroutine and can only execute after at least one `RunOnce` has populated `s.latest`. They aren't on the public-API critical path.

## Behaviour

- Fast path: scheduler already has a snapshot → return it (still routes through `scheduler.Latest()` so the speed-test history hydration from #294 keeps running).
- Slow path: scheduler cache empty → take `ensureLatestMu`, double-check the cache under the lock, load from `store.GetLatestSnapshot()`, seed `scheduler.SetLatest`, prime `metrics.Update`, return.
- Idempotent — once seeded, every subsequent caller short-circuits at the scheduler-cache check.

## Tests

- `TestEnsureLatestSnapshot_HydratesFromDisk` — empty scheduler cache + seeded disk → first call populates `s.latest`, second call hits the cache.
- `TestEnsureLatestSnapshot_NilWhenNoSnapshot` — fresh install (no disk snapshot) returns `nil` so empty-state branches still fire.
- `TestEnsureLatestSnapshot_PrefersSchedulerCache` — cache beats disk; stale disk row never clobbers a fresh in-memory snapshot.
- `TestEnsureLatestSnapshot_ConcurrentSafe` — 64 goroutines call simultaneously; `-race` clean; all see the hydrated state. Validates the mutex.
- `TestMetricsEndpoint_PostRestart_HasSpeedtestGauges` — explicit regression guard for the v0.9.11-rc1/rc2 finding that motivated this issue: `nasdoctor_speedtest_engine{engine=\"speedtest_go\"} 1` and `nasdoctor_speedtest_download_mbps` must appear in `/metrics` post-restart with no prior API hit.
- `TestMetricsEndpoint_PostRestart_AllSLatestGaugesPresent` — generic class-of-bug guard: enumerates eight system-family gauges derived from `s.latest` (CPU usage, load 1/5/15, uptime, cores, CPU temp, mobo temp) and asserts they all surface post-restart. New gauges added in future releases that break the hydration plumbing fail this test loudly across many lines.
- `TestMetricsHandler_CallsEnsureLatestSnapshot` — end-to-end via the real chi router, guarding against a future refactor that adds a new `/metrics` route without the hydration wrapper.

All 7 new tests pass under `go test -race -count=3`.

## §4b pre-push status

- `go build ./...` ✓
- `go test ./... -race -count=1` ✓ (every package green)
- `go vet ./...` ✓
- `gofmt -l .` — the 13 files reported are all pre-existing on `main` (verified by `git stash` + `gofmt -l .`); the four files this PR touches (`internal/api/api.go`, `internal/api/drive_events.go`, `internal/api/ensure_latest_snapshot_test.go`, `internal/api/api_extended.go`) are gofmt-clean except `api_extended.go` which has a pre-existing struct-tag column issue I deliberately did not fix to keep the diff minimal.

## Diff summary

```
internal/api/api.go                         | 140 +++++++++++++++++++--
internal/api/api_extended.go                |  12 +-
internal/api/drive_events.go                |   9 +-
internal/api/ensure_latest_snapshot_test.go | 352 +++++++++++++++++++++++++++++
4 files changed, 474 insertions(+), 39 deletions(-)
```

## Out of scope

- Pre-emptive hydration on container start (lazy is correct — would slow boot for installs with large snapshot history).
- Multi-instance cache invalidation (single-process app).
- Adding new metrics — this is a refactor + regression guard for the existing surface.