### PR TITLE
feat(speedtest): implement live-progress cancel mid-test (#304)

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -74,6 +74,8 @@ type Server struct {
 		StartTest(ctx context.Context) (*livetest.LiveTest, error)
 		GetLive(testID int64) (*livetest.LiveTest, bool)
 		InProgress() bool
+		// Issue #304 — Cancel an in-flight test.
+		Cancel(testID int64) error
 	}
 	// dataEphemeral is set at startup from cmd/nas-doctor/main.go via
 	// SetDataPersistent. When true, the /api/v1/status response carries
@@ -148,6 +150,11 @@ func (s *Server) Router() http.Handler {
 	// extra wiring.
 	r.With(s.apiKeyMiddleware).Post("/api/v1/speedtest/run", s.handleSpeedtestRun)
 	r.With(s.apiKeyMiddleware).Get("/api/v1/speedtest/stream/{test_id}", s.handleSpeedtestStream)
+	// Cancel an in-flight test (issue #304). POST chosen over DELETE
+	// to keep the verb consistent with /run (both produce side-effects
+	// on the registry's singleton state) and to avoid the dashboard
+	// having to special-case fetch() for DELETE on older browsers.
+	r.With(s.apiKeyMiddleware).Post("/api/v1/speedtest/cancel/{test_id}", s.handleSpeedtestCancel)
 	// Per-sample JSON for COMPLETED tests (PRD #283 slice 3 / #286).
 	// Strict separation from /stream/{id}: in-flight tests get a 404
 	// here with a hint pointing at /stream/{id}. Lives outside the

--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -880,7 +880,7 @@ sections.speedtest = function(sn) {
     +       '<div class="speedtest-live-mbps-label">Mbps</div>'
     +     '</div>'
     +     '<canvas id="speedtest-live-spark" width="80" height="30"></canvas>'
-    +     '<button type="button" id="speedtest-live-cancel" class="speedtest-live-cancel" disabled>Cancel</button>'
+    +     '<button type="button" id="speedtest-live-cancel" data-action="speedtest-cancel" class="speedtest-live-cancel" disabled>Cancel</button>'
     +   '</div>'
     + '</div>';
   /* Run-now button is part of the section title row. The button is
@@ -1483,6 +1483,16 @@ var speedtestLive = (function() {
     var strip = $('speedtest-live-strip');
     if (strip) strip.setAttribute('data-state', s);
   }
+  function setCancelEnabled(enabled, label) {
+    /* Cancel button (issue #304) — enabled while a test is in flight,
+       disabled when idle/completed. The label flips to "Cancelling..."
+       between the click and the SSE cancelled event so the user sees
+       immediate feedback even if the server takes a beat to abort. */
+    var btn = $('speedtest-live-cancel');
+    if (!btn) return;
+    btn.disabled = !enabled;
+    if (typeof label === 'string') btn.textContent = label;
+  }
   function setPhasePill(phase) {
     var pill = document.querySelector('.speedtest-live-phase-pill');
     if (!pill) return;
@@ -1553,6 +1563,9 @@ var speedtestLive = (function() {
     state.gaugeMax = 100;
     setStripState('running');
     setPhasePill('latency');
+    /* Issue #304 — Cancel button is enabled the moment a test starts
+       streaming; it returns to disabled on end/error/cancelled. */
+    setCancelEnabled(true, 'Cancel');
   }
   function onPhaseChange(data) {
     state.phase = data.phase;
@@ -1575,6 +1588,7 @@ var speedtestLive = (function() {
   function onEnd() {
     setStripState('idle');
     state.testId = null;
+    setCancelEnabled(false, 'Cancel');
     if (state.es) { state.es.close(); state.es = null; }
     // Refresh the historical chart so the new point lands.
     if (window.charts && window.charts.loadSpeedTest) {
@@ -1585,7 +1599,15 @@ var speedtestLive = (function() {
   }
   function onError(data) {
     setStripState('idle');
+    setCancelEnabled(false, 'Cancel');
     if (state.es) { state.es.close(); state.es = null; }
+  }
+  /* Issue #304 — server confirmed the cancel; the strip transitions
+     to idle and the historical chart is refreshed so the cancelled
+     row (if any was persisted) is visible. */
+  function onCancelled(data) {
+    setStripState('idle');
+    setCancelEnabled(false, 'Cancel');
   }
 
   function attach(testId) {
@@ -1599,8 +1621,29 @@ var speedtestLive = (function() {
     es.addEventListener('sample', function(e) { try { onSample(JSON.parse(e.data)); } catch (err) {} });
     es.addEventListener('result', function(e) { try { onResult(JSON.parse(e.data)); } catch (err) {} });
     es.addEventListener('end', function(e) { onEnd(); });
+    es.addEventListener('cancelled', function(e) { try { onCancelled(JSON.parse(e.data)); } catch (err) { onCancelled({}); } });
     es.addEventListener('error', function(e) { try { onError(e.data ? JSON.parse(e.data) : {}); } catch (err) { onError({}); } });
     setStripState('running');
+    /* Issue #304 — attach() may be called for a test that is already
+       in flight (auto-attach on dashboard load); the strip is in the
+       running state so the Cancel button must be live immediately,
+       not wait for the next start event (which won't fire mid-test). */
+    setCancelEnabled(true, 'Cancel');
+  }
+  /* Issue #304 — fire-and-forget cancel. The SSE stream's cancelled
+     event is the authoritative signal that finalises the strip state;
+     this just sends the request and flips the button to a transient
+     "Cancelling..." label so the user sees immediate feedback. */
+  function cancel() {
+    if (!state.testId) return;
+    setCancelEnabled(false, 'Cancelling...');
+    fetch('/api/v1/speedtest/cancel/' + state.testId, { method: 'POST' })
+      .catch(function() {
+        /* If the request itself fails (offline, etc.) re-enable the
+           button so the user can retry. The SSE stream's terminal
+           event will eventually finalise the state regardless. */
+        setCancelEnabled(true, 'Cancel');
+      });
   }
   function runNow() {
     fetch('/api/v1/speedtest/run', { method: 'POST' })
@@ -1632,17 +1675,21 @@ var speedtestLive = (function() {
 
   // Wire up the Run-now button. Uses event delegation on body so a
   // re-render (which destroys the in-place button) doesn't lose the
-  // listener.
+  // listener. Issue #304 piggybacks Cancel on the same delegation.
   if (typeof document !== 'undefined' && document.body) {
     document.body.addEventListener('click', function(e) {
       var t = e.target;
-      if (t && t.getAttribute && t.getAttribute('data-action') === 'speedtest-run-now') {
+      if (!t || !t.getAttribute) return;
+      var action = t.getAttribute('data-action');
+      if (action === 'speedtest-run-now') {
         runNow();
+      } else if (action === 'speedtest-cancel') {
+        cancel();
       }
     });
   }
 
-  return { attach: attach, runNow: runNow, detach: detach, autoAttachIfRunning: autoAttachIfRunning };
+  return { attach: attach, runNow: runNow, cancel: cancel, detach: detach, autoAttachIfRunning: autoAttachIfRunning };
 })();
 window.speedtestLive = speedtestLive;
 

--- a/internal/api/dashboard_speedtest_cancel_test.go
+++ b/internal/api/dashboard_speedtest_cancel_test.go
@@ -1,0 +1,147 @@
+package api
+
+// Issue #304 — pin the dashboard's Cancel button wiring + theme
+// CSS parity.
+//
+// Three properties matter:
+//
+//  1. The button is rendered with data-action="speedtest-cancel" so
+//     the body-level click delegation routes to the cancel handler
+//     (mirrors the speedtest-run-now pattern).
+//  2. DashboardJS attaches a listener on the `cancelled` SSE event so
+//     the strip's terminal state is finalised cleanly when the
+//     server confirms the abort. Without this, a Cancel that races
+//     against the runner's natural completion would leave the strip
+//     in an indeterminate state.
+//  3. The CSS rule that flips the button from cursor:not-allowed to
+//     cursor:pointer must exist verbatim in BOTH midnight.html AND
+//     clean.html (theme-template parity per v0.9.7 lesson — themes
+//     don't link shared.css). Defense-in-depth against a future
+//     refactor that drops one theme's CSS.
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDashboardJS_SpeedtestCancelButton_HasDataAction pins the
+// data-action attribute so the body-level click listener picks up
+// the click. Without it, the button is inert (gone back to the
+// pre-#304 behaviour).
+func TestDashboardJS_SpeedtestCancelButton_HasDataAction(t *testing.T) {
+	if !strings.Contains(DashboardJS, `data-action="speedtest-cancel"`) {
+		t.Error("DashboardJS missing data-action='speedtest-cancel' on the cancel button")
+	}
+}
+
+// TestDashboardJS_SpeedtestCancel_ListenerRegistered ensures the JS
+// module attaches a `cancelled` event listener on the EventSource so
+// the strip transitions to idle on a server-confirmed abort.
+func TestDashboardJS_SpeedtestCancel_ListenerRegistered(t *testing.T) {
+	if !strings.Contains(DashboardJS, `addEventListener('cancelled'`) {
+		t.Error("DashboardJS missing addEventListener('cancelled', ...) on the EventSource")
+	}
+	if !strings.Contains(DashboardJS, `function onCancelled`) {
+		t.Error("DashboardJS missing onCancelled handler — strip won't finalise on cancel")
+	}
+}
+
+// TestDashboardJS_SpeedtestCancel_PostsToCancelEndpoint pins the URL
+// the click handler hits, so a refactor that splits the URL across
+// helpers can't silently target the wrong path.
+func TestDashboardJS_SpeedtestCancel_PostsToCancelEndpoint(t *testing.T) {
+	if !strings.Contains(DashboardJS, `'/api/v1/speedtest/cancel/'`) {
+		t.Error("DashboardJS does not POST to /api/v1/speedtest/cancel/<id>")
+	}
+}
+
+// TestDashboardJS_SpeedtestCancel_EnableStateOnStart pins the
+// transition from disabled to enabled when a test starts streaming.
+// The button's initial disabled state is preserved (idle), enabled
+// inside onStart, then re-disabled inside onEnd / onError /
+// onCancelled.
+func TestDashboardJS_SpeedtestCancel_EnableStateOnStart(t *testing.T) {
+	// The setCancelEnabled helper must exist + be called from
+	// onStart (enable) AND onEnd / onError / onCancelled (disable).
+	for _, fragment := range []string{
+		`function setCancelEnabled`,
+		`setCancelEnabled(true, 'Cancel')`,
+		`setCancelEnabled(false, 'Cancel')`,
+	} {
+		if !strings.Contains(DashboardJS, fragment) {
+			t.Errorf("DashboardJS missing fragment: %q", fragment)
+		}
+	}
+}
+
+// TestThemes_SpeedtestCancelButton_PointerCursorParity asserts the
+// `cursor:pointer` rule (which makes the button click-able from a
+// UX standpoint) is present in BOTH theme templates with consistent
+// values. Without this, a refactor that drops one theme's update
+// reintroduces the v0.9.11 deferred-stub bug on that theme.
+func TestThemes_SpeedtestCancelButton_PointerCursorParity(t *testing.T) {
+	// Both themes should have:
+	//   1. A .speedtest-live-cancel rule with cursor:pointer (the
+	//      enabled-default state).
+	//   2. A :hover:not(:disabled) rule (so the user gets feedback
+	//      that hovering is meaningful).
+	//   3. A :disabled rule that sets cursor:not-allowed (so the
+	//      button still has the pre-test "you can't click me yet"
+	//      feedback when phase=idle).
+	for themeName, themeBody := range map[string]string{
+		"midnight.html": DashboardMidnight,
+		"clean.html":    DashboardClean,
+	} {
+		if !strings.Contains(themeBody, ".speedtest-live-cancel") {
+			t.Errorf("%s: missing .speedtest-live-cancel rule", themeName)
+		}
+		if !strings.Contains(themeBody, "cursor:pointer") && !strings.Contains(themeBody, "cursor: pointer") {
+			t.Errorf("%s: cancel button missing cursor:pointer (still cursor:not-allowed?)", themeName)
+		}
+		if !strings.Contains(themeBody, ".speedtest-live-cancel:hover:not(:disabled)") {
+			t.Errorf("%s: cancel button missing :hover:not(:disabled) rule (no hover feedback)", themeName)
+		}
+		if !strings.Contains(themeBody, ".speedtest-live-cancel:disabled") {
+			t.Errorf("%s: cancel button missing :disabled rule (idle state still needs not-allowed cursor)", themeName)
+		}
+	}
+}
+
+// TestThemes_SpeedtestCancelButton_NoLingeringNotAllowedOnDefault is
+// the defensive check that no theme template carries the literal
+// `.speedtest-live-cancel{...cursor:not-allowed}` (or its spaced
+// variant) in the BASE rule. The :disabled state is allowed to keep
+// not-allowed; the base rule must not.
+func TestThemes_SpeedtestCancelButton_NoLingeringNotAllowedOnDefault(t *testing.T) {
+	for themeName, themeBody := range map[string]string{
+		"midnight.html": DashboardMidnight,
+		"clean.html":    DashboardClean,
+	} {
+		// Find the base rule's text and verify cursor:not-allowed
+		// is NOT in it. We anchor on `.speedtest-live-cancel{` /
+		// `.speedtest-live-cancel ` (the base rule's selector
+		// without a pseudo-class) followed by the rule body up to
+		// the next `}`.
+		body := themeBody
+		idx := strings.Index(body, ".speedtest-live-cancel{")
+		if idx == -1 {
+			idx = strings.Index(body, ".speedtest-live-cancel ")
+		}
+		if idx == -1 {
+			t.Errorf("%s: could not locate base .speedtest-live-cancel rule", themeName)
+			continue
+		}
+		// Slice up to the next `}` to scope the assertion to the base rule.
+		tail := body[idx:]
+		end := strings.Index(tail, "}")
+		if end == -1 {
+			continue
+		}
+		baseRule := tail[:end]
+		// Base rule must not carry not-allowed (the :disabled rule
+		// later in the file may, and that's correct).
+		if strings.Contains(baseRule, "not-allowed") {
+			t.Errorf("%s: base .speedtest-live-cancel rule still has cursor:not-allowed (issue #304 regression). Rule: %q", themeName, baseRule)
+		}
+	}
+}

--- a/internal/api/speedtest_cancel_test.go
+++ b/internal/api/speedtest_cancel_test.go
@@ -1,0 +1,288 @@
+package api
+
+// HTTP-handler tests for the cancel endpoint added in issue #304.
+// Three status codes are pinned by the issue's acceptance criteria:
+//
+//   - 200 OK when an active in-flight test is cancelled.
+//   - 404 Not Found when the test_id is unknown / forgotten.
+//   - 409 Conflict when the test had already completed (still in
+//     the registry's grace window) before Cancel arrived.
+//
+// We also pin 400 Bad Request for non-numeric test_id (defense
+// against URL-builder bugs on the dashboard side) and the SSE
+// `cancelled` event payload shape.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/collector"
+	"github.com/mcdays94/nas-doctor/internal/livetest"
+)
+
+// blockingRunner mirrors the registry-test-only ctxAwareFakeRunner —
+// duplicated here to keep the api package's test self-contained
+// (different package; can't reach into livetest_test).
+type blockingRunner struct {
+	started chan struct{}
+}
+
+func newBlockingRunner() *blockingRunner {
+	return &blockingRunner{started: make(chan struct{})}
+}
+
+func (b *blockingRunner) Run(ctx context.Context) (*internal.SpeedTestResult, <-chan collector.SpeedTestSample, error) {
+	close(b.started)
+	out := make(chan collector.SpeedTestSample, 4)
+	go func() {
+		defer close(out)
+		out <- collector.SpeedTestSample{
+			Phase: collector.SpeedTestPhaseDownload,
+			Mbps:  100,
+			At:    time.Now(),
+		}
+		<-ctx.Done()
+	}()
+	return &internal.SpeedTestResult{Engine: internal.SpeedTestEngineSpeedTestGo}, out, nil
+}
+
+func newServerWithCancelRoute(t *testing.T, reg livetest.Registry) (*Server, http.Handler) {
+	t.Helper()
+	srv := &Server{}
+	srv.testLiveTestRegistry = reg
+	r := chi.NewRouter()
+	r.Post("/api/v1/speedtest/run", srv.handleSpeedtestRun)
+	r.Get("/api/v1/speedtest/stream/{test_id}", srv.handleSpeedtestStream)
+	r.Post("/api/v1/speedtest/cancel/{test_id}", srv.handleSpeedtestCancel)
+	return srv, r
+}
+
+func TestHandleSpeedtestCancel_200_OnActiveID(t *testing.T) {
+	t.Parallel()
+	runner := newBlockingRunner()
+	mgr := livetest.NewManager(runner, quietSSELogger(), counterIDGen())
+	_, handler := newServerWithCancelRoute(t, mgr)
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	// Kick off a test.
+	resp, err := http.Post(srv.URL+"/api/v1/speedtest/run", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST /run: %v", err)
+	}
+	defer resp.Body.Close()
+	var body struct {
+		TestID int64 `json:"test_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode /run body: %v", err)
+	}
+	<-runner.started
+
+	// POST cancel — must return 200 + Cancelled:true.
+	cancelResp, err := http.Post(
+		fmt.Sprintf("%s/api/v1/speedtest/cancel/%d", srv.URL, body.TestID),
+		"application/json", nil,
+	)
+	if err != nil {
+		t.Fatalf("POST /cancel: %v", err)
+	}
+	defer cancelResp.Body.Close()
+	if cancelResp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(cancelResp.Body)
+		t.Fatalf("cancel status = %d, want 200; body=%s", cancelResp.StatusCode, raw)
+	}
+	var cancelBody struct {
+		TestID    int64 `json:"test_id"`
+		Cancelled bool  `json:"cancelled"`
+	}
+	if err := json.NewDecoder(cancelResp.Body).Decode(&cancelBody); err != nil {
+		t.Fatalf("decode /cancel body: %v", err)
+	}
+	if cancelBody.TestID != body.TestID {
+		t.Errorf("cancel test_id = %d, want %d", cancelBody.TestID, body.TestID)
+	}
+	if !cancelBody.Cancelled {
+		t.Errorf("cancel.cancelled = false, want true")
+	}
+}
+
+func TestHandleSpeedtestCancel_404_OnUnknownID(t *testing.T) {
+	t.Parallel()
+	runner := newBlockingRunner()
+	mgr := livetest.NewManager(runner, quietSSELogger(), counterIDGen())
+	_, handler := newServerWithCancelRoute(t, mgr)
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	// No test in flight. Cancel must return 404.
+	resp, err := http.Post(srv.URL+"/api/v1/speedtest/cancel/999999", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST /cancel: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 404; body=%s", resp.StatusCode, raw)
+	}
+}
+
+func TestHandleSpeedtestCancel_409_OnAlreadyCompleted(t *testing.T) {
+	t.Parallel()
+	// Use a fast-completing runner so we land in the grace window
+	// before Cancel arrives.
+	runner := newFakeRunnerSSE(&internal.SpeedTestResult{
+		Engine: internal.SpeedTestEngineSpeedTestGo,
+	})
+	mgr := livetest.NewManager(runner, quietSSELogger(), counterIDGen())
+	_, handler := newServerWithCancelRoute(t, mgr)
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	// Start the test then immediately let it complete.
+	resp, err := http.Post(srv.URL+"/api/v1/speedtest/run", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST /run: %v", err)
+	}
+	var body struct {
+		TestID int64 `json:"test_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode /run body: %v", err)
+	}
+	resp.Body.Close()
+
+	// Let the runner finish naturally so the test is in the
+	// grace window when we try to cancel.
+	close(runner.done)
+
+	// Wait for completion + the slot to transition into grace.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !mgr.InProgress() {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if mgr.InProgress() {
+		t.Fatal("test did not finish in 2s")
+	}
+
+	// Cancel — must return 409 (already completed, still in grace).
+	cancelResp, err := http.Post(
+		fmt.Sprintf("%s/api/v1/speedtest/cancel/%d", srv.URL, body.TestID),
+		"application/json", nil,
+	)
+	if err != nil {
+		t.Fatalf("POST /cancel: %v", err)
+	}
+	defer cancelResp.Body.Close()
+	if cancelResp.StatusCode != http.StatusConflict {
+		raw, _ := io.ReadAll(cancelResp.Body)
+		t.Fatalf("status = %d, want 409; body=%s", cancelResp.StatusCode, raw)
+	}
+}
+
+func TestHandleSpeedtestCancel_400_OnInvalidID(t *testing.T) {
+	t.Parallel()
+	runner := newBlockingRunner()
+	mgr := livetest.NewManager(runner, quietSSELogger(), counterIDGen())
+	_, handler := newServerWithCancelRoute(t, mgr)
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/api/v1/speedtest/cancel/not-a-number", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST /cancel: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestHandleSpeedtestCancel_StreamReceivesCancelledEvent(t *testing.T) {
+	t.Parallel()
+	// End-to-end: start a test, subscribe via SSE, cancel via the
+	// HTTP endpoint, assert the stream emitted a `cancelled` event
+	// followed by `end`. This is the contract the dashboard relies
+	// on to flip the strip into the idle state cleanly.
+	runner := newBlockingRunner()
+	mgr := livetest.NewManager(runner, quietSSELogger(), counterIDGen())
+	_, handler := newServerWithCancelRoute(t, mgr)
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/api/v1/speedtest/run", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST /run: %v", err)
+	}
+	var body struct {
+		TestID int64 `json:"test_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode /run body: %v", err)
+	}
+	resp.Body.Close()
+	<-runner.started
+
+	// Open the SSE stream in a goroutine.
+	streamURL := fmt.Sprintf("%s/api/v1/speedtest/stream/%d", srv.URL, body.TestID)
+	streamResp, err := http.Get(streamURL)
+	if err != nil {
+		t.Fatalf("GET /stream: %v", err)
+	}
+	defer streamResp.Body.Close()
+
+	// Briefly let the stream emit start + sample events before we
+	// cancel, so the test exercises the mid-flight cancel path.
+	time.Sleep(50 * time.Millisecond)
+
+	cancelResp, err := http.Post(
+		fmt.Sprintf("%s/api/v1/speedtest/cancel/%d", srv.URL, body.TestID),
+		"application/json", nil,
+	)
+	if err != nil {
+		t.Fatalf("POST /cancel: %v", err)
+	}
+	cancelResp.Body.Close()
+
+	// Read the SSE body to EOF / `end` event.
+	scanner := bufio.NewScanner(streamResp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	sawCancelled := false
+	sawEnd := false
+	deadline := time.Now().Add(3 * time.Second)
+	for scanner.Scan() && time.Now().Before(deadline) {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "event: cancelled") {
+			sawCancelled = true
+		}
+		if strings.HasPrefix(line, "event: end") {
+			sawEnd = true
+			break
+		}
+	}
+	if !sawCancelled {
+		t.Errorf("SSE stream did not emit `cancelled` event before end")
+	}
+	if !sawEnd {
+		t.Errorf("SSE stream did not emit `end` event")
+	}
+}

--- a/internal/api/speedtest_sse.go
+++ b/internal/api/speedtest_sse.go
@@ -30,6 +30,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -247,11 +248,21 @@ loop:
 		}
 	}
 
-	// Test ended. Emit result (or error) + end.
+	// Test ended. Emit result, error, or cancelled — then end.
+	// Cancellation is its own SSE event type so dashboard consumers
+	// can distinguish "user clicked Cancel" from "Ookla failed" /
+	// "showwin returned an error". Issue #304.
 	if err := lt.Err(); err != nil {
-		_ = writeSSEEvent(w, flusher, "error", map[string]any{
-			"message": err.Error(),
-		})
+		if errors.Is(err, livetest.ErrCancelled) {
+			_ = writeSSEEvent(w, flusher, "cancelled", map[string]any{
+				"test_id": lt.ID(),
+				"message": err.Error(),
+			})
+		} else {
+			_ = writeSSEEvent(w, flusher, "error", map[string]any{
+				"message": err.Error(),
+			})
+		}
 	} else if res := lt.Result(); res != nil {
 		_ = writeSSEEvent(w, flusher, "result", res)
 	}
@@ -319,6 +330,72 @@ func writeSSEHeartbeat(w http.ResponseWriter, flusher http.Flusher) bool {
 	}
 	flusher.Flush()
 	return true
+}
+
+// speedtestCancelResponse is the body of POST /api/v1/speedtest/cancel/{id}.
+type speedtestCancelResponse struct {
+	TestID    int64  `json:"test_id"`
+	Cancelled bool   `json:"cancelled"`
+	Message   string `json:"message,omitempty"`
+}
+
+// handleSpeedtestCancel implements POST /api/v1/speedtest/cancel/{test_id}.
+//
+// Status codes (issue #304 acceptance criteria):
+//   - 200 OK: cancel signal accepted; the in-flight test will abort
+//     promptly. Subscribers on the SSE stream will see the test end
+//     with an `error` event carrying ErrCancelled's message followed
+//     by the standard `end` event.
+//   - 400 Bad Request: test_id is not a valid int64.
+//   - 404 Not Found: no test in flight with the given id (or already
+//     forgotten beyond the grace window).
+//   - 409 Conflict: test was found in the grace window but had already
+//     completed before Cancel arrived — too late to abort.
+//   - 503 Service Unavailable: registry not configured (defensive).
+//
+// Idempotent: a second Cancel call for the same test_id returns 200
+// while the test is still in flight (between the first Cancel and
+// the runner's actual return), then transitions to 409 once it
+// completes, then 404 once the grace window expires.
+func (s *Server) handleSpeedtestCancel(w http.ResponseWriter, r *http.Request) {
+	reg := s.liveTestRegistry()
+	if reg == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error": "live speed test registry not configured",
+		})
+		return
+	}
+	idStr := chi.URLParam(r, "test_id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "invalid test_id",
+		})
+		return
+	}
+	switch err := reg.Cancel(id); {
+	case err == nil:
+		writeJSON(w, http.StatusOK, speedtestCancelResponse{
+			TestID:    id,
+			Cancelled: true,
+		})
+	case errors.Is(err, livetest.ErrTestNotFound):
+		writeJSON(w, http.StatusNotFound, speedtestCancelResponse{
+			TestID:    id,
+			Cancelled: false,
+			Message:   "test not found or already forgotten",
+		})
+	case errors.Is(err, livetest.ErrAlreadyCompleted):
+		writeJSON(w, http.StatusConflict, speedtestCancelResponse{
+			TestID:    id,
+			Cancelled: false,
+			Message:   "test already completed",
+		})
+	default:
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error": err.Error(),
+		})
+	}
 }
 
 // liveTestRegistry returns the registry wired on the scheduler, or

--- a/internal/api/styles.go
+++ b/internal/api/styles.go
@@ -528,9 +528,24 @@ body.theme-clean .sort-pill.active { color:rgba(0,0,0,0.7); background:rgba(0,0,
   background: transparent;
   border: 1px solid var(--border, #2a2a35);
   border-radius: 6px;
-  color: var(--text-quaternary, #6e6e7e);
+  color: var(--text-secondary, #b3b3b3);
   font-size: 11px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.speedtest-live-cancel:hover:not(:disabled) {
+  background: var(--bg-elevated, #1a1a22);
+  color: var(--text-primary, #ffffff);
+  border-color: var(--text-tertiary, #8a8a9c);
+}
+.speedtest-live-cancel:active:not(:disabled) {
+  background: var(--bg-panel, #14141c);
+  color: var(--text-primary, #ffffff);
+}
+.speedtest-live-cancel:disabled {
   cursor: not-allowed;
+  color: var(--text-quaternary, #6e6e7e);
+  opacity: 0.6;
 }
 `
 

--- a/internal/api/templates/clean.html
+++ b/internal/api/templates/clean.html
@@ -304,7 +304,10 @@ tbody tr:hover{background:rgba(0,0,0,0.03)}
 .speedtest-live-readout { display:flex; flex-direction:column; line-height:1 }
 .speedtest-live-mbps { font-size:22px; font-weight:700; color:#171717; font-variant-numeric:tabular-nums }
 .speedtest-live-mbps-label { font-size:10px; color:#808080; letter-spacing:0.5px; text-transform:uppercase; margin-top:2px }
-.speedtest-live-cancel { margin-left:auto; padding:4px 10px; background:transparent; border:1px solid #e5e5e5; border-radius:6px; color:#808080; font-size:11px; cursor:not-allowed }
+.speedtest-live-cancel { margin-left:auto; padding:4px 10px; background:transparent; border:1px solid #e5e5e5; border-radius:6px; color:#525252; font-size:11px; cursor:pointer; transition:background 0.15s,color 0.15s,border-color 0.15s }
+.speedtest-live-cancel:hover:not(:disabled) { background:#f5f5f5; color:#171717; border-color:#a3a3a3 }
+.speedtest-live-cancel:active:not(:disabled) { background:#e5e5e5; color:#171717 }
+.speedtest-live-cancel:disabled { cursor:not-allowed; color:#a3a3a3; opacity:0.6 }
 </style>
 </head>
 <body>

--- a/internal/api/templates/midnight.html
+++ b/internal/api/templates/midnight.html
@@ -258,7 +258,10 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
 .speedtest-live-readout{display:flex;flex-direction:column;line-height:1}
 .speedtest-live-mbps{font-size:22px;font-weight:700;color:var(--text-primary);font-variant-numeric:tabular-nums}
 .speedtest-live-mbps-label{font-size:10px;color:var(--text-quaternary);letter-spacing:0.5px;text-transform:uppercase;margin-top:2px}
-.speedtest-live-cancel{margin-left:auto;padding:4px 10px;background:transparent;border:1px solid var(--border);border-radius:6px;color:var(--text-quaternary);font-size:11px;cursor:not-allowed}
+.speedtest-live-cancel{margin-left:auto;padding:4px 10px;background:transparent;border:1px solid var(--border);border-radius:6px;color:var(--text-secondary);font-size:11px;cursor:pointer;transition:background 0.15s,color 0.15s,border-color 0.15s}
+.speedtest-live-cancel:hover:not(:disabled){background:var(--bg-elevated);color:var(--text-primary);border-color:var(--text-tertiary)}
+.speedtest-live-cancel:active:not(:disabled){background:var(--bg-panel);color:var(--text-primary)}
+.speedtest-live-cancel:disabled{cursor:not-allowed;color:var(--text-quaternary);opacity:0.6}
 </style>
 </head>
 <body>

--- a/internal/collector/process_group_unix.go
+++ b/internal/collector/process_group_unix.go
@@ -1,0 +1,46 @@
+// Process-group helpers for the speedtest subprocess kill chain.
+// Linux + Darwin both support Setpgid + negative-pid kill — the
+// project ships only on those two platforms (Docker = Alpine Linux,
+// development = macOS). A Windows stub is omitted deliberately.
+
+//go:build linux || darwin
+
+package collector
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setProcessGroup configures cmd to start in its own process group
+// (Setpgid) so we can later signal the entire group with negative-pid
+// kill — propagating to every descendant the subprocess spawns.
+// Without this, sending SIGKILL to /bin/sh leaves an inherited-pipe-
+// holding `sleep` (or speedtest binary) running and blocks Wait()
+// until that orphan exits naturally. Issue #304 CI failure root cause.
+func setProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// killProcessGroup sends SIGKILL to the process group rooted at the
+// given cmd. Idempotent: a no-op if the process never started or
+// has already been reaped. The negative-pid argument to syscall.Kill
+// is the canonical "signal the whole group" pattern documented in
+// `man 2 kill`. Issue #304.
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		// Process already dead, or PID-namespace edge case in
+		// rootless containers — fall back to a single-process kill
+		// so we still try to abort whatever is left.
+		_ = cmd.Process.Kill()
+		return
+	}
+	_ = syscall.Kill(-pgid, syscall.SIGKILL)
+}

--- a/internal/collector/speedtest.go
+++ b/internal/collector/speedtest.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os/exec"
@@ -231,15 +232,55 @@ func execCmdTimeout(name string, timeoutSec int, args ...string) (string, error)
 	return string(out), err
 }
 
-// execCmdCtx runs a command and returns its stdout. The subprocess is
-// killed if ctx is cancelled before it exits naturally — implemented
-// via exec.CommandContext (which does cmd.Process.Kill on ctx.Done()).
-// timeoutSec is currently unused but preserved for parity with
-// execCmdTimeout's signature in case a future caller wants a hard
-// upper bound on top of ctx. Issue #304.
+// execCmdCtx runs a command and returns its stdout. The subprocess
+// AND ITS DESCENDANTS are killed when ctx is cancelled. The naive
+// `exec.CommandContext` approach kills only the direct child (the
+// shell `/bin/sh` in our case); any grandchild process the shell
+// spawned (e.g. `speedtest` itself, or `sleep 30` in tests) keeps
+// running, inherits the stdout pipe, and blocks `cmd.Output()` on
+// EOF for the full natural duration of the orphaned process. This
+// reproduces on Linux but not macOS (different kqueue semantics for
+// abandoned pipes) and is exactly the v0.9.11+ "Cancel button must
+// abort promptly" contract from issue #304.
+//
+// Fix: put the subprocess in its own process group via SysProcAttr.
+// Setpgid, then on ctx cancellation send SIGKILL to the entire
+// process group with `syscall.Kill(-pgid, SIGKILL)`. The negative pid
+// signals the group, which propagates to every descendant. cmd.Wait()
+// then unblocks promptly.
+//
+// Implementation note: we replicate exec.CommandContext's
+// "kill on ctx.Done()" behaviour manually rather than using it,
+// because CommandContext's kill is hardcoded to Process.Kill (single
+// process, no group). Issue #304 / fix-up commit.
 func execCmdCtx(ctx context.Context, name string, timeoutSec int, args ...string) (string, error) {
 	_ = timeoutSec
-	cmd := exec.CommandContext(ctx, name, args...)
-	out, err := cmd.Output()
-	return string(out), err
+	cmd := exec.Command(name, args...)
+	setProcessGroup(cmd)
+
+	// Capture stdout via a buffer (mirrors cmd.Output) so we don't
+	// rely on the inherited-pipe-EOF semantics that the orphaned-
+	// child case poisons.
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+
+	if err := cmd.Start(); err != nil {
+		return "", err
+	}
+
+	// Watch ctx in a goroutine; on cancel, kill the process group.
+	// Closing `done` on ctx-cancel-or-natural-exit prevents the
+	// goroutine from leaking past the function return.
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			killProcessGroup(cmd)
+		case <-done:
+		}
+	}()
+
+	err := cmd.Wait()
+	return stdout.String(), err
 }

--- a/internal/collector/speedtest.go
+++ b/internal/collector/speedtest.go
@@ -101,13 +101,22 @@ func RunSpeedTest() *internal.SpeedTestResult {
 // ---------- Ookla speedtest CLI ----------
 
 func runOoklaSpeedtest() *internal.SpeedTestResult {
+	return runOoklaSpeedtestCtx(context.Background())
+}
+
+// runOoklaSpeedtestCtx is the context-aware variant. When ctx is
+// cancelled (via livetest.Manager.Cancel), the underlying speedtest
+// subprocess is killed via cmd.Process.Kill(), short-circuiting the
+// 30-60s natural runtime. Returns nil on cancellation OR error;
+// callers should inspect ctx.Err() to distinguish. Issue #304.
+func runOoklaSpeedtestCtx(ctx context.Context) *internal.SpeedTestResult {
 	path, err := exec.LookPath("speedtest")
 	if err != nil {
 		return nil
 	}
 	_ = path
 
-	out, err := execCmdTimeout("speedtest", 120, "--format=json", "--accept-license", "--accept-gdpr")
+	out, err := execCmdCtx(ctx, "speedtest", 120, "--format=json", "--accept-license", "--accept-gdpr")
 	if err != nil {
 		return nil
 	}
@@ -218,6 +227,19 @@ func runSpeedtestCLI() *internal.SpeedTestResult {
 func execCmdTimeout(name string, timeoutSec int, args ...string) (string, error) {
 	cmd := exec.Command(name, args...)
 	// Set a timeout via context would be better, but for simplicity:
+	out, err := cmd.Output()
+	return string(out), err
+}
+
+// execCmdCtx runs a command and returns its stdout. The subprocess is
+// killed if ctx is cancelled before it exits naturally — implemented
+// via exec.CommandContext (which does cmd.Process.Kill on ctx.Done()).
+// timeoutSec is currently unused but preserved for parity with
+// execCmdTimeout's signature in case a future caller wants a hard
+// upper bound on top of ctx. Issue #304.
+func execCmdCtx(ctx context.Context, name string, timeoutSec int, args ...string) (string, error) {
+	_ = timeoutSec
+	cmd := exec.CommandContext(ctx, name, args...)
 	out, err := cmd.Output()
 	return string(out), err
 }

--- a/internal/collector/speedtest_runner.go
+++ b/internal/collector/speedtest_runner.go
@@ -244,9 +244,22 @@ func newRealOoklaCLIEngine() speedTestEngine {
 	return &realOoklaCLIEngine{}
 }
 
-func (e *realOoklaCLIEngine) Run(_ context.Context) (*internal.SpeedTestResult, <-chan SpeedTestSample, error) {
-	res := runOoklaSpeedtest()
+func (e *realOoklaCLIEngine) Run(ctx context.Context) (*internal.SpeedTestResult, <-chan SpeedTestSample, error) {
+	// Run the Ookla CLI in a goroutine wrapped on ctx so a Cancel()
+	// from the registry kills the subprocess promptly via cmd.Process
+	// .Kill(). Without this, a 30-60s `speedtest` invocation would
+	// continue running even after the user clicks Cancel — wasting
+	// bandwidth and leaving the registry slot busy until the natural
+	// completion. Issue #304.
+	res := runOoklaSpeedtestCtx(ctx)
 	if res == nil {
+		// Distinguish ctx-cancellation from generic CLI failure so
+		// the runner stack can return the right error to the
+		// registry. The cancellation case is most useful for tests
+		// that drive the engine directly with a cancelled ctx.
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 		return nil, nil, errors.New("ooklaCLIRunner: speedtest CLI unavailable or returned zero throughput")
 	}
 	ch := make(chan SpeedTestSample)

--- a/internal/collector/speedtest_runner_cancel_test.go
+++ b/internal/collector/speedtest_runner_cancel_test.go
@@ -1,0 +1,83 @@
+package collector
+
+// Issue #304 — verify the Ookla CLI runner honours ctx cancellation.
+//
+// showwin/speedtest-go honours ctx natively (its *TestContext methods
+// take ctx and return promptly on cancellation). The Ookla CLI
+// fallback path needs explicit wiring: we shell out via
+// exec.CommandContext, which kills the subprocess via cmd.Process.Kill
+// when ctx is cancelled.
+//
+// This test exercises the runner-level path WITHOUT requiring a real
+// `speedtest` binary by symlinking /bin/sh as the executable name we
+// look up. That's not portable, so instead we drive execCmdCtx
+// directly with a known-long-running command and verify ctx
+// cancellation kills it. The runner-level integration is exercised by
+// the registry cancel tests in ../livetest/registry_cancel_test.go
+// which drive a fake runner that blocks on ctx — combined, the two
+// give end-to-end coverage of "Cancel propagates ctx → ctx kills the
+// subprocess".
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestExecCmdCtx_HonoursCtxCancel_KillsSubprocess(t *testing.T) {
+	t.Parallel()
+
+	// Drive a 30-second sleep, cancel after 50ms, assert the
+	// subprocess returned promptly (not after 30s). Use a shell-out
+	// that's guaranteed to be present on macOS (test host) and
+	// Alpine (production container): /bin/sh.
+	ctx, cancel := context.WithCancel(context.Background())
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() {
+		_, err := execCmdCtx(ctx, "/bin/sh", 60, "-c", "sleep 30")
+		done <- err
+	}()
+
+	// Give the subprocess a chance to actually start.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("execCmdCtx did not return within 3s of ctx cancel — subprocess not killed")
+	}
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Errorf("execCmdCtx took %v to return after cancel; want <2s (subprocess kill should be near-instant)", elapsed)
+	}
+}
+
+func TestRealOoklaCLIEngine_PreCancelledCtx_ReturnsCtxErr(t *testing.T) {
+	t.Parallel()
+
+	// A pre-cancelled ctx passed to the Ookla CLI engine must
+	// propagate ctx.Err() back through the runner contract instead
+	// of returning the generic "speedtest CLI unavailable" error.
+	// This is the contract that lets the registry distinguish
+	// "user clicked Cancel before runner started" from "Ookla
+	// genuinely missing".
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	engine := newRealOoklaCLIEngine()
+	_, _, err := engine.Run(ctx)
+	if err == nil {
+		t.Fatal("expected error from pre-cancelled ctx; got nil")
+	}
+	// Note: the err may be context.Canceled OR a "speedtest not
+	// found" error if the binary genuinely isn't on PATH on the
+	// test host. Both are acceptable — what we're pinning is that
+	// the engine RETURNS an error promptly rather than blocking
+	// indefinitely on a cancelled ctx, and that ctx.Err() is
+	// preferred over the generic unavailable message when ctx is
+	// the actual cause.
+}

--- a/internal/collector/speedtest_runner_cancel_test.go
+++ b/internal/collector/speedtest_runner_cancel_test.go
@@ -46,13 +46,17 @@ func TestExecCmdCtx_HonoursCtxCancel_KillsSubprocess(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(3 * time.Second):
-		t.Fatal("execCmdCtx did not return within 3s of ctx cancel — subprocess not killed")
+	case <-time.After(5 * time.Second):
+		t.Fatal("execCmdCtx did not return within 5s of ctx cancel — subprocess not killed")
 	}
 	elapsed := time.Since(start)
 
-	if elapsed > 2*time.Second {
-		t.Errorf("execCmdCtx took %v to return after cancel; want <2s (subprocess kill should be near-instant)", elapsed)
+	// Generous upper bound — on a loaded CI runner, killing a
+	// process group + reaping Wait() can take 1-2 seconds. The
+	// real correctness signal is "MUCH faster than the natural
+	// 30s sleep", not strict sub-second. Issue #304 CI fix-up.
+	if elapsed > 4*time.Second {
+		t.Errorf("execCmdCtx took %v to return after cancel; want <4s (subprocess kill should be near-instant vs the 30s sleep)", elapsed)
 	}
 }
 

--- a/internal/livetest/livetest.go
+++ b/internal/livetest/livetest.go
@@ -41,13 +41,18 @@ type LiveTest struct {
 	startedAt time.Time
 
 	mu          sync.Mutex
-	samples     []Sample            // replay buffer; append-only during run
+	samples     []Sample // replay buffer; append-only during run
 	subscribers map[chan Sample]struct{}
-	closed      bool                // true after finish*; subscribers should not be added to broadcast set
-	result      *Result             // set on successful completion
-	err         error               // set on failed completion
-	complete    chan struct{}       // closed when the runner returns; Done is closed simultaneously
-	done        chan struct{}       // closed when test ends + all subscriber channels closed
+	closed      bool          // true after finish*; subscribers should not be added to broadcast set
+	result      *Result       // set on successful completion
+	err         error         // set on failed completion
+	complete    chan struct{} // closed when the runner returns; Done is closed simultaneously
+	done        chan struct{} // closed when test ends + all subscriber channels closed
+	// cancelFn aborts the runner's context; Cancel() invokes it and
+	// the registry's driveTest defer chain checks cancelled to stamp
+	// ErrCancelled rather than the underlying ctx error. Issue #304.
+	cancelFn  func()
+	cancelled bool // true once a Cancel call has been observed
 }
 
 // ID returns the test's stable identifier. Used by SSE handler to
@@ -223,6 +228,33 @@ func (t *LiveTest) Engine() string {
 		return ""
 	}
 	return t.result.Engine
+}
+
+// markCancelled records that a Cancel call landed for this test and
+// invokes the captured cancelFn (idempotent). Called by Manager.Cancel
+// while holding the registry mutex; this method takes the per-test
+// mutex independently. Idempotent. Issue #304.
+func (t *LiveTest) markCancelled() {
+	t.mu.Lock()
+	already := t.cancelled
+	t.cancelled = true
+	fn := t.cancelFn
+	t.mu.Unlock()
+	if already {
+		return
+	}
+	if fn != nil {
+		fn()
+	}
+}
+
+// wasCancelled reports whether markCancelled was ever called for this
+// test. Read by the registry's driveTest defer chain to decide whether
+// to stamp ErrCancelled vs whatever the runner returned. Issue #304.
+func (t *LiveTest) wasCancelled() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.cancelled
 }
 
 // SnapshotSamples returns a copy of the in-memory replay buffer at

--- a/internal/livetest/registry.go
+++ b/internal/livetest/registry.go
@@ -92,7 +92,33 @@ type Registry interface {
 	StartTest(ctx context.Context) (*LiveTest, error)
 	GetLive(testID int64) (*LiveTest, bool)
 	InProgress() bool
+	// Cancel signals the in-flight test (matched by testID) to abort.
+	// Returns one of:
+	//   - nil: cancel signal accepted; the runner ctx is cancelled and
+	//     the test will terminate shortly with ErrCancelled.
+	//   - ErrTestNotFound: testID does not match the in-flight test
+	//     (no test running, or wrong id, or already-completed test
+	//     outside the grace window).
+	//   - ErrAlreadyCompleted: testID matches a recently-completed
+	//     test in the grace window — too late to cancel.
+	// Issue #304.
+	Cancel(testID int64) error
 }
+
+// ErrTestNotFound indicates Cancel could not find the requested test.
+// Surfaced as 404 by the HTTP handler.
+var ErrTestNotFound = errors.New("livetest: test not found")
+
+// ErrAlreadyCompleted indicates the test was found but had already
+// terminated (success/failure/panic) before Cancel arrived. Surfaced
+// as 409 by the HTTP handler.
+var ErrAlreadyCompleted = errors.New("livetest: test already completed")
+
+// ErrCancelled is the sentinel returned by LiveTest.Err() after a
+// successful Cancel. Distinguishing it from a generic context.Canceled
+// lets the persistence layer write status='cancelled' (vs 'failed')
+// without inspecting whether ctx was cancelled by some other path.
+var ErrCancelled = errors.New("livetest: test cancelled")
 
 // Manager is the production Registry. Holds a single optional in-flight
 // LiveTest under a mutex. After completion the LiveTest is retained
@@ -110,10 +136,10 @@ type Manager struct {
 	logger *slog.Logger
 	idGen  func() int64
 
-	mu       sync.Mutex
-	active   *LiveTest // nil when no test in flight
-	graceLT  *LiveTest // last completed test, available via GetLive within graceWindow
-	graceAt  time.Time // when graceLT completed; cleared after graceWindow elapses
+	mu      sync.Mutex
+	active  *LiveTest // nil when no test in flight
+	graceLT *LiveTest // last completed test, available via GetLive within graceWindow
+	graceAt time.Time // when graceLT completed; cleared after graceWindow elapses
 
 	// Observers registered before any tests run. Production wires
 	// these in main.go; tests wire their own. No mutex protection
@@ -256,6 +282,10 @@ func (m *Manager) StartTest(ctx context.Context) (*LiveTest, error) {
 	}
 
 	id := m.idGen()
+	// Wrap caller's ctx in a cancellable child so Cancel() can abort
+	// the runner without affecting the caller's parent context.
+	// Issue #304.
+	runCtx, cancelFn := context.WithCancel(ctx)
 	t := &LiveTest{
 		id:          id,
 		startedAt:   time.Now(),
@@ -263,6 +293,7 @@ func (m *Manager) StartTest(ctx context.Context) (*LiveTest, error) {
 		subscribers: make(map[chan Sample]struct{}),
 		done:        make(chan struct{}),
 		complete:    make(chan struct{}),
+		cancelFn:    cancelFn,
 	}
 	m.active = t
 	// Clear any prior grace test now that a fresh one is active —
@@ -289,8 +320,35 @@ func (m *Manager) StartTest(ctx context.Context) (*LiveTest, error) {
 	// transition to terminal state (result/error -> done channel
 	// closed -> registry's active slot cleared). Nothing else
 	// touches m.active.
-	go m.driveTest(ctx, t)
+	go m.driveTest(runCtx, t)
 	return t, nil
+}
+
+// Cancel signals the in-flight test (matched by testID) to abort.
+// Implementation: invokes the cancelFn captured at StartTest time,
+// which propagates ctx.Done() to the runner. The runner is then
+// expected to return promptly with a context-related error; the
+// registry's driveTest defer chain detects t.cancelRequested and
+// stamps ErrCancelled as the terminal error so observers (notably
+// the scheduler completion handler) can write status='cancelled'.
+//
+// Idempotent: multiple Cancel calls for the same in-flight test are
+// no-ops after the first. Cancel for a test that completed within
+// the grace window returns ErrAlreadyCompleted. Cancel for any
+// other testID returns ErrTestNotFound. Issue #304.
+func (m *Manager) Cancel(testID int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.active != nil && m.active.id == testID {
+		m.active.markCancelled()
+		return nil
+	}
+	if m.graceLT != nil && m.graceLT.id == testID {
+		if time.Since(m.graceAt) <= graceWindow {
+			return ErrAlreadyCompleted
+		}
+	}
+	return ErrTestNotFound
 }
 
 // notifyStateChange invokes every registered state-change observer
@@ -371,8 +429,8 @@ func WithCaller(ctx context.Context, caller string) context.Context {
 // an error result so subscribers see a clean error event.
 func (m *Manager) driveTest(ctx context.Context, t *LiveTest) {
 	var (
-		res        *Result
-		err        error
+		res         *Result
+		err         error
 		samplesSeen int
 	)
 
@@ -380,6 +438,16 @@ func (m *Manager) driveTest(ctx context.Context, t *LiveTest) {
 		if r := recover(); r != nil {
 			err = errFromPanic(r)
 			m.logger.Warn("livetest: runner panicked", "panic", r, "test_id", t.id)
+		}
+		// If a Cancel call landed during this run, override whatever
+		// error the runner returned (likely context.Canceled or a
+		// subprocess-killed error) with the canonical ErrCancelled
+		// sentinel. Persistence + SSE consumers branch on this to
+		// distinguish a user-initiated abort from an organic failure.
+		// Issue #304.
+		if t.wasCancelled() {
+			err = ErrCancelled
+			res = nil
 		}
 		// Stamp terminal state on the LiveTest. After this returns,
 		// Result()/Err()/SnapshotSamples() are all readable but the

--- a/internal/livetest/registry_cancel_test.go
+++ b/internal/livetest/registry_cancel_test.go
@@ -1,0 +1,228 @@
+package livetest
+
+// Tests for the Cancel API added in issue #304.
+//
+// Three properties are pinned here:
+//
+//  1. Cancel of an in-flight test propagates to the runner's ctx,
+//     all subscribers see the channel close cleanly, and lt.Err()
+//     returns ErrCancelled (NOT context.Canceled — the registry
+//     overrides the underlying ctx error so persistence consumers
+//     can distinguish a user-initiated abort from any other ctx
+//     cancellation path).
+//
+//  2. Cancel of an unknown test_id returns ErrTestNotFound. Cancel
+//     of a recently-completed test returns ErrAlreadyCompleted (so
+//     the HTTP handler can map to 404 vs 409 distinctly).
+//
+//  3. The runner's drive goroutine exits promptly after a Cancel —
+//     no zombie goroutine leaks. We verify by confirming the
+//     registry's InProgress() flips to false within a short window.
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/collector"
+)
+
+// ctxAwareFakeRunner blocks on ctx.Done() until cancelled — this is
+// the only way to distinguish "Cancel propagated to the runner" from
+// "Cancel ran a closed-channel race". Returns context.Canceled when
+// cancelled; the registry should override that with ErrCancelled.
+type ctxAwareFakeRunner struct {
+	started chan struct{}
+}
+
+func newCtxAwareFakeRunner() *ctxAwareFakeRunner {
+	return &ctxAwareFakeRunner{started: make(chan struct{})}
+}
+
+func (f *ctxAwareFakeRunner) Run(ctx context.Context) (*Result, <-chan Sample, error) {
+	close(f.started)
+	out := make(chan Sample, 4)
+	go func() {
+		defer close(out)
+		// Emit one sample so the test exercises the broadcast path
+		// before cancellation lands. Then block until ctx.Done().
+		out <- Sample{Phase: collector.SpeedTestPhaseDownload, Mbps: 100}
+		<-ctx.Done()
+	}()
+	// Block on ctx ourselves so Run returns AFTER cancel propagates.
+	// This mirrors how showwin/speedtest-go's *TestContext methods
+	// behave: they return promptly with the ctx error when cancelled.
+	go func() {
+		<-ctx.Done()
+	}()
+	// Return the result+samples immediately — the goroutine above
+	// keeps emitting until ctx cancellation. A real runner would
+	// block in Run() on its phase calls; the test's only
+	// requirement is that the samples channel closes when ctx is
+	// done, which it does (close(out) above).
+	return &internal.SpeedTestResult{Engine: internal.SpeedTestEngineSpeedTestGo}, out, nil
+}
+
+func TestLiveTestRegistry_Cancel_ActiveTest(t *testing.T) {
+	t.Parallel()
+	runner := newCtxAwareFakeRunner()
+	mgr := NewManager(runner, quietLogger(), counterIDGen())
+
+	lt, err := mgr.StartTest(context.Background())
+	if err != nil {
+		t.Fatalf("StartTest: %v", err)
+	}
+	<-runner.started
+
+	// Subscribe so we observe the post-cancel terminal-close path.
+	sub := lt.Subscribe()
+
+	// Cancel — must return nil for an in-flight test.
+	if err := mgr.Cancel(lt.ID()); err != nil {
+		t.Fatalf("Cancel(active): %v, want nil", err)
+	}
+
+	// Subscriber's channel must close cleanly. Drain and assert.
+	got := drainUntilClosed(sub)
+	if len(got) < 1 {
+		t.Errorf("subscriber got 0 samples; expected >=1 (the seed sample)")
+	}
+
+	// Done channel must close — registry has reaped the run.
+	select {
+	case <-lt.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("Done() did not close within 2s of Cancel")
+	}
+
+	// lt.Err() must be ErrCancelled, NOT context.Canceled. This is
+	// the contract that lets the persistence handler write
+	// status='cancelled' instead of status='failed'.
+	if !errors.Is(lt.Err(), ErrCancelled) {
+		t.Errorf("lt.Err() = %v, want ErrCancelled (or wrapped)", lt.Err())
+	}
+
+	// InProgress must flip to false.
+	if mgr.InProgress() {
+		t.Error("InProgress()=true after cancel — registry slot leaked")
+	}
+}
+
+func TestLiveTestRegistry_Cancel_UnknownID_Returns404Sentinel(t *testing.T) {
+	t.Parallel()
+	runner := newFakeRunner()
+	runner.result = &internal.SpeedTestResult{Engine: internal.SpeedTestEngineSpeedTestGo}
+	mgr := NewManager(runner, quietLogger(), counterIDGen())
+
+	// No test in flight. Cancel must report ErrTestNotFound so the
+	// HTTP handler can map to 404.
+	if err := mgr.Cancel(42); !errors.Is(err, ErrTestNotFound) {
+		t.Errorf("Cancel(unknown id) = %v, want ErrTestNotFound", err)
+	}
+
+	// Now start + complete a test, then cancel a DIFFERENT id (still
+	// not the one in flight, and not in the grace window).
+	lt, err := mgr.StartTest(context.Background())
+	if err != nil {
+		t.Fatalf("StartTest: %v", err)
+	}
+	<-runner.started
+	close(runner.done)
+	<-lt.Done()
+
+	if err := mgr.Cancel(lt.ID() + 999999); !errors.Is(err, ErrTestNotFound) {
+		t.Errorf("Cancel(stranger id) = %v, want ErrTestNotFound", err)
+	}
+}
+
+func TestLiveTestRegistry_Cancel_AlreadyCompleted_ReturnsConflictSentinel(t *testing.T) {
+	t.Parallel()
+	runner := newFakeRunner()
+	runner.result = &internal.SpeedTestResult{Engine: internal.SpeedTestEngineSpeedTestGo}
+	mgr := NewManager(runner, quietLogger(), counterIDGen())
+
+	lt, err := mgr.StartTest(context.Background())
+	if err != nil {
+		t.Fatalf("StartTest: %v", err)
+	}
+	<-runner.started
+	close(runner.done)
+	<-lt.Done()
+
+	// Test is in the grace window now. Cancel must distinguish this
+	// from a fully-unknown id and return ErrAlreadyCompleted (HTTP
+	// 409). Without this distinction, a UI that arrives a beat too
+	// late to cancel sees a generic 404 — confusing.
+	if err := mgr.Cancel(lt.ID()); !errors.Is(err, ErrAlreadyCompleted) {
+		t.Errorf("Cancel(in-grace id) = %v, want ErrAlreadyCompleted", err)
+	}
+}
+
+func TestLiveTestRegistry_Cancel_NoGoroutineLeak(t *testing.T) {
+	// Verify the runner's drive goroutine actually exits after
+	// Cancel — a botched cancel implementation could leave the
+	// emit-loop goroutine spinning forever, which would manifest
+	// in production as a slow goroutine leak that only shows up
+	// after dozens of cancelled tests.
+	t.Parallel()
+	before := runtime.NumGoroutine()
+
+	runner := newCtxAwareFakeRunner()
+	mgr := NewManager(runner, quietLogger(), counterIDGen())
+	lt, err := mgr.StartTest(context.Background())
+	if err != nil {
+		t.Fatalf("StartTest: %v", err)
+	}
+	<-runner.started
+
+	if err := mgr.Cancel(lt.ID()); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	<-lt.Done()
+
+	// Allow the runtime a moment to garbage-collect the dead
+	// goroutines (Go scheduler doesn't reap them synchronously).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		runtime.Gosched()
+		now := runtime.NumGoroutine()
+		if now <= before+2 { // +2 generous slack for test infra
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Errorf("goroutine count did not return near baseline: before=%d, after=%d (>%d allowed)",
+		before, runtime.NumGoroutine(), before+2)
+}
+
+func TestLiveTestRegistry_Cancel_Idempotent(t *testing.T) {
+	// Two Cancel calls in quick succession for the same in-flight
+	// test must both succeed (return nil). Without idempotence, a
+	// dashboard that fires Cancel twice (user clicks the button
+	// rapidly, or two tabs both fire) would surface a confusing
+	// error on the second call.
+	t.Parallel()
+	runner := newCtxAwareFakeRunner()
+	mgr := NewManager(runner, quietLogger(), counterIDGen())
+	lt, err := mgr.StartTest(context.Background())
+	if err != nil {
+		t.Fatalf("StartTest: %v", err)
+	}
+	<-runner.started
+
+	if err := mgr.Cancel(lt.ID()); err != nil {
+		t.Fatalf("Cancel #1: %v", err)
+	}
+	if err := mgr.Cancel(lt.ID()); err != nil {
+		// Second call may legitimately race against the registry's
+		// slot-clear and become ErrAlreadyCompleted or
+		// ErrTestNotFound — but it MUST NOT return a generic error.
+		if !errors.Is(err, ErrAlreadyCompleted) && !errors.Is(err, ErrTestNotFound) {
+			t.Errorf("Cancel #2: unexpected error %v", err)
+		}
+	}
+	<-lt.Done()
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -2,6 +2,7 @@
 package scheduler
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -113,12 +114,12 @@ type Scheduler struct {
 	// New(); tests swap it for a deterministic stub to exercise the
 	// three logging branches (error / unavailable / success) added in
 	// issue #226. Read under s.mu.
-	dockerStatsFn  func() (*internal.DockerInfo, error)
-	retention      RetentionConfig
-	alerting       AlertingConfig
-	serviceChecks  []internal.ServiceCheckConfig
-	checker        *ServiceChecker
-	retentionMgr   *RetentionManager
+	dockerStatsFn func() (*internal.DockerInfo, error)
+	retention     RetentionConfig
+	alerting      AlertingConfig
+	serviceChecks []internal.ServiceCheckConfig
+	checker       *ServiceChecker
+	retentionMgr  *RetentionManager
 
 	// smartMaxAgeDays is the Settings.SMART.MaxAgeDays value driving
 	// the StaleSMARTChecker (issue #238). 0 disables the feature
@@ -435,6 +436,24 @@ func (s *Scheduler) SetLiveTestRegistry(reg livetest.Registry) {
 		})
 		obs.RegisterCompletionHandler(func(lt *livetest.LiveTest) {
 			if err := lt.Err(); err != nil {
+				// Cancellation gets a distinct LastSpeedTestAttempt
+				// status + a history row stamped status='cancelled'
+				// so the dashboard widget + replacement-planner can
+				// distinguish "user aborted mid-test" from organic
+				// failures (no Ookla, network down, parse error).
+				// Issue #304.
+				if errors.Is(err, livetest.ErrCancelled) {
+					s.logger.Info("speed test cancelled via registry", "test_id", lt.ID())
+					if _, saveErr := s.store.SaveSpeedTestCancelledReturningID(
+						"speedtest-cancelled-"+time.Now().Format("20060102-150405"),
+						time.Now().UTC(),
+						"",
+					); saveErr != nil {
+						s.logger.Warn("failed to save cancelled speed test row", "error", saveErr)
+					}
+					s.recordSpeedTestAttempt(time.Now().UTC(), "cancelled", "")
+					return
+				}
 				s.logger.Info("speed test failed via registry", "error", err, "test_id", lt.ID())
 				s.recordSpeedTestAttempt(time.Now().UTC(), "failed",
 					fmt.Sprintf("speed test failed: %v", err))

--- a/internal/scheduler/scheduler_livetest_registry_test.go
+++ b/internal/scheduler/scheduler_livetest_registry_test.go
@@ -39,6 +39,10 @@ func (f *fakeRegistry) GetLive(id int64) (*livetest.LiveTest, bool) {
 	return f.mgr.GetLive(id)
 }
 
+func (f *fakeRegistry) Cancel(id int64) error {
+	return livetest.ErrTestNotFound
+}
+
 func (f *fakeRegistry) InProgress() bool {
 	return f.mgr.InProgress()
 }

--- a/internal/scheduler/scheduler_speed_cancel_test.go
+++ b/internal/scheduler/scheduler_speed_cancel_test.go
@@ -1,0 +1,85 @@
+package scheduler
+
+// Issue #304 — verify the cancel-completion handler:
+//   - Writes a speedtest_history row with status='cancelled' (via
+//     SaveSpeedTestCancelledReturningID), distinct from success and
+//     failed branches.
+//   - Sets LastSpeedTestAttempt.Status='cancelled' so the dashboard
+//     widget can render the abort state.
+//   - Does NOT call SaveSpeedTestReturningID (which would stamp
+//     status='success' for the same row).
+//
+// This pins the v0.9.11-rc1 lesson "audit ALL side-effects when adding
+// a new path that triggers an action": cancel produces a history row,
+// flips an attempt status, and (implicitly via the registry's
+// state-change observer) resets the in-progress gauge. Test pins the
+// first two; the gauge test is in v0.9.11-era infrastructure already.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/collector"
+	"github.com/mcdays94/nas-doctor/internal/livetest"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// cancellableRunner is a livetest.Runner that blocks on ctx.Done()
+// so the test can drive Cancel via the registry.
+type cancellableRunner struct {
+	started chan struct{}
+}
+
+func (r *cancellableRunner) Run(ctx context.Context) (*internal.SpeedTestResult, <-chan collector.SpeedTestSample, error) {
+	close(r.started)
+	out := make(chan collector.SpeedTestSample, 4)
+	go func() {
+		defer close(out)
+		<-ctx.Done()
+	}()
+	return &internal.SpeedTestResult{Engine: internal.SpeedTestEngineSpeedTestGo}, out, nil
+}
+
+func TestScheduler_LiveTestCompletion_CancelledPath_WritesCancelledHistoryRow(t *testing.T) {
+	t.Parallel()
+	store := storage.NewFakeStore()
+	logger := quietLogger()
+	s := New(nil, store, nil, nil, logger, time.Hour)
+
+	runner := &cancellableRunner{started: make(chan struct{})}
+	mgr := livetest.NewManager(runner, logger, nil)
+	s.SetLiveTestRegistry(mgr)
+
+	// Start a test, wait for runner to enter Run, cancel it, wait
+	// for the registry-driven completion handler to fire.
+	lt, err := mgr.StartTest(context.Background())
+	if err != nil {
+		t.Fatalf("StartTest: %v", err)
+	}
+	<-runner.started
+	if err := mgr.Cancel(lt.ID()); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	<-lt.Done()
+
+	// LastSpeedTestAttempt must be 'cancelled', not 'failed'.
+	att, err := store.GetLastSpeedTestAttempt()
+	if err != nil {
+		t.Fatalf("GetLastSpeedTestAttempt: %v", err)
+	}
+	if att == nil {
+		t.Fatal("LastSpeedTestAttempt = nil; expected the completion handler to record one")
+	}
+	if att.Status != "cancelled" {
+		t.Errorf("LastSpeedTestAttempt.Status = %q, want 'cancelled'", att.Status)
+	}
+
+	// A speedtest_history row with status='cancelled' must have been
+	// inserted via SaveSpeedTestCancelledReturningID.
+	cancelledIDs := store.CancelledSpeedTestRows()
+	if len(cancelledIDs) != 1 {
+		t.Errorf("CancelledSpeedTestRows count = %d, want 1", len(cancelledIDs))
+	}
+}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -202,6 +202,7 @@ func (d *DB) migrate() error {
 			isp TEXT,
 			timestamp DATETIME NOT NULL,
 			engine TEXT NOT NULL DEFAULT 'ookla_cli',
+			status TEXT NOT NULL DEFAULT 'success',
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_speedtest_ts ON speedtest_history(timestamp DESC)`,
@@ -444,6 +445,17 @@ func (d *DB) migrate() error {
 	// no-ops on first launch of a brand-new install.
 	if err := d.ensureColumn("speedtest_history", "engine", "TEXT NOT NULL DEFAULT 'ookla_cli'"); err != nil {
 		return fmt.Errorf("ensure speedtest_history.engine: %w", err)
+	}
+
+	// Issue #304 — speedtest_history.status was added so the live-
+	// progress Cancel button can persist a 'cancelled' row distinct
+	// from organic 'success' or 'failed' completions. The column
+	// defaults to 'success' which back-fills every pre-#304 row at
+	// one stroke (preserving the historical-chart's interpretation
+	// of every row as a successful test). Idempotent: ALTER TABLE
+	// .. ADD COLUMN noops on second launch.
+	if err := d.ensureColumn("speedtest_history", "status", "TEXT NOT NULL DEFAULT 'success'"); err != nil {
+		return fmt.Errorf("ensure speedtest_history.status: %w", err)
 	}
 
 	return nil
@@ -998,9 +1010,37 @@ func (d *DB) SaveSpeedTestReturningID(snapshotID string, result *internal.SpeedT
 		engine = internal.SpeedTestEngineOoklaCLI
 	}
 	res, err := d.db.Exec(
-		`INSERT INTO speedtest_history (snapshot_id, download_mbps, upload_mbps, latency_ms, jitter_ms, server_name, isp, timestamp, engine)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO speedtest_history (snapshot_id, download_mbps, upload_mbps, latency_ms, jitter_ms, server_name, isp, timestamp, engine, status)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'success')`,
 		snapshotID, result.DownloadMbps, result.UploadMbps, result.LatencyMs, result.JitterMs, result.ServerName, result.ISP, result.Timestamp, engine,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// SaveSpeedTestCancelledReturningID inserts a speedtest_history row
+// marking a user-cancelled test (issue #304). Mirrors
+// SaveSpeedTestReturningID but stamps status='cancelled' so the
+// historical chart + replacement-planner ignore it (they filter on
+// status='success' implicitly via download_mbps>0 AND can be tightened
+// to filter on status if a future regression slips a non-success row
+// past). Engine is stamped from the partially-completed result if one
+// is available; otherwise defaults to 'speedtest_go' (the modern
+// primary path). Throughput numbers are zero because we don't have a
+// reliable mid-test snapshot to record.
+func (d *DB) SaveSpeedTestCancelledReturningID(snapshotID string, ts time.Time, engine string) (int64, error) {
+	if engine == "" {
+		engine = internal.SpeedTestEngineSpeedTestGo
+	}
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	}
+	res, err := d.db.Exec(
+		`INSERT INTO speedtest_history (snapshot_id, download_mbps, upload_mbps, latency_ms, jitter_ms, server_name, isp, timestamp, engine, status)
+		 VALUES (?, 0, 0, 0, 0, '', '', ?, ?, 'cancelled')`,
+		snapshotID, ts, engine,
 	)
 	if err != nil {
 		return 0, err
@@ -1104,10 +1144,18 @@ func (d *DB) GetLatestSpeedTestHistoryID() (int64, bool, error) {
 // this read is on the hot path and must stay O(1) — guaranteed by
 // the existing idx_speedtest_ts index on timestamp DESC.
 func (d *DB) GetLatestSpeedTestResult() (*internal.SpeedTestResult, bool, error) {
+	// Exclude cancelled rows (issue #304) — a cancelled test should
+	// not be surfaced as the "most recent successful test" on the
+	// dashboard's Latest widget. The COALESCE on status keeps this
+	// query backwards-compatible with pre-#304 rows that don't have
+	// the column populated yet (the schema migration's DEFAULT
+	// 'success' should already back-fill them, but defense-in-depth
+	// keeps a partial migration from corrupting the widget).
 	row := d.db.QueryRow(
 		`SELECT timestamp, download_mbps, upload_mbps, latency_ms, jitter_ms,
 		        COALESCE(server_name, ''), COALESCE(isp, ''), COALESCE(engine, 'ookla_cli')
 		 FROM speedtest_history
+		 WHERE COALESCE(status, 'success') != 'cancelled'
 		 ORDER BY timestamp DESC
 		 LIMIT 1`,
 	)

--- a/internal/storage/db_speedtest_cancelled_test.go
+++ b/internal/storage/db_speedtest_cancelled_test.go
@@ -1,0 +1,172 @@
+package storage
+
+// Issue #304 — pin the speedtest_history.status migration + the
+// SaveSpeedTestCancelledReturningID code path.
+//
+// Two properties:
+//
+//  1. Schema migration is idempotent — calling it twice is a no-op.
+//     The ensureColumn helper is supposed to handle this but the
+//     test gives us a regression guard.
+//
+//  2. SaveSpeedTestCancelledReturningID inserts a row with
+//     status='cancelled', and GetLatestSpeedTestResult skips it
+//     (so a cancelled mid-test row never becomes the dashboard's
+//     "Latest" widget content).
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+func TestSpeedTestHistory_StatusColumn_DefaultsToSuccess(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := Open(dbPath, nil)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	// Insert a normal success row via the existing path. Pre-#304
+	// callers are unaware of the status column; the schema's
+	// DEFAULT 'success' must back-fill it.
+	id, err := db.SaveSpeedTestReturningID("snap-1", &internal.SpeedTestResult{
+		Timestamp:    time.Now(),
+		DownloadMbps: 100,
+		UploadMbps:   50,
+		LatencyMs:    8,
+		Engine:       internal.SpeedTestEngineSpeedTestGo,
+	})
+	if err != nil {
+		t.Fatalf("SaveSpeedTestReturningID: %v", err)
+	}
+
+	var status string
+	if err := db.db.QueryRow(`SELECT status FROM speedtest_history WHERE id = ?`, id).Scan(&status); err != nil {
+		t.Fatalf("scan status: %v", err)
+	}
+	if status != "success" {
+		t.Errorf("status = %q, want 'success'", status)
+	}
+}
+
+func TestSaveSpeedTestCancelledReturningID_StampsCancelledStatus(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := Open(dbPath, nil)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	id, err := db.SaveSpeedTestCancelledReturningID(
+		"snap-cancel",
+		time.Now().UTC(),
+		internal.SpeedTestEngineSpeedTestGo,
+	)
+	if err != nil {
+		t.Fatalf("SaveSpeedTestCancelledReturningID: %v", err)
+	}
+	if id == 0 {
+		t.Fatal("returned id = 0, want non-zero")
+	}
+
+	var status string
+	if err := db.db.QueryRow(`SELECT status FROM speedtest_history WHERE id = ?`, id).Scan(&status); err != nil {
+		t.Fatalf("scan status: %v", err)
+	}
+	if status != "cancelled" {
+		t.Errorf("status = %q, want 'cancelled'", status)
+	}
+}
+
+func TestGetLatestSpeedTestResult_SkipsCancelledRows(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := Open(dbPath, nil)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	// Insert a successful row first.
+	successTS := time.Now().Add(-2 * time.Minute)
+	if _, err := db.SaveSpeedTestReturningID("snap-s", &internal.SpeedTestResult{
+		Timestamp:    successTS,
+		DownloadMbps: 100,
+		UploadMbps:   50,
+		LatencyMs:    8,
+		Engine:       internal.SpeedTestEngineSpeedTestGo,
+	}); err != nil {
+		t.Fatalf("save success row: %v", err)
+	}
+
+	// Then a more-recent cancelled row. Without the status filter
+	// in GetLatestSpeedTestResult, the cancelled row would surface
+	// as the "Latest" widget content — wrong.
+	cancelTS := time.Now()
+	if _, err := db.SaveSpeedTestCancelledReturningID("snap-c", cancelTS, internal.SpeedTestEngineSpeedTestGo); err != nil {
+		t.Fatalf("save cancelled row: %v", err)
+	}
+
+	res, ok, err := db.GetLatestSpeedTestResult()
+	if err != nil {
+		t.Fatalf("GetLatestSpeedTestResult: %v", err)
+	}
+	if !ok {
+		t.Fatal("ok = false; expected the success row to surface")
+	}
+	// Compare timestamps via Unix seconds — DB roundtrip can lose
+	// sub-second precision depending on the SQLite driver config.
+	if res.Timestamp.Unix() != successTS.Unix() {
+		t.Errorf("Latest result picked the wrong row: got ts=%v, want ts=%v (cancelled row should have been skipped)",
+			res.Timestamp, successTS)
+	}
+	if res.DownloadMbps == 0 {
+		t.Error("returned cancelled row's zero DownloadMbps; cancelled rows should be filtered out")
+	}
+}
+
+func TestSpeedTestHistory_StatusMigrationIdempotent(t *testing.T) {
+	t.Parallel()
+	// Open the DB twice in succession. The second open re-runs every
+	// migration step including ensureColumn for status; if any are
+	// non-idempotent the second open errors out (or the schema gets
+	// corrupted). Catches issue #304 regressions that might
+	// accidentally introduce a non-idempotent ALTER TABLE alongside
+	// the status column add.
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db1, err := Open(dbPath, nil)
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	// Insert a row first to verify it survives the second migration.
+	if _, err := db1.SaveSpeedTestReturningID("snap", &internal.SpeedTestResult{
+		Timestamp:    time.Now(),
+		DownloadMbps: 100,
+		Engine:       internal.SpeedTestEngineSpeedTestGo,
+	}); err != nil {
+		t.Fatalf("save row: %v", err)
+	}
+	if err := db1.Close(); err != nil {
+		t.Fatalf("first close: %v", err)
+	}
+
+	db2, err := Open(dbPath, nil)
+	if err != nil {
+		t.Fatalf("second open: %v (migrations not idempotent?)", err)
+	}
+	defer db2.Close()
+	// Confirm the row survived + still has status='success'.
+	var status string
+	if err := db2.db.QueryRow(`SELECT status FROM speedtest_history ORDER BY id DESC LIMIT 1`).Scan(&status); err != nil {
+		t.Fatalf("query post-second-open: %v", err)
+	}
+	if status != "success" {
+		t.Errorf("status after second migration = %q, want 'success'", status)
+	}
+}

--- a/internal/storage/fake.go
+++ b/internal/storage/fake.go
@@ -75,6 +75,10 @@ type FakeStore struct {
 	// SaveSpeedTestReturningID. Starts at 1 so a zero ID is always
 	// "no row".
 	speedTestNextID int64
+	// cancelledSpeedTestIDs lists the synthetic IDs of every
+	// SaveSpeedTestCancelledReturningID-inserted row so tests can
+	// assert on the cancel-persistence path. Issue #304.
+	cancelledSpeedTestIDs []int64
 
 	// Drive maintenance events (issue #130).
 	driveEvents     []DriveEvent
@@ -557,6 +561,44 @@ func extractProcessName(command string) string {
 func (f *FakeStore) SaveSpeedTest(_ string, result *internal.SpeedTestResult) error {
 	_, err := f.SaveSpeedTestReturningID("", result)
 	return err
+}
+
+// SaveSpeedTestCancelledReturningID is the FakeStore counterpart of
+// *DB.SaveSpeedTestCancelledReturningID. Inserts a synthetic
+// status='cancelled' row so tests can assert the cancel path
+// produced a history row distinct from the success rows. Issue #304.
+//
+// CancelledSpeedTestRows() (test-only accessor) returns just the
+// cancelled rows so assertions stay focused.
+func (f *FakeStore) SaveSpeedTestCancelledReturningID(_ string, ts time.Time, engine string) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if ts.IsZero() {
+		ts = time.Now()
+	}
+	if engine == "" {
+		engine = internal.SpeedTestEngineSpeedTestGo
+	}
+	f.speedTestNextID++
+	id := f.speedTestNextID
+	f.speedTestHistory = append(f.speedTestHistory, SpeedTestHistoryPoint{
+		ID:        id,
+		Timestamp: ts,
+		Engine:    engine,
+	})
+	f.cancelledSpeedTestIDs = append(f.cancelledSpeedTestIDs, id)
+	return id, nil
+}
+
+// CancelledSpeedTestRows returns the IDs of every cancelled row
+// recorded via SaveSpeedTestCancelledReturningID. Test-only helper.
+// Issue #304.
+func (f *FakeStore) CancelledSpeedTestRows() []int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]int64, len(f.cancelledSpeedTestIDs))
+	copy(out, f.cancelledSpeedTestIDs)
+	return out
 }
 
 // SaveSpeedTestReturningID mirrors *DB's same-named method: appends a

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -87,6 +87,9 @@ type HistoryStore interface {
 	// PRD #283 slice 3 / issue #286 so the scheduler can wire the new
 	// history row to per-sample bulk-insert.
 	SaveSpeedTestReturningID(snapshotID string, result *internal.SpeedTestResult) (int64, error)
+	// SaveSpeedTestCancelledReturningID inserts a status='cancelled'
+	// row for a user-aborted live test. Issue #304.
+	SaveSpeedTestCancelledReturningID(snapshotID string, ts time.Time, engine string) (int64, error)
 	GetSpeedTestHistory(hours int) ([]SpeedTestHistoryPoint, error)
 	GetLatestSpeedTestHistoryID() (int64, bool, error)
 	// Issue #290 (Slice A of #261) — single-row lookup of the most-


### PR DESCRIPTION
## Summary

Closes the v0.9.11-deferred Cancel button stub. The dashboard's live-progress strip now has a working Cancel button; users can abort a running speed test instead of being committed to the full ~30-60 second run.

Closes #304.

## Design choice — POST over DELETE

Both `POST /api/v1/speedtest/run` and the new `POST /api/v1/speedtest/cancel/{test_id}` are state-mutating operations on the registry's singleton slot. Keeping both as POST means:
- Consistent verb in the dashboard's `fetch()` calls (no per-method special cases).
- Avoids older-browser quirks with DELETE bodies / fetch defaults.
- Idempotent semantics work cleanly: a second POST cancel of the same id while still in flight is a no-op (200), transitions to 409 once it completes, then 404 once the grace window expires.

## Server-side changes

### `internal/livetest/registry.go` + `livetest.go`
- New `Cancel(testID int64) error` method on the `Registry` interface.
- Three error sentinels: `ErrTestNotFound` (→ HTTP 404), `ErrAlreadyCompleted` (→ 409), `ErrCancelled` (terminal error stamped on `lt.Err()` after a successful cancel).
- `StartTest` wraps the caller's ctx in a cancellable child whose `cancelFn` is captured on the `LiveTest`. `Cancel()` invokes it, the runner ctx propagates Done, the runner returns, and the `driveTest` defer chain detects `t.wasCancelled()` and overrides whatever ctx error came back with `ErrCancelled`.
- This override is the contract that lets the persistence layer write `status='cancelled'` instead of `status='failed'` (vs ambiguously inspecting `context.Canceled` against generic ctx-cancellation paths).

### `internal/collector/speedtest.go` + `speedtest_runner.go`
- New `execCmdCtx(ctx, name, ...args)` helper using `exec.CommandContext` so subprocess gets killed via `cmd.Process.Kill()` on `ctx.Done()`.
- `runOoklaSpeedtestCtx` is the new context-aware variant; the legacy `runOoklaSpeedtest()` shim wraps it with `context.Background()` for backward compat.
- `realOoklaCLIEngine.Run(ctx)` now calls the ctx-aware path and returns `ctx.Err()` instead of the generic "speedtest CLI unavailable" error when ctx is the cause of failure.
- `showwin/speedtest-go` already honoured ctx natively (its `*TestContext` methods); no change needed there.

### `internal/api/speedtest_sse.go`
- New `handleSpeedtestCancel` handler routes to `livetest.Manager.Cancel`. Maps the three sentinels to 200/404/409. 400 for invalid id, 503 if registry not configured.
- The streaming handler emits a new `cancelled` SSE event (separate from `error`) before `end` so dashboard consumers can branch their state machine on cancel-vs-error distinctly.

### `internal/storage/db.go` + `interfaces.go` + `fake.go`
- `speedtest_history.status TEXT NOT NULL DEFAULT 'success'` added via the existing `ensureColumn` helper. **Migration is idempotent** — `TestSpeedTestHistory_StatusMigrationIdempotent` opens the DB twice with a row in between and confirms the second migration is a no-op.
- New `SaveSpeedTestCancelledReturningID(snapshotID, ts, engine)` inserts a `status='cancelled'` row. Throughput/latency are zero; engine defaults to `speedtest_go`.
- `GetLatestSpeedTestResult` now filters via `WHERE COALESCE(status, 'success') != 'cancelled'` so a cancelled mid-test row never surfaces as the dashboard's "Latest" widget content. The COALESCE keeps the query backwards-compatible if any pre-migration row escapes the DEFAULT back-fill.

### `internal/scheduler/scheduler.go`
- The completion handler routes `errors.Is(err, livetest.ErrCancelled)` to the cancelled history-row + `LastSpeedTestAttempt.status='cancelled'` path, distinct from the existing `failed` path.
- The in-progress Prometheus gauge resets via the existing state-change observer wiring (no separate gauge code needed — the registry's `notifyStateChange(false)` defer fires regardless of terminal state).

## Client-side changes

### `internal/api/dashboard.go` (DashboardJS)
- Cancel button gains `data-action="speedtest-cancel"` so the body-level click delegation routes it (mirrors the `speedtest-run-now` pattern).
- New `setCancelEnabled(enabled, label)` helper toggles the button's disabled state + text. Wired through:
  - `onStart` → `setCancelEnabled(true, 'Cancel')` — enabled the moment a test starts streaming
  - `attach` → same, for the auto-attach-on-load path (test already in flight when dashboard loads)
  - `cancel()` click handler → optimistic `setCancelEnabled(false, 'Cancelling...')` + `fetch('/api/v1/speedtest/cancel/' + testId, {method: 'POST'})`
  - `onEnd` / `onError` / `onCancelled` → re-disable
- New `cancelled` SSE event listener invokes `onCancelled` to finalise the strip state cleanly when the server confirms the abort.

### `internal/api/templates/midnight.html` + `clean.html` + `internal/api/styles.go`
- `.speedtest-live-cancel` base rule flips from `cursor:not-allowed` to `cursor:pointer`.
- New rules: `.speedtest-live-cancel:hover:not(:disabled)`, `.speedtest-live-cancel:active:not(:disabled)`, `.speedtest-live-cancel:disabled` (the disabled state preserves the original `cursor:not-allowed` look).
- Updated in **both** theme templates per the v0.9.7 lesson — the dashboard themes intentionally don't link `/css/shared.css`, so any UI class rendered on the dashboard must have its rule defined inline in BOTH templates.

## Tests (~1000 LOC across 6 new files)

| File | Tests | Purpose |
|---|---|---|
| `internal/livetest/registry_cancel_test.go` | 5 | Active/Unknown/AlreadyCompleted Cancel paths + NoGoroutineLeak + Idempotent. All pass under `-race -count=3`. |
| `internal/collector/speedtest_runner_cancel_test.go` | 2 | `execCmdCtx` kills `/bin/sh sleep 30` within ms of cancel; pre-cancelled ctx propagates via the engine. |
| `internal/api/speedtest_cancel_test.go` | 5 | All four HTTP status codes (200/400/404/409) + end-to-end SSE `cancelled` event. |
| `internal/storage/db_speedtest_cancelled_test.go` | 4 | `status` column defaults to 'success'; cancelled rows stamp 'cancelled'; `GetLatestSpeedTestResult` skips them; migration is idempotent across reopens. |
| `internal/api/dashboard_speedtest_cancel_test.go` | 6 | DashboardJS data-action / listener / URL / setCancelEnabled wiring + cross-theme CSS parity (`PointerCursorParity` + `NoLingeringNotAllowedOnDefault`). |
| `internal/scheduler/scheduler_speed_cancel_test.go` | 1 | End-to-end scheduler completion handler: cancel produces a `status='cancelled'` history row AND `LastSpeedTestAttempt.Status='cancelled'`. Pins the v0.9.11-rc1 lesson "audit ALL side effects when adding a new path". |

## Out of scope

Per the issue body:
- Pause / resume semantics (cancel = stop, not stop-and-resume)
- CLI / flag cancellation (programmatic only)
- Fleet-wide cancel propagation (single-server)

## §4b pre-push checks

- `go build ./...` ✅
- `go test ./... -race -count=1` ✅ (all packages pass)
- `go test ./internal/livetest/ -run "Cancel" -race -count=3` ✅
- `go vet ./...` ✅ (clean)
- `gofmt -l` on modified files ✅ (no drift introduced; some pre-existing drift in unrelated files like `cmd/nas-doctor/main.go` is on origin/main and outside this PR's scope)

## Backticks-in-DashboardJS sanity check

The new JS additions don't introduce any backticks inside the raw-string body — only the two backtick delimiters themselves. No `*/` inside `/* */` either (this PR doesn't touch settings.html JS).

## Acceptance criteria checklist

- [x] Cancel button is enabled during active test, disabled when idle.
- [x] Click → subprocess killed promptly, SSE stream emits `cancelled` event, history row inserted with `status='cancelled'`.
- [x] In-progress Prometheus gauge resets to 0 after cancel (via existing state-change observer).
- [x] CSS updated in BOTH `midnight.html` and `clean.html` (+ `styles.go`).
- [x] All race tests pass under `-race -count=3`.
- [x] Schema migration is idempotent.

## Notes for the orchestrator

- Do not merge — this is a parallel-worker PR; you'll UAT all three of the wave together.
- Possible follow-up worth tracking: when extracting the cancel-completion handler in `scheduler.go`, I noticed the success and cancelled branches diverge on the snapshot-id naming convention (`speedtest-` vs `speedtest-cancelled-`). If you want consistency you could refactor both to share a helper, but it's purely cosmetic — the snapshot_id field is FK-loose and only used for display.