### PR TITLE
fix(service-checks): hide fleet-instance picker for type=speed (#215)

### DIFF
--- a/internal/api/settings_service_check_speed_fleet_target_test.go
+++ b/internal/api/settings_service_check_speed_fleet_target_test.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestSettingsHTML_OnServiceTypeChange_HidesInstanceForSpeedType pins
+// issue #215's UI fix: when the user picks type=speed in the
+// service-check editor, onServiceTypeChange must hide the
+// sc-instance-wrap (the fleet-target picker) AND coerce the
+// sc-instance value back to "" so the saved payload doesn't carry a
+// stale fleet ID.
+//
+// Background: every service-check type ignores ServiceCheckConfig.
+// Instance — the scheduler does not dispatch to peers, it always runs
+// the check against local state (resolvers, sockets, history rows).
+// For type=speed this is especially confusing because the dashboard
+// reads from the local speedtest_history table; selecting a peer in
+// the dropdown would silently measure the local instance's WAN. The
+// safest UX is to remove the option for the type that makes the
+// confusion most acute.
+//
+// If a future PR wires up real fleet dispatch (likely alongside #205
+// — Uptime Kuma federation — which needs the same primitives), this
+// test will fail and the diff will surface the deliberate behaviour
+// change.
+func TestSettingsHTML_OnServiceTypeChange_HidesInstanceForSpeedType(t *testing.T) {
+	html := loadSettingsHTML(t)
+
+	startRe := regexp.MustCompile(`function\s+onServiceTypeChange\s*\(\s*\)\s*\{`)
+	loc := startRe.FindStringIndex(html)
+	if loc == nil {
+		t.Fatal("onServiceTypeChange() not found in settings.html")
+	}
+	// Function body window — generous because this function has grown
+	// over time as new check types were added; 4 KB easily covers it.
+	end := loc[1] + 4000
+	if end > len(html) {
+		end = len(html)
+	}
+	body := html[loc[0]:end]
+
+	if !strings.Contains(body, `"sc-instance-wrap"`) {
+		t.Errorf("onServiceTypeChange should reference sc-instance-wrap; body:\n%s", body)
+	}
+	if !strings.Contains(body, `"sc-instance"`) {
+		t.Errorf("onServiceTypeChange should reference sc-instance (to clear its value); body:\n%s", body)
+	}
+	// The function body must contain a guard that, when type === "speed",
+	// hides the wrap. Two-axis check: (1) the type comparison appears,
+	// (2) the wrap's display is set to "none" within speed-type scope.
+	speedGuard := regexp.MustCompile(`type\s*===\s*["']speed["']`)
+	if !speedGuard.MatchString(body) {
+		t.Errorf("onServiceTypeChange should branch on type=='speed'; body:\n%s", body)
+	}
+	// String-match on the precise pair we wrote to make a "fixed but
+	// later silently regressed" outcome impossible: hiding the wrap
+	// AND clearing the value have to both be present. If a future
+	// refactor changes the local variable name, this test will fail
+	// and force the author to update the regression guard
+	// deliberately.
+	if !regexp.MustCompile(`instanceWrap\.style\.display\s*=\s*"none"`).MatchString(body) {
+		t.Errorf("onServiceTypeChange should set instanceWrap.style.display=\"none\" for type=speed; body:\n%s", body)
+	}
+	if !regexp.MustCompile(`instanceSelect\.value\s*=\s*""`).MatchString(body) {
+		t.Errorf("onServiceTypeChange should clear instanceSelect.value for type=speed; body:\n%s", body)
+	}
+}
+
+// TestSettingsHTML_InstanceFieldStillExistsForOtherTypes is a defensive
+// guard: the fix for #215 is type-targeted; it must NOT remove the
+// sc-instance-wrap markup from the template (existing fleet-targeted
+// HTTP/TCP/etc. checks still need to render their picker on edit). We
+// pin both the wrapper element and the select so a future cleanup PR
+// that decides to remove the picker globally is forced to update this
+// test deliberately.
+func TestSettingsHTML_InstanceFieldStillExistsForOtherTypes(t *testing.T) {
+	html := loadSettingsHTML(t)
+
+	if !strings.Contains(html, `id="sc-instance-wrap"`) {
+		t.Error("settings.html missing sc-instance-wrap container — fleet picker removed entirely?")
+	}
+	if !strings.Contains(html, `id="sc-instance"`) {
+		t.Error("settings.html missing sc-instance select — fleet picker removed entirely?")
+	}
+}

--- a/internal/api/settings_service_check_test_button_test.go
+++ b/internal/api/settings_service_check_test_button_test.go
@@ -120,10 +120,12 @@ func TestSettingsHTML_SpeedCheckInterval_DefaultsToDaily(t *testing.T) {
 	if loc == nil {
 		t.Fatal("onServiceTypeChange() function not found")
 	}
-	// Window widened from 2000 → 2500 to accommodate additional
-	// type-specific branches (traceroute, #189). The function body is
-	// still comfortably <3000 chars.
-	end := loc[1] + 2500
+	// Window widened over time as new type-specific branches were added:
+	// 2000 → 2500 (traceroute, #189) → 4000 (instance-picker hide for
+	// type=speed, #215). The function body is still comfortably <5000
+	// chars; bump again if a future branch pushes the interval-check
+	// past the window.
+	end := loc[1] + 4000
 	if end > len(html) {
 		end = len(html)
 	}

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -2496,12 +2496,36 @@ function onServiceTypeChange() {
   var traceWrap = document.getElementById("sc-traceroute-wrap");
   var dnsWrap = document.getElementById("sc-dns-wrap");
   var targetWrap = document.getElementById("sc-target-wrap");
+  var instanceWrap = document.getElementById("sc-instance-wrap");
   if (httpWrap) httpWrap.style.display = (type === "http") ? "block" : "none";
   if (portWrap) portWrap.style.display = (type === "tcp" || type === "smb" || type === "nfs") ? "block" : "none";
   if (headersWrap) headersWrap.style.display = (type === "http") ? "block" : "none";
   if (speedWrap) speedWrap.style.display = (type === "speed") ? "block" : "none";
   if (traceWrap) traceWrap.style.display = (type === "traceroute") ? "block" : "none";
   if (dnsWrap) dnsWrap.style.display = (type === "dns") ? "block" : "none";
+  // Issue #215 — fleet-instance targeting is decorative metadata for every
+  // check type (the scheduler does not dispatch to peers; checks always run
+  // locally). For type=speed this is especially confusing because the
+  // dashboard reads from the local speedtest_history table, so picking a
+  // peer in the dropdown would silently measure the local instance's WAN.
+  // Hide the picker AND coerce the value back to "" (local) so the saved
+  // payload doesn't carry a stale fleet ID that would mislead a future
+  // version where fleet dispatch lands. Existing saved checks that already
+  // have a fleet instance get their value cleared on next edit-save round
+  // through this form (deliberately conservative — no silent on-load
+  // mutation of stored config).
+  var instanceSelect = document.getElementById("sc-instance");
+  if (type === "speed") {
+    if (instanceWrap) instanceWrap.style.display = "none";
+    if (instanceSelect) instanceSelect.value = "";
+  } else if (instanceWrap) {
+    // Restore the default visibility logic: show the wrap only when there
+    // is at least one fleet server configured. populateInstanceSelector()
+    // sets this on form open/edit; we mirror its rule here so toggling
+    // away from speed re-shows it correctly without re-running the full
+    // populate (which would clobber the user's currently-selected option).
+    instanceWrap.style.display = (typeof fleetServers !== "undefined" && fleetServers && fleetServers.length > 0) ? "" : "none";
+  }
   // Hide target field for speed checks — speedtest auto-selects the best server
   if (targetWrap) targetWrap.style.display = (type === "speed") ? "none" : "";
   var targetInput = document.getElementById("sc-target");

--- a/internal/scheduler/checks.go
+++ b/internal/scheduler/checks.go
@@ -577,6 +577,14 @@ func extractPacketLossPercent(out string) float64 {
 // alongside #205 — Uptime Kuma federation — which needs the same
 // primitives).
 //
+// Issue #215 resolution: starting in v0.9.x the Settings UI hides the
+// Instance picker when type=speed is selected, so newly-saved speed
+// checks always carry Instance="". Legacy saved configs created
+// before that fix may still arrive here with a non-empty Instance —
+// we ignore it (read local history regardless) rather than silently
+// dropping it on load. Documented + pinned by
+// TestRunSpeedCheck_FleetTargetReadsLocalHistory.
+//
 // Test-button carve-out: the /api/v1/service-checks/test endpoint
 // (handleTestServiceCheck) builds a fresh ServiceChecker and injects
 // collector.RunSpeedTest via SetSpeedTestRunner. When the runner is

--- a/internal/scheduler/checks_speed_fleet_target_test.go
+++ b/internal/scheduler/checks_speed_fleet_target_test.go
@@ -1,0 +1,82 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// TestRunSpeedCheck_FleetTargetReadsLocalHistory pins issue #215's
+// resolution: a legacy saved speed check carrying a non-empty
+// Instance (= a fleet server ID) is evaluated against the LOCAL
+// speedtest_history table, exactly the same as a check with
+// Instance="". This is the same behaviour as every other service
+// check type — the Instance field is decorative metadata that the
+// scheduler does not dispatch on (see runSpeedCheck docstring +
+// internal/models.go ServiceCheckConfig.Instance docs).
+//
+// The actual user-visible fix is in the Settings UI
+// (onServiceTypeChange in settings.html hides the Instance picker
+// when type=speed and coerces the value to ""). This test exists
+// because legacy saved configs may already have a non-empty
+// Instance and we want to document + guard the runtime behaviour:
+// the scheduler reads local data and never silently routes
+// elsewhere. If a future PR wires up real fleet dispatch (alongside
+// #205), this test will fail and the diff will surface the
+// behaviour change for explicit review.
+func TestRunSpeedCheck_FleetTargetReadsLocalHistory(t *testing.T) {
+	tests := []struct {
+		name     string
+		instance string
+	}{
+		{"local target (Instance empty)", ""},
+		{"legacy fleet target (Instance set)", "fleet-server-id-abc123"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sc, store := newTestChecker()
+
+			now := time.Now().UTC()
+			if err := store.SaveSpeedTestAttempt(storage.LastSpeedTestAttempt{
+				Timestamp: now.Add(-1 * time.Minute),
+				Status:    "success",
+			}); err != nil {
+				t.Fatalf("SaveSpeedTestAttempt: %v", err)
+			}
+			if err := store.SaveSpeedTest("local-row-1", &internal.SpeedTestResult{
+				Timestamp:    now.Add(-1 * time.Minute),
+				DownloadMbps: 750,
+				UploadMbps:   200,
+				LatencyMs:    8,
+			}); err != nil {
+				t.Fatalf("SaveSpeedTest: %v", err)
+			}
+
+			check := internal.ServiceCheckConfig{
+				Name:     "speed-fleet-or-local",
+				Type:     internal.ServiceCheckSpeed,
+				Enabled:  true,
+				Instance: tc.instance,
+				// Blank thresholds → success path = up regardless
+				// of measured throughput. Lets us prove the path
+				// reached the local history row.
+			}
+
+			result := sc.RunCheck(check, now)
+			if result.Status != "up" {
+				t.Fatalf("expected up (local history is %.0f/%.0f Mbps), got %q (error=%q)",
+					750.0, 200.0, result.Status, result.Error)
+			}
+			if result.DownloadMbps != 750 {
+				t.Errorf("DownloadMbps = %.0f, want 750 (proves local history was read regardless of Instance=%q)",
+					result.DownloadMbps, tc.instance)
+			}
+			if result.UploadMbps != 200 {
+				t.Errorf("UploadMbps = %.0f, want 200 (proves local history was read regardless of Instance=%q)",
+					result.UploadMbps, tc.instance)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #215.

## Investigation finding

**Outcome (a) from the dispatch prompt: reads local regardless.**

`ServiceCheckConfig.Instance` is purely decorative metadata across every
service-check type — the scheduler does not dispatch to peers, all
checks run against local state.

Confirmed by source-tree grep: the only two non-test references to
`check.Instance` in the scheduler/api production code are the
docstrings that explicitly document this as a known limitation:

- `internal/scheduler/checks.go:571-578` — `runSpeedCheck` docstring
- `internal/models.go:230-247` — `ServiceCheckConfig.Instance` field doc

Fleet aggregation works by each peer independently running its own
checks and the hub reading pre-computed results from peer snapshots
(see `internal/fleet/fleet.go`) — NOT by remote dispatch.

For `type=speed` specifically, `runSpeedCheck` reads the LOCAL
`speedtest_history` table regardless of `Instance`. Selecting a peer in
the picker would silently measure the LOCAL instance's WAN — exactly
the v0.9.x's most-confusing failure mode for a UI option.

## Fix

UI surgical: `onServiceTypeChange()` in `settings.html` now hides
`sc-instance-wrap` and coerces `sc-instance.value` back to `""` when
the user picks `type=speed`. Other check types are unaffected — the
picker still appears whenever fleet servers are configured.

Chose this over removing `speed` from the Type dropdown so the user
flow remains symmetrical with every other check type — speed isn't
"missing", it just doesn't have a fleet-target sub-control.

Backend behaviour PINNED, not changed: even legacy saved configs that
arrive with a non-empty `Instance` continue to evaluate against local
`speedtest_history`. No silent on-load mutation of stored config —
existing configs get cleared on the next edit-save round through this
form (deliberately conservative).

## Tests

1. `TestRunSpeedCheck_FleetTargetReadsLocalHistory` (new, scheduler)
   table-driven: `Instance=""` and `Instance="fleet-server-id-abc123"`
   both read the same local `speedtest_history` row. Pins behaviour so
   a future PR wiring up real fleet dispatch (likely alongside #205 —
   Uptime Kuma federation, which needs the same primitives) is forced
   to update the test deliberately.

2. `TestSettingsHTML_OnServiceTypeChange_HidesInstanceForSpeedType` (new, api)
   regex-grep on the `onServiceTypeChange` function body: must hide
   `instanceWrap.style.display = "none"` AND clear
   `instanceSelect.value = ""` for `type === "speed"`.

3. `TestSettingsHTML_InstanceFieldStillExistsForOtherTypes` (new, api)
   defensive guard: the picker markup itself must not be removed —
   existing fleet-targeted HTTP/TCP/etc. checks still need it.

4. `TestSettingsTemplate_JSBlocksParse` continues to pass (regression
   guard from v0.9.9-rc1 — `node --check` against every `<script>`
   block).

5. `TestSettingsHTML_SpeedCheckInterval_DefaultsToDaily` (existing)
   needed its function-body window widened from 2500 → 4000 chars to
   accommodate the new branch. Comment updated to track the history.

## §4b pre-push verification

- `go build ./...` ✅
- `go test ./... -race -count=1` ✅ (full suite green, including the
  new tests)
- `go vet ./...` ✅
- `gofmt -l` of files changed in this PR ✅ (pre-existing gofmt drift
  on main against unrelated files is out of scope)