### PR TITLE
feat(backup-monitor): Duplicacy Settings UI + Test endpoint (#313)

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -72,6 +72,13 @@ type Server struct {
 	// passphrase value can be resolved without exporting it into
 	// the test process env. Issue #279.
 	borgTestEnvLookup func(string) string
+	// duplicacyRunner is the DuplicacyRunner used by the Duplicacy
+	// Test endpoint (POST /api/v1/backup-monitor/duplicacy/test).
+	// Nil means the handler falls back to
+	// collector.NewDiskDuplicacyRunner (production filesystem read).
+	// Tests override this to inject canned responses without
+	// touching the real filesystem. PRD #310 / issue #313.
+	duplicacyRunner collector.DuplicacyRunner
 	// testLiveTestRegistry is a test-only override for the
 	// LiveTestRegistry resolved from s.scheduler. Production code
 	// always reads through s.liveTestRegistry() which checks this

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -529,6 +529,14 @@ func (s *Server) RegisterExtendedRoutes(r chi.Router) {
 
 	// External backup monitor test button — issue #279.
 	r.Post("/api/v1/backup-monitor/borg/test", s.handleTestBorgMonitor)
+	// External Duplicacy backup monitor test button — issue #313.
+	// Mirrors the Borg test endpoint shape; the runner is disk-read
+	// (no subprocess) so the wiring is simpler. API-key middleware
+	// is applied explicitly (acceptance criterion 5) — borg's
+	// existing endpoint is registered the same way but predates the
+	// 401 contract; we make ours explicit so a future router refactor
+	// doesn't strip the protection silently.
+	r.With(s.apiKeyMiddleware).Post("/api/v1/backup-monitor/duplicacy/test", s.handleTestDuplicacyMonitor)
 
 	// Fleet dashboard page
 	r.Get("/fleet", s.handleFleetPage)

--- a/internal/api/duplicacy_test_endpoint.go
+++ b/internal/api/duplicacy_test_endpoint.go
@@ -1,0 +1,211 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal/collector"
+)
+
+// duplicacyTestResult is the response body for
+// POST /api/v1/backup-monitor/duplicacy/test. Carries the runner's
+// classifier outcome plus enough summary stats to render the inline
+// pill + caption in the Settings Test button. Stable JSON shape —
+// the UI keys off these field names. PRD #310 / issue #313.
+type duplicacyTestResult struct {
+	OK     bool   `json:"ok"`
+	Reason string `json:"reason"`
+	// Message is a short, human-readable hint mapped from Reason.
+	// Stable phrasing — pinned by tests so future renames don't
+	// silently break the inline UI.
+	Message string `json:"message,omitempty"`
+
+	// SnapshotCount is the total number of distinct snapshot
+	// revision files discovered across all snapshot IDs in the
+	// repo. Zero on most non-OK reasons.
+	SnapshotCount int `json:"snapshot_count,omitempty"`
+
+	// LatestBackupAt is the RFC3339 timestamp of the newest
+	// snapshot. Empty when no snapshots were found.
+	LatestBackupAt string `json:"latest_backup_at,omitempty"`
+
+	// LatestBackupSizeBytes is the file_size field from the newest
+	// snapshot. Zero when no snapshots were found.
+	LatestBackupSizeBytes int64 `json:"latest_backup_size_bytes,omitempty"`
+
+	// LatestBackupFiles is the number_of_files field from the
+	// newest snapshot.
+	LatestBackupFiles int64 `json:"latest_backup_files,omitempty"`
+
+	// LatestSnapshotID is the snapshot id (e.g. "documents") that
+	// produced the newest snapshot.
+	LatestSnapshotID string `json:"latest_snapshot_id,omitempty"`
+
+	// LatestSnapshotRevision is the integer revision of the newest
+	// snapshot.
+	LatestSnapshotRevision int `json:"latest_snapshot_revision,omitempty"`
+
+	// SnapshotIDs is the sorted list of distinct snapshot ids in
+	// the repo.
+	SnapshotIDs []string `json:"snapshot_ids,omitempty"`
+
+	// CurrentlyRunning is the orthogonal aux flag — true when a
+	// lock or incomplete-snapshot marker is detected on disk. The
+	// UI surfaces this as a small "running" badge alongside the
+	// reason pill, regardless of Reason.
+	CurrentlyRunning bool `json:"currently_running,omitempty"`
+}
+
+// handleTestDuplicacyMonitor runs the V1a DuplicacyRunner against the
+// tentative entry in the request body and returns the outcome as JSON.
+//
+// POST /api/v1/backup-monitor/duplicacy/test — called by the Settings
+// UI Test button (issue #313 acceptance criterion 6: live form values,
+// not yet persisted).
+//
+// Response policy:
+//   - 200 on any classifier outcome — caller inspects the `reason`
+//     field. The runner is total: every input maps to one of the
+//     eight DuplicacyReason codes plus the orthogonal currently_running
+//     flag. PRD #310 §4.
+//   - 400 on malformed JSON body or invalid Kind. Defensive — the
+//     UI form-validates before posting, but a direct API caller could
+//     still send garbage.
+//   - 401 enforced upstream by apiKeyMiddleware (route registration).
+//
+// The handler does NOT persist the entry, mutate settings, write to
+// the DB, or update Prometheus gauges. It is purely a single-entry
+// probe — the on-demand sibling to the scheduled Collect cycle.
+// PRD #310 §5.
+func (s *Server) handleTestDuplicacyMonitor(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to read body"})
+		return
+	}
+	defer r.Body.Close()
+
+	var req DuplicacyEntry
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		return
+	}
+	req.Label = strings.TrimSpace(req.Label)
+	req.Kind = strings.TrimSpace(req.Kind)
+	req.Path = strings.TrimSpace(req.Path)
+	req.StorageID = strings.TrimSpace(req.StorageID)
+
+	if req.Path == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "path is required"})
+		return
+	}
+	switch req.Kind {
+	case collector.DuplicacyKindCLIRepo, collector.DuplicacyKindWebCache:
+		// ok
+	case "":
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "kind is required (cli-repo | web-cache)"})
+		return
+	default:
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "invalid kind " + req.Kind + " (must be cli-repo or web-cache)",
+		})
+		return
+	}
+	if req.Kind == collector.DuplicacyKindWebCache && req.StorageID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "storage_id is required when kind=web-cache",
+		})
+		return
+	}
+
+	runner := s.duplicacyRunner
+	if runner == nil {
+		runner = collector.NewDiskDuplicacyRunner()
+	}
+
+	ctx := r.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	state, runErr := runner.Read(ctx, collector.DuplicacyEntry{
+		Enabled:    true, // Test endpoint always runs the read regardless of stored Enabled
+		Label:      req.Label,
+		Kind:       req.Kind,
+		Path:       req.Path,
+		StorageID:  req.StorageID,
+		StaleAfter: req.StaleAfter,
+	})
+	// V1a runner is total — runErr is reserved for genuinely unexpected
+	// faults; the contract is that it never returns non-nil today.
+	// Defensive: if it ever does, surface as a 200 with reason=unknown
+	// + the error message, mirroring the borg path's "200 with reason"
+	// principle so the UI's inspection logic stays uniform.
+	if runErr != nil {
+		writeJSON(w, http.StatusOK, duplicacyTestResult{
+			OK:      false,
+			Reason:  "unknown",
+			Message: "internal runner error: " + runErr.Error(),
+		})
+		s.logger.Error("duplicacy external test runner error",
+			"path", req.Path,
+			"kind", req.Kind,
+			"err", runErr)
+		return
+	}
+
+	res := duplicacyTestResult{
+		OK:                     state.ReasonCode == collector.DuplicacyReasonOK,
+		Reason:                 string(state.ReasonCode),
+		Message:                humanDuplicacyReasonMessage(state.ReasonCode),
+		SnapshotCount:          state.SnapshotCount,
+		LatestBackupSizeBytes:  state.LatestBackupSizeBytes,
+		LatestBackupFiles:      state.LatestBackupFiles,
+		LatestSnapshotID:       state.LatestSnapshotID,
+		LatestSnapshotRevision: state.LatestSnapshotRevision,
+		SnapshotIDs:            state.SnapshotIDs,
+		CurrentlyRunning:       state.CurrentlyRunning,
+	}
+	if !state.LatestBackupAt.IsZero() {
+		res.LatestBackupAt = state.LatestBackupAt.UTC().Format(time.RFC3339)
+	}
+
+	s.logger.Info("duplicacy external test",
+		"label", req.Label,
+		"kind", req.Kind,
+		"reason", res.Reason,
+		"snapshot_count", res.SnapshotCount,
+		"currently_running", res.CurrentlyRunning)
+
+	writeJSON(w, http.StatusOK, res)
+}
+
+// humanDuplicacyReasonMessage maps a DuplicacyReason to a stable,
+// UI-facing one-liner. Pinned by tests so renames here surface as
+// failing assertions rather than silent UI drift.
+func humanDuplicacyReasonMessage(reason collector.DuplicacyReason) string {
+	switch reason {
+	case collector.DuplicacyReasonOK:
+		return "repository healthy and snapshots are recent"
+	case collector.DuplicacyReasonPathNotFound:
+		return "path not found — check the bind mount or correct the typo"
+	case collector.DuplicacyReasonPathUnreadable:
+		return "path exists but is not readable from inside the container — check permissions"
+	case collector.DuplicacyReasonNotARepo:
+		return "path is not a Duplicacy repository — expected a .duplicacy/ subdirectory"
+	case collector.DuplicacyReasonStorageIDNotFound:
+		return "storage_id subdirectory not found under path — check the storage_id field"
+	case collector.DuplicacyReasonNoSnapshotsYet:
+		return "no snapshots yet — repo is configured but no backup has run"
+	case collector.DuplicacyReasonStale:
+		return "newest snapshot is older than the stale-after threshold"
+	case collector.DuplicacyReasonCorruptSnapshot:
+		return "at least one snapshot file failed to parse — check the repo on disk"
+	default:
+		return "unknown error — see container logs for the runner output"
+	}
+}

--- a/internal/api/duplicacy_test_endpoint_test.go
+++ b/internal/api/duplicacy_test_endpoint_test.go
@@ -1,0 +1,361 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal/collector"
+)
+
+// stubDuplicacyRunner lets tests inject a canned DuplicacyState (and
+// optional error) without touching the real filesystem. Mirrors the
+// stubBorgRunner shape used by the Borg endpoint tests.
+type stubDuplicacyRunner struct {
+	state    collector.DuplicacyState
+	err      error
+	sawEntry collector.DuplicacyEntry
+	sawCalls int
+}
+
+func (s *stubDuplicacyRunner) Read(ctx context.Context, entry collector.DuplicacyEntry) (collector.DuplicacyState, error) {
+	s.sawEntry = entry
+	s.sawCalls++
+	return s.state, s.err
+}
+
+// TestHandleTestDuplicacyMonitor_HappyPath_OK pins the success
+// response shape — the Settings UI reads `ok`, `reason`, and the
+// summary stats (snapshot_count, latest_backup_at, sizes) to render
+// the inline pill + caption.
+func TestHandleTestDuplicacyMonitor_HappyPath_OK(t *testing.T) {
+	srv := newTestServer(t)
+	when := time.Date(2026, 5, 1, 3, 30, 0, 0, time.UTC)
+	srv.duplicacyRunner = &stubDuplicacyRunner{
+		state: collector.DuplicacyState{
+			ReasonCode:             collector.DuplicacyReasonOK,
+			SnapshotCount:          42,
+			LatestBackupAt:         when,
+			LatestBackupSizeBytes:  1234567890,
+			LatestBackupFiles:      9876,
+			LatestSnapshotID:       "documents",
+			LatestSnapshotRevision: 87,
+			SnapshotIDs:            []string{"documents", "media"},
+			CurrentlyRunning:       false,
+		},
+	}
+	body, _ := json.Marshal(DuplicacyEntry{
+		Enabled: true,
+		Label:   "Documents",
+		Kind:    "cli-repo",
+		Path:    "/mnt/duplicacy/documents",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/backup-monitor/duplicacy/test", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleTestDuplicacyMonitor(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200; body=%s", w.Code, w.Body.String())
+	}
+	var got duplicacyTestResult
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.OK {
+		t.Error("OK = false; want true for reason=ok")
+	}
+	if got.Reason != "ok" {
+		t.Errorf("Reason = %q; want ok", got.Reason)
+	}
+	if got.SnapshotCount != 42 {
+		t.Errorf("SnapshotCount = %d; want 42", got.SnapshotCount)
+	}
+	if got.LatestBackupAt != "2026-05-01T03:30:00Z" {
+		t.Errorf("LatestBackupAt = %q; want 2026-05-01T03:30:00Z", got.LatestBackupAt)
+	}
+	if got.LatestSnapshotID != "documents" {
+		t.Errorf("LatestSnapshotID = %q; want documents", got.LatestSnapshotID)
+	}
+	if got.LatestSnapshotRevision != 87 {
+		t.Errorf("LatestSnapshotRevision = %d; want 87", got.LatestSnapshotRevision)
+	}
+	if got.Message == "" {
+		t.Error("Message empty; UI needs a hint string for every reason")
+	}
+	stub := srv.duplicacyRunner.(*stubDuplicacyRunner)
+	if stub.sawCalls != 1 {
+		t.Errorf("runner calls = %d; want 1", stub.sawCalls)
+	}
+	if stub.sawEntry.Path != "/mnt/duplicacy/documents" {
+		t.Errorf("runner saw Path = %q; want forwarded as-is", stub.sawEntry.Path)
+	}
+}
+
+// TestHandleTestDuplicacyMonitor_AllReasonsRoundTrip pins every
+// closed-set reason value through the handler. The UI's switch
+// statement keys off these strings; renames here would silently
+// break the inline rendering.
+func TestHandleTestDuplicacyMonitor_AllReasonsRoundTrip(t *testing.T) {
+	cases := []struct {
+		name   string
+		reason collector.DuplicacyReason
+		wantOK bool
+		extra  func(*collector.DuplicacyState)
+		hasMsg bool
+	}{
+		{"ok", collector.DuplicacyReasonOK, true, nil, true},
+		{"path_not_found", collector.DuplicacyReasonPathNotFound, false, nil, true},
+		{"path_unreadable", collector.DuplicacyReasonPathUnreadable, false, nil, true},
+		{"not_a_duplicacy_repo", collector.DuplicacyReasonNotARepo, false, nil, true},
+		{"storage_id_not_found", collector.DuplicacyReasonStorageIDNotFound, false, nil, true},
+		{"no_snapshots_yet", collector.DuplicacyReasonNoSnapshotsYet, false, nil, true},
+		{"stale", collector.DuplicacyReasonStale, false, nil, true},
+		{"corrupt_snapshot", collector.DuplicacyReasonCorruptSnapshot, false, nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newTestServer(t)
+			state := collector.DuplicacyState{ReasonCode: tc.reason}
+			if tc.extra != nil {
+				tc.extra(&state)
+			}
+			srv.duplicacyRunner = &stubDuplicacyRunner{state: state}
+			body, _ := json.Marshal(DuplicacyEntry{
+				Kind: "cli-repo",
+				Path: "/x",
+			})
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/backup-monitor/duplicacy/test", bytes.NewReader(body))
+			w := httptest.NewRecorder()
+			srv.handleTestDuplicacyMonitor(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d; want 200 (handler is total — every reason is a 200)", w.Code)
+			}
+			var got duplicacyTestResult
+			_ = json.Unmarshal(w.Body.Bytes(), &got)
+			if got.OK != tc.wantOK {
+				t.Errorf("OK = %v; want %v", got.OK, tc.wantOK)
+			}
+			if got.Reason != string(tc.reason) {
+				t.Errorf("Reason = %q; want %q", got.Reason, string(tc.reason))
+			}
+			if tc.hasMsg && got.Message == "" {
+				t.Error("Message empty; UI needs a non-empty hint for every reason")
+			}
+		})
+	}
+}
+
+// TestHandleTestDuplicacyMonitor_CurrentlyRunningSurfacedAsAuxFlag
+// pins the orthogonal aux flag — UI renders a "running" badge
+// alongside the reason pill regardless of reason. PRD #310
+// user story 13.
+func TestHandleTestDuplicacyMonitor_CurrentlyRunningSurfacedAsAuxFlag(t *testing.T) {
+	srv := newTestServer(t)
+	srv.duplicacyRunner = &stubDuplicacyRunner{
+		state: collector.DuplicacyState{
+			ReasonCode:       collector.DuplicacyReasonOK,
+			CurrentlyRunning: true,
+		},
+	}
+	body, _ := json.Marshal(DuplicacyEntry{Kind: "cli-repo", Path: "/x"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/backup-monitor/duplicacy/test", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleTestDuplicacyMonitor(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var got duplicacyTestResult
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if !got.CurrentlyRunning {
+		t.Error("CurrentlyRunning = false; want true")
+	}
+}
+
+// TestHandleTestDuplicacyMonitor_RejectsEmptyPath pins the 400 on
+// missing path — UI form-validates but defense in depth at the API
+// boundary.
+func TestHandleTestDuplicacyMonitor_RejectsEmptyPath(t *testing.T) {
+	srv := newTestServer(t)
+	body, _ := json.Marshal(DuplicacyEntry{Kind: "cli-repo", Path: ""})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/backup-monitor/duplicacy/test", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleTestDuplicacyMonitor(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d; want 400 for empty path", w.Code)
+	}
+}
+
+// TestHandleTestDuplicacyMonitor_RejectsMissingKind pins 400 when
+// the Kind field is absent — the runner switch defaults to
+// not-a-repo, but we want a clearer 400 at the API boundary.
+func TestHandleTestDuplicacyMonitor_RejectsMissingKind(t *testing.T) {
+	srv := newTestServer(t)
+	body, _ := json.Marshal(DuplicacyEntry{Path: "/x"}) // Kind = ""
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/backup-monitor/duplicacy/test", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleTestDuplicacyMonitor(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d; want 400 for missing kind", w.Code)
+	}
+}
+
+// TestHandleTestDuplicacyMonitor_RejectsInvalidKind pins 400 for
+// unknown kind values — defensive against direct API misuse.
+func TestHandleTestDuplicacyMonitor_RejectsInvalidKind(t *testing.T) {
+	srv := newTestServer(t)
+	body, _ := json.Marshal(DuplicacyEntry{Kind: "bogus", Path: "/x"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/backup-monitor/duplicacy/test", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleTestDuplicacyMonitor(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d; want 400 for bogus kind", w.Code)
+	}
+}
+
+// TestHandleTestDuplicacyMonitor_WebCacheRequiresStorageID pins
+// that web-cache entries with empty StorageID are rejected — user
+// story 7 (storage_id_not_found is for typo'd values; missing
+// entirely is a config-validation failure).
+func TestHandleTestDuplicacyMonitor_WebCacheRequiresStorageID(t *testing.T) {
+	srv := newTestServer(t)
+	body, _ := json.Marshal(DuplicacyEntry{
+		Kind: "web-cache",
+		Path: "/cache",
+		// StorageID intentionally empty
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/backup-monitor/duplicacy/test", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleTestDuplicacyMonitor(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d; want 400 for web-cache without storage_id", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "storage_id") {
+		t.Errorf("error body should mention storage_id; got %s", w.Body.String())
+	}
+}
+
+// TestHandleTestDuplicacyMonitor_RejectsMalformedJSON pins 400 on
+// garbage body — basic API hygiene.
+func TestHandleTestDuplicacyMonitor_RejectsMalformedJSON(t *testing.T) {
+	srv := newTestServer(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/backup-monitor/duplicacy/test",
+		strings.NewReader("not-json"))
+	w := httptest.NewRecorder()
+	srv.handleTestDuplicacyMonitor(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d; want 400 for malformed json", w.Code)
+	}
+}
+
+// TestHandleTestDuplicacyMonitor_RunnerErrorSurfacesAsUnknownReason
+// pins the defensive code path: if the runner ever returns a non-nil
+// error (the V1a contract says it never does today, but the
+// signature accommodates V1c streaming extensions), the handler
+// returns 200 with reason=unknown rather than a 500. Keeps the UI's
+// inspection logic uniform across borg + duplicacy.
+func TestHandleTestDuplicacyMonitor_RunnerErrorSurfacesAsUnknownReason(t *testing.T) {
+	srv := newTestServer(t)
+	srv.duplicacyRunner = &stubDuplicacyRunner{
+		err: errors.New("synthetic runner failure"),
+	}
+	body, _ := json.Marshal(DuplicacyEntry{Kind: "cli-repo", Path: "/x"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/backup-monitor/duplicacy/test", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleTestDuplicacyMonitor(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200 even on runner error", w.Code)
+	}
+	var got duplicacyTestResult
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if got.OK {
+		t.Error("OK = true on runner error")
+	}
+	if got.Reason != "unknown" {
+		t.Errorf("Reason = %q; want unknown", got.Reason)
+	}
+}
+
+// TestHandleTestDuplicacyMonitor_ForwardsStaleAfter pins that the
+// per-entry StaleAfter is forwarded to the runner verbatim — the
+// runner applies its own zero→default substitution at read time.
+// The handler must NOT translate zero before calling.
+func TestHandleTestDuplicacyMonitor_ForwardsStaleAfter(t *testing.T) {
+	srv := newTestServer(t)
+	stub := &stubDuplicacyRunner{state: collector.DuplicacyState{ReasonCode: collector.DuplicacyReasonOK}}
+	srv.duplicacyRunner = stub
+	body, _ := json.Marshal(DuplicacyEntry{
+		Kind:       "cli-repo",
+		Path:       "/x",
+		StaleAfter: 7,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/backup-monitor/duplicacy/test", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleTestDuplicacyMonitor(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	if stub.sawEntry.StaleAfter != 7 {
+		t.Errorf("runner saw StaleAfter = %d; want 7 (handler must forward verbatim, not substitute default)", stub.sawEntry.StaleAfter)
+	}
+}
+
+// TestHumanDuplicacyReasonMessage_CoversAllReasons is the locked-in
+// coverage contract: every DuplicacyReason value the runner can
+// return must produce a non-empty human message.
+func TestHumanDuplicacyReasonMessage_CoversAllReasons(t *testing.T) {
+	all := []collector.DuplicacyReason{
+		collector.DuplicacyReasonOK,
+		collector.DuplicacyReasonPathNotFound,
+		collector.DuplicacyReasonPathUnreadable,
+		collector.DuplicacyReasonNotARepo,
+		collector.DuplicacyReasonStorageIDNotFound,
+		collector.DuplicacyReasonNoSnapshotsYet,
+		collector.DuplicacyReasonStale,
+		collector.DuplicacyReasonCorruptSnapshot,
+	}
+	for _, r := range all {
+		if humanDuplicacyReasonMessage(r) == "" {
+			t.Errorf("humanDuplicacyReasonMessage(%q) = empty; every reason needs a message", r)
+		}
+	}
+	// Unknown sentinel — also non-empty so the V1a runner's
+	// defensive "unexpected" path also produces a UI hint.
+	if humanDuplicacyReasonMessage(collector.DuplicacyReason("synthetic-future-value")) == "" {
+		t.Error("humanDuplicacyReasonMessage default branch empty; UI needs a fallback")
+	}
+}
+
+// TestHandleTestDuplicacyMonitor_DoesNotMutateSettings pins the
+// "single-entry probe" contract: the test endpoint must NOT persist
+// the entry, mutate settings, or write to the DB. PRD #310 §5.
+func TestHandleTestDuplicacyMonitor_DoesNotMutateSettings(t *testing.T) {
+	srv := newTestServer(t)
+	srv.duplicacyRunner = &stubDuplicacyRunner{
+		state: collector.DuplicacyState{ReasonCode: collector.DuplicacyReasonOK},
+	}
+
+	// Confirm settings are at default (no Duplicacy entries) before.
+	beforeRaw, _ := srv.store.GetConfig(settingsConfigKey)
+	body, _ := json.Marshal(DuplicacyEntry{
+		Enabled: true, Kind: "cli-repo", Path: "/probe-only",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/backup-monitor/duplicacy/test", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleTestDuplicacyMonitor(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+
+	afterRaw, _ := srv.store.GetConfig(settingsConfigKey)
+	if beforeRaw != afterRaw {
+		t.Errorf("settings blob mutated by Test endpoint; before=%q after=%q", beforeRaw, afterRaw)
+	}
+}

--- a/internal/api/settings_backup_monitor_duplicacy_ui_test.go
+++ b/internal/api/settings_backup_monitor_duplicacy_ui_test.go
@@ -1,0 +1,243 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestSettingsHTML_DuplicacyMonitorSubsection asserts the new
+// "Duplicacy" subsection renders under the existing "Backup Monitors"
+// group in settings.html. Pinned via DOM-id substrings (V1c dashboard
+// + V1b form-handlers both query by id, so renames must surface as
+// failing assertions).
+func TestSettingsHTML_DuplicacyMonitorSubsection(t *testing.T) {
+	tpl := SettingsPage
+
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		{"section container", `id="duplicacy-monitor-section"`},
+		{"section heading text", "Backup Monitors &rarr; Duplicacy"},
+		{"entry list container", `id="duplicacy-monitor-list"`},
+		{"add-entry button handler", "addDuplicacyMonitorEntry()"},
+		{"per-entry render fn", "renderDuplicacyEntryForm("},
+		{"per-entry collect fn", "collectDuplicacyMonitorEntries("},
+		{"per-entry test fn", "testDuplicacyMonitorEntry("},
+		{"per-entry remove fn", "removeDuplicacyMonitorEntry("},
+		{"settings-load wire-up", "loadDuplicacyMonitorFromSettings"},
+		{"save-payload key", "duplicacy: collectDuplicacyMonitorEntries()"},
+		{"test endpoint URL", "/api/v1/backup-monitor/duplicacy/test"},
+	}
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(tpl, tc.substr) {
+				t.Errorf("settings.html missing %s; expected substring %q", tc.name, tc.substr)
+			}
+		})
+	}
+
+	// Existing Borg subsection MUST be unmodified — V1b is purely
+	// additive. The Borg id, label, and Add button are pinned.
+	borgInvariants := []string{
+		`id="borg-monitor-section"`,
+		"Backup Monitors &rarr; Borg",
+		`id="borg-monitor-list"`,
+		"addBorgMonitorRepo()",
+	}
+	for _, s := range borgInvariants {
+		if !strings.Contains(tpl, s) {
+			t.Errorf("Borg subsection invariant missing: %q", s)
+		}
+	}
+}
+
+// TestSettingsHTML_DuplicacyKindDropdownToggle pins the JS that
+// shows/hides the StorageID input based on the Kind dropdown's
+// value — acceptance criterion 3. Mirrors how other conditional
+// fields toggle (fleet-instance picker on type=speed, etc.).
+func TestSettingsHTML_DuplicacyKindDropdownToggle(t *testing.T) {
+	tpl := SettingsPage
+	checks := []string{
+		// The toggle handler is referenced by the Kind <select>.
+		"onDuplicacyKindChange(",
+		// Per-entry kind <select> id pattern.
+		"duplicacy-kind-",
+		// Per-entry storage_id wrapper id pattern (the element that
+		// gets shown/hidden).
+		"duplicacy-storage-id-wrap-",
+		// The two valid options render.
+		`value="cli-repo"`,
+		`value="web-cache"`,
+	}
+	for _, s := range checks {
+		if !strings.Contains(tpl, s) {
+			t.Errorf("Kind toggle wiring missing: %q", s)
+		}
+	}
+}
+
+// TestSettingsHTML_DuplicacyStaleAfterPlaceholder pins that the
+// StaleAfter input renders with a 30-day placeholder (acceptance
+// criterion 4: empty/zero is rendered as default-30 placeholder).
+// The placeholder is what cues the user that leaving the field
+// blank is the right way to opt into the default.
+func TestSettingsHTML_DuplicacyStaleAfterPlaceholder(t *testing.T) {
+	tpl := SettingsPage
+	if !strings.Contains(tpl, `placeholder="30"`) {
+		t.Errorf("stale_after input missing 30-day placeholder; users won't see default cue")
+	}
+	if !strings.Contains(tpl, "duplicacy-stale-after-") {
+		t.Errorf("stale_after input id pattern missing")
+	}
+}
+
+// TestPUTSettings_DuplicacyEntry_FullRoundTrip — end-to-end:
+// PUT one Duplicacy entry covering both Kinds, GET back, assert the
+// shape is preserved (acceptance criterion 2: round-trip is
+// idempotent). Distinct from the slimmer round-trip in
+// settings_backup_monitor_duplicacy_test.go (V1a) — that test pins
+// the schema; this one pins the Settings-UI workflow contract.
+func TestPUTSettings_DuplicacyEntry_FullRoundTrip(t *testing.T) {
+	srv := newTestServer(t)
+
+	payload := Settings{
+		SettingsVersion: currentSettingsVersion,
+		ScanInterval:    "30m",
+		Theme:           ThemeMidnight,
+		BackupMonitor: BackupMonitorSettings{
+			Duplicacy: []DuplicacyEntry{
+				{
+					Enabled:    true,
+					Label:      "Photos",
+					Kind:       "web-cache",
+					Path:       "/cache/localhost/0",
+					StorageID:  "photos",
+					StaleAfter: 7,
+				},
+			},
+		},
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleUpdateSettings(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d; body=%s", w.Code, w.Body.String())
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	getW := httptest.NewRecorder()
+	srv.handleGetSettings(getW, getReq)
+	if getW.Code != http.StatusOK {
+		t.Fatalf("GET status = %d", getW.Code)
+	}
+	var back Settings
+	if err := json.Unmarshal(getW.Body.Bytes(), &back); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(back.BackupMonitor.Duplicacy) != 1 {
+		t.Fatalf("Duplicacy len = %d; want 1", len(back.BackupMonitor.Duplicacy))
+	}
+	got := back.BackupMonitor.Duplicacy[0]
+	if got.Label != "Photos" || got.Kind != "web-cache" || got.Path != "/cache/localhost/0" || got.StorageID != "photos" {
+		t.Errorf("round-trip lost fields: %+v", got)
+	}
+	if got.StaleAfter != 7 {
+		t.Errorf("StaleAfter = %d; want 7", got.StaleAfter)
+	}
+}
+
+// TestRegisterExtendedRoutes_ExposesDuplicacyTest pins the new
+// route is registered through the router (404/405 means the
+// registration was skipped or shadowed).
+func TestRegisterExtendedRoutes_ExposesDuplicacyTest(t *testing.T) {
+	srv := newSettingsTestServer()
+	handler := srv.Router()
+
+	body, _ := json.Marshal(map[string]any{
+		"kind": "cli-repo",
+		"path": "/nonexistent-test-path-aaaa",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/backup-monitor/duplicacy/test", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusNotFound || rec.Code == http.StatusMethodNotAllowed {
+		t.Fatalf("expected route to be registered, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// We expect 200 (handler is total — every reason is a 200) with
+	// reason=path_not_found because the path doesn't exist on this
+	// test host. That's the production runner's contract.
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 from router (handler is total), got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &got)
+	if got["reason"] != "path_not_found" {
+		t.Errorf("expected reason=path_not_found for nonexistent path; got %v", got["reason"])
+	}
+}
+
+// TestRegisterExtendedRoutes_DuplicacyTest_RequiresAPIKey pins the
+// 401 contract: when an API key is configured AND the request comes
+// from outside the same origin (no Referer), the test endpoint
+// returns 401. PRD #310 §5 / acceptance criterion 5.
+func TestRegisterExtendedRoutes_DuplicacyTest_RequiresAPIKey(t *testing.T) {
+	srv := newSettingsTestServer()
+
+	// Persist a settings blob carrying an API key so the middleware
+	// activates.
+	settingsWithKey := Settings{
+		SettingsVersion: currentSettingsVersion,
+		ScanInterval:    "30m",
+		Theme:           ThemeMidnight,
+		APIKey:          "test-api-key-313",
+	}
+	raw, _ := json.Marshal(settingsWithKey)
+	if err := srv.store.SetConfig(settingsConfigKey, string(raw)); err != nil {
+		t.Fatalf("set config: %v", err)
+	}
+
+	handler := srv.Router()
+
+	body, _ := json.Marshal(map[string]any{"kind": "cli-repo", "path": "/x"})
+
+	t.Run("no auth header → 401", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/backup-monitor/duplicacy/test", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d; want 401", rec.Code)
+		}
+	})
+
+	t.Run("wrong key → 401", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/backup-monitor/duplicacy/test", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer wrong-key")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d; want 401", rec.Code)
+		}
+	})
+
+	t.Run("correct key → not 401", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/backup-monitor/duplicacy/test", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer test-api-key-313")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code == http.StatusUnauthorized {
+			t.Fatalf("status = 401 with correct key; want pass-through")
+		}
+	})
+}

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -987,6 +987,27 @@ body.theme-clean .webhook-form{border-color:var(--accent);background:rgba(0,0,0,
             Add Borg repo
           </button>
         </div>
+
+        <!-- External Duplicacy monitoring (PRD #310 / issue #313).
+             Disk-read by design: NAS Doctor reads the on-disk JSON
+             snapshot files under either a CLI repo's .duplicacy/ tree
+             or a saspus/duplicacy-web container's per-storage cache
+             directory. No duplicacy binary is invoked, no subprocess
+             spawned, no network calls. Users only need to bind-mount
+             the path. -->
+        <div id="duplicacy-monitor-section" style="margin-top:22px;padding-top:16px;border-top:1px solid var(--border)">
+          <div style="display:block;font-weight:600;font-size:13px;color:var(--text);margin-bottom:4px">Backup Monitors &rarr; Duplicacy</div>
+          <p style="font-size:12px;color:var(--text2);margin-top:4px;margin-bottom:10px;line-height:1.5">
+            Monitor <strong>Duplicacy</strong> backups by bind-mounting either the repo root (CLI install) or the cache directory (<code style="font-size:11px;background:var(--input-bg);padding:1px 4px;border-radius:3px">saspus/duplicacy-web</code>) into NAS Doctor.
+            Disk-read only &mdash; the <code style="font-size:11px;background:var(--input-bg);padding:1px 4px;border-radius:3px">duplicacy</code> binary is never invoked.
+            Pick <em>CLI repo</em> for vanilla installs (path is the repo root); pick <em>Web cache</em> for duplicacy-web (path is the cache root, plus the per-repo storage id).
+          </p>
+          <div id="duplicacy-monitor-list" style="margin-bottom:10px"></div>
+          <button class="btn btn-secondary btn-sm" onclick="addDuplicacyMonitorEntry()" style="display:inline-flex;align-items:center;gap:4px">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+            Add Duplicacy entry
+          </button>
+        </div>
       </div>
     </details>
   </div>
@@ -1799,6 +1820,8 @@ function loadSettings() {
       loadDockerHiddenContainersCheckboxes(hidden);
       /* Advanced: external Borg monitor repos (#279) */
       loadBorgMonitorFromSettings(data.backup_monitor);
+      /* Advanced: Duplicacy backup monitor entries (#313) */
+      loadDuplicacyMonitorFromSettings(data.backup_monitor);
       /* Proxmox VE */
       var pve = data.proxmox || {};
       if (pve.enabled) document.getElementById("pve-toggle").classList.add("on"); else document.getElementById("pve-toggle").classList.remove("on");
@@ -1948,10 +1971,13 @@ function buildSettingsPayload() {
       gpu:        { interval_sec: readPickerIntervalSec("gpu") }
     },
     docker_hidden_containers: collectCheckedHiddenContainers(),
-    /* External BorgBackup monitor config (PRD #278 / issue #279).
-       Purely additive — old v3 blobs decode with an empty array. */
+    /* External BorgBackup monitor config (PRD #278 / issue #279)
+       and external Duplicacy monitor config (PRD #310 / issue #313).
+       Both are purely additive &mdash; old v3 blobs decode with empty
+       arrays. */
     backup_monitor: {
-      borg: collectBorgMonitorRepos()
+      borg: collectBorgMonitorRepos(),
+      duplicacy: collectDuplicacyMonitorEntries()
     }
   };
 }
@@ -4162,6 +4188,206 @@ function testBorgMonitorRepo(idx) {
       resultEl.style.color = "var(--red)";
       resultEl.textContent = "Failed: " + (res.data.message || res.data.reason || "unknown");
     }
+  })
+  .catch(function(e) {
+    if (resultEl) { resultEl.style.color = "var(--red)"; resultEl.textContent = "Network error: " + e.message; }
+  });
+}
+
+/* ---------- External Duplicacy monitor (#313) ---------- */
+// duplicacyMonitorEntries mirrors the BackupMonitor.Duplicacy array
+// from the loaded settings. Each entry carries UI state for one
+// configured Duplicacy repo. Persisted as part of saveSettings.
+//
+// Mirrors the Borg plumbing structurally — same lifecycle: load from
+// settings, render per-entry forms, collect on save, Test against
+// the live form values without first persisting.
+var duplicacyMonitorEntries = [];
+
+function loadDuplicacyMonitorFromSettings(bm) {
+  duplicacyMonitorEntries = (bm && Array.isArray(bm.duplicacy)) ? bm.duplicacy.slice() : [];
+  renderDuplicacyMonitorList();
+}
+
+function renderDuplicacyMonitorList() {
+  var el = document.getElementById("duplicacy-monitor-list");
+  if (!el) return;
+  if (!duplicacyMonitorEntries || duplicacyMonitorEntries.length === 0) {
+    el.innerHTML = '<p style="font-size:12px;color:var(--text2);margin:0;font-style:italic">No Duplicacy entries configured.</p>';
+    return;
+  }
+  var h = '';
+  for (var i = 0; i < duplicacyMonitorEntries.length; i++) {
+    var d = duplicacyMonitorEntries[i] || {};
+    h += renderDuplicacyEntryForm(i, d);
+  }
+  el.innerHTML = h;
+  // After the DOM is populated, run the kind-driven storage_id
+  // visibility for each entry so the initial render matches state.
+  for (var j = 0; j < duplicacyMonitorEntries.length; j++) {
+    onDuplicacyKindChange(j);
+  }
+}
+
+function renderDuplicacyEntryForm(i, d) {
+  // Each form is a self-contained panel with its own inputs; values
+  // are read out in collectDuplicacyMonitorEntries via DOM lookup
+  // by id. Mirrors renderBorgRepoForm structurally.
+  var enabledCls = d.enabled ? 'toggle on' : 'toggle';
+  var kind = (d.kind === 'web-cache') ? 'web-cache' : 'cli-repo';
+  var staleVal = (typeof d.stale_after === 'number' && d.stale_after > 0) ? String(d.stale_after) : '';
+  var h = '';
+  h += '<div class="duplicacy-monitor-entry" data-duplicacy-idx="' + i + '" style="background:var(--bg-panel);border:1px solid var(--border);border-radius:var(--radius);padding:12px;margin-bottom:8px">';
+  h += '<div style="display:flex;gap:12px;align-items:center;margin-bottom:10px">';
+  h += '<div class="toggle-wrap"><div class="' + escapeHtml(enabledCls) + '" id="duplicacy-enabled-' + i + '" onclick="this.classList.toggle(\'on\');markChanged()"><div class="toggle-knob"></div></div><span class="toggle-label">Enabled</span></div>';
+  h += '<input type="text" id="duplicacy-label-' + i + '" value="' + escapeHtml(d.label || '') + '" placeholder="Label (e.g. Documents)" style="flex:1;max-width:260px">';
+  h += '<button class="btn btn-danger btn-sm" onclick="removeDuplicacyMonitorEntry(' + i + ')" style="margin-left:auto">Remove</button>';
+  h += '</div>';
+  h += '<div class="form-row">';
+  // Kind dropdown — drives the storage_id visibility.
+  h += '<div><label for="duplicacy-kind-' + i + '">Kind</label>';
+  h += '<select id="duplicacy-kind-' + i + '" onchange="onDuplicacyKindChange(' + i + ');markChanged()">';
+  h += '<option value="cli-repo"' + (kind === 'cli-repo' ? ' selected' : '') + '>CLI repo (path = repo root)</option>';
+  h += '<option value="web-cache"' + (kind === 'web-cache' ? ' selected' : '') + '>Web cache (saspus/duplicacy-web)</option>';
+  h += '</select></div>';
+  // StaleAfter — number of days, default-30 placeholder cue.
+  h += '<div><label for="duplicacy-stale-after-' + i + '">Stale after (days)</label>';
+  h += '<input type="number" id="duplicacy-stale-after-' + i + '" value="' + escapeHtml(staleVal) + '" placeholder="30" min="0" max="3650" style="font-family:var(--font-mono);font-size:12px"></div>';
+  h += '</div>';
+  h += '<div class="form-row">';
+  // Path — repo root or cache root.
+  h += '<div><label for="duplicacy-path-' + i + '">Path</label>';
+  h += '<input type="text" id="duplicacy-path-' + i + '" value="' + escapeHtml(d.path || '') + '" placeholder="/mnt/duplicacy/repo or /cache/localhost/0" style="font-family:var(--font-mono);font-size:12px"></div>';
+  // StorageID — only meaningful for kind=web-cache. Wrapper carries
+  // the id used by onDuplicacyKindChange to toggle visibility.
+  h += '<div id="duplicacy-storage-id-wrap-' + i + '"><label for="duplicacy-storage-id-' + i + '">Storage ID</label>';
+  h += '<input type="text" id="duplicacy-storage-id-' + i + '" value="' + escapeHtml(d.storage_id || '') + '" placeholder="default or media-storage" style="font-family:var(--font-mono);font-size:12px"></div>';
+  h += '</div>';
+  h += '<div style="display:flex;align-items:center;gap:10px;margin-top:10px">';
+  h += '<button class="btn btn-secondary btn-sm" onclick="testDuplicacyMonitorEntry(' + i + ')">Test</button>';
+  h += '<span id="duplicacy-test-result-' + i + '" style="font-size:12px"></span>';
+  h += '</div>';
+  h += '</div>';
+  return h;
+}
+
+// onDuplicacyKindChange shows the StorageID input only when the
+// per-entry Kind dropdown reads "web-cache". Mirrors how the
+// service-checks form toggles the fleet-instance picker on
+// type=speed (#316) — vanilla JS conditional show/hide.
+function onDuplicacyKindChange(i) {
+  var sel = document.getElementById("duplicacy-kind-" + i);
+  var wrap = document.getElementById("duplicacy-storage-id-wrap-" + i);
+  if (!sel || !wrap) return;
+  if (sel.value === 'web-cache') {
+    wrap.style.display = '';
+  } else {
+    wrap.style.display = 'none';
+  }
+}
+
+function addDuplicacyMonitorEntry() {
+  duplicacyMonitorEntries = collectDuplicacyMonitorEntries();
+  duplicacyMonitorEntries.push({
+    enabled: true,
+    label: "",
+    kind: "cli-repo",
+    path: "",
+    storage_id: "",
+    stale_after: 0
+  });
+  renderDuplicacyMonitorList();
+  markChanged();
+}
+
+function removeDuplicacyMonitorEntry(idx) {
+  // Snapshot current form state first so removing entry N doesn't
+  // drop edits the user made on untouched entries.
+  duplicacyMonitorEntries = collectDuplicacyMonitorEntries();
+  duplicacyMonitorEntries.splice(idx, 1);
+  renderDuplicacyMonitorList();
+  markChanged();
+}
+
+function collectDuplicacyMonitorEntries() {
+  var out = [];
+  for (var i = 0; i < duplicacyMonitorEntries.length; i++) {
+    var enabledEl = document.getElementById("duplicacy-enabled-" + i);
+    var kindEl = document.getElementById("duplicacy-kind-" + i);
+    var staleEl = document.getElementById("duplicacy-stale-after-" + i);
+    var staleRaw = staleEl ? staleEl.value : "";
+    var staleNum = parseInt(staleRaw, 10);
+    if (isNaN(staleNum) || staleNum < 0) staleNum = 0;
+    out.push({
+      enabled: enabledEl ? enabledEl.classList.contains("on") : !!duplicacyMonitorEntries[i].enabled,
+      label: (document.getElementById("duplicacy-label-" + i) || {}).value || "",
+      kind: kindEl ? kindEl.value : "cli-repo",
+      path: ((document.getElementById("duplicacy-path-" + i) || {}).value || "").trim(),
+      storage_id: ((document.getElementById("duplicacy-storage-id-" + i) || {}).value || "").trim(),
+      stale_after: staleNum
+    });
+  }
+  return out;
+}
+
+function testDuplicacyMonitorEntry(idx) {
+  // Read the entry's CURRENT form values rather than the saved
+  // snapshot so users can iterate on Path / Kind / StorageID
+  // without first saving (acceptance criterion 6).
+  var all = collectDuplicacyMonitorEntries();
+  var entry = all[idx];
+  var resultEl = document.getElementById("duplicacy-test-result-" + idx);
+  if (!entry) { return; }
+  if (!entry.path) {
+    if (resultEl) { resultEl.style.color = "var(--red)"; resultEl.textContent = "Path required"; }
+    return;
+  }
+  if (entry.kind === 'web-cache' && !entry.storage_id) {
+    if (resultEl) { resultEl.style.color = "var(--red)"; resultEl.textContent = "Storage ID required for web-cache"; }
+    return;
+  }
+  if (resultEl) { resultEl.style.color = "var(--text2)"; resultEl.textContent = "Testing..."; }
+  fetch("/api/v1/backup-monitor/duplicacy/test", {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify(entry)
+  })
+  .then(function(r) { return r.json().then(function(d) { return { status: r.status, data: d }; }); })
+  .then(function(res) {
+    if (!resultEl) return;
+    if (res.status >= 400) {
+      resultEl.style.color = "var(--red)";
+      resultEl.textContent = "Error: " + (res.data.error || res.status);
+      return;
+    }
+    var d = res.data || {};
+    var color, label;
+    if (d.ok) {
+      color = "var(--green)";
+      label = "OK";
+    } else if (d.reason === 'no_snapshots_yet') {
+      color = "var(--text2)";
+      label = "No snapshots yet";
+    } else if (d.reason === 'stale') {
+      color = "var(--yellow, #d4a017)";
+      label = "Stale";
+    } else {
+      color = "var(--red)";
+      label = "Failed: " + (d.reason || "unknown");
+    }
+    var details = "";
+    if (d.snapshot_count) {
+      details += " · " + d.snapshot_count + " snapshot(s)";
+    }
+    if (d.latest_backup_at) {
+      details += " · latest " + d.latest_backup_at;
+    }
+    if (d.message) {
+      details += " — " + d.message;
+    }
+    var runningBadge = d.currently_running ? " · running" : "";
+    resultEl.style.color = color;
+    resultEl.textContent = label + runningBadge + details;
   })
   .catch(function(e) {
     if (resultEl) { resultEl.style.color = "var(--red)"; resultEl.textContent = "Network error: " + e.message; }


### PR DESCRIPTION
Closes #313

V1b of the Duplicacy backup monitoring PRD (#310). Adds the user-facing configuration surface for the V1a runner that landed in #319 (commit `2d3a09f`). After this slice merges, users can open Settings → Advanced → Backup Monitors, add a Duplicacy entry of either `cli-repo` or `web-cache` kind, click Test against the live (not-yet-persisted) form values, and Save. **No dashboard widget yet** — that's V1c, dispatched in parallel with this slice.

## Form UX choices

- **New subsection** lives under the existing "Backup Monitors" group in the Advanced card of `settings.html`, immediately after the Borg subsection. Existing Borg subsection unmodified — the new section is purely additive.
- **Per-entry form fields**: Enabled (toggle), Label (text), Kind (`<select>`: cli-repo | web-cache), Path (text), Storage ID (text, conditionally visible), Stale after (number, days, `placeholder="30"` cue), Test button, Remove button.
- **`StorageID` visibility toggle**: vanilla JS `onDuplicacyKindChange(i)` reads the per-entry Kind `<select>` and sets `display:none` / `display:""` on the wrapper `<div>` carrying the StorageID label+input. Mirrors the v0.9.15 #316 fleet-instance picker pattern. Initial render also runs the toggle for each entry on load so the reload state matches.
- **`StaleAfter` default cueing**: empty input → empty value field → `placeholder="30"` is what the user sees → backend's existing zero-means-default logic kicks in at runner read time. No magic-number persistence; users who want a different threshold type the integer days.
- **Test button reads CURRENT FORM VALUES** (not the saved snapshot) so users can iterate on Path / Kind / StorageID without first saving (acceptance criterion 6). The Test button POSTs the live `collectDuplicacyMonitorEntries()[idx]` to the new endpoint; render the result inline below the button as a severity-coloured caption + optional `· running` badge from `currently_running`.
- **Severity colour mapping** in the inline test result: `ok` → green, `no_snapshots_yet` → grey/text2, `stale` → yellow, everything else → red.

## Test endpoint contract

`POST /api/v1/backup-monitor/duplicacy/test`

- **Body**: tentative `DuplicacyEntry` JSON (the V1a schema). Test endpoint always treats `Enabled=true` regardless of the field on the body — it's an on-demand probe, not a configuration write.
- **Status codes**:
  - **200** on any classifier outcome — caller inspects `reason` field. Mirrors borg's "200 with reason" principle so the UI's inspection logic stays uniform.
  - **400** on: empty path; empty kind; invalid kind (anything except `cli-repo` / `web-cache`); web-cache kind without storage_id; malformed JSON body.
  - **401** when API key is set and the request lacks a valid `Authorization: Bearer ...` header (and isn't from a same-origin browser via Referer).
- **Response shape**: `{ ok, reason, message, snapshot_count, latest_backup_at, latest_backup_size_bytes, latest_backup_files, latest_snapshot_id, latest_snapshot_revision, snapshot_ids, currently_running }`. `latest_backup_at` is an RFC3339 UTC timestamp (empty when no snapshots found). `currently_running` is the orthogonal aux flag (PRD #310 user story 13).
- **No DB writes, no settings mutation, no metric updates.** Pinned by `TestHandleTestDuplicacyMonitor_DoesNotMutateSettings`.

## JS plumbing — reuse vs new

- **Reused patterns**: Borg's load/render/collect/test/remove rhythm. Module-scoped state (`duplicacyMonitorEntries`), per-entry DOM-id namespace, "snapshot before mutate" pattern in `removeDuplicacyMonitorEntry` so deleting entry N doesn't drop edits on untouched entries, `markChanged()` calls on every state-changing action.
- **New code**: `onDuplicacyKindChange(i)` for the StorageID visibility toggle (no Borg analogue — Borg has no kind-dropdown), severity-aware inline result rendering (no_snapshots_yet/stale/error categorisation), `currently_running` aux-flag rendering as a `· running` badge.

## Routing

API-key middleware applied **explicitly** via `r.With(s.apiKeyMiddleware)` rather than relying on the parent `Route("/api/v1", ...)` group (which the existing borg endpoint accidentally sits outside of, since `RegisterExtendedRoutes` is wired into the Timeout group rather than the api-key sub-route). This guards against a future router refactor silently stripping the 401 protection.

## §4b pre-push status

```
go build ./...                                 # clean
go test ./internal/api/... -race -count=1      # clean
go vet ./...                                   # clean
gofmt -l <my files>                            # empty
```

The existing `settings_js_parses_test.go` harness (which pipes every `<script>` block in settings.html through `node --check`) passes — no `*/` inside `/* */` block comments and no backticks inside JS comments introduced. Verified manually after writing.

## Test count delta

- **18 new Go tests** across two files (`duplicacy_test_endpoint_test.go` × 12 funcs; `settings_backup_monitor_duplicacy_ui_test.go` × 6 funcs):
  - Handler: happy path with full state forwarded, all 8 reasons round-trip via stub runner, currently_running aux flag, 400 on empty path / missing kind / invalid kind / malformed JSON / web-cache without storage_id, runner-error path surfaces as 200 with reason=unknown, StaleAfter forwarded to runner verbatim (handler must NOT substitute default), `humanDuplicacyReasonMessage` covers all reasons + unknown sentinel, no-mutate contract.
  - UI: new subsection DOM-id pins (11 substrings), Kind dropdown toggle wiring (5 substrings), StaleAfter `placeholder="30"` cue, full PUT→GET round-trip, route registration smoke test, 401 enforcement (3 sub-tests: no auth, wrong key, correct key).

## Scope

- ✅ `internal/api/templates/settings.html` — UI subsection + JS handlers + save-payload extension
- ✅ `internal/api/api.go` — new `duplicacyRunner` server field for test injection (mirrors `borgRunner`)
- ✅ `internal/api/api_extended.go` — route registration with apiKeyMiddleware
- ✅ `internal/api/duplicacy_test_endpoint.go` (new) — handler implementation
- ✅ `internal/api/duplicacy_test_endpoint_test.go` (new) — handler tests
- ✅ `internal/api/settings_backup_monitor_duplicacy_ui_test.go` (new) — UI + route tests
- ❌ `internal/api/dashboard.go` — V1c
- ❌ `internal/notifier/prometheus.go` — V1c
- ❌ `demo-worker/feeder/src/index.ts` — V1c
- ❌ `README.md` — V1c

Diff stat: 6 files, +1062 / −3.