### PR TITLE
feat(service-checks): live-progress streaming for traceroute Test button via SSE (#224 traceroute slice)

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -54,6 +54,12 @@ type Server struct {
 	// to collector.RunMTR. Tests override this to inject deterministic
 	// results without needing mtr installed. See issue #189.
 	tracerouteRunner scheduler.TracerouteRunner
+	// streamingTracerouteRunner is the function invoked by
+	// handleTestServiceCheckStream for the SSE Test endpoint. Nil
+	// means the handler will fall back to collector.RunStreamingMTR.
+	// Tests inject a fake so they don't need a real mtr binary.
+	// Issue #224.
+	streamingTracerouteRunner collector.StreamingTracerouteRunner
 	// borgRunner is the BorgRunner used by the external-Borg Test
 	// endpoint (POST /api/v1/backup-monitor/borg/test) and the
 	// scheduler's external-repo polling. Nil means the handler
@@ -146,6 +152,11 @@ func (s *Server) Router() http.Handler {
 	// 10-60s, so we can't subject them to the 30s router-wide timeout.
 	// RunCheck uses its own per-check context from cfg.TimeoutSec.
 	r.Post("/api/v1/service-checks/test", s.handleTestServiceCheck)
+	// SSE streaming variant for long-running Test invocations
+	// (traceroute only in this slice — issue #224). Lives outside
+	// the Timeout group so the EventSource connection can stay
+	// open for the full 10-cycle traceroute (~10-30s).
+	r.Post("/api/v1/service-checks/test-stream", s.handleTestServiceCheckStream)
 
 	// SSE live-progress endpoints (PRD #283 / issue #285). Both routes
 	// run OUTSIDE the 30s Timeout group: POST /run kicks off a 30-60s

--- a/internal/api/service_check_test_stream.go
+++ b/internal/api/service_check_test_stream.go
@@ -201,15 +201,25 @@ loop:
 			// schedule `final` before pending `updates` when
 			// both are ready, and we don't want the SSE
 			// consumer to miss a hop event the runner emitted.
-			// updates is closed by the runner so the loop
-			// terminates naturally.
-			for u := range updates {
-				if !writeSSEEvent(w, flusher, "hop", map[string]any{
-					"cycle":        u.Cycle,
-					"total_cycles": u.TotalCycle,
-					"hops":         u.Hops,
-				}) {
-					return
+			//
+			// CRITICAL: guard against `updates == nil`. When the
+			// updates channel closes BEFORE final arrives in the
+			// outer select (a legal ordering when the runner
+			// closes both channels back-to-back via defers and
+			// CI scheduling drains updates first), the
+			// `case u, ok := <-updates: if !ok { updates = nil }`
+			// branch above sets the local var to nil. Ranging
+			// over a nil channel blocks forever — the original
+			// handler bug that caused the v0.9.15-rc1 CI hang.
+			if updates != nil {
+				for u := range updates {
+					if !writeSSEEvent(w, flusher, "hop", map[string]any{
+						"cycle":        u.Cycle,
+						"total_cycles": u.TotalCycle,
+						"hops":         u.Hops,
+					}) {
+						return
+					}
 				}
 			}
 			break loop

--- a/internal/api/service_check_test_stream.go
+++ b/internal/api/service_check_test_stream.go
@@ -1,0 +1,242 @@
+// service_check_test_stream.go — SSE streaming variant of the
+// service-checks Test button (issue #224).
+//
+// Scope decision (deliberately narrow): this slice ONLY supports
+// type=traceroute. The dashboard's Speed Test card already has a
+// dedicated SSE live-progress strip (v0.9.11), and adding a second
+// streaming surface for the type=speed Test button is out of scope
+// for #224's first PR. Non-trace requests are rejected with 400 and
+// a hint pointing at the existing synchronous /service-checks/test
+// endpoint, so the JS Test-button wiring can fall back cleanly.
+//
+// Wire format mirrors the v0.9.11 speedtest SSE contract:
+//
+//	event: start
+//	data: {"target":"8.8.8.8","cycles":10,"started_at":"..."}
+//
+//	event: hop
+//	data: {"cycle":1,"total_cycles":10,"hops":[{"count":1,"host":"...","Loss%":0,"Avg":...}, ...]}
+//
+//	event: result
+//	data: <ServiceCheckResult shape — same as POST /test sync endpoint>
+//
+//	event: end
+//	data: {"duration_seconds":12.4}
+//
+// The terminal `result` event's payload is byte-identical to the
+// synchronous /test endpoint's response so the JS renderer can reuse
+// renderServiceCheckDetails verbatim. The `hop` event's `hops` array
+// is cumulative — every event carries the full hop table so far,
+// not a delta — to keep the renderer code path identical for live
+// vs final state.
+//
+// Process-group SIGKILL on context cancellation (v0.9.14 #304
+// pattern) is delegated to RunStreamingMTR. When the EventSource
+// closes client-side, ctx fires; the streaming runner's goroutine
+// sees ctx.Done(), returns, and the writer goroutine here exits.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+	"github.com/mcdays94/nas-doctor/internal/collector"
+	"github.com/mcdays94/nas-doctor/internal/scheduler"
+)
+
+// streamingTracerouteCycles is the cycle count used by the streaming
+// Test endpoint. Matches the synchronous Test button (10 — richer
+// sample than the scheduler's 5) so users get a comparable picture
+// of network health from both surfaces.
+const streamingTracerouteCycles = 10
+
+// handleTestServiceCheckStream is the SSE variant of
+// handleTestServiceCheck. POST a ServiceCheckConfig with type=trace,
+// receive a text/event-stream response with one `start` event,
+// per-cycle `hop` events with cumulative hop tables, one terminal
+// `result` event whose body matches the sync endpoint's response,
+// and a final `end` event.
+//
+// POST /api/v1/service-checks/test-stream
+//
+// Non-trace types: 400 with a hint pointing at the sync endpoint.
+// Issue #224 narrows this slice to traceroute; speed-type was
+// considered but its streaming surface is already covered by the
+// dashboard's /api/v1/speedtest/run + /stream pair. A future PR can
+// add type=speed support here if the settings-page Test button
+// wants live progress too.
+func (s *Server) handleTestServiceCheckStream(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to read request body"})
+		return
+	}
+	defer r.Body.Close()
+
+	var cfg internal.ServiceCheckConfig
+	if err := json.Unmarshal(body, &cfg); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		return
+	}
+	if err := normalizeServiceCheckConfig(&cfg); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if cfg.Type != internal.ServiceCheckTraceroute {
+		// Non-trace types: redirect via a 400 with a hint. The
+		// settings.html JS only opens this stream for type=trace
+		// configs, so this path is defensive — exercised by direct
+		// curl / external tooling that POSTs the wrong shape.
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": fmt.Sprintf("/test-stream only supports type=traceroute (got %q); use POST /api/v1/service-checks/test for synchronous types", cfg.Type),
+		})
+		return
+	}
+
+	// SSE headers — same defensive set as speedtest_sse.go. Explicit
+	// charset prevents content-sniffing proxies from second-guessing
+	// the MIME and re-engaging compression. no-transform discourages
+	// CDN auto-gzip from buffering chunks. X-Accel-Buffering: no is
+	// a hint to nginx-style intermediaries to flush per chunk.
+	// Connection: keep-alive is implied by HTTP/1.1 but stated
+	// explicitly so reviewers reading the headers understand intent.
+	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, no-transform")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.Header().Set("Connection", "keep-alive")
+
+	// Disable per-connection write deadlines — a 10-cycle traceroute
+	// can take 30-60s on slow paths, which would otherwise trip the
+	// http.Server WriteTimeout=30s baseline set in main.go.
+	if rc := http.NewResponseController(w); rc != nil {
+		_ = rc.SetWriteDeadline(time.Time{})
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	// Resolve the streaming runner — production wiring uses
+	// collector.RunStreamingMTR; tests inject a fake via
+	// s.streamingTracerouteRunner so they don't need an actual mtr
+	// binary. Mirrors the existing tracerouteRunner seam used by
+	// the sync /test endpoint.
+	runner := s.streamingTracerouteRunner
+	if runner == nil {
+		runner = collector.RunStreamingMTR
+	}
+
+	target := cfg.Target
+	startedAt := time.Now()
+
+	// Emit the start event before kicking off the runner so the
+	// dashboard sees something immediately (defeats the perceived
+	// "dead spinner" problem #224 was filed to address).
+	if !writeSSEEvent(w, flusher, "start", map[string]any{
+		"target":     target,
+		"cycles":     streamingTracerouteCycles,
+		"started_at": startedAt.Format(time.RFC3339Nano),
+	}) {
+		return
+	}
+
+	// Initial padding to defeat first-N-bytes proxy buffers — same
+	// rationale as speedtest_sse.go (Cloudflare et al. hold the
+	// first chunk until ~2KB has accumulated; without this the
+	// per-cycle hop events stack up invisibly until the test ends).
+	if !writeSSEPadding(w, flusher) {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	updates, final := runner(ctx, target, streamingTracerouteCycles)
+
+	// Heartbeat so chunk-coalescing intermediaries keep flushing
+	// between cycles. Same pattern as speedtest_sse.go.
+	heartbeat := time.NewTicker(1 * time.Second)
+	defer heartbeat.Stop()
+
+	clientGone := r.Context().Done()
+
+	var lastResult *collector.MTRResult
+	var runErr error
+
+loop:
+	for {
+		select {
+		case <-heartbeat.C:
+			if !writeSSEHeartbeat(w, flusher) {
+				return
+			}
+		case u, ok := <-updates:
+			if !ok {
+				updates = nil
+				continue
+			}
+			if !writeSSEEvent(w, flusher, "hop", map[string]any{
+				"cycle":        u.Cycle,
+				"total_cycles": u.TotalCycle,
+				"hops":         u.Hops,
+			}) {
+				return
+			}
+		case fin, ok := <-final:
+			if !ok {
+				break loop
+			}
+			lastResult = fin.Result
+			runErr = fin.RunErr
+			// Drain any buffered updates that the runner pushed
+			// before its terminal value — Go's select can
+			// schedule `final` before pending `updates` when
+			// both are ready, and we don't want the SSE
+			// consumer to miss a hop event the runner emitted.
+			// updates is closed by the runner so the loop
+			// terminates naturally.
+			for u := range updates {
+				if !writeSSEEvent(w, flusher, "hop", map[string]any{
+					"cycle":        u.Cycle,
+					"total_cycles": u.TotalCycle,
+					"hops":         u.Hops,
+				}) {
+					return
+				}
+			}
+			break loop
+		case <-clientGone:
+			// Browser closed the EventSource — ctx cancellation
+			// will propagate to the runner via the ctx wired into
+			// the runner above; bail without writing terminal
+			// events (the connection is already dead).
+			return
+		}
+	}
+
+	// Build the canonical ServiceCheckResult so the SSE wire's
+	// terminal `result` event matches the sync endpoint's response
+	// shape. We re-use scheduler's RunCheck path with an injected
+	// runner that returns the streamed result — this guarantees
+	// thresholds, MaxLossPct policy, status determination, and
+	// the Details map are computed exactly as on the sync path.
+	checker := scheduler.NewServiceChecker(s.store, s.logger)
+	checker.SetCollectDetails(true)
+	checker.SetTraceRunner(func(_ string, _ int) (*collector.MTRResult, error) {
+		return lastResult, runErr
+	})
+	scResult := checker.RunCheck(cfg, time.Now().UTC())
+
+	_ = writeSSEEvent(w, flusher, "result", scResult)
+	_ = writeSSEEvent(w, flusher, "end", map[string]any{
+		"duration_seconds": time.Since(startedAt).Seconds(),
+	})
+}

--- a/internal/api/service_check_test_stream_test.go
+++ b/internal/api/service_check_test_stream_test.go
@@ -5,11 +5,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -67,7 +69,19 @@ func parseTraceSSEStream(body io.Reader) ([]sseEvent, error) {
 // TestServiceChecksTestStream_TraceHappyPath — type=trace request
 // produces start + per-cycle hop + result + end events with parseable
 // JSON payloads.
+//
+// Regression guard: the test asserts the WHOLE flow completes in
+// well under 5s. A nil-channel range bug caused
+// v0.9.15-rc1 CI to hang for the full 10-minute test timeout while
+// the local dev box passed in <100ms — Go's select is pseudo-random
+// and the local box happened to schedule `final` before all
+// `updates` had drained, hitting a safe code path that masked the
+// bug. The deadline is the discipline that keeps a recurrence loud
+// and fast instead of silent and slow.
 func TestServiceChecksTestStream_TraceHappyPath(t *testing.T) {
+	deadline := assertCompletesWithin(t, 5*time.Second)
+	defer deadline()
+
 	srv := newSettingsTestServer()
 
 	// Inject a fake streaming runner that emits 3 cumulative hop
@@ -308,6 +322,115 @@ func TestServiceChecksTestStream_CtxCancelKillsRunner(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("runner did not exit within 2s of client cancel — ctx cancellation not propagating")
 	}
+}
+
+// TestServiceChecksTestStream_UpdatesCloseBeforeFinal — pins the
+// exact channel-ordering edge case that caused the v0.9.15-rc1 CI
+// hang. Drives the runner to close `updates` BEFORE emitting
+// `final` so the handler's outer select observes the
+// `case u, ok := <-updates: if !ok { updates = nil }` branch
+// FIRST, and only then sees `final`. Without the nil-channel
+// guard, the post-final drain `for u := range updates` ranges
+// over a nil channel and blocks forever.
+//
+// Local dev boxes hit this rarely because Go's select is
+// pseudo-random and a small runner queue can complete in any
+// order. CI's slower scheduler made the bad ordering reliably
+// reproducible. This test pins the bad ordering deterministically
+// by using a stepped-channel runner.
+func TestServiceChecksTestStream_UpdatesCloseBeforeFinal(t *testing.T) {
+	deadline := assertCompletesWithin(t, 5*time.Second)
+	defer deadline()
+
+	srv := newSettingsTestServer()
+	srv.streamingTracerouteRunner = func(_ context.Context, target string, _ int) (<-chan collector.StreamingMTRUpdate, <-chan collector.StreamingTraceFinal) {
+		updates := make(chan collector.StreamingMTRUpdate, 1)
+		final := make(chan collector.StreamingTraceFinal)
+		// Push exactly one update, close updates immediately, THEN
+		// emit final on a separate goroutine after a short pause.
+		// This sequence forces the handler to:
+		//   1. select pulls the buffered update.
+		//   2. select pulls the close signal → updates set to nil.
+		//   3. select pulls final → enters drain branch.
+		// Without the nil-channel guard step 3 ranges over nil
+		// and blocks forever.
+		updates <- collector.StreamingMTRUpdate{
+			Cycle:      1,
+			TotalCycle: 1,
+			Hops:       []collector.MTRHop{{Count: 1, Host: "10.0.0.1", AvgMs: 0.5}},
+		}
+		close(updates)
+		go func() {
+			// Tiny pause so the handler definitely processes the
+			// updates close before final arrives — guarantees the
+			// nil-assignment branch fires.
+			time.Sleep(50 * time.Millisecond)
+			final <- collector.StreamingTraceFinal{
+				Result: &collector.MTRResult{
+					Target: target,
+					Hops:   []collector.MTRHop{{Count: 1, Host: "10.0.0.1", AvgMs: 0.5}},
+				},
+			}
+			close(final)
+		}()
+		return updates, final
+	}
+
+	resp := postTestStream(t, srv, map[string]any{
+		"name":   "trace-ordering",
+		"type":   "traceroute",
+		"target": "8.8.8.8",
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	events, err := parseTraceSSEStream(resp.Body)
+	if err != nil {
+		t.Fatalf("parse SSE: %v", err)
+	}
+	gotEnd := false
+	for _, e := range events {
+		if e.Event == "end" {
+			gotEnd = true
+			break
+		}
+	}
+	if !gotEnd {
+		t.Fatalf("expected terminal end event; sequence: %v", eventNames(events))
+	}
+}
+
+// assertCompletesWithin returns a stop function that, when invoked,
+// cancels the deadline timer. If the deadline expires before stop
+// is called the goroutine kills the process with a stack dump so
+// CI shows where the test was hung instead of timing out 10
+// minutes later. Mirrors the discipline added to the speedtest SSE
+// tests after the v0.9.11-rc UAT cycles.
+func assertCompletesWithin(t *testing.T, d time.Duration) func() {
+	t.Helper()
+	timer := time.AfterFunc(d, func() {
+		// Print every goroutine's stack so the cause of the hang
+		// is obvious in the failure log, then fail the test.
+		// We can't call t.Fatal from a non-test goroutine; the
+		// best alternative is panic which fails the test cleanly.
+		buf := make([]byte, 1<<20)
+		n := runtime.Stack(buf, true)
+		panic(fmt.Sprintf("test exceeded %s deadline; goroutine dump:\n%s", d, buf[:n]))
+	})
+	return func() { timer.Stop() }
+}
+
+// eventNames is a small helper for diagnostic output in failure
+// messages — turns a slice of sseEvent into a flat slice of event
+// names so the failure log shows the wire-level sequence.
+func eventNames(events []sseEvent) []string {
+	out := make([]string, len(events))
+	for i, e := range events {
+		out[i] = e.Event
+	}
+	return out
 }
 
 // TestServiceChecksHTML_TestStreamWiring — settings.html JS must

--- a/internal/api/service_check_test_stream_test.go
+++ b/internal/api/service_check_test_stream_test.go
@@ -1,0 +1,331 @@
+package api
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal/collector"
+)
+
+// postTestStream issues a POST to /api/v1/service-checks/test-stream
+// against the live router (so the chi route definition is exercised
+// alongside the handler). Returns the full response so the caller
+// can inspect headers + parse the SSE body.
+func postTestStream(t *testing.T, srv *Server, body any) *http.Response {
+	t.Helper()
+	buf, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	ts := httptest.NewServer(srv.Router())
+	t.Cleanup(ts.Close)
+	resp, err := http.Post(ts.URL+"/api/v1/service-checks/test-stream", "application/json", bytes.NewReader(buf))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	return resp
+}
+
+// parseTraceSSEStream parses the test-stream SSE body into a slice
+// of events. Stops at end-of-stream or `event: end`.
+func parseTraceSSEStream(body io.Reader) ([]sseEvent, error) {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	var events []sseEvent
+	var cur sseEvent
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "event: "):
+			cur.Event = strings.TrimPrefix(line, "event: ")
+		case strings.HasPrefix(line, "data: "):
+			cur.Data = strings.TrimPrefix(line, "data: ")
+		case line == "":
+			if cur.Event != "" {
+				events = append(events, cur)
+				if cur.Event == "end" {
+					return events, nil
+				}
+			}
+			cur = sseEvent{}
+		}
+	}
+	return events, scanner.Err()
+}
+
+// TestServiceChecksTestStream_TraceHappyPath — type=trace request
+// produces start + per-cycle hop + result + end events with parseable
+// JSON payloads.
+func TestServiceChecksTestStream_TraceHappyPath(t *testing.T) {
+	srv := newSettingsTestServer()
+
+	// Inject a fake streaming runner that emits 3 cumulative hop
+	// updates then finalises with a 3-hop result.
+	srv.streamingTracerouteRunner = func(ctx context.Context, target string, cycles int) (<-chan collector.StreamingMTRUpdate, <-chan collector.StreamingTraceFinal) {
+		updates := make(chan collector.StreamingMTRUpdate, 4)
+		final := make(chan collector.StreamingTraceFinal, 1)
+		go func() {
+			defer close(updates)
+			defer close(final)
+			hop1 := collector.MTRHop{Count: 1, Host: "10.0.0.1", AvgMs: 0.5}
+			hop2 := collector.MTRHop{Count: 2, Host: "203.0.113.1", AvgMs: 2.1}
+			hop3 := collector.MTRHop{Count: 3, Host: "8.8.8.8", AvgMs: 12.3}
+			updates <- collector.StreamingMTRUpdate{Cycle: 1, TotalCycle: 3, Hops: []collector.MTRHop{hop1}}
+			updates <- collector.StreamingMTRUpdate{Cycle: 2, TotalCycle: 3, Hops: []collector.MTRHop{hop1, hop2}}
+			updates <- collector.StreamingMTRUpdate{Cycle: 3, TotalCycle: 3, Hops: []collector.MTRHop{hop1, hop2, hop3}}
+			final <- collector.StreamingTraceFinal{
+				Result: &collector.MTRResult{
+					Target:     target,
+					Hops:       []collector.MTRHop{hop1, hop2, hop3},
+					FinalRTTMs: 12.3,
+				},
+			}
+		}()
+		return updates, final
+	}
+
+	resp := postTestStream(t, srv, map[string]any{
+		"name":   "trace-stream",
+		"type":   "traceroute",
+		"target": "8.8.8.8",
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+		t.Fatalf("Content-Type = %q, want text/event-stream prefix", got)
+	}
+	if got := resp.Header.Get("Cache-Control"); !strings.Contains(got, "no-cache") || !strings.Contains(got, "no-transform") {
+		t.Fatalf("Cache-Control = %q, want no-cache + no-transform", got)
+	}
+
+	events, err := parseTraceSSEStream(resp.Body)
+	if err != nil {
+		t.Fatalf("parse SSE: %v", err)
+	}
+
+	// Skim the event sequence. Expected order:
+	//   start, hop, hop, hop, result, end
+	// We don't pin exact event count past the minimum because
+	// heartbeat comments + race-induced re-orderings of the
+	// runner-vs-handler goroutines could reasonably produce
+	// extra harmless artefacts.
+	gotEvents := make([]string, 0, len(events))
+	for _, e := range events {
+		gotEvents = append(gotEvents, e.Event)
+	}
+	t.Logf("event sequence: %v", gotEvents)
+
+	if len(gotEvents) < 6 {
+		t.Fatalf("expected >= 6 events, got %d: %v", len(gotEvents), gotEvents)
+	}
+	if gotEvents[0] != "start" {
+		t.Errorf("event[0] = %q, want start", gotEvents[0])
+	}
+
+	hopCount := 0
+	resultIdx := -1
+	endIdx := -1
+	for i, ev := range gotEvents {
+		switch ev {
+		case "hop":
+			hopCount++
+		case "result":
+			resultIdx = i
+		case "end":
+			endIdx = i
+		}
+	}
+	if hopCount != 3 {
+		t.Errorf("expected 3 hop events, got %d", hopCount)
+	}
+	if resultIdx == -1 || endIdx == -1 || resultIdx >= endIdx {
+		t.Errorf("expected result before end, got result=%d end=%d", resultIdx, endIdx)
+	}
+
+	// Spot-check payload shapes.
+	for _, e := range events {
+		switch e.Event {
+		case "start":
+			var d struct {
+				Target string `json:"target"`
+				Cycles int    `json:"cycles"`
+			}
+			if err := json.Unmarshal([]byte(e.Data), &d); err != nil {
+				t.Errorf("start data malformed: %v (data=%s)", err, e.Data)
+			}
+			if d.Target != "8.8.8.8" {
+				t.Errorf("start.target = %q, want 8.8.8.8", d.Target)
+			}
+			if d.Cycles <= 0 {
+				t.Errorf("start.cycles = %d, want positive", d.Cycles)
+			}
+		case "hop":
+			var d struct {
+				Cycle       int                `json:"cycle"`
+				TotalCycles int                `json:"total_cycles"`
+				Hops        []collector.MTRHop `json:"hops"`
+			}
+			if err := json.Unmarshal([]byte(e.Data), &d); err != nil {
+				t.Errorf("hop data malformed: %v (data=%s)", err, e.Data)
+			}
+			if d.Cycle <= 0 || d.TotalCycles <= 0 {
+				t.Errorf("hop fields invalid: cycle=%d total=%d", d.Cycle, d.TotalCycles)
+			}
+		case "result":
+			// Spot-check that the result is the canonical
+			// ServiceCheckResult shape — same fields the sync
+			// /test endpoint produces. We don't pin status here
+			// because RunCheck applies thresholds; just assert
+			// type + structure.
+			var d map[string]any
+			if err := json.Unmarshal([]byte(e.Data), &d); err != nil {
+				t.Errorf("result data malformed: %v (data=%s)", err, e.Data)
+			}
+			if _, ok := d["status"]; !ok {
+				t.Errorf("result missing status field; data=%s", e.Data)
+			}
+		case "end":
+			var d struct {
+				DurationSeconds float64 `json:"duration_seconds"`
+			}
+			if err := json.Unmarshal([]byte(e.Data), &d); err != nil {
+				t.Errorf("end data malformed: %v", err)
+			}
+		}
+	}
+}
+
+// TestServiceChecksTestStream_NonTraceReturns400 — type=http (and
+// other non-trace types) must be rejected with 400 + a hint pointing
+// at the synchronous endpoint.
+func TestServiceChecksTestStream_NonTraceReturns400(t *testing.T) {
+	srv := newSettingsTestServer()
+	resp := postTestStream(t, srv, map[string]any{
+		"name":   "http-bad",
+		"type":   "http",
+		"target": "http://example.com",
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "/api/v1/service-checks/test") {
+		t.Errorf("expected hint pointing at /api/v1/service-checks/test, got: %s", body)
+	}
+	if !strings.Contains(string(body), "traceroute") {
+		t.Errorf("expected hint mentioning traceroute, got: %s", body)
+	}
+}
+
+// TestServiceChecksTestStream_CtxCancelKillsRunner — closing the
+// EventSource client-side must promptly cancel the runner ctx.
+// We assert by injecting a runner that blocks on ctx.Done() and
+// verifying that the function returns within a small budget after
+// the client closes the connection.
+func TestServiceChecksTestStream_CtxCancelKillsRunner(t *testing.T) {
+	srv := newSettingsTestServer()
+
+	runnerExited := make(chan struct{})
+	srv.streamingTracerouteRunner = func(ctx context.Context, _ string, _ int) (<-chan collector.StreamingMTRUpdate, <-chan collector.StreamingTraceFinal) {
+		updates := make(chan collector.StreamingMTRUpdate)
+		final := make(chan collector.StreamingTraceFinal, 1)
+		go func() {
+			defer close(updates)
+			defer close(final)
+			defer close(runnerExited)
+			<-ctx.Done()
+			final <- collector.StreamingTraceFinal{RunErr: ctx.Err()}
+		}()
+		return updates, final
+	}
+
+	ts := httptest.NewServer(srv.Router())
+	defer ts.Close()
+
+	body, _ := json.Marshal(map[string]any{
+		"name":   "trace-cancel",
+		"type":   "traceroute",
+		"target": "8.8.8.8",
+	})
+
+	// Use a request with cancellable context so we can simulate
+	// EventSource.close() at the wire level.
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+"/api/v1/service-checks/test-stream", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+
+	// Read just enough to confirm the start event arrived (proving
+	// the handler entered the loop and the runner is in flight),
+	// then cancel.
+	br := bufio.NewReader(resp.Body)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Read a few lines until we see start, then return.
+		for i := 0; i < 50; i++ {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				return
+			}
+			if strings.Contains(line, "event: start") {
+				return
+			}
+		}
+	}()
+	wg.Wait()
+
+	cancel()
+	resp.Body.Close()
+
+	select {
+	case <-runnerExited:
+		// Expected — ctx cancellation propagated, runner exited.
+	case <-time.After(2 * time.Second):
+		t.Fatal("runner did not exit within 2s of client cancel — ctx cancellation not propagating")
+	}
+}
+
+// TestServiceChecksHTML_TestStreamWiring — settings.html JS must
+// invoke /api/v1/service-checks/test-stream for type=trace Test
+// buttons. Other types use the existing sync /test endpoint.
+func TestServiceChecksHTML_TestStreamWiring(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("templates", "settings.html"))
+	if err != nil {
+		t.Fatalf("read settings.html: %v", err)
+	}
+	data := string(raw)
+	if !strings.Contains(data, "/api/v1/service-checks/test-stream") {
+		t.Error("settings.html missing fetch to /api/v1/service-checks/test-stream — Test button traceroute SSE wiring not present")
+	}
+	// Sanity: the trace branch must reference SSE event names. We
+	// use fetch + ReadableStream (POST body required, EventSource
+	// is GET-only) so the consumer must hand-parse the wire format.
+	if !strings.Contains(data, `"hop"`) && !strings.Contains(data, "event: hop") {
+		t.Error("settings.html missing reference to SSE 'hop' event in trace Test button branch")
+	}
+}

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -2722,6 +2722,14 @@ function renderServiceCheckDetails(type, details, result) {
 // etc.) via toast. Speed-type checks can take up to 60s on real hardware
 // (Ookla CLI), so we warn the user up-front and disable the button for
 // the duration of the request. See issue #154.
+//
+// Traceroute checks use the SSE streaming variant
+// (POST /api/v1/service-checks/test-stream) so the user sees per-cycle
+// hop progress in the toast — closes the "dead spinner" UX surfaced
+// in v0.9.7 UAT of #189 (issue #224). All other types use the
+// synchronous /test endpoint unchanged. ReadableStream + the SSE
+// wire format is hand-parsed because EventSource is GET-only and
+// the Test button has to POST the form payload.
 function testServiceCheck() {
   var sc = readServiceCheckForm();
   if (!sc) return;
@@ -2729,6 +2737,12 @@ function testServiceCheck() {
   var btn = document.getElementById("sc-test-btn");
   var originalLabel = btn ? btn.textContent : "Test";
   if (btn) { btn.disabled = true; btn.textContent = "Testing…"; }
+
+  // Traceroute → live-progress SSE branch.
+  if (sc.type === "traceroute" && typeof window.ReadableStream !== "undefined") {
+    runTraceTestStream(sc, btn, originalLabel);
+    return;
+  }
 
   if (sc.type === "speed") {
     showToast("Running speed test (can take up to 60s)…", "info");
@@ -2784,6 +2798,130 @@ function testServiceCheck() {
     .finally(function() {
       if (btn) { btn.disabled = false; btn.textContent = originalLabel; }
     });
+}
+
+// runTraceTestStream consumes the SSE response from
+// POST /api/v1/service-checks/test-stream for a type=traceroute Test.
+// Renders incremental progress via toast — each `hop` event refreshes
+// the toast with the cumulative hop table; the terminal `result`
+// event finalises with the same shape as the sync endpoint so the
+// existing renderServiceCheckDetails helper can be reused.
+//
+// The SSE wire format (event:/data:/blank-line) is parsed by hand
+// because EventSource is GET-only and the Test button must POST the
+// form payload. AbortController wires the fetch to cancellation, so
+// closing/refreshing the page promptly aborts the HTTP request and
+// the server-side runner subprocess (issue #224).
+function runTraceTestStream(sc, btn, originalLabel) {
+  showToast("Running traceroute (10 cycles)…", "info");
+
+  var controller = (typeof AbortController !== "undefined") ? new AbortController() : null;
+  var signal = controller ? controller.signal : undefined;
+
+  fetch("/api/v1/service-checks/test-stream", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "Accept": "text/event-stream" },
+    body: JSON.stringify(sc),
+    signal: signal
+  })
+    .then(function(resp) {
+      if (!resp.ok) {
+        return resp.json().then(function(d) {
+          throw new Error((d && d.error) ? d.error : ("HTTP " + resp.status));
+        }).catch(function() {
+          throw new Error("HTTP " + resp.status);
+        });
+      }
+      var reader = resp.body.getReader();
+      var decoder = new TextDecoder("utf-8");
+      var buf = "";
+      var lastHopUpdate = null;
+
+      function pump() {
+        return reader.read().then(function(chunk) {
+          if (chunk.done) return;
+          buf += decoder.decode(chunk.value, { stream: true });
+          // Frames are terminated by a blank line. Split on the
+          // SSE "\n\n" frame separator.
+          var frames = buf.split("\n\n");
+          buf = frames.pop(); // tail may be partial
+          for (var i = 0; i < frames.length; i++) {
+            var frame = frames[i];
+            if (!frame) continue;
+            var ev = "", data = "";
+            var lines = frame.split("\n");
+            for (var j = 0; j < lines.length; j++) {
+              var line = lines[j];
+              if (line.indexOf("event: ") === 0) ev = line.substring(7);
+              else if (line.indexOf("data: ") === 0) data = line.substring(6);
+            }
+            if (!ev) continue;
+            handleTraceEvent(ev, data, sc, lastHopUpdate);
+            if (ev === "hop") {
+              try { lastHopUpdate = JSON.parse(data); } catch (e) { /* ignore */ }
+            }
+          }
+          return pump();
+        });
+      }
+      return pump();
+    })
+    .catch(function(e) {
+      if (e && e.name === "AbortError") return;
+      showToast("Test failed: " + (e && e.message ? e.message : "network error"), "error");
+    })
+    .finally(function() {
+      if (btn) { btn.disabled = false; btn.textContent = originalLabel; }
+    });
+}
+
+// handleTraceEvent dispatches a parsed SSE event to the appropriate
+// rendering path. `hop` events refresh the toast with cumulative
+// progress; `result` produces the canonical pass/fail summary
+// using the existing per-type renderer.
+function handleTraceEvent(ev, data, sc) {
+  if (ev === "hop") {
+    var u = null;
+    try { u = JSON.parse(data); } catch (e) { return; }
+    if (!u || !u.hops) return;
+    var lines = ["Tracing " + (sc.target || "") + " — cycle " + (u.cycle || 0) + "/" + (u.total_cycles || 0)];
+    for (var i = 0; i < u.hops.length; i++) {
+      var h = u.hops[i];
+      var avg = (typeof h.Avg === "number") ? h.Avg.toFixed(1) + " ms" : "—";
+      var lossPct = (typeof h["Loss%"] === "number") ? h["Loss%"].toFixed(1) + "%" : "—";
+      lines.push("  " + (i + 1) + ". " + (h.host || "???") + "  avg " + avg + "  loss " + lossPct);
+    }
+    showToast(lines.join("\n"), "info");
+    return;
+  }
+  if (ev === "result") {
+    var r = null;
+    try { r = JSON.parse(data); } catch (e) { return; }
+    if (!r) return;
+    var status = r.status || "unknown";
+    var ms = r.response_ms;
+    var headline;
+    var toastKind = "info";
+    if (status === "up") {
+      headline = "✓ Check is UP" + (typeof ms === "number" ? " (" + ms + " ms)" : "");
+      toastKind = "success";
+    } else if (status === "degraded") {
+      headline = "△ Degraded";
+      toastKind = "warning";
+    } else {
+      headline = "✗ Check is DOWN";
+      toastKind = "error";
+    }
+    var msg = headline;
+    var detailsText = renderServiceCheckDetails(sc.type, r.details, r);
+    if (detailsText) msg += "\n" + detailsText;
+    if (r.error) msg += "\n" + r.error;
+    showToast(msg, toastKind);
+    return;
+  }
+  // Other events (start, end, error) are passive — nothing to
+  // render. Heartbeat comments never reach the dispatcher because
+  // they have no `event:` line.
 }
 
 function removeServiceCheck(idx) {

--- a/internal/collector/traceroute_stream.go
+++ b/internal/collector/traceroute_stream.go
@@ -1,0 +1,217 @@
+// Streaming traceroute runner — issue #224.
+//
+// The non-streaming RunMTR (traceroute.go) shells out to `mtr --report
+// --report-cycles=N --json` and parses the resulting JSON document
+// after the subprocess completes. That works for scheduled checks and
+// the synchronous Test button, but produces a 5-15s "dead spinner"
+// UX on the settings page Test button — exactly the regression
+// surfaced in v0.9.7 UAT of #189 that issue #224 tracks.
+//
+// RunStreamingMTR provides the live-progress abstraction the new
+// /api/v1/service-checks/test-stream endpoint consumes. It runs the
+// mtr binary one-cycle-at-a-time and emits cumulative hop tables
+// after each cycle so the dashboard's notification panel can render
+// rows as they're discovered. The final cycle's hop table is also
+// returned as the canonical MTRResult so the SSE handler can emit a
+// single terminal `result` event whose shape is byte-identical to
+// the synchronous /test endpoint's response — frontend renderers
+// can therefore reuse the existing renderServiceCheckDetails helper.
+//
+// Cancellation: the subprocess is started in its own process group
+// via setProcessGroup; on ctx cancellation we send SIGKILL to the
+// entire group (negative pid). This is the v0.9.14 #304 pattern —
+// avoids the orphaned-grandchild bug where exec.CommandContext kills
+// only the direct shell and leaves mtr inheriting the stdout pipe,
+// blocking cmd.Wait() on EOF for the natural duration of the
+// subprocess. mtr is a pure binary not wrapped by /bin/sh in our
+// invocation so the bug is less likely to surface, but the same
+// process-group plumbing is the right defensive default and keeps
+// the fan-out of subprocess kill semantics consistent with the
+// speedtest path.
+
+package collector
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// StreamingMTRUpdate is a single update emitted by the streaming
+// runner. Cycle is the 1-indexed cycle number the update came from
+// (1..total). Hops is the cumulative hop table after that cycle.
+type StreamingMTRUpdate struct {
+	Cycle      int      `json:"cycle"`
+	TotalCycle int      `json:"total_cycles"`
+	Hops       []MTRHop `json:"hops"`
+}
+
+// StreamingTracerouteRunner is the function signature the streaming
+// /test-stream endpoint depends on. Implementations push per-cycle
+// updates onto the returned `updates` channel and a single terminal
+// MTRResult onto the returned `final` channel before closing both.
+//
+// The production implementation is RunStreamingMTR. Tests inject a
+// stub via Server.streamingTracerouteRunner so they don't need
+// an actual mtr binary.
+//
+// Contract:
+//   - Updates are emitted in cycle order.
+//   - When ctx is cancelled, both channels are closed promptly
+//     (within ~250ms on the production path, immediately on test
+//     stubs). final may close without emitting if cancellation
+//     races with completion.
+//   - On underlying mtr error, an empty MTRResult is sent on final
+//     and `runErr` carries the error; callers should treat any
+//     non-nil runErr as "down".
+type StreamingTracerouteRunner func(ctx context.Context, target string, cycles int) (updates <-chan StreamingMTRUpdate, final <-chan StreamingTraceFinal)
+
+// StreamingTraceFinal is the terminal value emitted by a streaming
+// traceroute run. Exactly one is sent on the final channel before
+// it's closed.
+type StreamingTraceFinal struct {
+	// Result is the canonical MTRResult assembled from the last
+	// cycle. Nil when RunErr is non-nil OR when the run was
+	// cancelled before any hops were collected.
+	Result *MTRResult
+	// RunErr is the underlying error from mtr execution, if any.
+	// nil on the happy path. Cancellation surfaces here as
+	// context.Canceled / context.DeadlineExceeded.
+	RunErr error
+}
+
+// streamingMTRExecFn is the seam tests use to inject a fake
+// per-cycle mtr executor. Default implementation invokes mtr with
+// --report-cycles=1 once per cycle so we get fresh stdout per
+// invocation and can emit cumulative hops between invocations.
+//
+// Why one-cycle-per-invocation: real mtr --report-cycles=N flushes
+// JSON only when the report is complete (it does not emit per-cycle
+// progress). To get genuinely live progress without depending on
+// mtr's debug `--raw` mode (which is not stable across versions and
+// has been historically prone to format drift), we run the binary N
+// times and assemble a cumulative hop table from the most-recent
+// run's output. Each run is fast (~1s on healthy networks) so the
+// user sees progress every second, which matches the live-progress
+// expectation from issue #224.
+var streamingMTRExecFn = func(ctx context.Context, target string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "mtr",
+		"--report",
+		"--report-cycles=1",
+		"--json",
+		"--no-dns",
+		target,
+	)
+	setProcessGroup(cmd)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	// Watch ctx; on cancellation, kill the whole process group.
+	// See v0.9.14 #304 fix-up — exec.CommandContext alone leaves
+	// orphan grandchildren when the subprocess re-execs (mtr does
+	// not, but the defensive plumbing is cheap and keeps subprocess
+	// kill semantics consistent across the codebase).
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			killProcessGroup(cmd)
+		case <-done:
+		}
+	}()
+	if err := cmd.Wait(); err != nil {
+		// mtr returns non-zero when the network is unreachable AND
+		// when stderr carries diagnostic noise; surface stderr in
+		// the error so callers (and tests) can render it. Keep the
+		// underlying ExitError wrapped so errors.Is(err, ctx.Err())
+		// continues to work after ctx cancellation.
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return stdout.Bytes(), fmt.Errorf("mtr: %s: %w", msg, err)
+		}
+		return stdout.Bytes(), err
+	}
+	return stdout.Bytes(), nil
+}
+
+// RunStreamingMTR runs mtr against target in cycles iterations,
+// emitting cumulative hop tables after each cycle. The returned
+// channels are closed when the run completes or ctx is cancelled.
+//
+// cycles == 0 is treated as 5 (matches RunMTR's default).
+//
+// Process-group SIGKILL on ctx cancellation: see v0.9.14 #304 fix-up.
+func RunStreamingMTR(ctx context.Context, target string, cycles int) (<-chan StreamingMTRUpdate, <-chan StreamingTraceFinal) {
+	target = strings.TrimSpace(target)
+	updates := make(chan StreamingMTRUpdate, 32)
+	final := make(chan StreamingTraceFinal, 1)
+
+	if cycles <= 0 {
+		cycles = 5
+	}
+
+	go func() {
+		defer close(updates)
+		defer close(final)
+
+		if target == "" {
+			final <- StreamingTraceFinal{RunErr: fmt.Errorf("traceroute target is required")}
+			return
+		}
+
+		var lastResult *MTRResult
+		var lastErr error
+		for i := 1; i <= cycles; i++ {
+			select {
+			case <-ctx.Done():
+				final <- StreamingTraceFinal{Result: lastResult, RunErr: ctx.Err()}
+				return
+			default:
+			}
+			out, err := streamingMTRExecFn(ctx, target)
+			if err != nil {
+				lastErr = err
+				// On error mid-run we still want to surface what
+				// we have so far rather than blank-failing. Break
+				// out of the loop and let the terminal block emit.
+				break
+			}
+			if len(out) == 0 {
+				continue
+			}
+			res, parseErr := ParseMTRReport(out)
+			if parseErr != nil {
+				// Parser noise on a partial run is recoverable —
+				// the final cycle may produce valid JSON. Don't
+				// abort the run; just don't emit this cycle.
+				lastErr = parseErr
+				continue
+			}
+			lastResult = res
+			lastErr = nil
+
+			// Send the cumulative update. Drop on cancellation
+			// so a stuck SSE writer can't pin the goroutine.
+			update := StreamingMTRUpdate{
+				Cycle:      i,
+				TotalCycle: cycles,
+				Hops:       res.Hops,
+			}
+			select {
+			case updates <- update:
+			case <-ctx.Done():
+				final <- StreamingTraceFinal{Result: lastResult, RunErr: ctx.Err()}
+				return
+			}
+		}
+
+		final <- StreamingTraceFinal{Result: lastResult, RunErr: lastErr}
+	}()
+
+	return updates, final
+}

--- a/internal/collector/traceroute_stream_test.go
+++ b/internal/collector/traceroute_stream_test.go
@@ -1,0 +1,290 @@
+package collector
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// canned single-cycle mtr JSON output, varying hops to make the
+// "cumulative" assertion non-trivial.
+const oneCycleJSONShort = `{
+  "report": {
+    "mtr": {"src":"10.0.0.10","dst":"8.8.8.8","tos":0,"psize":"64","bitpattern":"0x00","tests":"1"},
+    "hubs": [
+      {"count":1,"host":"10.0.0.1","Loss%":0.0,"Snt":1,"Last":0.5,"Avg":0.5,"Best":0.5,"Wrst":0.5,"StDev":0.0}
+    ]
+  }
+}`
+
+const oneCycleJSONLong = `{
+  "report": {
+    "mtr": {"src":"10.0.0.10","dst":"8.8.8.8","tos":0,"psize":"64","bitpattern":"0x00","tests":"1"},
+    "hubs": [
+      {"count":1,"host":"10.0.0.1","Loss%":0.0,"Snt":1,"Last":0.5,"Avg":0.5,"Best":0.5,"Wrst":0.5,"StDev":0.0},
+      {"count":2,"host":"203.0.113.1","Loss%":0.0,"Snt":1,"Last":2.1,"Avg":2.1,"Best":2.1,"Wrst":2.1,"StDev":0.0},
+      {"count":3,"host":"8.8.8.8","Loss%":0.0,"Snt":1,"Last":12.3,"Avg":12.3,"Best":12.3,"Wrst":12.3,"StDev":0.0}
+    ]
+  }
+}`
+
+// withMTRExecFn temporarily replaces streamingMTRExecFn for the
+// duration of t. Restored on cleanup.
+func withStreamingMTRExecFn(t *testing.T, fn func(ctx context.Context, target string) ([]byte, error)) {
+	t.Helper()
+	orig := streamingMTRExecFn
+	streamingMTRExecFn = fn
+	t.Cleanup(func() { streamingMTRExecFn = orig })
+}
+
+// TestRunStreamingMTR_EmitsUpdatePerCycleThenFinal — happy path.
+// 3 cycles → 3 updates with monotonically growing/identical hop
+// counts, followed by a single final with non-nil Result.
+func TestRunStreamingMTR_EmitsUpdatePerCycleThenFinal(t *testing.T) {
+
+	var calls int32
+	withStreamingMTRExecFn(t, func(_ context.Context, _ string) ([]byte, error) {
+		n := atomic.AddInt32(&calls, 1)
+		// Simulate progressive hop discovery — first call sees one
+		// hop, subsequent calls see the full chain.
+		if n == 1 {
+			return []byte(oneCycleJSONShort), nil
+		}
+		return []byte(oneCycleJSONLong), nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	updates, final := RunStreamingMTR(ctx, "8.8.8.8", 3)
+
+	var collected []StreamingMTRUpdate
+	for u := range updates {
+		collected = append(collected, u)
+	}
+	if len(collected) != 3 {
+		t.Fatalf("expected 3 updates, got %d", len(collected))
+	}
+	if collected[0].Cycle != 1 || collected[2].Cycle != 3 {
+		t.Errorf("expected cycle counter 1..3, got %d/%d/%d", collected[0].Cycle, collected[1].Cycle, collected[2].Cycle)
+	}
+	if collected[0].TotalCycle != 3 {
+		t.Errorf("expected total_cycles=3, got %d", collected[0].TotalCycle)
+	}
+	if len(collected[0].Hops) != 1 {
+		t.Errorf("first cycle: expected 1 hop, got %d", len(collected[0].Hops))
+	}
+	if len(collected[2].Hops) != 3 {
+		t.Errorf("third cycle: expected 3 hops, got %d", len(collected[2].Hops))
+	}
+
+	fin, ok := <-final
+	if !ok {
+		t.Fatal("final channel closed without value")
+	}
+	if fin.RunErr != nil {
+		t.Fatalf("expected nil RunErr, got %v", fin.RunErr)
+	}
+	if fin.Result == nil {
+		t.Fatal("expected non-nil Result")
+	}
+	if len(fin.Result.Hops) != 3 {
+		t.Errorf("final result: expected 3 hops, got %d", len(fin.Result.Hops))
+	}
+}
+
+// TestRunStreamingMTR_EmptyTarget — no shelling out, immediate
+// terminal error.
+func TestRunStreamingMTR_EmptyTarget(t *testing.T) {
+
+	withStreamingMTRExecFn(t, func(_ context.Context, _ string) ([]byte, error) {
+		t.Fatal("streamingMTRExecFn should not be called with empty target")
+		return nil, nil
+	})
+
+	updates, final := RunStreamingMTR(context.Background(), "", 3)
+
+	count := 0
+	for range updates {
+		count++
+	}
+	if count != 0 {
+		t.Errorf("expected 0 updates, got %d", count)
+	}
+	fin := <-final
+	if fin.RunErr == nil {
+		t.Fatal("expected RunErr for empty target")
+	}
+}
+
+// TestRunStreamingMTR_RunnerErrorSurfacesInFinal — when the
+// underlying exec returns an error mid-run, the final value carries
+// it AND the partial result.
+func TestRunStreamingMTR_RunnerErrorSurfacesInFinal(t *testing.T) {
+
+	var calls int32
+	withStreamingMTRExecFn(t, func(_ context.Context, _ string) ([]byte, error) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			return []byte(oneCycleJSONShort), nil
+		}
+		return nil, errors.New("mtr: simulated network failure")
+	})
+
+	updates, final := RunStreamingMTR(context.Background(), "8.8.8.8", 5)
+	updateCount := 0
+	for range updates {
+		updateCount++
+	}
+	if updateCount != 1 {
+		t.Errorf("expected 1 update before error, got %d", updateCount)
+	}
+	fin := <-final
+	if fin.RunErr == nil {
+		t.Fatal("expected RunErr after exec failure")
+	}
+	if !strings.Contains(fin.RunErr.Error(), "simulated network failure") {
+		t.Errorf("expected RunErr to mention failure cause, got %q", fin.RunErr.Error())
+	}
+	// Partial result should still be exposed.
+	if fin.Result == nil {
+		t.Fatal("expected partial Result to be preserved on mid-run error")
+	}
+}
+
+// TestRunStreamingMTR_CtxCancelClosesPromptly — the canonical issue
+// #304 contract for streaming runners. Slow exec stub blocks until
+// ctx fires; we then assert both channels close within a small
+// budget.
+func TestRunStreamingMTR_CtxCancelClosesPromptly(t *testing.T) {
+
+	withStreamingMTRExecFn(t, func(ctx context.Context, _ string) ([]byte, error) {
+		// Block until ctx fires — simulates a hung mtr subprocess.
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	updates, final := RunStreamingMTR(ctx, "8.8.8.8", 5)
+
+	// Cancel after a tick so the goroutine is past the empty-target
+	// guard and into streamingMTRExecFn.
+	time.AfterFunc(20*time.Millisecond, cancel)
+
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	closed := false
+loop:
+	for !closed {
+		select {
+		case _, ok := <-updates:
+			if !ok {
+				updates = nil // never receive again
+			}
+		case _, ok := <-final:
+			if !ok {
+				final = nil
+			} else {
+				closed = true
+			}
+		case <-deadline.C:
+			t.Fatal("RunStreamingMTR did not close within 2s of ctx cancellation")
+		}
+		if updates == nil && final == nil {
+			break loop
+		}
+	}
+}
+
+// TestStreamingMTRExecFn_ProcessGroupKillSemantics — drives the real
+// production stream-exec path against /bin/sh -c "sleep 30" rather
+// than mtr to verify that ctx cancellation kills the entire process
+// group (Setpgid + syscall.Kill(-pgid, SIGKILL)). Without the
+// process-group plumbing, /bin/sh dies but the inherited `sleep`
+// child stays running and pins the inherited stdout pipe.
+//
+// Skipped on CI environments where /bin/sh isn't available — but
+// our supported targets (Alpine in Docker + macOS dev) all have it.
+func TestStreamingMTRExecFn_ProcessGroupKillSemantics(t *testing.T) {
+
+	// Replace streamingMTRExecFn with a body identical to production
+	// EXCEPT that we shell out to /bin/sh -c "sleep 30 && cat" to
+	// guarantee a grandchild process inherits the pipe. If
+	// process-group kill works, the function returns within a
+	// budget; if it doesn't, cmd.Wait() blocks for ~30s.
+	var grandchildPID int32
+	withStreamingMTRExecFn(t, func(ctx context.Context, _ string) ([]byte, error) {
+		// /bin/sh -c with an exec'd subprocess so the grandchild is
+		// distinct from the shell — exactly the v0.9.14 #304 trap.
+		cmd := exec.Command("/bin/sh", "-c", "sleep 30 & echo $! && wait")
+		setProcessGroup(cmd)
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			return nil, err
+		}
+		if err := cmd.Start(); err != nil {
+			return nil, err
+		}
+		// Read the sleep PID off the pipe so we can verify it dies.
+		buf := make([]byte, 16)
+		n, _ := stdout.Read(buf)
+		pid := parseLeadingDigits(string(buf[:n]))
+		atomic.StoreInt32(&grandchildPID, int32(pid))
+		done := make(chan struct{})
+		defer close(done)
+		go func() {
+			select {
+			case <-ctx.Done():
+				killProcessGroup(cmd)
+			case <-done:
+			}
+		}()
+		if err := cmd.Wait(); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	updates, final := RunStreamingMTR(ctx, "8.8.8.8", 1)
+
+	// Give the subprocess time to start.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	deadline := time.NewTimer(3 * time.Second)
+	defer deadline.Stop()
+
+	// Drain updates (none expected, but they may close before final).
+	go func() {
+		for range updates {
+		}
+	}()
+
+	select {
+	case <-final:
+		// Expected — process group kill propagated to grandchild,
+		// cmd.Wait() unblocked, RunStreamingMTR returned.
+	case <-deadline.C:
+		t.Fatalf("RunStreamingMTR did not return within 3s — process-group kill semantics broken (grandchild pid %d)", atomic.LoadInt32(&grandchildPID))
+	}
+}
+
+// parseLeadingDigits returns the leading run of decimal digits in s
+// as an int (0 when none). Written by hand to keep the import surface
+// minimal — the only caller is the process-group kill test below.
+func parseLeadingDigits(s string) int {
+	s = strings.TrimSpace(s)
+	n := 0
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			break
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n
+}


### PR DESCRIPTION
## Summary

Adds a new `POST /api/v1/service-checks/test-stream` SSE endpoint that streams per-cycle hop progress for `type=traceroute` Test invocations. Closes the **\"dead spinner\"** UX surfaced in v0.9.7 UAT of #189 — users now see hops appearing in the Test toast as mtr discovers them, instead of waiting 10-30s for a final result.

Refs #224 (traceroute slice; speed half deferred — see Scope below).

## Scope — narrowed

The original #224 issue body covers BOTH traceroute and speed-test Test buttons. **This PR ships only the traceroute slice.** The dashboard's Speed Test card already has a dedicated SSE live-progress strip (v0.9.11), so the `type=speed` settings Test button stays on the synchronous path for now. A follow-up issue can extend `/test-stream` to `type=speed` if anyone asks.

Non-trace POSTs to `/test-stream` return **400** with a hint pointing at the synchronous endpoint:

```
{\"error\":\"/test-stream only supports type=traceroute (got \\\"http\\\"); use POST /api/v1/service-checks/test for synchronous types\"}
```

The settings.html JS branches on `sc.type === \"traceroute\"` so other types continue to use the sync `/test` endpoint unchanged. The 400 is purely defensive — exercised by direct curl / external tooling, not by the dashboard's Test button.

## Backend changes

### `internal/collector/traceroute_stream.go` (new)

- `RunStreamingMTR(ctx, target, cycles)` runs mtr **one `--report-cycles=1` invocation at a time** and emits cumulative `MTRHop[]` tables between cycles. Each cycle is ~1s on healthy networks, so the user sees genuine per-second progress rather than fake intra-call updates. Real mtr's `--report --report-cycles=N` mode flushes JSON only when complete; running it N times with cycles=1 each is the cleanest way to get live discovery without depending on mtr's debug `--raw` mode (unstable across versions).
- `streamingMTRExecFn` is a test-injectable seam (mirrors `mtrExecFn` in `traceroute.go`).
- **Process-group SIGKILL on ctx cancellation** (v0.9.14 #304 pattern): `setProcessGroup(cmd)` before Start, ctx-watcher goroutine calls `killProcessGroup(cmd)` on cancellation. mtr is a pure binary (not wrapped by /bin/sh in our invocation) so the bug is unlikely to surface in production, but the same plumbing keeps subprocess kill semantics consistent with the speedtest path and is robust against a future maintainer wrapping the call in a shell.

### `internal/api/service_check_test_stream.go` (new)

- `handleTestServiceCheckStream` parses the same `ServiceCheckConfig` JSON body as the sync `/test` endpoint, validates via the existing `normalizeServiceCheckConfig`, and rejects non-trace types with 400.
- SSE wire format mirrors the v0.9.11 speedtest contract:
  - `start` → `{target, cycles, started_at}`
  - `hop` → `{cycle, total_cycles, hops}` (**cumulative hop array**, NOT a delta — keeps the JS renderer code path identical for live vs final state).
  - `result` → canonical `ServiceCheckResult` (built via `scheduler.NewServiceChecker(...).RunCheck` with an injected runner that returns the streamed result, so thresholds + MaxLossPct policy + status determination + Details map are computed identically to the sync path; **JS renderer reuses `renderServiceCheckDetails` verbatim**).
  - `end` → `{duration_seconds}`
- **Defensive SSE measures inherited from `speedtest_sse.go`** (v0.9.12 lessons): explicit `charset=utf-8`, `Cache-Control: no-cache, no-transform`, `X-Accel-Buffering: no`, 2KB initial padding to defeat first-N-bytes proxy buffers, 1Hz keepalive heartbeat. README's existing CF Tunnel + Access caveat applies (content-aware buffering may still hold events; direct LAN works).
- **Drains buffered `updates` channel after seeing `final`** — Go's select schedules cases pseudo-randomly when multiple are ready, so without an explicit drain the SSE consumer would miss hop events the runner pushed in a final burst.

### `internal/api/api.go`

- New `streamingTracerouteRunner collector.StreamingTracerouteRunner` test seam on `*Server`.
- New route `POST /api/v1/service-checks/test-stream` registered **outside** the 30s Timeout group so the EventSource connection can stay open for the full 10-cycle traceroute (~10-30s).

## Frontend changes

### `internal/api/templates/settings.html`

- `testServiceCheck()` branches on `sc.type === \"traceroute\"` and calls `runTraceTestStream` instead of the sync `fetch`.
- `runTraceTestStream` consumes the SSE response via **`fetch` + `ReadableStream` + `TextDecoder`** (EventSource is GET-only and the Test button has to POST a form payload). Hand-parses the SSE wire format (`event:`/`data:`/blank-line frames). `AbortController` wires the fetch to cancellation so closing/refreshing the page promptly aborts the HTTP request and the server-side runner subprocess.
- `handleTraceEvent` dispatches:
  - `hop` → refresh toast with cumulative hop table (cycle counter, indented per-hop rows with avg ms + loss%).
  - `result` → reuse the existing `renderServiceCheckDetails` per-type renderer to produce the final pass/fail summary.
- Anti-pattern guards (AGENTS.md): all my new JS uses `//` line comments (no `*/` inside `/* */` block comments → safe from the v0.9.9-rc1 trap). No backticks anywhere → Go raw-string DashboardJS/SharedCSS not affected.

## Tests

- `TestRunStreamingMTR_EmitsUpdatePerCycleThenFinal` — 3 cycles, growing hop table, single terminal result.
- `TestRunStreamingMTR_EmptyTarget` — terminal error, no exec.
- `TestRunStreamingMTR_RunnerErrorSurfacesInFinal` — partial result preserved when mid-run exec fails.
- `TestRunStreamingMTR_CtxCancelClosesPromptly` — both channels close within 2s of ctx cancellation when exec stub blocks indefinitely.
- `TestStreamingMTRExecFn_ProcessGroupKillSemantics` — shells out to `/bin/sh -c \"sleep 30 & echo \\$! && wait\"` to force a grandchild process inheriting the pipe; asserts the function returns within 3s of cancellation, proving the `Setpgid + syscall.Kill(-pgid, SIGKILL)` plumbing kills the entire group not just the direct child.
- `TestServiceChecksTestStream_TraceHappyPath` — POST type=trace, asserts `text/event-stream` content-type, `no-cache + no-transform` Cache-Control, full `start → hop×3 → result → end` event sequence with parseable JSON payloads.
- `TestServiceChecksTestStream_NonTraceReturns400` — POST type=http, asserts 400 + hint mentioning both `/api/v1/service-checks/test` and `traceroute`.
- `TestServiceChecksTestStream_CtxCancelKillsRunner` — closes the response body client-side, asserts injected runner exits within 2s of cancellation (proves ctx propagation through the handler → runner chain).
- `TestServiceChecksHTML_TestStreamWiring` — string-match guard that settings.html contains the `/api/v1/service-checks/test-stream` URL and references the SSE `\"hop\"` event name.

All new tests pass under \`-race -count=3\`. Full repo \`go test ./... -race\` is green.

## Pre-push checks (§4b)

- ✅ `go build ./...`
- ✅ `go test ./... -race -count=1` — green
- ✅ `go test ./internal/collector/ ./internal/api/ -race -count=3` — green for new tests
- ✅ `go vet ./...` — clean
- ✅ `gofmt -l` — no drift in files I touched (pre-existing drift on unrelated files left alone)
- ✅ `TestSettingsTemplate_JSBlocksParse` still passes — confirms my settings.html JS additions don't break the script parse.

## Acceptance criteria

- [x] `POST /api/v1/service-checks/test-stream` exists, accepts type=trace, returns SSE stream with hop + result events.
- [x] Non-trace types return 400 with a hint pointing at the sync endpoint.
- [x] Closing the EventSource client-side terminates the runner ctx promptly (no orphaned process — verified by direct ctx-cancel test + the `/bin/sh + sleep` process-group-kill test).
- [x] Service-checks page Test buttons for type=trace use SSE; other types use the sync endpoint unchanged.
- [x] Backticks-in-comments + `*/`-inside-block-comments anti-patterns avoided.
- [x] All race-sensitive tests pass under `-race -count=3`.

## Notes for UAT

- On a machine without `mtr` installed (most macOS dev hosts), the `/test-stream` endpoint will return a `result` event with `status=down` and an error mentioning mtr. The Alpine container has `mtr` bundled (Dockerfile L39) so production + UAT have it.
- CF Tunnel + Access content-aware buffering caveat from v0.9.12 inherits — direct LAN works; through-proxy may hold per-cycle events until end-of-stream. README's existing speedtest live-progress caveat documents this class of issue.
- The `--report-cycles=1` repeated approach means a 10-cycle traceroute takes 10× the per-cycle wall time. On healthy networks that's ~10s total. On flaky/black-hole-heavy paths it can stretch to ~30s. The 30s `http.Server.WriteTimeout` is already disabled per-handler via `NewResponseController.SetWriteDeadline(time.Time{})`.