### PR TITLE
fix(settings): debounce auto-save calls to collapse rapid-fire PUTs (#258)

### DIFF
--- a/internal/api/settings_save_debounce_test.go
+++ b/internal/api/settings_save_debounce_test.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSettingsHTML_SaveSettingsIsDebounced asserts that the
+// settings page wraps auto-save flows in a debounce window so a
+// rapid burst of change events (e.g. clicking through a per-
+// subsystem interval picker dropdown) collapses into a single
+// PUT /api/v1/settings call.
+//
+// Background: during v0.9.8-rc1 UAT the container log showed 7
+// full settings-save cycles within ~1s while the user clicked
+// through a small number of pickers. Each picker change event
+// fires saveSettings(); without debouncing, a 4-step picker walk
+// produces 4 PUTs back-to-back. v0.9.9-rc2 confirmed the cause
+// during slice 2b UAT. Issue #258 tracks the fix.
+//
+// Contract this test pins:
+//
+//  1. saveSettings() must be a thin debounced wrapper that uses
+//     setTimeout + clearTimeout to collapse rapid invocations.
+//  2. The actual PUT-firing function must live under a separate
+//     name (saveSettingsImmediate) so the explicit "Save All
+//     Settings" button can bypass the debounce.
+//  3. The "Save All Settings" sticky-bar button MUST call
+//     saveSettingsImmediate() — explicit user clicks should not
+//     be delayed.
+//  4. The previously-existing async PUT body (fetch, .then,
+//     showToast, markSaved, .catch error path) must move into
+//     saveSettingsImmediate so error reporting still surfaces
+//     promptly to the user.
+func TestSettingsHTML_SaveSettingsIsDebounced(t *testing.T) {
+	html := SettingsPage
+
+	// (1) A debounce helper exists. We pin both the timer-handle
+	// variable name and the setTimeout/clearTimeout pair, and we
+	// assert the wrapper function is actually named saveSettings
+	// so the 49 existing call sites continue to flow through it.
+	mustContain(t, html, "var saveSettingsDebounceTimer = null;",
+		"expected debounce timer handle declaration")
+	mustContain(t, html, "function saveSettings() {",
+		"expected saveSettings to remain the public entry point (debounced wrapper)")
+	mustContain(t, html, "clearTimeout(saveSettingsDebounceTimer)",
+		"debounce wrapper must clear any pending timer before scheduling a new one")
+	mustContain(t, html, "saveSettingsDebounceTimer = setTimeout(",
+		"debounce wrapper must schedule the deferred save via setTimeout")
+	mustContain(t, html, "SAVE_SETTINGS_DEBOUNCE_MS",
+		"debounce window must be a named constant (kept hardcoded; not user-configurable)")
+	// 300ms is the agreed default — short enough to be invisible
+	// to users, long enough to coalesce the 150-200ms cadence
+	// observed in the rc1 log.
+	mustContain(t, html, "var SAVE_SETTINGS_DEBOUNCE_MS = 300;",
+		"debounce window must default to 300ms")
+
+	// (2) The PUT-firing function lives under a separate name so
+	// callers that need synchronous behaviour (the explicit Save
+	// button) can target it directly.
+	mustContain(t, html, "function saveSettingsImmediate()",
+		"expected saveSettingsImmediate to host the actual PUT logic")
+
+	// (3) The sticky save bar's explicit button must NOT be
+	// debounced. Find the save-bar block and assert it calls the
+	// immediate variant.
+	saveBarIdx := strings.Index(html, `<div class="save-bar"`)
+	if saveBarIdx < 0 {
+		t.Fatal("could not locate save-bar block")
+	}
+	saveBarEnd := strings.Index(html[saveBarIdx:], "</div>")
+	if saveBarEnd < 0 {
+		t.Fatal("malformed save-bar block")
+	}
+	saveBarBlock := html[saveBarIdx : saveBarIdx+saveBarEnd+200]
+	if !strings.Contains(saveBarBlock, `onclick="saveSettingsImmediate()"`) {
+		t.Errorf("Save All Settings button must call saveSettingsImmediate() directly so explicit clicks bypass the debounce, got block:\n%s", saveBarBlock)
+	}
+
+	// (4) The async body (fetch + .then chain + .catch error
+	// path) must live inside saveSettingsImmediate, not the
+	// debounced wrapper. We anchor on the function header and
+	// scan for the fetch + error toast pattern within it.
+	immStart := strings.Index(html, "function saveSettingsImmediate()")
+	if immStart < 0 {
+		t.Fatal("saveSettingsImmediate not found")
+	}
+	// Scan the next ~3000 chars — enough to cover the body, well
+	// short of the next top-level function.
+	tail := immStart + 3000
+	if tail > len(html) {
+		tail = len(html)
+	}
+	body := html[immStart:tail]
+	if !strings.Contains(body, `fetch("/api/v1/settings"`) {
+		t.Error("saveSettingsImmediate must contain the PUT /api/v1/settings fetch call")
+	}
+	if !strings.Contains(body, `method: "PUT"`) {
+		t.Error("saveSettingsImmediate must issue a PUT request")
+	}
+	if !strings.Contains(body, `showToast("Error: " + e.message, "error")`) {
+		t.Error("saveSettingsImmediate must preserve the .catch error-toast path so debouncing does not swallow failures")
+	}
+	if !strings.Contains(body, `showToast("Settings saved", "success")`) {
+		t.Error("saveSettingsImmediate must preserve the success toast")
+	}
+	if !strings.Contains(body, "markSaved()") {
+		t.Error("saveSettingsImmediate must preserve the markSaved() call so the sticky bar dismisses after a save")
+	}
+
+	// The debounced wrapper's body should be small — roughly the
+	// clearTimeout + setTimeout pair, no fetch. Pin that the
+	// fetch lives ONLY in the immediate variant.
+	wrapStart := strings.Index(html, "function saveSettings() {")
+	if wrapStart < 0 {
+		t.Fatal("saveSettings wrapper not found")
+	}
+	wrapEnd := strings.Index(html[wrapStart:], "\n}\n")
+	if wrapEnd < 0 {
+		t.Fatal("saveSettings wrapper has no closing brace")
+	}
+	wrapBody := html[wrapStart : wrapStart+wrapEnd]
+	if strings.Contains(wrapBody, `fetch("/api/v1/settings"`) {
+		t.Errorf("saveSettings (the debounced wrapper) must NOT issue the fetch directly — the PUT belongs in saveSettingsImmediate. Wrapper body:\n%s", wrapBody)
+	}
+}

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -1003,7 +1003,7 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
 <div class="save-bar" id="save-bar">
   <div class="save-bar-inner">
     <span class="save-bar-text" id="save-bar-text">Unsaved changes</span>
-    <button class="btn btn-primary" onclick="saveSettings()">Save All Settings</button>
+    <button class="btn btn-primary" onclick="saveSettingsImmediate()">Save All Settings</button>
   </div>
 </div>
 
@@ -2095,7 +2095,12 @@ function smartMaxAgeConflictConfirm(payload) {
   } catch (e) { return true; }
 }
 
-function saveSettings() {
+function saveSettingsImmediate() {
+  // Cancel any pending debounced save — this immediate call supersedes it.
+  if (saveSettingsDebounceTimer !== null) {
+    clearTimeout(saveSettingsDebounceTimer);
+    saveSettingsDebounceTimer = null;
+  }
   var payload = buildSettingsPayload();
   if (!smartMaxAgeConflictConfirm(payload)) {
     showToast("Save aborted", "info");
@@ -2127,6 +2132,28 @@ function saveSettings() {
     renderServiceChecks();
   })
   .catch(function(e) { showToast("Error: " + e.message, "error"); });
+}
+
+// Debounce window for auto-save flows (#258). 300ms collapses the
+// rapid-fire PUT cycle observed during v0.9.8-rc1 UAT (7 saves in
+// ~1s while clicking through a per-subsystem interval picker
+// dropdown) into a single PUT after the user stops triggering
+// changes. The explicit "Save All Settings" button calls
+// saveSettingsImmediate() directly so user-initiated saves are
+// never delayed. Errors from the network/validation path are
+// surfaced via the existing showToast("Error: ...") in
+// saveSettingsImmediate, so debouncing does not swallow failures.
+var SAVE_SETTINGS_DEBOUNCE_MS = 300;
+var saveSettingsDebounceTimer = null;
+
+function saveSettings() {
+  if (saveSettingsDebounceTimer !== null) {
+    clearTimeout(saveSettingsDebounceTimer);
+  }
+  saveSettingsDebounceTimer = setTimeout(function() {
+    saveSettingsDebounceTimer = null;
+    saveSettingsImmediate();
+  }, SAVE_SETTINGS_DEBOUNCE_MS);
 }
 
 /* ---------- Webhooks ---------- */


### PR DESCRIPTION
Closes #258

## Summary

Wrap the 49 auto-save callsites in a 300ms debounce so a burst of
change events collapses into a single `PUT /api/v1/settings` after the
user stops triggering changes. The explicit "Save All Settings"
sticky-bar button bypasses the debounce so user-initiated saves remain
synchronous. Error reporting is preserved untouched.

## Before / after

- **Before** (v0.9.8-rc1 log, real UAT): 7 full settings-save cycles
  in ~1s (150-200ms apart) while clicking through ~2 per-subsystem
  interval pickers — every picker `change` event fired `saveSettings()`
  unthrottled.
- **After**: The same picker walk produces **1 PUT** ~300ms after the
  user stops. Each click within the 300ms window cancels the pending
  timer and reschedules — only the final state is persisted.

## Why 300ms

- Short enough to be invisible to users (well below the 500ms
  perceptible-delay threshold).
- Long enough to coalesce the 150-200ms cadence observed in the rc1
  log (each click would fall inside the window of the previous click,
  so the timer keeps getting reset until the user actually stops).
- Hardcoded as `SAVE_SETTINGS_DEBOUNCE_MS = 300` per the issue scope —
  not user-configurable.

## Implementation

- `saveSettings()` is now a thin wrapper: `clearTimeout` any pending
  timer, then `setTimeout(saveSettingsImmediate, 300)`. The 49 existing
  call sites are untouched and now flow through the debounce.
- `saveSettingsImmediate()` hosts the async body verbatim — `fetch`,
  `.then` chain (settings/webhooks/rules/maintenance/checks state
  rehydration, `showToast("Settings saved")`, `markSaved()`, theme
  apply), and `.catch` error path with `showToast("Error: ...")`.
  Errors from the network/validation path therefore still surface to
  the user, just delayed by at most one debounce window — debouncing
  does **not** swallow failures.
- `saveSettingsImmediate()` cancels any pending debounced save before
  firing so the explicit "Save All Settings" button supersedes a
  pending auto-save (no double PUT).
- The sticky save-bar button at line 1006 changes from
  `onclick="saveSettings()"` to `onclick="saveSettingsImmediate()"` so
  explicit user clicks are never delayed.

## Tests

- **New**: `TestSettingsHTML_SaveSettingsIsDebounced` pins the wrapper
  shape (`setTimeout` + `clearTimeout`), the 300ms constant, the
  `saveSettingsImmediate` name, the Save-bar button's bypass of the
  debounce, and confirms the `fetch` + `showToast("Error: ...")` paths
  live in `saveSettingsImmediate` (not the wrapper).
- **Continues to pass**: `TestSettingsTemplate_JSBlocksParse` (the
  `node --check` JS-parse harness — exercised every `<script>` block
  including the new wrapper, no `*/`-in-`/* */`-comment hazard).

## §4b pre-push checks

- `go build ./...` — clean
- `go test ./internal/api/... -race -count=1` — `ok 3.229s`
- `go vet ./...` — clean
- `gofmt -l internal/api/templates/settings.html
  internal/api/settings_save_debounce_test.go` — empty (other gofmt
  reports on `gofmt -l .` are pre-existing in unrelated files; not
  touched by this PR)

## Scope

Tight: 1 production file (`internal/api/templates/settings.html`,
+27 / -2) and 1 new test file (`internal/api/settings_save_debounce_test.go`,
+128). No other changes.