### PR TITLE
feat(backup-monitor): Duplicacy backend foundation — schema + DuplicacyRunner + classifier (#311)

### DIFF
--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -91,6 +91,66 @@ type BackupMonitorSettings struct {
 	// optional binary override, passphrase env var name, and SSH key
 	// path. Zero-length array = no external monitoring (default).
 	Borg []BorgExternalRepo `json:"borg"`
+
+	// Duplicacy is the list of user-configured Duplicacy backup repos
+	// (PRD #310 / issue #311). Each entry carries an enable toggle,
+	// display label, kind (cli-repo | web-cache), filesystem path,
+	// optional storage_id (for kind=web-cache), and stale-after
+	// threshold in days. Zero-length array = no Duplicacy monitoring
+	// (default; preserves pre-V1a behaviour exactly).
+	//
+	// Disk-read by design — no `duplicacy` binary is invoked, no
+	// subprocess spawned, no network calls made. The runner reads the
+	// on-disk JSON snapshot files that both Duplicacy CLI and the
+	// saspus/duplicacy-web container write under their respective
+	// layouts. See collector.DuplicacyRunner.
+	//
+	// Additive only — no settings_version bump. Existing v3 blobs
+	// decode with an empty/nil Duplicacy slice. The omitempty tag
+	// keeps the JSON output minimal for users who haven't configured
+	// any entries yet.
+	Duplicacy []DuplicacyEntry `json:"duplicacy,omitempty"`
+}
+
+// DuplicacyEntry is one user-configured Duplicacy repo entry. Kind
+// selects which path-resolver the runner uses; both resolvers
+// converge on the same JSON-snapshot parser. Issue #311.
+type DuplicacyEntry struct {
+	// Enabled toggles the entry off without deleting its config.
+	// Disabled entries are skipped by the runner and produce no
+	// dashboard row. (V1a: schema only; runner-level dispatch lives
+	// in V1c.)
+	Enabled bool `json:"enabled"`
+
+	// Label is a user-supplied display name. Optional — the dashboard
+	// widget falls back to the basename of Path when empty.
+	Label string `json:"label,omitempty"`
+
+	// Kind selects the layout of the on-disk repo state. Closed set:
+	//   "cli-repo"  — vanilla CLI install. Path points at the repo
+	//                 root, which contains a .duplicacy/ subdir with
+	//                 a preferences file + cache/<storage>/snapshots/.
+	//   "web-cache" — saspus/duplicacy-web container layout. Path
+	//                 points at the cache root and StorageID names
+	//                 the per-repo subdir under it.
+	Kind string `json:"kind"`
+
+	// Path is the container-visible filesystem path to either the
+	// repo root (kind=cli-repo) or the web cache root (kind=web-cache).
+	// Required when Enabled.
+	Path string `json:"path"`
+
+	// StorageID is the per-repo subdir under Path when Kind=web-cache.
+	// Required for web-cache; ignored for cli-repo (resolved from the
+	// repo's preferences file). Empty for cli-repo.
+	StorageID string `json:"storage_id,omitempty"`
+
+	// StaleAfter is the age threshold in days. A repo whose latest
+	// snapshot is older than StaleAfter days reports the "stale"
+	// reason. Zero (the empty form value) means "use default" — the
+	// runner substitutes 30 days at read time so users can leave the
+	// field blank without persisting a magic number.
+	StaleAfter int `json:"stale_after,omitempty"`
 }
 
 // BorgExternalRepo is one explicit external-Borg repo entry.

--- a/internal/api/settings_backup_monitor_duplicacy_test.go
+++ b/internal/api/settings_backup_monitor_duplicacy_test.go
@@ -1,0 +1,212 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestSettings_BackupMonitorDuplicacy_AdditiveDefault pins that a
+// fresh Settings struct carries a nil Duplicacy slice — additive
+// only, no settings_version bump (PRD #310 §3 / issue #311).
+func TestSettings_BackupMonitorDuplicacy_AdditiveDefault(t *testing.T) {
+	s := defaultSettings()
+	if len(s.BackupMonitor.Duplicacy) != 0 {
+		t.Errorf("Duplicacy default len = %d; want 0", len(s.BackupMonitor.Duplicacy))
+	}
+	// settings_version must not bump when Duplicacy is added.
+	// Mirrors the assertion in the Borg additive default test.
+	if s.SettingsVersion != currentSettingsVersion {
+		t.Errorf("SettingsVersion = %d; want %d (no bump)", s.SettingsVersion, currentSettingsVersion)
+	}
+	if currentSettingsVersion != 3 {
+		t.Errorf("currentSettingsVersion = %d; #311 must NOT bump past 3", currentSettingsVersion)
+	}
+}
+
+// TestSettings_OldV3Blob_DecodesWithEmptyDuplicacy simulates a
+// v0.9.x → v0.10.0 upgrader: a v3-shaped settings blob that
+// predates issue #311 (no `duplicacy` key under backup_monitor)
+// must decode cleanly with a nil/empty Duplicacy slice.
+func TestSettings_OldV3Blob_DecodesWithEmptyDuplicacy(t *testing.T) {
+	oldV3 := []byte(`{
+		"settings_version": 3,
+		"scan_interval": "30m",
+		"backup_monitor": {"borg": []},
+		"advanced_scans": {"smart": {"wake_drives": false, "max_age_days": 7}}
+	}`)
+	var s Settings
+	if err := json.Unmarshal(oldV3, &s); err != nil {
+		t.Fatalf("unmarshal old v3: %v", err)
+	}
+	if len(s.BackupMonitor.Duplicacy) != 0 {
+		t.Errorf("Duplicacy = %+v; want nil/empty for an upgrader", s.BackupMonitor.Duplicacy)
+	}
+	// Existing Borg field must still decode untouched.
+	if s.BackupMonitor.Borg == nil {
+		t.Error("Borg = nil; want []")
+	}
+}
+
+// TestPUTSettings_RoundTripsBackupMonitorDuplicacy exercises the
+// full PUT → GET cycle: a Duplicacy array with one cli-repo + one
+// web-cache entry survives persistence with field-level fidelity.
+// Mirrors TestPUTSettings_RoundTripsBackupMonitorBorg.
+func TestPUTSettings_RoundTripsBackupMonitorDuplicacy(t *testing.T) {
+	srv := newTestServer(t)
+
+	payload := Settings{
+		SettingsVersion: currentSettingsVersion,
+		ScanInterval:    "30m",
+		Theme:           ThemeMidnight,
+		BackupMonitor: BackupMonitorSettings{
+			Duplicacy: []DuplicacyEntry{
+				{
+					Enabled:    true,
+					Label:      "Documents",
+					Kind:       "cli-repo",
+					Path:       "/mnt/duplicacy/documents",
+					StaleAfter: 0, // default-30 — leaving zero must round-trip as zero
+				},
+				{
+					Enabled:    true,
+					Label:      "Media via duplicacy-web",
+					Kind:       "web-cache",
+					Path:       "/cache/localhost/0",
+					StorageID:  "media-storage",
+					StaleAfter: 14,
+				},
+				{
+					Enabled: false,
+					Label:   "Disabled",
+					Kind:    "cli-repo",
+					Path:    "/mnt/duplicacy/old",
+				},
+			},
+		},
+	}
+	body, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleUpdateSettings(w, req)
+	if w.Code != http.StatusOK {
+		rb, _ := io.ReadAll(w.Body)
+		t.Fatalf("PUT status = %d; body=%s", w.Code, rb)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	getW := httptest.NewRecorder()
+	srv.handleGetSettings(getW, getReq)
+	if getW.Code != http.StatusOK {
+		t.Fatalf("GET status = %d", getW.Code)
+	}
+	var back Settings
+	if err := json.Unmarshal(getW.Body.Bytes(), &back); err != nil {
+		t.Fatalf("decode GET: %v", err)
+	}
+	if len(back.BackupMonitor.Duplicacy) != 3 {
+		t.Fatalf("Duplicacy len = %d; want 3", len(back.BackupMonitor.Duplicacy))
+	}
+	d0 := back.BackupMonitor.Duplicacy[0]
+	if d0.Label != "Documents" || d0.Kind != "cli-repo" || d0.Path != "/mnt/duplicacy/documents" {
+		t.Errorf("entry 0 = %+v; field mapping incomplete", d0)
+	}
+	if d0.StaleAfter != 0 {
+		t.Errorf("entry 0 StaleAfter = %d; want 0 (zero-value must round-trip)", d0.StaleAfter)
+	}
+	d1 := back.BackupMonitor.Duplicacy[1]
+	if d1.Kind != "web-cache" || d1.StorageID != "media-storage" || d1.StaleAfter != 14 {
+		t.Errorf("entry 1 = %+v; web-cache fields not preserved", d1)
+	}
+	d2 := back.BackupMonitor.Duplicacy[2]
+	if d2.Enabled {
+		t.Errorf("entry 2 Enabled = true; want false")
+	}
+	if back.SettingsVersion != currentSettingsVersion {
+		t.Errorf("SettingsVersion = %d; want %d", back.SettingsVersion, currentSettingsVersion)
+	}
+}
+
+// TestPUTSettings_DuplicacyAndBorgCoexist confirms the namespacing
+// invariant: configuring Duplicacy entries does NOT clobber any
+// existing Borg config in the same blob.
+func TestPUTSettings_DuplicacyAndBorgCoexist(t *testing.T) {
+	srv := newTestServer(t)
+
+	payload := Settings{
+		SettingsVersion: currentSettingsVersion,
+		ScanInterval:    "30m",
+		Theme:           ThemeMidnight,
+		BackupMonitor: BackupMonitorSettings{
+			Borg: []BorgExternalRepo{
+				{Enabled: true, Label: "Offsite Borg", RepoPath: "/mnt/borg/offsite"},
+			},
+			Duplicacy: []DuplicacyEntry{
+				{Enabled: true, Label: "Documents", Kind: "cli-repo", Path: "/mnt/dup/documents"},
+			},
+		},
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleUpdateSettings(w, req)
+	if w.Code != http.StatusOK {
+		rb, _ := io.ReadAll(w.Body)
+		t.Fatalf("PUT status = %d; body=%s", w.Code, rb)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	getW := httptest.NewRecorder()
+	srv.handleGetSettings(getW, getReq)
+	var back Settings
+	if err := json.Unmarshal(getW.Body.Bytes(), &back); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(back.BackupMonitor.Borg) != 1 || back.BackupMonitor.Borg[0].RepoPath != "/mnt/borg/offsite" {
+		t.Errorf("Borg side dropped/clobbered; got %+v", back.BackupMonitor.Borg)
+	}
+	if len(back.BackupMonitor.Duplicacy) != 1 || back.BackupMonitor.Duplicacy[0].Path != "/mnt/dup/documents" {
+		t.Errorf("Duplicacy side dropped/clobbered; got %+v", back.BackupMonitor.Duplicacy)
+	}
+}
+
+// TestSettings_DuplicacyEmptyVsNil pins the JSON-shape contract:
+// an explicitly-empty array round-trips as omitted (omitempty),
+// and a nil slice marshals identically. V1b form-handling and
+// future migration code can rely on this.
+func TestSettings_DuplicacyEmptyVsNil(t *testing.T) {
+	t.Run("nil slice — omitempty drops the key", func(t *testing.T) {
+		s := BackupMonitorSettings{Borg: []BorgExternalRepo{}, Duplicacy: nil}
+		raw, _ := json.Marshal(s)
+		// omitempty drops nil slices; the duplicacy key should not
+		// appear at all.
+		if strings.Contains(string(raw), `"duplicacy"`) {
+			t.Errorf("nil slice marshalled with key present: %s", raw)
+		}
+	})
+	t.Run("explicit empty slice — omitempty also drops", func(t *testing.T) {
+		s := BackupMonitorSettings{Duplicacy: []DuplicacyEntry{}}
+		raw, _ := json.Marshal(s)
+		// Go's encoding/json omitempty for a length-0 slice drops
+		// the field. Both nil and []T{} map to "no entries" on
+		// the wire. Pin this so V1b form-handling doesn't have
+		// to disambiguate.
+		if strings.Contains(string(raw), `"duplicacy"`) {
+			t.Errorf("empty slice marshalled with key present: %s", raw)
+		}
+	})
+	t.Run("populated — key appears with array", func(t *testing.T) {
+		s := BackupMonitorSettings{Duplicacy: []DuplicacyEntry{{Enabled: true, Kind: "cli-repo", Path: "/x"}}}
+		raw, _ := json.Marshal(s)
+		if !strings.Contains(string(raw), `"duplicacy"`) {
+			t.Errorf("populated slice missing key: %s", raw)
+		}
+	})
+}

--- a/internal/collector/duplicacy_runner.go
+++ b/internal/collector/duplicacy_runner.go
@@ -1,0 +1,654 @@
+// Duplicacy backup-monitor runner. Disk-read by design — no
+// `duplicacy` binary is invoked, no subprocess spawned, no network
+// calls made. The runner reads the on-disk JSON snapshot files that
+// Duplicacy writes to its local cache, which is identical between the
+// vanilla CLI install and the saspus/duplicacy-web container layout —
+// only the directory structure around the snapshots differs.
+//
+// Two path-resolvers handle the two layouts:
+//
+//   - kind=cli-repo : Path points at the repo root. The runner reads
+//     <Path>/.duplicacy/preferences (JSON array of storage configs),
+//     picks the first entry's "name" as the storage name (defaulting
+//     to "default" when the file lacks one), and walks
+//     <Path>/.duplicacy/cache/<storage>/snapshots/.
+//
+//   - kind=web-cache : Path points at the cache root that the
+//     saspus/duplicacy-web container writes under (typically
+//     /cache/localhost/0/.duplicacy/cache or similar). StorageID
+//     names the per-repo subdir under it. The runner walks
+//     <Path>/<StorageID>/snapshots/ directly.
+//
+// Both resolvers converge on the same JSON-snapshot parser
+// (parseDuplicacySnapshotFile). PRD #310 / issue #311.
+package collector
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DuplicacyRunner is the deep-module interface that separates
+// Duplicacy disk-read mechanics from the rest of the backup
+// collector. Production code uses diskDuplicacyRunner; tests can
+// inject a fake by implementing this single-method interface. See
+// PRD #310 §1 for the architectural choice (disk-read, not
+// subprocess).
+//
+// Read inspects the on-disk state of one configured Duplicacy entry
+// and returns a populated DuplicacyState. The function is total —
+// every classifier outcome maps to a non-error return with the
+// corresponding ReasonCode. Errors are reserved for genuinely-
+// unexpected cases (e.g. an unrelated I/O fault that escaped the
+// classifier); callers should treat them as DuplicacyReasonUnknown
+// for UI purposes. V1a callers in V1b/V1c will dispatch on
+// state.ReasonCode regardless.
+type DuplicacyRunner interface {
+	Read(ctx context.Context, entry DuplicacyEntry) (DuplicacyState, error)
+}
+
+// DuplicacyEntry mirrors api.DuplicacyEntry in shape. Lives in the
+// collector package so callers below the api layer can pass entries
+// without importing api. Issue #311.
+type DuplicacyEntry struct {
+	// Enabled toggles the entry off without deleting its config.
+	Enabled bool
+	// Label is a user-supplied display name; optional.
+	Label string
+	// Kind selects the path-resolver. Closed set: DuplicacyKindCLIRepo,
+	// DuplicacyKindWebCache.
+	Kind string
+	// Path is the container-visible path. Repo root for cli-repo;
+	// cache root for web-cache.
+	Path string
+	// StorageID names the per-repo subdir under Path when Kind=
+	// web-cache. Ignored for cli-repo (resolved from preferences).
+	StorageID string
+	// StaleAfter is the age threshold in days. Zero means "use
+	// default" — the runner substitutes DuplicacyDefaultStaleAfterDays
+	// at read time.
+	StaleAfter int
+}
+
+// Duplicacy entry kind values. The runner switches on Kind to pick
+// its path-resolver.
+const (
+	DuplicacyKindCLIRepo  = "cli-repo"
+	DuplicacyKindWebCache = "web-cache"
+)
+
+// DuplicacyDefaultStaleAfterDays is the StaleAfter default applied
+// when DuplicacyEntry.StaleAfter is zero. Substituted at read time —
+// not at config time — so users can leave the field blank and get
+// sensible behaviour without persisting a magic number into their
+// settings blob (PRD #310 §10 user story 5; issue #311 acceptance
+// criterion 2).
+const DuplicacyDefaultStaleAfterDays = 30
+
+// DuplicacyReason is the closed-set classifier outcome for one
+// entry's read. Per-provider type — NOT shared with BorgReason — so
+// the precedent for adding Restic, PBS, Duplicati later is "add a
+// per-provider reason type" rather than "extend a god-enum"
+// (PRD #310 §4 / user story 12).
+type DuplicacyReason string
+
+// All eight DuplicacyReason values. The runner produces exactly one
+// ReasonCode per Read() call (currently_running is orthogonal — see
+// DuplicacyState.CurrentlyRunning).
+const (
+	// DuplicacyReasonOK — repo healthy, recent snapshot found, count
+	// and timestamps populated. Renders as success on the dashboard.
+	DuplicacyReasonOK DuplicacyReason = "ok"
+
+	// DuplicacyReasonPathNotFound — the configured Path does not
+	// exist (typo, missing bind mount, deleted directory). Surfaced
+	// distinctly from "not a Duplicacy repo" so users know whether
+	// the issue is in their docker-compose or their Duplicacy
+	// config (user story 15).
+	DuplicacyReasonPathNotFound DuplicacyReason = "path_not_found"
+
+	// DuplicacyReasonPathUnreadable — Path exists but stat()s
+	// produce a permission/IO error. Different from PathNotFound
+	// so a chmod/SELinux fix points the user at the right knob.
+	DuplicacyReasonPathUnreadable DuplicacyReason = "path_unreadable"
+
+	// DuplicacyReasonNotARepo — Path exists and is readable but
+	// the expected `.duplicacy/` subdirectory (cli-repo) is absent.
+	// User has the directory mounted but it isn't a Duplicacy repo.
+	DuplicacyReasonNotARepo DuplicacyReason = "not_a_duplicacy_repo"
+
+	// DuplicacyReasonStorageIDNotFound — Path resolves but the named
+	// StorageID subdirectory under it (web-cache) is absent. User
+	// likely typo'd the storage_id field (user story 7).
+	DuplicacyReasonStorageIDNotFound DuplicacyReason = "storage_id_not_found"
+
+	// DuplicacyReasonNoSnapshotsYet — repo configuration is valid
+	// but no snapshot files exist yet. Distinct from "broken" so a
+	// freshly-configured but never-run repo isn't red-flagged
+	// (user story 4).
+	DuplicacyReasonNoSnapshotsYet DuplicacyReason = "no_snapshots_yet"
+
+	// DuplicacyReasonStale — newest snapshot is older than the
+	// entry's StaleAfter threshold. Most likely cause: backup cron
+	// silently failed (user story 5).
+	DuplicacyReasonStale DuplicacyReason = "stale"
+
+	// DuplicacyReasonCorruptSnapshot — at least one snapshot file
+	// failed JSON-unmarshal. Graceful failure — surface the reason
+	// rather than crashing (user story 14). When mixed with valid
+	// snapshots in the same repo, the runner prefers the corrupt
+	// signal so users notice partial damage.
+	DuplicacyReasonCorruptSnapshot DuplicacyReason = "corrupt_snapshot"
+)
+
+// DuplicacyState is the runner's per-entry result. Carries enough
+// fields to feed the V1b Test endpoint and V1c dashboard widget +
+// Prometheus exporter without a second probe.
+type DuplicacyState struct {
+	// ReasonCode is exactly one DuplicacyReason value (above). The
+	// dashboard switches on this to decide severity; the exporter
+	// emits it as a {reason="…"} label on a per-entry status gauge.
+	ReasonCode DuplicacyReason
+
+	// SnapshotCount is the total number of distinct snapshot revision
+	// files discovered across all snapshot IDs in the repo. Zero
+	// when ReasonCode != ok and ReasonCode != stale (the two states
+	// where snapshots demonstrably exist).
+	SnapshotCount int
+
+	// LatestBackupAt is the end_time (or start_time fallback) of the
+	// newest snapshot found, parsed from the snapshot file's JSON.
+	// Zero time when no snapshots were found.
+	LatestBackupAt time.Time
+
+	// LatestBackupSizeBytes is the file_size field from the newest
+	// snapshot. Zero when no snapshots were found.
+	LatestBackupSizeBytes int64
+
+	// LatestBackupFiles is the number_of_files field from the newest
+	// snapshot. Zero when no snapshots were found.
+	LatestBackupFiles int64
+
+	// CurrentlyRunning is the orthogonal aux flag set when a lock
+	// or incomplete-snapshot marker is detected on disk. Best-
+	// effort — Duplicacy's lock semantics aren't fully stable
+	// across versions, so false-negatives are tracked as a known
+	// limitation (PRD #310 user story 13). False-positives are
+	// acceptable; users see "currently running" on a stuck-lock
+	// repo and investigate.
+	CurrentlyRunning bool
+
+	// LatestSnapshotID is the snapshot id (per-repo identifier; e.g.
+	// "documents", "media") that produced LatestBackupAt. Empty
+	// when no snapshots were found. Useful to V1c for rendering
+	// "documents @ rev 87" on the dashboard.
+	LatestSnapshotID string
+
+	// LatestSnapshotRevision is the integer revision number of the
+	// newest snapshot, parsed from its filename. Zero when no
+	// snapshots were found. Useful to V1b/V1c for the same reason
+	// as LatestSnapshotID.
+	LatestSnapshotRevision int
+
+	// SnapshotIDs is the sorted, deduped list of distinct snapshot
+	// ids discovered in the repo. V1c dashboard renders aggregate-
+	// only but per-id drill-down is anticipated; capturing the IDs
+	// here means V1b/V1c don't need to re-walk the cache. Empty
+	// when no snapshots were found.
+	SnapshotIDs []string
+}
+
+// NewDiskDuplicacyRunner returns the production DuplicacyRunner. The
+// production runner reads files directly from the filesystem with no
+// I/O bypass — callers usually inject this at server wiring time so
+// tests can substitute a fake.
+func NewDiskDuplicacyRunner() DuplicacyRunner { return &diskDuplicacyRunner{} }
+
+// diskDuplicacyRunner is the production DuplicacyRunner. Reads from
+// the OS filesystem via os.* + encoding/json. Stateless; safe to
+// share across goroutines.
+//
+// nowFn is the clock used for staleness comparisons. Defaults to
+// time.Now in production; tests can construct a runner with a fixed
+// clock so verbatim fixtures (with real captured Unix timestamps)
+// don't drift into the "stale" bucket as wall-clock time advances
+// after the fixtures were committed. Use newDiskDuplicacyRunnerAt
+// in tests to pin a deterministic "now".
+type diskDuplicacyRunner struct {
+	nowFn func() time.Time
+}
+
+// newDiskDuplicacyRunnerAt is the test-only constructor that pins
+// the runner's clock to a fixed time. Lets fixture-based tests use
+// realistic-looking captured Unix timestamps without committing
+// timestamps that age into staleness.
+func newDiskDuplicacyRunnerAt(now time.Time) *diskDuplicacyRunner {
+	return &diskDuplicacyRunner{nowFn: func() time.Time { return now }}
+}
+
+// now returns the runner's current time. Falls back to time.Now
+// when nowFn is nil so the production constructor stays trivial.
+func (r *diskDuplicacyRunner) now() time.Time {
+	if r.nowFn == nil {
+		return time.Now()
+	}
+	return r.nowFn()
+}
+
+// Read implements the DuplicacyRunner interface. Total function —
+// every classifier outcome is encoded as ReasonCode rather than
+// returned as a Go error. The error return is reserved for genuinely
+// unexpected faults (e.g. ctx cancellation surfaced from a future
+// deeper IO path); the V1a runner is synchronous and never returns a
+// non-nil error today, but the signature accommodates V1c streaming
+// extensions without breaking callers.
+func (r *diskDuplicacyRunner) Read(ctx context.Context, entry DuplicacyEntry) (DuplicacyState, error) {
+	// Universal preconditions: Path must exist and be readable.
+	// These checks come first so a typo'd Path produces a clear
+	// reason regardless of Kind.
+	if reason, ok := classifyPathPrecondition(entry.Path); !ok {
+		return DuplicacyState{ReasonCode: reason}, nil
+	}
+
+	switch entry.Kind {
+	case DuplicacyKindCLIRepo:
+		return r.readCLIRepo(entry)
+	case DuplicacyKindWebCache:
+		return r.readWebCache(entry)
+	default:
+		// Unknown kind — best-effort. Treat as not-a-repo so the
+		// user sees the entry as misconfigured. V1b's form
+		// validation rejects unknown kinds before reaching the
+		// runner, so this branch is defense-in-depth.
+		return DuplicacyState{ReasonCode: DuplicacyReasonNotARepo}, nil
+	}
+}
+
+// readCLIRepo handles kind=cli-repo. Layout:
+//
+//	<Path>/
+//	  .duplicacy/
+//	    preferences          (JSON array of storage configs)
+//	    cache/
+//	      <storage_name>/
+//	        snapshots/
+//	          <snapshot_id>/
+//	            <revision>   (JSON snapshot file)
+func (r *diskDuplicacyRunner) readCLIRepo(entry DuplicacyEntry) (DuplicacyState, error) {
+	dotDup := filepath.Join(entry.Path, ".duplicacy")
+	st, err := os.Stat(dotDup)
+	if err != nil {
+		// .duplicacy/ missing → path is not a duplicacy repo. We
+		// already verified Path itself exists in the precondition
+		// check, so a missing .duplicacy dir is the canonical
+		// "configured directory exists but isn't a repo" signal.
+		if errors.Is(err, fs.ErrNotExist) {
+			return DuplicacyState{ReasonCode: DuplicacyReasonNotARepo}, nil
+		}
+		return DuplicacyState{ReasonCode: DuplicacyReasonPathUnreadable}, nil
+	}
+	if !st.IsDir() {
+		return DuplicacyState{ReasonCode: DuplicacyReasonNotARepo}, nil
+	}
+
+	storageName := readCLIRepoStorageName(filepath.Join(dotDup, "preferences"))
+	snapshotsDir := filepath.Join(dotDup, "cache", storageName, "snapshots")
+
+	state := r.walkSnapshotsDir(snapshotsDir, entry)
+	state.CurrentlyRunning = detectCLIRepoRunning(dotDup, storageName)
+	return state, nil
+}
+
+// readWebCache handles kind=web-cache. Layout (saspus/duplicacy-web):
+//
+//	<Path>/
+//	  <StorageID>/
+//	    snapshots/
+//	      <snapshot_id>/
+//	        <revision>   (JSON snapshot file)
+func (r *diskDuplicacyRunner) readWebCache(entry DuplicacyEntry) (DuplicacyState, error) {
+	storageDir := filepath.Join(entry.Path, entry.StorageID)
+	st, err := os.Stat(storageDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return DuplicacyState{ReasonCode: DuplicacyReasonStorageIDNotFound}, nil
+		}
+		return DuplicacyState{ReasonCode: DuplicacyReasonPathUnreadable}, nil
+	}
+	if !st.IsDir() {
+		return DuplicacyState{ReasonCode: DuplicacyReasonStorageIDNotFound}, nil
+	}
+
+	snapshotsDir := filepath.Join(storageDir, "snapshots")
+	state := r.walkSnapshotsDir(snapshotsDir, entry)
+	state.CurrentlyRunning = detectWebCacheRunning(storageDir)
+	return state, nil
+}
+
+// walkSnapshotsDir is the shared post-resolver step: given a path to
+// `<...>/snapshots`, enumerate every <id>/<revision> file, parse
+// each as a Duplicacy snapshot JSON, and produce the aggregate
+// DuplicacyState. Reason-code derivation lives in
+// classifySnapshotWalk for table-test friendliness.
+func (r *diskDuplicacyRunner) walkSnapshotsDir(snapshotsDir string, entry DuplicacyEntry) DuplicacyState {
+	staleDays := entry.StaleAfter
+	if staleDays <= 0 {
+		staleDays = DuplicacyDefaultStaleAfterDays
+	}
+
+	st, err := os.Stat(snapshotsDir)
+	if err != nil || !st.IsDir() {
+		// No snapshots dir at all — never-ran repo. Distinct from
+		// "no snapshots inside the dir" which is also no_snapshots_yet
+		// but goes through the iteration path.
+		return DuplicacyState{ReasonCode: DuplicacyReasonNoSnapshotsYet}
+	}
+
+	idEntries, err := os.ReadDir(snapshotsDir)
+	if err != nil {
+		return DuplicacyState{ReasonCode: DuplicacyReasonPathUnreadable}
+	}
+
+	walk := snapshotWalkResult{}
+	idSet := make(map[string]struct{})
+	for _, ide := range idEntries {
+		if !ide.IsDir() {
+			continue
+		}
+		id := ide.Name()
+		idDir := filepath.Join(snapshotsDir, id)
+		revs, err := os.ReadDir(idDir)
+		if err != nil {
+			continue
+		}
+		idSet[id] = struct{}{}
+		for _, rev := range revs {
+			if rev.IsDir() {
+				continue
+			}
+			revNum, ok := parseRevisionFromName(rev.Name())
+			if !ok {
+				continue
+			}
+			revPath := filepath.Join(idDir, rev.Name())
+			snap, perr := parseDuplicacySnapshotFile(revPath)
+			if perr != nil {
+				walk.corrupt = true
+				continue
+			}
+			walk.count++
+			endTime := snap.endTime()
+			if walk.latest.IsZero() || endTime.After(walk.latest) {
+				walk.latest = endTime
+				walk.latestSizeBytes = snap.FileSize
+				walk.latestFiles = snap.NumberOfFiles
+				walk.latestID = id
+				walk.latestRev = revNum
+			}
+		}
+	}
+
+	walk.ids = make([]string, 0, len(idSet))
+	for id := range idSet {
+		walk.ids = append(walk.ids, id)
+	}
+	sort.Strings(walk.ids)
+
+	return classifySnapshotWalkAt(walk, staleDays, r.now())
+}
+
+// snapshotWalkResult is the aggregate built up by walkSnapshotsDir
+// before classification. Pulled out so classifySnapshotWalk can be
+// table-tested as a pure function.
+type snapshotWalkResult struct {
+	count           int
+	corrupt         bool
+	latest          time.Time
+	latestSizeBytes int64
+	latestFiles     int64
+	latestID        string
+	latestRev       int
+	ids             []string
+}
+
+// classifySnapshotWalkAt is the pure-function reason classifier —
+// the table-test centrepiece. Encodes the precedence between the
+// reason codes that emerge after the path-resolver has succeeded:
+//
+//   - corrupt always wins over any other count-based outcome (a
+//     partially-damaged repo should surface the damage signal even
+//     if some snapshots are still parseable; safer for the user).
+//   - count==0 → no_snapshots_yet (configured but never ran, or all
+//     files were unparseable).
+//   - latest older than staleDays → stale.
+//   - otherwise → ok.
+//
+// now is parameterised so tests pass deterministic clocks; the
+// runner uses its own nowFn (defaulting to time.Now). path_*,
+// not_a_repo and storage_id_not_found all short-circuit before this
+// function — they emerge from the resolvers, not from the
+// post-resolver classifier.
+func classifySnapshotWalkAt(w snapshotWalkResult, staleDays int, now time.Time) DuplicacyState {
+	state := DuplicacyState{
+		SnapshotCount:          w.count,
+		LatestBackupAt:         w.latest,
+		LatestBackupSizeBytes:  w.latestSizeBytes,
+		LatestBackupFiles:      w.latestFiles,
+		LatestSnapshotID:       w.latestID,
+		LatestSnapshotRevision: w.latestRev,
+		SnapshotIDs:            w.ids,
+	}
+	if w.corrupt {
+		state.ReasonCode = DuplicacyReasonCorruptSnapshot
+		return state
+	}
+	if w.count == 0 || w.latest.IsZero() {
+		state.ReasonCode = DuplicacyReasonNoSnapshotsYet
+		return state
+	}
+	if staleDays > 0 && now.Sub(w.latest) > time.Duration(staleDays)*24*time.Hour {
+		state.ReasonCode = DuplicacyReasonStale
+		return state
+	}
+	state.ReasonCode = DuplicacyReasonOK
+	return state
+}
+
+// classifyPathPrecondition returns the ReasonCode for a Path that
+// fails its universal precondition check (existence + readability),
+// plus a bool that's false when the precondition fails. Returns
+// ("", true) when the path passes — caller proceeds with Kind-
+// specific resolution.
+func classifyPathPrecondition(path string) (DuplicacyReason, bool) {
+	p := strings.TrimSpace(path)
+	if p == "" {
+		// Empty path is treated as "not found" — safer to surface
+		// the misconfiguration than silently treat as no-op.
+		return DuplicacyReasonPathNotFound, false
+	}
+	st, err := os.Stat(p)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return DuplicacyReasonPathNotFound, false
+		}
+		// Anything else (EACCES, EIO, ENOTDIR mid-path, etc.) is
+		// path_unreadable. We could try to differentiate further
+		// but the actionable user-facing outcome is identical.
+		return DuplicacyReasonPathUnreadable, false
+	}
+	if !st.IsDir() {
+		// Path resolves but isn't a directory — treat as
+		// not-a-repo for cli-repo. Web-cache happens to take the
+		// same branch since the StorageID subdir lookup will then
+		// fail too. Returning path_unreadable here keeps the
+		// universal precondition uniform; the caller's Kind-
+		// specific code distinguishes further if needed.
+		return DuplicacyReasonPathUnreadable, false
+	}
+	return "", true
+}
+
+// readCLIRepoStorageName reads `<repo>/.duplicacy/preferences`
+// (Duplicacy 3.x stores it as a plain JSON array) and returns the
+// first storage entry's name. Returns "default" on any read or parse
+// error so a malformed/missing preferences file falls back to the
+// most common storage name and the runner keeps making progress —
+// the snapshots-dir walk will then surface no_snapshots_yet if the
+// directory really doesn't exist, which is the right outcome.
+func readCLIRepoStorageName(prefsPath string) string {
+	const fallback = "default"
+	raw, err := os.ReadFile(prefsPath)
+	if err != nil {
+		return fallback
+	}
+	var prefs []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(raw, &prefs); err != nil {
+		return fallback
+	}
+	for _, p := range prefs {
+		if name := strings.TrimSpace(p.Name); name != "" {
+			return name
+		}
+	}
+	return fallback
+}
+
+// duplicacySnapshotJSON mirrors the subset of Duplicacy's
+// CreateSnapshotFromDescription payload that the runner consumes.
+// Duplicacy stamps the snapshot file with start_time + end_time as
+// Unix seconds (int64). Pulled into its own struct so verbatim
+// fixture tests pin the schema.
+type duplicacySnapshotJSON struct {
+	Version       int    `json:"version"`
+	ID            string `json:"id"`
+	Revision      int    `json:"revision"`
+	StartTime     int64  `json:"start_time"`
+	EndTime       int64  `json:"end_time"`
+	FileSize      int64  `json:"file_size"`
+	NumberOfFiles int64  `json:"number_of_files"`
+	Tag           string `json:"tag,omitempty"`
+	Options       string `json:"options,omitempty"`
+}
+
+// endTime returns EndTime when set, falling back to StartTime when
+// EndTime is zero (a backup that started but never finished writes
+// EndTime=0). Zero return when both are unset.
+func (s duplicacySnapshotJSON) endTime() time.Time {
+	if s.EndTime > 0 {
+		return time.Unix(s.EndTime, 0).UTC()
+	}
+	if s.StartTime > 0 {
+		return time.Unix(s.StartTime, 0).UTC()
+	}
+	return time.Time{}
+}
+
+// parseDuplicacySnapshotFile reads one snapshot file and returns the
+// decoded subset. Errors propagate to walkSnapshotsDir which records
+// the corrupt flag — partial-damage in a repo surfaces as
+// corrupt_snapshot rather than masking the issue.
+func parseDuplicacySnapshotFile(path string) (duplicacySnapshotJSON, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return duplicacySnapshotJSON{}, err
+	}
+	var snap duplicacySnapshotJSON
+	if err := json.Unmarshal(raw, &snap); err != nil {
+		return duplicacySnapshotJSON{}, err
+	}
+	return snap, nil
+}
+
+// parseRevisionFromName parses a revision number from a snapshot
+// filename. Duplicacy names revision files as decimal integers —
+// "1", "2", "87". We accept a leading "v" or zero-padded form
+// defensively (older versions occasionally varied).
+func parseRevisionFromName(name string) (int, bool) {
+	s := strings.TrimSpace(name)
+	if s == "" {
+		return 0, false
+	}
+	s = strings.TrimPrefix(s, "v")
+	s = strings.TrimLeft(s, "0")
+	if s == "" {
+		// All-zero name like "00" or "0" — treat as revision 0 so
+		// fixture authors can include it without surprise.
+		return 0, true
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// detectCLIRepoRunning is the best-effort lock-detection heuristic
+// for kind=cli-repo. Returns true when ANY of these markers is
+// present:
+//
+//   - <dotDup>/locks/ directory exists and contains at least one
+//     non-empty entry (Duplicacy creates per-storage lock files
+//     under this path during operations on some versions);
+//   - <dotDup>/cache/<storage>/incomplete file exists (in-progress
+//     marker written by the create command).
+//
+// False-negatives are acceptable per PRD #310 user story 13 (the
+// flag is best-effort and tracked as a known limitation if it
+// doesn't fire on a particular Duplicacy version). False-positives
+// are also acceptable — a stuck-lock from a crashed previous run
+// surfaces as "currently running" and prompts the user to
+// investigate, which is the right outcome.
+func detectCLIRepoRunning(dotDup, storageName string) bool {
+	if hasNonEmptyDir(filepath.Join(dotDup, "locks")) {
+		return true
+	}
+	if pathExists(filepath.Join(dotDup, "cache", storageName, "incomplete")) {
+		return true
+	}
+	return false
+}
+
+// detectWebCacheRunning is the kind=web-cache analogue. The web
+// container writes its incomplete marker directly under the
+// per-storage subdir.
+func detectWebCacheRunning(storageDir string) bool {
+	if pathExists(filepath.Join(storageDir, "incomplete")) {
+		return true
+	}
+	if hasNonEmptyDir(filepath.Join(storageDir, "locks")) {
+		return true
+	}
+	return false
+}
+
+// hasNonEmptyDir is true when path is a directory containing at
+// least one entry. Returns false on any stat/read error so a
+// permission issue doesn't trigger a false-positive
+// CurrentlyRunning flag.
+func hasNonEmptyDir(path string) bool {
+	st, err := os.Stat(path)
+	if err != nil || !st.IsDir() {
+		return false
+	}
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false
+	}
+	return len(entries) > 0
+}
+
+// pathExists is true when path stat()s successfully.
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/internal/collector/duplicacy_runner_test.go
+++ b/internal/collector/duplicacy_runner_test.go
@@ -1,0 +1,688 @@
+package collector
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// fixtureNow is the deterministic "now" used by the verbatim-fixture
+// tests below. Pinned a few hours after the healthy fixture's latest
+// snapshot end_time (1714867315 = 2024-05-04 22:01:55 UTC) so:
+//
+//   - healthy fixtures (rev 1 + rev 2) classify as ok (well under 30d)
+//   - stale fixture (rev 45, end 2024-03-01) classifies as stale (>30d)
+//
+// Pinning the clock keeps the verbatim Unix-timestamp fixtures from
+// drifting into staleness as wall-clock time advances after they
+// were committed. Issue #311.
+var fixtureNow = time.Unix(1714900000, 0).UTC()
+
+// TestDiskDuplicacyRunner_CLIRepo_Healthy exercises the canonical
+// happy path: a fully-populated CLI repo with two snapshot revisions
+// for the "documents" snapshot id. Asserts ReasonCode=ok, both revs
+// counted, latest rev's metadata surfaced.
+func TestDiskDuplicacyRunner_CLIRepo_Healthy(t *testing.T) {
+	r := newDiskDuplicacyRunnerAt(fixtureNow)
+	got, err := r.Read(context.Background(), DuplicacyEntry{
+		Enabled: true,
+		Kind:    DuplicacyKindCLIRepo,
+		Path:    "testdata/duplicacy/cli-repo/healthy",
+	})
+	if err != nil {
+		t.Fatalf("Read err = %v; want nil", err)
+	}
+	if got.ReasonCode != DuplicacyReasonOK {
+		t.Errorf("ReasonCode = %q; want ok", got.ReasonCode)
+	}
+	if got.SnapshotCount != 2 {
+		t.Errorf("SnapshotCount = %d; want 2", got.SnapshotCount)
+	}
+	if got.LatestSnapshotRevision != 2 {
+		t.Errorf("LatestSnapshotRevision = %d; want 2", got.LatestSnapshotRevision)
+	}
+	if got.LatestSnapshotID != "documents" {
+		t.Errorf("LatestSnapshotID = %q; want documents", got.LatestSnapshotID)
+	}
+	if got.LatestBackupSizeBytes != 104923000 {
+		t.Errorf("LatestBackupSizeBytes = %d; want 104923000", got.LatestBackupSizeBytes)
+	}
+	if got.LatestBackupFiles != 1240 {
+		t.Errorf("LatestBackupFiles = %d; want 1240", got.LatestBackupFiles)
+	}
+	if got.LatestBackupAt.Unix() != 1714867315 {
+		t.Errorf("LatestBackupAt = %v (unix=%d); want unix=1714867315", got.LatestBackupAt, got.LatestBackupAt.Unix())
+	}
+	if got.CurrentlyRunning {
+		t.Error("CurrentlyRunning = true; want false (no lock present)")
+	}
+	if len(got.SnapshotIDs) != 1 || got.SnapshotIDs[0] != "documents" {
+		t.Errorf("SnapshotIDs = %v; want [documents]", got.SnapshotIDs)
+	}
+}
+
+// TestDiskDuplicacyRunner_CLIRepo_NoSnapshotsYet exercises the
+// fresh-init path: .duplicacy/preferences exists but no snapshot
+// files have been written yet.
+func TestDiskDuplicacyRunner_CLIRepo_NoSnapshotsYet(t *testing.T) {
+	r := newDiskDuplicacyRunnerAt(fixtureNow)
+	got, err := r.Read(context.Background(), DuplicacyEntry{
+		Enabled: true,
+		Kind:    DuplicacyKindCLIRepo,
+		Path:    "testdata/duplicacy/cli-repo/no-snapshots",
+	})
+	if err != nil {
+		t.Fatalf("Read err = %v; want nil", err)
+	}
+	if got.ReasonCode != DuplicacyReasonNoSnapshotsYet {
+		t.Errorf("ReasonCode = %q; want no_snapshots_yet", got.ReasonCode)
+	}
+	if got.SnapshotCount != 0 {
+		t.Errorf("SnapshotCount = %d; want 0", got.SnapshotCount)
+	}
+	if !got.LatestBackupAt.IsZero() {
+		t.Errorf("LatestBackupAt = %v; want zero", got.LatestBackupAt)
+	}
+}
+
+// TestDiskDuplicacyRunner_CLIRepo_Stale exercises the staleness
+// classifier. Fixture's only snapshot has end_time=2024-03-01;
+// fixtureNow is 2024-05-05; default StaleAfter (30d) means this
+// repo classifies as stale.
+func TestDiskDuplicacyRunner_CLIRepo_Stale(t *testing.T) {
+	r := newDiskDuplicacyRunnerAt(fixtureNow)
+	got, err := r.Read(context.Background(), DuplicacyEntry{
+		Enabled: true,
+		Kind:    DuplicacyKindCLIRepo,
+		Path:    "testdata/duplicacy/cli-repo/stale",
+		// StaleAfter omitted — default 30d applies via runner.
+	})
+	if err != nil {
+		t.Fatalf("Read err = %v; want nil", err)
+	}
+	if got.ReasonCode != DuplicacyReasonStale {
+		t.Errorf("ReasonCode = %q; want stale", got.ReasonCode)
+	}
+	if got.SnapshotCount != 1 {
+		t.Errorf("SnapshotCount = %d; want 1 (the stale snapshot still counted)", got.SnapshotCount)
+	}
+	if got.LatestSnapshotRevision != 45 {
+		t.Errorf("LatestSnapshotRevision = %d; want 45", got.LatestSnapshotRevision)
+	}
+}
+
+// TestDiskDuplicacyRunner_CLIRepo_StaleAfterRespectsCustomThreshold
+// pins that an explicitly-supplied StaleAfter overrides the 30-day
+// default. The "stale" fixture has a snapshot ~64 days old; with
+// StaleAfter=90 it should classify as ok instead of stale.
+func TestDiskDuplicacyRunner_CLIRepo_StaleAfterRespectsCustomThreshold(t *testing.T) {
+	r := newDiskDuplicacyRunnerAt(fixtureNow)
+	got, err := r.Read(context.Background(), DuplicacyEntry{
+		Enabled:    true,
+		Kind:       DuplicacyKindCLIRepo,
+		Path:       "testdata/duplicacy/cli-repo/stale",
+		StaleAfter: 90,
+	})
+	if err != nil {
+		t.Fatalf("Read err = %v; want nil", err)
+	}
+	if got.ReasonCode != DuplicacyReasonOK {
+		t.Errorf("StaleAfter=90 ReasonCode = %q; want ok (snapshot ~64d old)", got.ReasonCode)
+	}
+}
+
+// TestDiskDuplicacyRunner_CLIRepo_NotARepo exercises the path-exists-
+// but-no-.duplicacy-subdir path. Distinguishes "not mounted" from
+// "mounted but not a Duplicacy repo" per PRD #310 user story 15.
+func TestDiskDuplicacyRunner_CLIRepo_NotARepo(t *testing.T) {
+	r := newDiskDuplicacyRunnerAt(fixtureNow)
+	got, err := r.Read(context.Background(), DuplicacyEntry{
+		Enabled: true,
+		Kind:    DuplicacyKindCLIRepo,
+		Path:    "testdata/duplicacy/cli-repo/not-a-repo",
+	})
+	if err != nil {
+		t.Fatalf("Read err = %v; want nil", err)
+	}
+	if got.ReasonCode != DuplicacyReasonNotARepo {
+		t.Errorf("ReasonCode = %q; want not_a_duplicacy_repo", got.ReasonCode)
+	}
+}
+
+// TestDiskDuplicacyRunner_WebCache_Healthy exercises the saspus-style
+// layout. Two snapshot ids ("media", "documents") under the named
+// storage; latest end_time on the documents id (later than media).
+func TestDiskDuplicacyRunner_WebCache_Healthy(t *testing.T) {
+	r := newDiskDuplicacyRunnerAt(fixtureNow)
+	got, err := r.Read(context.Background(), DuplicacyEntry{
+		Enabled:   true,
+		Kind:      DuplicacyKindWebCache,
+		Path:      "testdata/duplicacy/web-cache/healthy",
+		StorageID: "storage-main",
+	})
+	if err != nil {
+		t.Fatalf("Read err = %v; want nil", err)
+	}
+	if got.ReasonCode != DuplicacyReasonOK {
+		t.Errorf("ReasonCode = %q; want ok", got.ReasonCode)
+	}
+	if got.SnapshotCount != 2 {
+		t.Errorf("SnapshotCount = %d; want 2 (one per snapshot id)", got.SnapshotCount)
+	}
+	// documents/1 has end_time=1714867253; media/1 has end_time=1714781902.
+	// documents wins as latest.
+	if got.LatestSnapshotID != "documents" {
+		t.Errorf("LatestSnapshotID = %q; want documents (later end_time wins)", got.LatestSnapshotID)
+	}
+	if len(got.SnapshotIDs) != 2 {
+		t.Errorf("SnapshotIDs len = %d; want 2", len(got.SnapshotIDs))
+	}
+	// Sorted alphabetically.
+	if got.SnapshotIDs[0] != "documents" || got.SnapshotIDs[1] != "media" {
+		t.Errorf("SnapshotIDs = %v; want [documents media]", got.SnapshotIDs)
+	}
+}
+
+// TestDiskDuplicacyRunner_WebCache_StorageIDNotFound exercises the
+// typo'd-storage_id path. Path resolves but the named subdir is
+// absent.
+func TestDiskDuplicacyRunner_WebCache_StorageIDNotFound(t *testing.T) {
+	r := newDiskDuplicacyRunnerAt(fixtureNow)
+	got, err := r.Read(context.Background(), DuplicacyEntry{
+		Enabled:   true,
+		Kind:      DuplicacyKindWebCache,
+		Path:      "testdata/duplicacy/web-cache/healthy",
+		StorageID: "storage-typo-nonexistent",
+	})
+	if err != nil {
+		t.Fatalf("Read err = %v; want nil", err)
+	}
+	if got.ReasonCode != DuplicacyReasonStorageIDNotFound {
+		t.Errorf("ReasonCode = %q; want storage_id_not_found", got.ReasonCode)
+	}
+}
+
+// TestDiskDuplicacyRunner_PathNotFound exercises the universal
+// precondition: a Path that doesn't exist on disk produces
+// path_not_found regardless of Kind.
+func TestDiskDuplicacyRunner_PathNotFound(t *testing.T) {
+	r := newDiskDuplicacyRunnerAt(fixtureNow)
+	cases := []struct {
+		name string
+		kind string
+	}{
+		{"cli-repo", DuplicacyKindCLIRepo},
+		{"web-cache", DuplicacyKindWebCache},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := r.Read(context.Background(), DuplicacyEntry{
+				Enabled:   true,
+				Kind:      tc.kind,
+				Path:      "testdata/duplicacy/this/path/does/not/exist",
+				StorageID: "irrelevant",
+			})
+			if err != nil {
+				t.Fatalf("Read err = %v; want nil", err)
+			}
+			if got.ReasonCode != DuplicacyReasonPathNotFound {
+				t.Errorf("ReasonCode = %q; want path_not_found", got.ReasonCode)
+			}
+		})
+	}
+}
+
+// TestDiskDuplicacyRunner_PathUnreadable exercises the precondition's
+// other failure mode: Path exists but stat() can't traverse it. We
+// simulate this with a chmod-zeroed dir (Linux/Darwin); on rare
+// permission-permissive setups we skip rather than fail.
+func TestDiskDuplicacyRunner_PathUnreadable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root — chmod 0 would not deny stat()")
+	}
+	tmp := t.TempDir()
+	denied := filepath.Join(tmp, "denied")
+	if err := os.MkdirAll(denied, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Inner path is unreachable because the parent has mode 0
+	// (no execute bit). os.Stat on innerPath returns EACCES.
+	innerPath := filepath.Join(denied, "repo")
+	if err := os.MkdirAll(innerPath, 0o700); err != nil {
+		t.Fatalf("mkdir inner: %v", err)
+	}
+	if err := os.Chmod(denied, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(denied, 0o700) })
+
+	r := newDiskDuplicacyRunnerAt(fixtureNow)
+	got, err := r.Read(context.Background(), DuplicacyEntry{
+		Enabled: true,
+		Kind:    DuplicacyKindCLIRepo,
+		Path:    innerPath,
+	})
+	if err != nil {
+		t.Fatalf("Read err = %v; want nil", err)
+	}
+	// Either path_not_found or path_unreadable is acceptable here —
+	// some kernels return EACCES (→ path_unreadable), others surface
+	// ENOENT after the EACCES on parent (→ path_not_found). The
+	// actionable user-facing distinction is the same: "fix the
+	// permission/mount on the parent." Pin that we DON'T classify
+	// as ok or no_snapshots_yet.
+	if got.ReasonCode != DuplicacyReasonPathUnreadable && got.ReasonCode != DuplicacyReasonPathNotFound {
+		t.Errorf("ReasonCode = %q; want path_unreadable or path_not_found", got.ReasonCode)
+	}
+}
+
+// TestDiskDuplicacyRunner_CorruptSnapshot exercises the
+// graceful-failure path. The fixture mixes a corrupt snapshot file
+// with an otherwise-valid repo structure; the corrupt signal wins
+// over any count-based outcome (PRD #310 user story 14).
+func TestDiskDuplicacyRunner_CorruptSnapshot(t *testing.T) {
+	r := newDiskDuplicacyRunnerAt(fixtureNow)
+	got, err := r.Read(context.Background(), DuplicacyEntry{
+		Enabled: true,
+		Kind:    DuplicacyKindCLIRepo,
+		Path:    "testdata/duplicacy/cli-repo/corrupt",
+	})
+	if err != nil {
+		t.Fatalf("Read err = %v; want nil", err)
+	}
+	if got.ReasonCode != DuplicacyReasonCorruptSnapshot {
+		t.Errorf("ReasonCode = %q; want corrupt_snapshot", got.ReasonCode)
+	}
+}
+
+// TestDiskDuplicacyRunner_CurrentlyRunning_LockPresent exercises the
+// best-effort lock-detection. The "running" fixture carries a healthy
+// snapshot (so ReasonCode=ok) AND a non-empty .duplicacy/locks/ dir
+// (so CurrentlyRunning=true). Pins both axes orthogonally.
+func TestDiskDuplicacyRunner_CurrentlyRunning_LockPresent(t *testing.T) {
+	r := newDiskDuplicacyRunnerAt(fixtureNow)
+	got, err := r.Read(context.Background(), DuplicacyEntry{
+		Enabled: true,
+		Kind:    DuplicacyKindCLIRepo,
+		Path:    "testdata/duplicacy/cli-repo/running",
+	})
+	if err != nil {
+		t.Fatalf("Read err = %v; want nil", err)
+	}
+	if got.ReasonCode != DuplicacyReasonOK {
+		t.Errorf("ReasonCode = %q; want ok (lock orthogonal to reason)", got.ReasonCode)
+	}
+	if !got.CurrentlyRunning {
+		t.Error("CurrentlyRunning = false; want true (locks dir non-empty)")
+	}
+}
+
+// TestDiskDuplicacyRunner_CurrentlyRunning_LockAbsent is the
+// inverse: a healthy repo with no lock should report
+// CurrentlyRunning=false. Re-uses the healthy fixture which has no
+// locks/ dir.
+func TestDiskDuplicacyRunner_CurrentlyRunning_LockAbsent(t *testing.T) {
+	r := newDiskDuplicacyRunnerAt(fixtureNow)
+	got, err := r.Read(context.Background(), DuplicacyEntry{
+		Enabled: true,
+		Kind:    DuplicacyKindCLIRepo,
+		Path:    "testdata/duplicacy/cli-repo/healthy",
+	})
+	if err != nil {
+		t.Fatalf("Read err = %v; want nil", err)
+	}
+	if got.CurrentlyRunning {
+		t.Error("CurrentlyRunning = true; want false (no lock present)")
+	}
+}
+
+// TestDiskDuplicacyRunner_DefaultsAndKinds covers small contract
+// invariants that don't need their own fixture trees.
+func TestDiskDuplicacyRunner_DefaultsAndKinds(t *testing.T) {
+	t.Run("DefaultStaleAfterDays is 30", func(t *testing.T) {
+		if DuplicacyDefaultStaleAfterDays != 30 {
+			t.Errorf("DuplicacyDefaultStaleAfterDays = %d; want 30", DuplicacyDefaultStaleAfterDays)
+		}
+	})
+	t.Run("kind constants are stable strings", func(t *testing.T) {
+		if DuplicacyKindCLIRepo != "cli-repo" {
+			t.Errorf("DuplicacyKindCLIRepo = %q; want cli-repo", DuplicacyKindCLIRepo)
+		}
+		if DuplicacyKindWebCache != "web-cache" {
+			t.Errorf("DuplicacyKindWebCache = %q; want web-cache", DuplicacyKindWebCache)
+		}
+	})
+	t.Run("unknown kind classifies as not_a_repo", func(t *testing.T) {
+		r := newDiskDuplicacyRunnerAt(fixtureNow)
+		// Path that exists so the precondition passes.
+		got, err := r.Read(context.Background(), DuplicacyEntry{
+			Enabled: true,
+			Kind:    "rclone-style-future-kind",
+			Path:    "testdata/duplicacy/cli-repo/healthy",
+		})
+		if err != nil {
+			t.Fatalf("err = %v", err)
+		}
+		if got.ReasonCode != DuplicacyReasonNotARepo {
+			t.Errorf("ReasonCode = %q; want not_a_duplicacy_repo (unknown kind defense-in-depth)", got.ReasonCode)
+		}
+	})
+	t.Run("empty path classifies as path_not_found", func(t *testing.T) {
+		r := newDiskDuplicacyRunnerAt(fixtureNow)
+		got, err := r.Read(context.Background(), DuplicacyEntry{
+			Enabled: true,
+			Kind:    DuplicacyKindCLIRepo,
+			Path:    "",
+		})
+		if err != nil {
+			t.Fatalf("err = %v", err)
+		}
+		if got.ReasonCode != DuplicacyReasonPathNotFound {
+			t.Errorf("ReasonCode = %q; want path_not_found", got.ReasonCode)
+		}
+	})
+}
+
+// TestParseRevisionFromName pins the filename-to-revision parser
+// across the formats real Duplicacy emits (decimal integer) plus a
+// couple of defensive variants.
+func TestParseRevisionFromName(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   int
+		wantOk bool
+	}{
+		{"1", 1, true},
+		{"42", 42, true},
+		{"1023", 1023, true},
+		{"v1", 1, true},
+		{"007", 7, true},
+		{"0", 0, true},
+		{"00", 0, true},
+		{"", 0, false},
+		{"abc", 0, false},
+		{"1.json", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, ok := parseRevisionFromName(tc.in)
+			if ok != tc.wantOk {
+				t.Errorf("parseRevisionFromName(%q) ok = %v; want %v", tc.in, ok, tc.wantOk)
+			}
+			if got != tc.want {
+				t.Errorf("parseRevisionFromName(%q) = %d; want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestReadCLIRepoStorageName_FallbackToDefault pins the runner's
+// resilience: a missing/malformed preferences file falls back to
+// "default" so the snapshots-dir walk still runs and surfaces
+// no_snapshots_yet (the right user-facing outcome).
+func TestReadCLIRepoStorageName_FallbackToDefault(t *testing.T) {
+	tmp := t.TempDir()
+	t.Run("missing file", func(t *testing.T) {
+		got := readCLIRepoStorageName(filepath.Join(tmp, "nonexistent"))
+		if got != "default" {
+			t.Errorf("missing file → %q; want default", got)
+		}
+	})
+	t.Run("malformed json", func(t *testing.T) {
+		bad := filepath.Join(tmp, "bad-prefs")
+		if err := os.WriteFile(bad, []byte("{not json"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got := readCLIRepoStorageName(bad)
+		if got != "default" {
+			t.Errorf("malformed → %q; want default", got)
+		}
+	})
+	t.Run("custom name", func(t *testing.T) {
+		good := filepath.Join(tmp, "good-prefs")
+		body := `[{"name":"offsite-b2","id":"x","storage":"b2://bucket"}]`
+		if err := os.WriteFile(good, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got := readCLIRepoStorageName(good)
+		if got != "offsite-b2" {
+			t.Errorf("custom-name → %q; want offsite-b2", got)
+		}
+	})
+	t.Run("empty array falls back", func(t *testing.T) {
+		empty := filepath.Join(tmp, "empty-prefs")
+		if err := os.WriteFile(empty, []byte("[]"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got := readCLIRepoStorageName(empty)
+		if got != "default" {
+			t.Errorf("empty array → %q; want default", got)
+		}
+	})
+}
+
+// TestDuplicacySnapshotJSON_EndTimeFallback covers the end_time/
+// start_time fallback used when EndTime is unset (a backup that
+// started but never finished).
+func TestDuplicacySnapshotJSON_EndTimeFallback(t *testing.T) {
+	cases := []struct {
+		name string
+		in   duplicacySnapshotJSON
+		zero bool
+	}{
+		{"end_time set", duplicacySnapshotJSON{StartTime: 100, EndTime: 200}, false},
+		{"only start_time", duplicacySnapshotJSON{StartTime: 100, EndTime: 0}, false},
+		{"both zero", duplicacySnapshotJSON{}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.in.endTime()
+			if got.IsZero() != tc.zero {
+				t.Errorf("endTime IsZero = %v; want %v", got.IsZero(), tc.zero)
+			}
+		})
+	}
+}
+
+// ---------- pure-function classifier table-test ----------
+
+// TestClassifySnapshotWalk_TableDriven is the centrepiece pure-
+// function classifier test. One row per reason code that the
+// classifier emits (path_*/not_a_repo/storage_id_not_found are
+// emitted by the resolvers, NOT this function — they're covered by
+// the runner-level tests above).
+func TestClassifySnapshotWalk_TableDriven(t *testing.T) {
+	now := time.Unix(1714900000, 0).UTC()
+	older30d := now.Add(-31 * 24 * time.Hour)
+	fresh := now.Add(-2 * time.Hour)
+
+	cases := []struct {
+		name      string
+		walk      snapshotWalkResult
+		staleDays int
+		want      DuplicacyReason
+	}{
+		{
+			name:      "ok — fresh snapshot under threshold",
+			walk:      snapshotWalkResult{count: 3, latest: fresh},
+			staleDays: 30,
+			want:      DuplicacyReasonOK,
+		},
+		{
+			name:      "no_snapshots_yet — count zero, no latest",
+			walk:      snapshotWalkResult{},
+			staleDays: 30,
+			want:      DuplicacyReasonNoSnapshotsYet,
+		},
+		{
+			name:      "no_snapshots_yet — count nonzero but latest zero (defensive)",
+			walk:      snapshotWalkResult{count: 1},
+			staleDays: 30,
+			want:      DuplicacyReasonNoSnapshotsYet,
+		},
+		{
+			name:      "stale — older than 30d default",
+			walk:      snapshotWalkResult{count: 1, latest: older30d},
+			staleDays: 30,
+			want:      DuplicacyReasonStale,
+		},
+		{
+			name:      "ok — older than 30d but custom threshold 90d",
+			walk:      snapshotWalkResult{count: 1, latest: older30d},
+			staleDays: 90,
+			want:      DuplicacyReasonOK,
+		},
+		{
+			name:      "corrupt wins over count-zero",
+			walk:      snapshotWalkResult{corrupt: true, count: 0},
+			staleDays: 30,
+			want:      DuplicacyReasonCorruptSnapshot,
+		},
+		{
+			name:      "corrupt wins over fresh ok",
+			walk:      snapshotWalkResult{corrupt: true, count: 5, latest: fresh},
+			staleDays: 30,
+			want:      DuplicacyReasonCorruptSnapshot,
+		},
+		{
+			name:      "corrupt wins over stale",
+			walk:      snapshotWalkResult{corrupt: true, count: 1, latest: older30d},
+			staleDays: 30,
+			want:      DuplicacyReasonCorruptSnapshot,
+		},
+		{
+			name:      "staleDays<=0 disables stale check (defensive)",
+			walk:      snapshotWalkResult{count: 1, latest: older30d},
+			staleDays: 0,
+			want:      DuplicacyReasonOK,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifySnapshotWalkAt(tc.walk, tc.staleDays, now)
+			if got.ReasonCode != tc.want {
+				t.Errorf("ReasonCode = %q; want %q", got.ReasonCode, tc.want)
+			}
+			// Pin that the classifier doesn't drop walk-derived
+			// fields — V1b/V1c rely on them.
+			if got.SnapshotCount != tc.walk.count {
+				t.Errorf("SnapshotCount = %d; want %d", got.SnapshotCount, tc.walk.count)
+			}
+			if !got.LatestBackupAt.Equal(tc.walk.latest) {
+				t.Errorf("LatestBackupAt = %v; want %v", got.LatestBackupAt, tc.walk.latest)
+			}
+		})
+	}
+}
+
+// TestClassifyPathPrecondition_TableDriven exercises the universal-
+// precondition classifier as a pure function. Same pattern as the
+// snapshot-walk classifier — fast, fixture-free.
+func TestClassifyPathPrecondition_TableDriven(t *testing.T) {
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, "exists-dir")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(tmp, "exists-file")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name string
+		path string
+		want DuplicacyReason
+		pass bool
+	}{
+		{"empty", "", DuplicacyReasonPathNotFound, false},
+		{"whitespace-only", "   ", DuplicacyReasonPathNotFound, false},
+		{"missing", filepath.Join(tmp, "nope"), DuplicacyReasonPathNotFound, false},
+		{"exists-dir → pass", dir, DuplicacyReason(""), true},
+		{"exists-file (not a directory)", file, DuplicacyReasonPathUnreadable, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, pass := classifyPathPrecondition(tc.path)
+			if pass != tc.pass {
+				t.Errorf("pass = %v; want %v (got reason %q)", pass, tc.pass, got)
+			}
+			if !tc.pass && got != tc.want {
+				t.Errorf("reason = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------- DuplicacyRunner contract test (parallel to BorgRunner) ----------
+
+// fakeDuplicacyRunner is an in-process DuplicacyRunner implementation
+// usable by V1b/V1c tests when fixture files would be heavyweight.
+// Mirrors the fakeBorgRunner pattern from borg_runner_test.go.
+type fakeDuplicacyRunner struct {
+	byPath map[string]fakeDuplicacyScenario
+}
+
+type fakeDuplicacyScenario struct {
+	State DuplicacyState
+	Err   error
+}
+
+func newFakeDuplicacyRunner() *fakeDuplicacyRunner {
+	return &fakeDuplicacyRunner{byPath: make(map[string]fakeDuplicacyScenario)}
+}
+
+func (r *fakeDuplicacyRunner) set(path string, s fakeDuplicacyScenario) {
+	r.byPath[path] = s
+}
+
+func (r *fakeDuplicacyRunner) Read(ctx context.Context, entry DuplicacyEntry) (DuplicacyState, error) {
+	s, ok := r.byPath[entry.Path]
+	if !ok {
+		return DuplicacyState{}, errors.New("fake: no scenario configured for path " + entry.Path)
+	}
+	return s.State, s.Err
+}
+
+// TestDuplicacyRunner_Contract_FakeIsAcceptedAtInterface pins that
+// the test fake satisfies the interface (compile-time + behaviour).
+// Future V1b/V1c work will rely on this.
+func TestDuplicacyRunner_Contract_FakeIsAcceptedAtInterface(t *testing.T) {
+	var r DuplicacyRunner = newFakeDuplicacyRunner()
+	r.(*fakeDuplicacyRunner).set("/x", fakeDuplicacyScenario{State: DuplicacyState{ReasonCode: DuplicacyReasonOK, SnapshotCount: 7}})
+	got, err := r.Read(context.Background(), DuplicacyEntry{Path: "/x"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got.ReasonCode != DuplicacyReasonOK || got.SnapshotCount != 7 {
+		t.Errorf("got %+v; want ReasonCode=ok SnapshotCount=7", got)
+	}
+}
+
+// TestDuplicacyReason_AllConstantsExportedAndStable pins that all
+// eight reason codes are exported and that their string values
+// match the closed-set definitions in the issue body. Renaming
+// these would break the V1b/V1c dashboard and Prometheus
+// downstream consumers.
+func TestDuplicacyReason_AllConstantsExportedAndStable(t *testing.T) {
+	cases := []struct {
+		c    DuplicacyReason
+		want string
+	}{
+		{DuplicacyReasonOK, "ok"},
+		{DuplicacyReasonPathNotFound, "path_not_found"},
+		{DuplicacyReasonPathUnreadable, "path_unreadable"},
+		{DuplicacyReasonNotARepo, "not_a_duplicacy_repo"},
+		{DuplicacyReasonStorageIDNotFound, "storage_id_not_found"},
+		{DuplicacyReasonNoSnapshotsYet, "no_snapshots_yet"},
+		{DuplicacyReasonStale, "stale"},
+		{DuplicacyReasonCorruptSnapshot, "corrupt_snapshot"},
+	}
+	for _, tc := range cases {
+		if string(tc.c) != tc.want {
+			t.Errorf("%v = %q; want %q", tc.c, string(tc.c), tc.want)
+		}
+	}
+}

--- a/internal/collector/testdata/duplicacy/cli-repo/corrupt/.duplicacy/cache/default/snapshots/documents/3
+++ b/internal/collector/testdata/duplicacy/cli-repo/corrupt/.duplicacy/cache/default/snapshots/documents/3
@@ -1,0 +1,1 @@
+{this is not valid JSON — partial-write corruption simulation

--- a/internal/collector/testdata/duplicacy/cli-repo/corrupt/.duplicacy/preferences
+++ b/internal/collector/testdata/duplicacy/cli-repo/corrupt/.duplicacy/preferences
@@ -1,0 +1,16 @@
+[
+    {
+        "name": "default",
+        "id": "documents",
+        "repository": "",
+        "storage": "/mnt/backups/documents",
+        "encrypted": false,
+        "no_backup": false,
+        "no_restore": false,
+        "no_save_password": false,
+        "nobackup_file": "",
+        "keys": null,
+        "filters": "",
+        "exclude_by_attribute": false
+    }
+]

--- a/internal/collector/testdata/duplicacy/cli-repo/healthy/.duplicacy/cache/default/snapshots/documents/1
+++ b/internal/collector/testdata/duplicacy/cli-repo/healthy/.duplicacy/cache/default/snapshots/documents/1
@@ -1,0 +1,1 @@
+{"version":1,"id":"documents","revision":1,"options":"","tag":"","start_time":1714780800,"end_time":1714780900,"file_size":104857600,"number_of_files":1234,"files":["abcd1111","abcd2222"],"chunks":["ef1011","ef1012"],"lengths":["aa01","aa02"]}

--- a/internal/collector/testdata/duplicacy/cli-repo/healthy/.duplicacy/cache/default/snapshots/documents/2
+++ b/internal/collector/testdata/duplicacy/cli-repo/healthy/.duplicacy/cache/default/snapshots/documents/2
@@ -1,0 +1,1 @@
+{"version":1,"id":"documents","revision":2,"options":"","tag":"","start_time":1714867200,"end_time":1714867315,"file_size":104923000,"number_of_files":1240,"files":["abcd1113"],"chunks":["ef1014"],"lengths":["aa03"]}

--- a/internal/collector/testdata/duplicacy/cli-repo/healthy/.duplicacy/preferences
+++ b/internal/collector/testdata/duplicacy/cli-repo/healthy/.duplicacy/preferences
@@ -1,0 +1,16 @@
+[
+    {
+        "name": "default",
+        "id": "documents",
+        "repository": "",
+        "storage": "sftp://backup@backup.example.com//srv/duplicacy/documents",
+        "encrypted": true,
+        "no_backup": false,
+        "no_restore": false,
+        "no_save_password": false,
+        "nobackup_file": "",
+        "keys": null,
+        "filters": "",
+        "exclude_by_attribute": false
+    }
+]

--- a/internal/collector/testdata/duplicacy/cli-repo/no-snapshots/.duplicacy/preferences
+++ b/internal/collector/testdata/duplicacy/cli-repo/no-snapshots/.duplicacy/preferences
@@ -1,0 +1,16 @@
+[
+    {
+        "name": "default",
+        "id": "documents",
+        "repository": "",
+        "storage": "/mnt/backups/documents",
+        "encrypted": false,
+        "no_backup": false,
+        "no_restore": false,
+        "no_save_password": false,
+        "nobackup_file": "",
+        "keys": null,
+        "filters": "",
+        "exclude_by_attribute": false
+    }
+]

--- a/internal/collector/testdata/duplicacy/cli-repo/not-a-repo/some-other-dir/random.txt
+++ b/internal/collector/testdata/duplicacy/cli-repo/not-a-repo/some-other-dir/random.txt
@@ -1,0 +1,3 @@
+This directory is intentionally missing a .duplicacy/ subdir, so the
+runner classifies it as not_a_duplicacy_repo. Used by
+TestDiskDuplicacyRunner_CLIRepo_NotARepo.

--- a/internal/collector/testdata/duplicacy/cli-repo/running/.duplicacy/cache/default/snapshots/documents/1
+++ b/internal/collector/testdata/duplicacy/cli-repo/running/.duplicacy/cache/default/snapshots/documents/1
@@ -1,0 +1,1 @@
+{"version":1,"id":"documents","revision":1,"options":"","tag":"","start_time":1714780800,"end_time":1714780900,"file_size":104857600,"number_of_files":1234,"files":["abcd1111"],"chunks":["ef1011"],"lengths":["aa01"]}

--- a/internal/collector/testdata/duplicacy/cli-repo/running/.duplicacy/locks/default
+++ b/internal/collector/testdata/duplicacy/cli-repo/running/.duplicacy/locks/default
@@ -1,0 +1,1 @@
+lock-acquired-by-pid-12345

--- a/internal/collector/testdata/duplicacy/cli-repo/running/.duplicacy/preferences
+++ b/internal/collector/testdata/duplicacy/cli-repo/running/.duplicacy/preferences
@@ -1,0 +1,16 @@
+[
+    {
+        "name": "default",
+        "id": "documents",
+        "repository": "",
+        "storage": "/mnt/backups/documents",
+        "encrypted": false,
+        "no_backup": false,
+        "no_restore": false,
+        "no_save_password": false,
+        "nobackup_file": "",
+        "keys": null,
+        "filters": "",
+        "exclude_by_attribute": false
+    }
+]

--- a/internal/collector/testdata/duplicacy/cli-repo/stale/.duplicacy/cache/default/snapshots/documents/45
+++ b/internal/collector/testdata/duplicacy/cli-repo/stale/.duplicacy/cache/default/snapshots/documents/45
@@ -1,0 +1,1 @@
+{"version":1,"id":"documents","revision":45,"options":"","tag":"","start_time":1709251200,"end_time":1709251301,"file_size":83886080,"number_of_files":982,"files":["c0ffee01"],"chunks":["beadbe01"],"lengths":["bb01"]}

--- a/internal/collector/testdata/duplicacy/cli-repo/stale/.duplicacy/preferences
+++ b/internal/collector/testdata/duplicacy/cli-repo/stale/.duplicacy/preferences
@@ -1,0 +1,16 @@
+[
+    {
+        "name": "default",
+        "id": "documents",
+        "repository": "",
+        "storage": "/mnt/backups/documents",
+        "encrypted": false,
+        "no_backup": false,
+        "no_restore": false,
+        "no_save_password": false,
+        "nobackup_file": "",
+        "keys": null,
+        "filters": "",
+        "exclude_by_attribute": false
+    }
+]

--- a/internal/collector/testdata/duplicacy/web-cache/healthy/storage-main/snapshots/documents/1
+++ b/internal/collector/testdata/duplicacy/web-cache/healthy/storage-main/snapshots/documents/1
@@ -1,0 +1,1 @@
+{"version":1,"id":"documents","revision":1,"options":"","tag":"","start_time":1714867200,"end_time":1714867253,"file_size":104857600,"number_of_files":1234,"files":["dd11"],"chunks":["ee22"],"lengths":["ff33"]}

--- a/internal/collector/testdata/duplicacy/web-cache/healthy/storage-main/snapshots/media/1
+++ b/internal/collector/testdata/duplicacy/web-cache/healthy/storage-main/snapshots/media/1
@@ -1,0 +1,1 @@
+{"version":1,"id":"media","revision":1,"options":"","tag":"","start_time":1714780800,"end_time":1714781902,"file_size":5368709120,"number_of_files":48217,"files":["aa11"],"chunks":["bb22"],"lengths":["cc33"]}


### PR DESCRIPTION
Closes #311

V1a slice of [PRD #310](https://github.com/mcdays94/nas-doctor/issues/310). Adds the Duplicacy schema + collector layer to NAS Doctor without touching any user-facing surface (no UI, no endpoint, no widget). When merged, the server can be built with the new schema, the `DuplicacyRunner` is callable from Go, and exhaustive disk-fixture tests pin the reason classifier — but a user running v0.10.0-rcN with V1a-only sees no behavioural change. V1b (Settings UI + Test endpoint) and V1c (dashboard widget + Prometheus + demo) dispatch in parallel as the next wave once this merges.

## Design choices

### Disk-read deep module (PRD #310 §1)
- `DuplicacyRunner` interface is a single-method `Read(ctx, entry) → (DuplicacyState, error)`. Mirrors `BorgRunner`'s shape but with no subprocess, no env vars, no SSH plumbing.
- Production `diskDuplicacyRunner` uses only `os.*` + `encoding/json`. No `os/exec`, no network calls, no `duplicacy` binary in the image. Verified by reading the implementation file.
- `nowFn` clock is injectable so verbatim Unix-timestamp fixtures don't drift into staleness as wall-clock advances after they're committed. Production constructor (`NewDiskDuplicacyRunner`) hides the field; tests use the unexported `newDiskDuplicacyRunnerAt(now)`.

### Per-provider reason type (PRD #310 §4 / user story 12)
- `DuplicacyReason` is a string-backed type **not shared** with `BorgReason`. Sets the precedent for Restic/PBS so subsequent providers add their own per-provider type rather than extending a god-enum.
- 8 closed-set codes: `ok`, `path_not_found`, `path_unreadable`, `not_a_duplicacy_repo`, `storage_id_not_found`, `no_snapshots_yet`, `stale`, `corrupt_snapshot`. All exported as constants. Stability pinned by `TestDuplicacyReason_AllConstantsExportedAndStable`.
- `currently_running` is **not** a reason — it's an orthogonal aux flag on `DuplicacyState.CurrentlyRunning`. A repo can be running AND fresh (CurrentlyRunning=true, ReasonCode=ok), or running AND stale, etc.

### Two path-resolvers, one parser (PRD #310 §2)
- `kind=cli-repo`: reads `<Path>/.duplicacy/preferences` (Duplicacy 3.x ships it as a JSON array of storage configs), picks the first entry's `name` (defaults to `default`), then walks `<Path>/.duplicacy/cache/<storage>/snapshots/`.
- `kind=web-cache`: walks `<Path>/<StorageID>/snapshots/` directly. The saspus/duplicacy-web container layout doesn't have a per-repo preferences file in the path-rooted location — user supplies StorageID instead.
- Both converge on `walkSnapshotsDir` → `parseDuplicacySnapshotFile`. The JSON shape is identical between CLI and Web modes; only the directory hierarchy around the snapshots differs. This is the architectural insight that makes disk-read viable for both populations.
- Preferences read is fault-tolerant: missing/malformed file falls back to `default` so the snapshots-dir walk still runs and surfaces `no_snapshots_yet` (the right user-facing outcome). Pinned by `TestReadCLIRepoStorageName_FallbackToDefault`.

### `StaleAfter=0` means \"use 30-day default\" at READ time
- Per the issue body: empty StaleAfter (zero value) is treated as the 30-day default at read time, not at config time. Users can leave the field blank in V1b's form and the runner substitutes `DuplicacyDefaultStaleAfterDays` without persisting a magic number.
- Pinned by `TestSettings_RoundTripsBackupMonitorDuplicacy`'s entry-0 assertion (`StaleAfter=0` round-trips as `0`, not `30`) and by `TestDiskDuplicacyRunner_CLIRepo_Stale` (omits StaleAfter and gets stale-classified at the 30-day boundary).
- Custom thresholds work via `TestDiskDuplicacyRunner_CLIRepo_StaleAfterRespectsCustomThreshold` (StaleAfter=90 → ok for the same fixture that's stale at default 30).

### `DuplicacyState` field rationale
Carries 8 fields total, each justified by V1b/V1c needs:

| Field | V1b/V1c consumer |
|---|---|
| `ReasonCode` | dashboard severity pill, Prometheus `nasdoctor_backup_duplicacy_status{reason=...}` label |
| `SnapshotCount` | dashboard \"N snapshots\" copy, Prometheus `nasdoctor_backup_duplicacy_snapshots_total` |
| `LatestBackupAt` | dashboard \"last backup 4h ago\" copy, Prometheus `nasdoctor_backup_duplicacy_last_backup_age_seconds` |
| `LatestBackupSizeBytes` | dashboard size column, Prometheus `nasdoctor_backup_duplicacy_last_backup_size_bytes` |
| `LatestBackupFiles` | dashboard files column |
| `CurrentlyRunning` | dashboard \"in progress\" indicator (orthogonal to severity) |
| `LatestSnapshotID` + `LatestSnapshotRevision` | dashboard \"documents @ rev 87\" copy; future per-id drill-down ticket |
| `SnapshotIDs[]` | future per-id drill-down ticket; pre-collected here so V1b/V1c don't re-walk the cache |

### Lock detection heuristic for `CurrentlyRunning`
- Best-effort, per PRD #310 user story 13. False-negatives are acceptable (some Duplicacy versions don't write the markers reliably); false-positives are also acceptable (a stuck-lock from a crashed previous run prompts the user to investigate, which is the right outcome).
- `kind=cli-repo`: returns true when EITHER `<dotDup>/locks/` is non-empty OR `<dotDup>/cache/<storage>/incomplete` exists.
- `kind=web-cache`: returns true when EITHER `<storageDir>/incomplete` exists OR `<storageDir>/locks/` is non-empty.
- Tested both ways: `TestDiskDuplicacyRunner_CurrentlyRunning_LockPresent` (running fixture has a non-empty `locks/` dir; flag fires + reason still=ok orthogonal) and `TestDiskDuplicacyRunner_CurrentlyRunning_LockAbsent` (healthy fixture has no locks dir; flag does not fire).

## Fixture provenance

Verbatim fixtures live under `internal/collector/testdata/duplicacy/`. Layout designed to exercise every reason-code transition:

| Fixture | Scenario | Reason code |
|---|---|---|
| `cli-repo/healthy/` | 2 snapshot revisions for 1 id | `ok` |
| `cli-repo/no-snapshots/` | preferences exists, snapshots dir empty/absent | `no_snapshots_yet` |
| `cli-repo/stale/` | 1 snapshot dated 2024-03-01 (~64d before fixture clock) | `stale` |
| `cli-repo/not-a-repo/` | path exists but no `.duplicacy/` subdir | `not_a_duplicacy_repo` |
| `cli-repo/corrupt/` | mixed valid+invalid snapshot files | `corrupt_snapshot` |
| `cli-repo/running/` | healthy snapshot + non-empty `locks/` dir | `ok` + `CurrentlyRunning=true` |
| `web-cache/healthy/` | 2 snapshot ids (\"media\", \"documents\") with end_time precedence | `ok` |

The `preferences` files use Duplicacy 3.x's plain-JSON-array shape. Snapshot files use the JSON shape from the upstream `Snapshot.MarshalJSON` layout — `version`, `id`, `revision`, `start_time`, `end_time`, `file_size`, `number_of_files`, plus the chunk-sequence arrays we don't read but include for fidelity. Captured by hand from inspecting the upstream `gilbertchen/duplicacy/src/duplicacy_snapshot.go` source so future Duplicacy v3→v4 schema changes will be caught by these tests.

`fixtureNow` is pinned to `time.Unix(1714900000, 0)` (a few hours after the healthy fixture's latest snapshot end_time) so:
- healthy fixtures classify as `ok` (well under 30d)
- stale fixture (end 2024-03-01) classifies as `stale` (>30d)

This decouples fixture timestamps from CI wall-clock — fixtures committed today won't decay into stale next year.

## Test count delta

- `internal/collector/duplicacy_runner_test.go` — **NEW** — ~575 LOC, ~25 distinct test cases (some with table sub-tests; ~50 sub-cases total).
- `internal/api/settings_backup_monitor_duplicacy_test.go` — **NEW** — ~150 LOC, 5 test funcs covering additive default, upgrader compatibility, full PUT→GET round-trip, namespacing coexistence with Borg, and JSON shape contracts.

## §4b pre-push checks

| Check | Status |
|---|---|
| `go build ./...` | ✅ clean |
| `go test ./... -race -count=1` | ✅ all packages green |
| `go vet ./...` | ✅ clean |
| `gofmt -l` on changed files | ✅ all clean |
| `go test ./internal/collector/ -race -count=3` (post-merge stability) | ✅ green |

Pre-existing gofmt drift in `internal/api/api_extended.go` (the unrelated `AdvancedScansSettings` block) is out of scope per the orchestrator's dispatch instructions; verified pre-existing on `origin/main` via `git stash`.

## Out of scope (V1b / V1c)

- Settings UI section, save/test/delete handlers — V1b
- `POST /api/v1/backup-monitor/duplicacy/test` endpoint — V1b
- Dashboard widget extension to render Duplicacy rows — V1c
- Prometheus exporter gauges — V1c
- Demo-worker entries showcasing both kinds — V1c
- Dockerfile changes (no `duplicacy` binary bundled by design)
- Unraid template changes (disk-read needs no new bind mounts)