### PR TITLE
feat(backup-monitor): Duplicacy dashboard widget + Prometheus gauges + demo + README (#314)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,15 @@ Auto-detects and tracks backups from the following tools when their CLI
 is reachable from the NAS Doctor container:
 
 - **Borg**, **Restic**, **Proxmox Backup Server (PBS)**, **Duplicati** — probed via `exec.LookPath` at each scan
+- **Duplicacy** — disk-read, no `duplicacy` binary required (since v0.10.0). Configure CLI repos or saspus/duplicacy-web cache layouts in **Settings → Advanced → Backup Monitors → Duplicacy**. See [Duplicacy Monitoring](#duplicacy-monitoring-disk-read-no-binary-required) below.
 - Tracks last backup time, size, snapshot count, duration, encryption status
 - **Stale backup alerts**: warning >24h, critical >48h, failed backups
 
 > **Note**: Restic, PBS, and Duplicati binaries don't ship in the
 > NAS Doctor Docker image. Borg **is** bundled (since v0.9.10; see
 > External Borg Monitoring below) and can be pointed at host-managed
-> repos via a Read Only bind-mount — no custom image needed. For
+> repos via a Read Only bind-mount — no custom image needed. **Duplicacy**
+> needs no binary at all (disk-read; see Duplicacy Monitoring below). For
 > Restic/PBS/Duplicati the Backup dashboard section stays empty unless
 > you install the provider CLI inside the container (custom Dockerfile)
 > or run the provider in a sibling container that shares volumes/network
@@ -190,6 +192,55 @@ SSH Key Path:      (leave blank — local repo)
 Click **Test** to verify; the response shows the archive count on
 success or a specific error reason on failure. No container restart
 needed — the repo appears on the dashboard at the next scan tick.
+
+#### Duplicacy Monitoring (disk-read, no binary required)
+
+Both vanilla Duplicacy CLI installs and the popular
+[saspus/duplicacy-web](https://hub.docker.com/r/saspus/duplicacy-web)
+container are monitored by **reading the on-disk JSON snapshot files**
+that Duplicacy writes alongside its repo cache — **no `duplicacy` binary
+is invoked, no subprocess spawned, no network call made**. This sidesteps
+Duplicacy's source-available CLI licence (so we don't bundle a binary)
+and works equally well for both deployment shapes.
+
+Configure in **Settings → Advanced → Backup Monitors → Duplicacy**:
+
+1. **Kind** — `cli-repo` (vanilla CLI install) or `web-cache` (saspus/
+   duplicacy-web container layout).
+2. **Path** — repo root (cli-repo) or the cache root (web-cache),
+   visible inside the NAS Doctor container. Bind-mount your Duplicacy
+   path **Read Only** — disk-read makes RO mounts safe.
+3. **Storage ID** — only for `kind=web-cache`. Names the per-repo
+   subdir under Path that the saspus container writes to.
+4. **Stale After (days)** — repo whose newest snapshot is older than
+   this threshold reports the `stale` reason. Default 30 days; set
+   per-entry to support mixed daily/weekly/monthly schedules.
+5. **Label** — optional display name for the dashboard.
+
+Each entry has a **Test** button that runs the disk-read against the
+tentative config and shows the outcome immediately (no save+scan+wait
+loop). Reason codes are a closed set:
+
+`ok` · `path_not_found` · `path_unreadable` · `not_a_duplicacy_repo` ·
+`storage_id_not_found` · `no_snapshots_yet` · `stale` · `corrupt_snapshot`
+
+The dashboard widget renders one row per configured entry with the
+kind tag (`DUPLICACY:CLI-REPO` / `DUPLICACY:WEB-CACHE`), a
+severity-coloured status pill keyed off the reason code (ok=success,
+no_snapshots_yet=info, stale=warning, anything else=error), snapshot
+count, last-backup-age, and an orthogonal `RUNNING` badge when a
+lock or `incomplete` marker is detected on disk. Failed entries
+render as red error cards with the specific reason so users can tell
+at a glance whether they have a misconfigured Path, a missing Storage
+ID, or a fresh-never-run repo.
+
+Per-entry Prometheus gauges:
+`nasdoctor_backup_duplicacy_snapshots_total{label="…"}`,
+`_last_backup_age_seconds{label="…"}`,
+`_last_backup_size_bytes{label="…"}`,
+`_status{label="…",reason="…"}` (1 for the entry's current reason
+code, 0 for the others — same convention as
+`nasdoctor_speedtest_engine`).
 
 ### Network Speed Test
 
@@ -712,6 +763,12 @@ nasdoctor_gpu_encoder_percent / _decoder_percent
 # Backup (labels: provider, name)
 nasdoctor_backup_last_success_timestamp / _size_bytes / _status
 
+# Backup — Duplicacy (labels: label, +reason on _status) — 4 gauges per entry
+nasdoctor_backup_duplicacy_snapshots_total{label="…"}
+nasdoctor_backup_duplicacy_last_backup_age_seconds{label="…"}     # resolves at scrape time, monotonic between scans
+nasdoctor_backup_duplicacy_last_backup_size_bytes{label="…"}
+nasdoctor_backup_duplicacy_status{label="…",reason="…"}           # 1 for current reason, 0 for others (8-reason closed set)
+
 # Speed Test
 nasdoctor_speedtest_download_mbps / _upload_mbps / _latency_ms
 nasdoctor_speedtest_in_progress                            # 1 while a test is running
@@ -785,6 +842,8 @@ All bind mounts in one place — match the per-platform Quick Start tables above
 | `/var/run/tailscale` | `/var/run/tailscale` | Tailscale peer graph (mount only if you use Tailscale on the host) |
 
 > **External Borg repos** add their own bind-mount entries on top of the table — see [External Borg Monitoring (host-managed repos)](#external-borg-monitoring-host-managed-repos) above for repo-path mount conventions and required env vars.
+>
+> **Duplicacy entries** also add bind-mount entries (one per repo or cache root, **Read Only** — disk-read makes RO mounts safe). See [Duplicacy Monitoring (disk-read, no binary required)](#duplicacy-monitoring-disk-read-no-binary-required) above. **No env vars required**, no binary mount, no extra Docker capability.
 
 ### Source tree
 
@@ -829,7 +888,7 @@ Each platform renders realistic per-platform telemetry:
 - **Compute** — 3–11 Docker containers per platform, Top Processes with container attribution, GPU monitoring (Unraid RTX A2000, Proxmox Tesla P4), CPU + mainboard temperature gauges in the header (Unraid, TrueNAS, Proxmox; gracefully hidden on Synology / Kubernetes to showcase the empty-sensor fallback)
 - **Storage health** — ZFS pools where applicable (TrueNAS raidz2, Proxmox mirror), UPS power monitoring, parity history (Unraid)
 - **Network** — 8 service checks (one per check type: http/tcp/dns/ping/smb/nfs/speed/traceroute) with 7 days of history, 24h speed-test history with `via {engine}` caption on the latest result and per-row engine annotation, expand any speed entry on `/service-checks` for the per-sample throughput chart, Cloudflared + Tailscale tunnels (Unraid + Proxmox)
-- **Backups** — Borg / Restic / PBS / Duplicati / rclone repos with healthy + warning + error states, including v0.9.10's external-Borg "CONFIGURED" pill and error-card reason codes
+- **Backups** — Borg / Restic / PBS / Duplicati / rclone repos with healthy + warning + error states, v0.9.10's external-Borg "CONFIGURED" pill + error-card reason codes, **and v0.10.0's Duplicacy rows** showing both `cli-repo` + `web-cache` layouts on Unraid (one healthy + one stale-with-RUNNING-badge to demonstrate the V1c severity rendering and orthogonal aux flag)
 - **Alerts & incidents** — Active + resolved + snoozed alerts, 10-event incident timeline with system-metric correlation, webhook delivery history
 - **Fleet** — 4 remote servers with topology view and tunnel-type detection
 

--- a/cmd/nas-doctor/main.go
+++ b/cmd/nas-doctor/main.go
@@ -31,9 +31,9 @@ import (
 	"github.com/mcdays94/nas-doctor/internal/analyzer"
 	"github.com/mcdays94/nas-doctor/internal/api"
 	"github.com/mcdays94/nas-doctor/internal/collector"
-	"github.com/mcdays94/nas-doctor/internal/livetest"
 	"github.com/mcdays94/nas-doctor/internal/demo"
 	"github.com/mcdays94/nas-doctor/internal/fleet"
+	"github.com/mcdays94/nas-doctor/internal/livetest"
 	"github.com/mcdays94/nas-doctor/internal/notifier"
 	"github.com/mcdays94/nas-doctor/internal/scheduler"
 	"github.com/mcdays94/nas-doctor/internal/storage"
@@ -421,6 +421,26 @@ func main() {
 				}
 				coll.SetBackupMonitorBorg(ext)
 				logger.Info("external backup monitor loaded", "borg_repos", len(ext))
+			}
+			// Apply Duplicacy monitor config on startup (#314 / V1c).
+			// Mirrors the Borg startup wire-up above. Without this,
+			// configured Duplicacy entries wouldn't appear on the
+			// dashboard (or in /metrics) until the user re-saved
+			// settings.
+			if len(persistedSettings.BackupMonitor.Duplicacy) > 0 {
+				dup := make([]collector.DuplicacyEntry, 0, len(persistedSettings.BackupMonitor.Duplicacy))
+				for _, e := range persistedSettings.BackupMonitor.Duplicacy {
+					dup = append(dup, collector.DuplicacyEntry{
+						Enabled:    e.Enabled,
+						Label:      e.Label,
+						Kind:       e.Kind,
+						Path:       e.Path,
+						StorageID:  e.StorageID,
+						StaleAfter: e.StaleAfter,
+					})
+				}
+				coll.SetBackupMonitorDuplicacy(dup)
+				logger.Info("duplicacy backup monitor loaded", "entries", len(dup))
 			}
 		}
 		// Wire the LiveTestRegistry so manual /api/v1/speedtest/run +

--- a/demo-worker/feeder/src/index.ts
+++ b/demo-worker/feeder/src/index.ts
@@ -98,6 +98,52 @@ export interface PlatformProfile {
   // error card with the matching error_reason code (showcases the
   // failure UI without needing real broken repos).
   configuredBorgRepos?: ConfiguredBorgRepo[];
+  // Duplicacy entries configured under Settings → Advanced → Backup
+  // Monitors → Duplicacy (PRD #310 / V1c, issue #314, shipped in
+  // v0.10.0). Each entry shows up in two places:
+  // (1) snapshot.backup.duplicacy[] as a DuplicacyJobState — the
+  //     dashboard widget renders one row per entry with the kind
+  //     tag, status pill keyed off reason_code, snapshot count,
+  //     last-backup-age, optional running badge, and (on non-OK
+  //     reasons) an error-card body.
+  // (2) settings.backup_monitor.duplicacy as the user-configured
+  //     list, so visitors who click into Settings see the entries
+  //     pre-populated rather than an empty form.
+  // The feeder synthesises plausible aggregate state per entry so
+  // both healthy + stale layouts are demonstrated on the public
+  // demo without a real Duplicacy install.
+  configuredDuplicacyEntries?: ConfiguredDuplicacyEntry[];
+}
+
+// ConfiguredDuplicacyEntry mirrors api.DuplicacyEntry (CLI-repo or
+// web-cache layouts) plus the synthetic state the feeder fabricates
+// for the snapshot. Reason codes form a closed set; severity mapping
+// matches the dashboard widget (ok=success, no_snapshots_yet=info,
+// stale=warning, everything else=error). Issue #314.
+interface ConfiguredDuplicacyEntry {
+  label: string;
+  // Closed set: "cli-repo" | "web-cache". Validated by the demo
+  // widget-coverage test so a typo in this file fails CI.
+  kind: "cli-repo" | "web-cache";
+  // Container-visible path. Repo root for cli-repo; cache root for
+  // web-cache.
+  path: string;
+  // Per-repo subdir for kind=web-cache. Empty for cli-repo.
+  storage_id?: string;
+  stale_after_days?: number;
+  // Synthetic state for the snapshot. reason_code closed set:
+  //   "ok" | "no_snapshots_yet" | "stale" | "path_not_found" |
+  //   "path_unreadable" | "not_a_duplicacy_repo" |
+  //   "storage_id_not_found" | "corrupt_snapshot"
+  reason_code: string;
+  snapshot_count?: number;
+  last_backup_hours_ago?: number;
+  last_backup_size_bytes?: number;
+  last_backup_files?: number;
+  currently_running?: boolean;
+  latest_snapshot_id?: string;
+  latest_snapshot_revision?: number;
+  snapshot_ids?: string[];
 }
 
 // ConfiguredBorgRepo is one external-Borg entry the demo wires into
@@ -162,6 +208,47 @@ export const PROFILES: Record<Platform, PlatformProfile> = {
       // like in the dashboard widget. v0.9.10 #279 user stories 12-14.
       { label: "Cold Storage", repo_path: "/mnt/user/borg/cold", passphrase_env: "BORG_PASSPHRASE_COLD", error: { reason: "passphrase_rejected", message: "borg list exited 2: passphrase supplied in BORG_PASSPHRASE_COLD does not decrypt the repository" } },
     ],
+    // Duplicacy entries — one healthy CLI repo and one stale
+    // web-cache so visitors see BOTH layout kinds + BOTH severity
+    // bands rendered in the same dashboard widget. PRD #310 V1c /
+    // issue #314 acceptance criterion 3.
+    configuredDuplicacyEntries: [
+      // Healthy CLI-layout repo, daily backups.
+      {
+        label: "Documents",
+        kind: "cli-repo",
+        path: "/mnt/user/duplicacy/documents",
+        stale_after_days: 7,
+        reason_code: "ok",
+        snapshot_count: 217,
+        last_backup_hours_ago: 5.2,
+        last_backup_size_bytes: 44_000_000_000,
+        last_backup_files: 38500,
+        currently_running: false,
+        latest_snapshot_id: "documents",
+        latest_snapshot_revision: 217,
+        snapshot_ids: ["documents"],
+      },
+      // Stale saspus/duplicacy-web layout — last successful backup
+      // 12 days ago, StaleAfter=7d → stale reason. Currently running
+      // is true to also showcase the orthogonal RUNNING badge.
+      {
+        label: "Media via duplicacy-web",
+        kind: "web-cache",
+        path: "/mnt/user/appdata/duplicacy-web/cache/localhost/0/.duplicacy/cache",
+        storage_id: "media",
+        stale_after_days: 7,
+        reason_code: "stale",
+        snapshot_count: 36,
+        last_backup_hours_ago: 288, // 12 days
+        last_backup_size_bytes: 1_840_000_000_000,
+        last_backup_files: 1_120_000,
+        currently_running: true,
+        latest_snapshot_id: "media",
+        latest_snapshot_revision: 36,
+        snapshot_ids: ["media"],
+      },
+    ],
   },
   synology: {
     hostname: "synology-nas", platformName: "Synology DSM 7.2.2", cpuModel: "Intel Celeron J4125", cpuCores: 4, ramGB: 8, uptimeDays: 90,
@@ -182,6 +269,27 @@ export const PROFILES: Record<Platform, PlatformProfile> = {
     speedTest: { downloadMbps: 450, uploadMbps: 42, latencyMs: 14.2, jitterMs: 2.8, serverName: "BT Wholesale Manchester", isp: "BT Broadband" },
     configuredBorgRepos: [
       { label: "Photos Nightly", repo_path: "/volume1/borg/photos-nightly", passphrase_env: "BORG_PASSPHRASE", snapshotCount: 152, sizeBytes: 920_000_000_000, lastSuccessHoursAgo: 5.1 },
+    ],
+    // One healthy Duplicacy CLI-repo on Synology — same path-layout
+    // most saspus-web users have, just shown via the cli-repo kind
+    // because the demo profile already showcases web-cache on
+    // Unraid. PRD #310 V1c / issue #314.
+    configuredDuplicacyEntries: [
+      {
+        label: "Family Photos",
+        kind: "cli-repo",
+        path: "/volume1/duplicacy/family-photos",
+        stale_after_days: 14,
+        reason_code: "ok",
+        snapshot_count: 89,
+        last_backup_hours_ago: 11.3,
+        last_backup_size_bytes: 612_000_000_000,
+        last_backup_files: 425000,
+        currently_running: false,
+        latest_snapshot_id: "family-photos",
+        latest_snapshot_revision: 89,
+        snapshot_ids: ["family-photos"],
+      },
     ],
   },
   truenas: {
@@ -213,6 +321,26 @@ export const PROFILES: Record<Platform, PlatformProfile> = {
     configuredBorgRepos: [
       { label: "Tank Archive", repo_path: "/mnt/tank/backups/borg-archive", passphrase_env: "BORG_PASSPHRASE", snapshotCount: 218, sizeBytes: 2_700_000_000_000, lastSuccessHoursAgo: 14.3 },
     ],
+    configuredDuplicacyEntries: [
+      // Healthy web-cache layout to give TrueNAS visitors a
+      // representative view too.
+      {
+        label: "Tank Snapshots",
+        kind: "web-cache",
+        path: "/mnt/tank/duplicacy-web/cache/localhost/0/.duplicacy/cache",
+        storage_id: "tank-main",
+        stale_after_days: 30,
+        reason_code: "ok",
+        snapshot_count: 142,
+        last_backup_hours_ago: 16.1,
+        last_backup_size_bytes: 4_900_000_000_000,
+        last_backup_files: 2_100_000,
+        currently_running: false,
+        latest_snapshot_id: "tank-main",
+        latest_snapshot_revision: 142,
+        snapshot_ids: ["tank-main"],
+      },
+    ],
   },
   proxmox: {
     hostname: "pve-node01", platformName: "Proxmox VE 8.3.2", cpuModel: "Intel Xeon E-2388G", cpuCores: 8, ramGB: 128, uptimeDays: 45,
@@ -236,6 +364,23 @@ export const PROFILES: Record<Platform, PlatformProfile> = {
     gpuDevice: { name: "NVIDIA Tesla P4", vendor: "nvidia", driver: "535.216", memTotalMB: 8192, memUsedPct: 58, powerMaxW: 75, usagePct: 62, tempC: 48 },
     configuredBorgRepos: [
       { label: "VM Config Snapshots", repo_path: "/mnt/vm-storage/borg-vmconf", passphrase_env: "BORG_PASSPHRASE", snapshotCount: 96, sizeBytes: 48_000_000_000, lastSuccessHoursAgo: 3.7 },
+    ],
+    configuredDuplicacyEntries: [
+      {
+        label: "VM Snapshots",
+        kind: "cli-repo",
+        path: "/mnt/vm-storage/duplicacy-vmsnap",
+        stale_after_days: 7,
+        reason_code: "ok",
+        snapshot_count: 168,
+        last_backup_hours_ago: 4.1,
+        last_backup_size_bytes: 2_300_000_000_000,
+        last_backup_files: 88000,
+        currently_running: false,
+        latest_snapshot_id: "vm-snapshots",
+        latest_snapshot_revision: 168,
+        snapshot_ids: ["vm-snapshots"],
+      },
     ],
   },
   kubernetes: {
@@ -379,6 +524,21 @@ export function transformSettings(d: Record<string, unknown>, p: PlatformProfile
     },
     backup_monitor: {
       borg: borgMonitorList,
+      // Duplicacy entries (PRD #310 V1c / issue #314) — mirror of
+      // PlatformProfile.configuredDuplicacyEntries with the
+      // {enabled, label, kind, path, storage_id, stale_after}
+      // shape that api.DuplicacyEntry persists. Used by the
+      // Settings page's Backup Monitors → Duplicacy subsection
+      // (V1b) so visitors clicking through Settings see the
+      // entries pre-populated.
+      duplicacy: (p.configuredDuplicacyEntries || []).map((d) => ({
+        enabled: true,
+        label: d.label,
+        kind: d.kind,
+        path: d.path,
+        storage_id: d.storage_id || "",
+        stale_after: d.stale_after_days || 0,
+      })),
     },
     service_checks: {
       checks: [
@@ -1191,7 +1351,7 @@ function buildBackup(p: PlatformProfile, platform: Platform): Record<string, unk
     // dashboard renders the "no backup provider detected" empty
     // state, which is what a Velero-managed cluster would show
     // to NAS Doctor.
-    return { available: false, jobs: [] };
+    return { available: false, jobs: [], duplicacy: [] };
   }
   // Append the explicit external Borg repos configured under
   // Settings → Backup Monitors → Borg (v0.9.10 / #279). These
@@ -1199,7 +1359,40 @@ function buildBackup(p: PlatformProfile, platform: Platform): Record<string, unk
   // an injected `error` render as red error cards with the
   // matching reason code.
   const configured = buildConfiguredBorgEntries(p);
-  return { available: true, jobs: [...repos, ...configured] };
+  // Append the Duplicacy entries (PRD #310 V1c / issue #314) as a
+  // sibling field. The dashboard widget reads backup.duplicacy[]
+  // separately from backup.jobs[] and renders the two groups in
+  // one combined "Backup Jobs (N)" section, distinguished by the
+  // Kind tag on each Duplicacy row.
+  const duplicacy = buildDuplicacyEntries(p);
+  return { available: true, jobs: [...repos, ...configured], duplicacy };
+}
+
+// buildDuplicacyEntries — converts the profile's
+// configuredDuplicacyEntries list into snapshot.backup.duplicacy[]
+// matching internal.DuplicacyJobState. Mirrors what the production
+// scheduler's CollectBackups path produces from the disk-read runner.
+// PRD #310 V1c / issue #314.
+function buildDuplicacyEntries(p: PlatformProfile): Record<string, unknown>[] {
+  const entries = p.configuredDuplicacyEntries;
+  if (!entries || entries.length === 0) return [];
+  const nowMs = Date.now();
+  const hoursAgoIso = (h: number) => new Date(nowMs - h * 3600000).toISOString();
+  return entries.map((e): Record<string, unknown> => ({
+    label: e.label,
+    kind: e.kind,
+    path: e.path,
+    storage_id: e.storage_id || "",
+    reason_code: e.reason_code,
+    snapshot_count: e.snapshot_count ?? 0,
+    latest_backup_at: e.last_backup_hours_ago !== undefined ? hoursAgoIso(e.last_backup_hours_ago) : null,
+    latest_backup_size_bytes: e.last_backup_size_bytes ?? 0,
+    latest_backup_files: e.last_backup_files ?? 0,
+    currently_running: e.currently_running ?? false,
+    latest_snapshot_id: e.latest_snapshot_id || "",
+    latest_snapshot_revision: e.latest_snapshot_revision ?? 0,
+    snapshot_ids: e.snapshot_ids ?? [],
+  }));
 }
 
 // buildTopProcesses — produces snapshot.system.top_processes matching

--- a/demo-worker/feeder/src/widget-coverage.test.ts
+++ b/demo-worker/feeder/src/widget-coverage.test.ts
@@ -124,6 +124,23 @@ const EXPECTED_WIDGETS: WidgetExpectation[] = [
     // k8s uses its own backup story (velero, etc) and hides the widget.
     platforms: ["unraid", "synology", "truenas", "proxmox"],
   },
+  // sections.backup also reads snapshot.backup.duplicacy[] — the
+  // V1c surface added by issue #314. One entry minimum on every
+  // non-k8s platform; field-level shape guarded by the per-entry
+  // tests below.
+  {
+    widget: "backup_duplicacy",
+    requiredKeys: [
+      "backup.duplicacy.0.label",
+      "backup.duplicacy.0.kind",
+      "backup.duplicacy.0.path",
+      "backup.duplicacy.0.reason_code",
+      "backup.duplicacy.0.snapshot_count",
+      "backup.duplicacy.0.latest_backup_size_bytes",
+      "backup.duplicacy.0.currently_running",
+    ],
+    platforms: ["unraid", "synology", "truenas", "proxmox"],
+  },
   // sections.processes in dashboard.go L1144 — reads
   //   snapshot.system.top_processes[].{command, cpu_percent, mem_percent, user, container_name}
   {
@@ -262,6 +279,90 @@ describe("demo feeder widget coverage", () => {
     // Empty array is fine — populated array would be wrong.
     expect(Array.isArray(borgList)).toBe(true);
     expect(borgList.length).toBe(0);
+  });
+
+  // ── External Duplicacy Monitor demo coverage (v0.10.0 / #314) ──────
+  // Sibling test family to the Borg coverage above. Pins the
+  // contract so a future refactor can't silently drop the demo's
+  // Duplicacy showcase. The dashboard widget reads
+  // snapshot.backup.duplicacy[].{label, kind, reason_code,
+  // snapshot_count, latest_backup_at, latest_backup_size_bytes,
+  // currently_running} and the Settings page reads
+  // settings.backup_monitor.duplicacy[].{enabled, label, kind, path,
+  // storage_id, stale_after}.
+
+  it("emits at least one Duplicacy entry on each non-k8s platform's snapshot.backup.duplicacy", () => {
+    for (const platform of ["unraid", "synology", "truenas", "proxmox"] as Platform[]) {
+      const snap = transformSnapshot(SEED, PROFILES[platform], platform);
+      const entries = (getPath(snap, "backup.duplicacy") as Array<Record<string, unknown>>) || [];
+      expect(
+        entries.length,
+        `${platform} should have at least one Duplicacy entry to showcase the V1c dashboard rendering`,
+      ).toBeGreaterThan(0);
+      // Each entry must carry every field the dashboard widget reads.
+      const validKinds = new Set(["cli-repo", "web-cache"]);
+      const validReasons = new Set([
+        "ok",
+        "no_snapshots_yet",
+        "stale",
+        "path_not_found",
+        "path_unreadable",
+        "not_a_duplicacy_repo",
+        "storage_id_not_found",
+        "corrupt_snapshot",
+      ]);
+      for (const e of entries) {
+        expect(typeof e.label, `${platform} entry must have a string label`).toBe("string");
+        expect(validKinds.has(e.kind as string), `${platform} entry kind ${JSON.stringify(e.kind)} must be cli-repo or web-cache`).toBe(true);
+        expect(typeof e.path, `${platform} entry must have a string path`).toBe("string");
+        expect(validReasons.has(e.reason_code as string), `${platform} reason_code ${JSON.stringify(e.reason_code)} must be in the canonical V1a closed set`).toBe(true);
+        expect(typeof e.snapshot_count, `${platform} snapshot_count must be a number`).toBe("number");
+        expect(typeof e.latest_backup_size_bytes, `${platform} latest_backup_size_bytes must be a number`).toBe("number");
+        expect(typeof e.currently_running, `${platform} currently_running must be a boolean`).toBe("boolean");
+      }
+    }
+  });
+
+  it("kubernetes does not surface a backup.duplicacy list (Velero territory)", () => {
+    const snap = transformSnapshot(SEED, PROFILES.kubernetes, "kubernetes");
+    const entries = getPath(snap, "backup.duplicacy") as Array<unknown>;
+    expect(Array.isArray(entries), "backup.duplicacy must be an array (empty is fine)").toBe(true);
+    expect(entries.length, "k8s must not emit Duplicacy entries (Velero-territory)").toBe(0);
+  });
+
+  it("Unraid showcases BOTH cli-repo AND web-cache layouts to demonstrate severity rendering", () => {
+    const snap = transformSnapshot(SEED, PROFILES.unraid, "unraid");
+    const entries = (getPath(snap, "backup.duplicacy") as Array<Record<string, unknown>>) || [];
+    const kinds = new Set(entries.map((e) => e.kind as string));
+    expect(kinds.has("cli-repo"), "Unraid demo must include a cli-repo entry").toBe(true);
+    expect(kinds.has("web-cache"), "Unraid demo must include a web-cache entry").toBe(true);
+    // At least one stale entry so the demo demonstrates the warning
+    // severity band (the v0.9.10 Borg demo did this for error severity;
+    // Duplicacy's stale=warning is the equivalent showcase).
+    const stale = entries.filter((e) => e.reason_code === "stale");
+    expect(stale.length, "Unraid demo must include at least one stale=warning Duplicacy entry to showcase severity").toBeGreaterThan(0);
+  });
+
+  it("transformSettings populates backup_monitor.duplicacy matching the profile's configured entries", () => {
+    const seedSettings: Record<string, unknown> = { sections: {}, backup_monitor: { borg: [], duplicacy: [] } };
+    for (const platform of ["unraid", "synology", "truenas", "proxmox"] as Platform[]) {
+      const profile = PROFILES[platform];
+      const settings = transformSettings(seedSettings, profile);
+      const list = (getPath(settings, "backup_monitor.duplicacy") as Array<Record<string, unknown>>) || [];
+      const expectedCount = profile.configuredDuplicacyEntries?.length ?? 0;
+      expect(
+        list.length,
+        `${platform} settings.backup_monitor.duplicacy length must match profile.configuredDuplicacyEntries`,
+      ).toBe(expectedCount);
+      for (let i = 0; i < list.length; i++) {
+        const entry = list[i];
+        const expected = profile.configuredDuplicacyEntries![i];
+        expect(entry.enabled, "configured Duplicacy entries default enabled=true on the demo").toBe(true);
+        expect(entry.label, "label round-trips").toBe(expected.label);
+        expect(entry.kind, "kind round-trips").toBe(expected.kind);
+        expect(entry.path, "path round-trips").toBe(expected.path);
+      }
+    }
   });
 
   it("emits at least one error-card Borg entry on Unraid (showcases v0.9.10 error UI)", () => {

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -186,12 +186,12 @@ type BorgExternalRepo struct {
 // slice-1 WakeDrives and MaxAgeDays knobs that it inherited from the
 // retired top-level Settings.SMART.
 type AdvancedScansSettings struct {
-	SMART      AdvancedScansSMART      `json:"smart"`
-	Docker     AdvancedScansSubsystem  `json:"docker"`
-	Proxmox    AdvancedScansSubsystem  `json:"proxmox"`
-	Kubernetes AdvancedScansSubsystem  `json:"kubernetes"`
-	ZFS        AdvancedScansSubsystem  `json:"zfs"`
-	GPU        AdvancedScansSubsystem  `json:"gpu"`
+	SMART      AdvancedScansSMART     `json:"smart"`
+	Docker     AdvancedScansSubsystem `json:"docker"`
+	Proxmox    AdvancedScansSubsystem `json:"proxmox"`
+	Kubernetes AdvancedScansSubsystem `json:"kubernetes"`
+	ZFS        AdvancedScansSubsystem `json:"zfs"`
+	GPU        AdvancedScansSubsystem `json:"gpu"`
 }
 
 // AdvancedScansSubsystem is the minimal shape shared by the five
@@ -1171,6 +1171,10 @@ func (s *Server) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		// next backup tick picks up changes without a restart
 		// (issue #279 user stories 2/4/7).
 		s.collector.SetBackupMonitorBorg(apiBorgReposToCollector(settings.BackupMonitor.Borg))
+		// Push Duplicacy entry config onto the collector so the next
+		// backup tick picks up changes without a restart (issue #314 /
+		// PRD #310 V1c). Mirrors the Borg pattern above.
+		s.collector.SetBackupMonitorDuplicacy(apiDuplicacyEntriesToCollector(settings.BackupMonitor.Duplicacy))
 		// Update the max-age safety-net threshold on the scheduler
 		// (#238). The scheduler owns this policy (the collector stays
 		// DB-unaware) and applies it after each scan's Collect().

--- a/internal/api/backup_monitor.go
+++ b/internal/api/backup_monitor.go
@@ -90,3 +90,25 @@ func apiBorgReposToCollector(repos []BorgExternalRepo) []collector.BorgExternalR
 	}
 	return out
 }
+
+// apiDuplicacyEntriesToCollector converts the API-layer DuplicacyEntry
+// list into the collector-layer list. Mirrors apiBorgReposToCollector
+// in shape so the conversion stays trivial as more provider types
+// are added. Issue #314.
+func apiDuplicacyEntriesToCollector(entries []DuplicacyEntry) []collector.DuplicacyEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]collector.DuplicacyEntry, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, collector.DuplicacyEntry{
+			Enabled:    e.Enabled,
+			Label:      strings.TrimSpace(e.Label),
+			Kind:       strings.TrimSpace(e.Kind),
+			Path:       strings.TrimSpace(e.Path),
+			StorageID:  strings.TrimSpace(e.StorageID),
+			StaleAfter: e.StaleAfter,
+		})
+	}
+	return out
+}

--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -757,11 +757,26 @@ sections.backup = function(sn) {
   var h = '';
   h += '<div class="section-block" data-section="backup">';
   var backup = sn ? sn.backup : null;
-  if (backup && backup.available && backup.jobs && backup.jobs.length > 0) {
+  /* Duplicacy reason → severity mapping (PRD #310 §4 / issue #314).
+     Mirrors the dashboard widget contract for the new per-provider
+     reason set. ok=success, no_snapshots_yet=info, stale=warning,
+     everything else=error. Kept inline so the dashboard JS stays
+     self-contained — the runner-side classifier produces these
+     exact codes. */
+  var dupSeverity = function(reason) {
+    if (reason === 'ok') return 'ok';
+    if (reason === 'no_snapshots_yet') return 'info';
+    if (reason === 'stale') return 'warning';
+    return 'error';
+  };
+  var jobsList = (backup && backup.available && backup.jobs) ? backup.jobs : [];
+  var dupList  = (backup && backup.duplicacy) ? backup.duplicacy : [];
+  var totalRows = jobsList.length + dupList.length;
+  if (backup && backup.available && totalRows > 0) {
     h += '<div>';
-    h += '<div class="section-title">Backup Jobs (' + backup.jobs.length + ')</div>';
-    for (var bi = 0; bi < backup.jobs.length; bi++) {
-      var bj = backup.jobs[bi];
+    h += '<div class="section-title">Backup Jobs (' + totalRows + ')</div>';
+    for (var bi = 0; bi < jobsList.length; bi++) {
+      var bj = jobsList[bi];
       var isError = !!bj.error;
       var statusClass = isError ? 'td-crit' : (bj.status === 'ok' ? 'td-healthy' : bj.status === 'warning' ? 'td-warn' : 'td-crit');
       var provLabel = bj.provider.toUpperCase();
@@ -808,12 +823,77 @@ sections.backup = function(sn) {
       }
       h += '</div>';
     }
+    /* Duplicacy rows — rendered with the same per-row visual rhythm
+       as Borg, but driven by the per-provider DuplicacyJobState
+       shape (reason_code + currently_running + kind). Issue #314 /
+       PRD #310 V1c.
+
+       The rendering mirrors the Borg row's structure on purpose
+       so operators see one coherent "Backup Jobs (N)" section
+       rather than two visually-different lists. The Kind tag
+       ("DUPLICACY:CLI-REPO" or "DUPLICACY:WEB-CACHE") + the
+       per-provider reason pill is what distinguishes a Duplicacy
+       row from a Borg row at a glance. */
+    for (var di = 0; di < dupList.length; di++) {
+      var de = dupList[di];
+      var dupReason = de.reason_code || 'unknown';
+      var dupSev = dupSeverity(dupReason);
+      var dupIsError = (dupSev === 'error');
+      var dupStatusClass = dupSev === 'ok' ? 'td-healthy' : dupSev === 'warning' || dupSev === 'info' ? 'td-warn' : 'td-crit';
+      var dupCardBorder = dupIsError ? '1px solid var(--red,#dc2626)' : '1px solid var(--border)';
+      var dupDisplayName = de.label || (de.path ? (de.path.split('/').filter(function(x){return x;}).pop() || de.path) : 'Duplicacy');
+      var dupKindTag = ('DUPLICACY' + (de.kind ? ':' + de.kind.toUpperCase() : '')).replace(/_/g, '-');
+      h += '<div class="backup-card backup-card-duplicacy' + (dupIsError ? ' backup-card-error' : '') + '" data-provider="duplicacy" style="background:var(--bg-panel);border:' + dupCardBorder + ';border-radius:calc(var(--radius)*1.5);padding:12px;margin-bottom:6px">';
+      h += '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">';
+      h += '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">';
+      h += '<span style="font-weight:600;font-size:13px;color:var(--text-primary)">' + esc(dupDisplayName) + '</span>';
+      /* Kind tag — purpose-built CSS class so themes can theme it
+         independently from the existing Borg provider chip. Locked
+         by the 3-source theme-parity test. */
+      h += '<span class="duplicacy-kind-tag" style="font-size:10px;padding:2px 6px;border-radius:4px;background:rgba(168,85,247,0.15);color:#c084fc;font-weight:600;letter-spacing:0.5px">' + esc(dupKindTag) + '</span>';
+      /* "Configured" pill — every Duplicacy entry is by definition
+         user-configured (we don't auto-detect Duplicacy repos), so
+         render the pill unconditionally to match Borg's pattern. */
+      h += '<span style="font-size:10px;padding:2px 6px;border-radius:4px;background:var(--accent,#3b82f6);color:#fff">CONFIGURED</span>';
+      /* currently_running aux flag (PRD #310 user story 13). Renders
+         orthogonally to the reason pill so a stuck-lock + stale repo
+         can show both signals at once. */
+      if (de.currently_running) {
+        h += '<span class="duplicacy-running-badge" style="font-size:10px;padding:2px 6px;border-radius:4px;background:rgba(34,211,238,0.15);color:#22d3ee;font-weight:600;letter-spacing:0.5px">RUNNING</span>';
+      }
+      h += '</div>';
+      var dupStatusText = dupReason.toUpperCase().replace(/_/g, ' ');
+      h += '<span class="' + dupStatusClass + '" style="font-size:12px;font-weight:600">' + esc(dupStatusText) + '</span>';
+      h += '</div>';
+      if (dupIsError) {
+        /* Error-card body: the reason text + path. No "error message"
+           string from the runner — Duplicacy runs disk-read and the
+           reason code itself is the actionable signal (e.g.
+           PATH NOT FOUND vs STORAGE ID NOT FOUND). */
+        h += '<div style="font-size:12px;color:var(--text-tertiary);line-height:1.5">';
+        var dupReasonHuman = dupStatusText.charAt(0) + dupStatusText.slice(1).toLowerCase();
+        h += '<div style="color:var(--red,#dc2626);font-weight:500;margin-bottom:4px">' + esc(dupReasonHuman) + '</div>';
+        if (de.path) {
+          var dupPathDisplay = de.path + (de.storage_id ? ' / ' + de.storage_id : '');
+          h += '<div style="font-family:var(--font-mono,monospace);font-size:11px;color:var(--text-quaternary);word-break:break-all">' + esc(dupPathDisplay) + '</div>';
+        }
+        h += '</div>';
+      } else {
+        h += '<div style="display:flex;gap:16px;font-size:12px;color:var(--text-tertiary);flex-wrap:wrap">';
+        if (de.snapshot_count) h += '<span>Snapshots: <strong style="color:var(--text-primary)">' + de.snapshot_count + '</strong></span>';
+        if (de.latest_backup_size_bytes > 0) h += '<span>Size: <strong style="color:var(--text-primary)">' + fmtBytes(de.latest_backup_size_bytes) + '</strong></span>';
+        if (de.latest_backup_at) { var dupAge = Math.round((Date.now() - new Date(de.latest_backup_at).getTime()) / 3600000); h += '<span>Last: <strong style="color:var(--text-primary)">' + (dupAge < 1 ? '<1h ago' : dupAge + 'h ago') + '</strong></span>'; }
+        if (de.latest_snapshot_id && de.latest_snapshot_revision) h += '<span style="color:var(--text-quaternary)">' + esc(de.latest_snapshot_id) + ' @ rev ' + de.latest_snapshot_revision + '</span>';
+        h += '</div>';
+      }
+      h += '</div>';
+    }
     h += '</div>';
   } else {
     h += '<div>';
     h += '<div class="section-title">Backup Monitoring</div>';
     h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:14px;font-size:12px;color:var(--text-tertiary);line-height:1.5">';
-    h += 'No backup provider detected or configured. NAS Doctor <strong>bundles the Borg CLI</strong> and auto-detects local Borg repos. For externally-managed Borg setups (e.g. Unraid User Scripts), configure the repo path in <a href="/settings#backup-monitors" style="color:var(--brand)">Settings &rarr; Backup Monitors &rarr; Borg</a>. For <strong>Restic</strong>, <strong>Proxmox Backup Server</strong>, or <strong>Duplicati</strong> monitoring, install those CLIs via a custom Dockerfile or sibling container.';
+    h += 'No backup provider detected or configured. NAS Doctor <strong>bundles the Borg CLI</strong> and auto-detects local Borg repos. For externally-managed Borg setups (e.g. Unraid User Scripts), configure the repo path in <a href="/settings#backup-monitors" style="color:var(--brand)">Settings &rarr; Backup Monitors &rarr; Borg</a>. For <strong>Duplicacy</strong> repos (CLI or saspus/duplicacy-web layouts), configure the path in <a href="/settings#backup-monitors" style="color:var(--brand)">Settings &rarr; Backup Monitors &rarr; Duplicacy</a> — disk-read, no extra binary required. For <strong>Restic</strong>, <strong>Proxmox Backup Server</strong>, or <strong>Duplicati</strong> monitoring, install those CLIs via a custom Dockerfile or sibling container.';
     h += '<br><br><span style="font-size:11px;color:var(--text-quaternary)">You can hide this section in <a href="/settings#card-sections" style="color:var(--brand)">Settings → Dashboard Sections</a> if it does not apply to you.</span>';
     h += '</div></div>';
   }

--- a/internal/api/dashboard_backup_duplicacy_test.go
+++ b/internal/api/dashboard_backup_duplicacy_test.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDashboardJS_BackupSection_DuplicacySupport pins the V1c
+// dashboard rendering surface (PRD #310 / issue #314). The Backup
+// section must:
+//
+//  1. Iterate snapshot.backup.duplicacy[] in ADDITION to backup.jobs[].
+//  2. Render a per-entry kind tag ("DUPLICACY:CLI-REPO" /
+//     "DUPLICACY:WEB-CACHE") so users can tell Borg rows from
+//     Duplicacy rows at a glance.
+//  3. Render a CONFIGURED pill on every Duplicacy row (entries are
+//     always user-configured — there's no auto-detect for Duplicacy).
+//  4. Render a status pill keyed off reason_code with the per-PRD
+//     severity mapping (ok=success, no_snapshots_yet=info,
+//     stale=warning, anything else=error).
+//  5. Render the orthogonal RUNNING badge when currently_running is
+//     true.
+//  6. Render an error-card body when the reason maps to error
+//     severity (path_not_found, path_unreadable, not_a_duplicacy_repo,
+//     storage_id_not_found, corrupt_snapshot).
+//  7. Combine Duplicacy + Borg counts in the section title so the
+//     "Backup Jobs (N)" caption is correct in mixed-provider layouts.
+//
+// The test is JS-substring-driven (not a runtime exec) — same shape
+// as the existing TestDashboardJS_BackupSection_* family. Asserts on
+// the SOURCE of DashboardJS so any future refactor that splits
+// rendering into a helper is caught immediately when the helper is
+// renamed/relocated without preserving the dashboard contract.
+func TestDashboardJS_BackupSection_DuplicacySupport(t *testing.T) {
+	js := DashboardJS
+
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		// (1) iterate backup.duplicacy
+		{"reads backup.duplicacy", "backup.duplicacy"},
+		{"loops over duplicacy entries", "for (var di = 0; di < dupList.length; di++)"},
+		// (2) Kind tag — "DUPLICACY:" prefix + uppercase kind value
+		{"emits DUPLICACY: kind prefix", "'DUPLICACY' + (de.kind ? ':' + de.kind.toUpperCase() : '')"},
+		{"applies duplicacy-kind-tag class", "duplicacy-kind-tag"},
+		// (3) CONFIGURED pill always rendered for duplicacy rows
+		{"unconditional CONFIGURED pill on duplicacy rows", ">CONFIGURED<"},
+		// (4) reason-code → severity mapping (closed set)
+		{"defines dupSeverity helper", "var dupSeverity = function(reason)"},
+		{"maps ok to success severity", "if (reason === 'ok') return 'ok'"},
+		{"maps no_snapshots_yet to info severity", "if (reason === 'no_snapshots_yet') return 'info'"},
+		{"maps stale to warning severity", "if (reason === 'stale') return 'warning'"},
+		// (5) RUNNING badge — orthogonal aux flag
+		{"renders RUNNING badge for currently_running entries", "duplicacy-running-badge"},
+		{"badge text is RUNNING", ">RUNNING<"},
+		{"guards on currently_running flag", "if (de.currently_running)"},
+		// (6) error-card path
+		{"branches on dupIsError for error-card body", "if (dupIsError)"},
+		// (7) combined section title count
+		{"counts both jobs and duplicacy in title", "totalRows = jobsList.length + dupList.length"},
+		// per-row data fields the widget consumes (regression guards)
+		{"reads de.snapshot_count", "de.snapshot_count"},
+		{"reads de.latest_backup_size_bytes", "de.latest_backup_size_bytes"},
+		{"reads de.latest_backup_at", "de.latest_backup_at"},
+		{"reads de.latest_snapshot_id", "de.latest_snapshot_id"},
+		{"reads de.latest_snapshot_revision", "de.latest_snapshot_revision"},
+	}
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(js, tc.substr) {
+				t.Errorf("DashboardJS missing %q — expected substring: %q", tc.name, tc.substr)
+			}
+		})
+	}
+}
+
+// TestDashboardJS_BackupSection_EmptyState_AfterDuplicacy asserts the
+// "no backup provider detected" empty-state copy is updated to mention
+// Duplicacy as a configurable option. PRD #310 V1c README scour
+// alignment.
+func TestDashboardJS_BackupSection_DuplicacyEmptyStateMention(t *testing.T) {
+	js := DashboardJS
+	// Empty-state hint should mention Duplicacy as a configurable
+	// provider so users know it's an option without having to dig
+	// through Settings.
+	if !strings.Contains(js, "Duplicacy") {
+		t.Error("DashboardJS empty-state copy missing 'Duplicacy' — visitors with no backup configured won't know it's an option")
+	}
+	if !strings.Contains(js, "disk-read") {
+		t.Error("DashboardJS empty-state copy missing 'disk-read' — should communicate that Duplicacy needs no extra binary install")
+	}
+}
+
+// TestDashboardJS_BackupSection_NoBackticks asserts the rendered JS
+// contains no backtick characters, which would terminate the Go
+// raw-string DashboardJS literal early (AGENTS.md "backticks inside
+// JS comments" gotcha).
+func TestDashboardJS_BackupSection_NoBackticks(t *testing.T) {
+	if strings.Contains(DashboardJS, "`") {
+		t.Error("DashboardJS contains a backtick — would prematurely terminate the Go raw-string literal in dashboard.go")
+	}
+}

--- a/internal/api/dashboard_backup_test.go
+++ b/internal/api/dashboard_backup_test.go
@@ -65,7 +65,12 @@ func TestDashboardJS_BackupSection_PreservesExistingBehavior(t *testing.T) {
 		{"sections.backup defined", "sections.backup = function(sn)"},
 		{"data-section attribute", `data-section="backup"`},
 		{"renders backup jobs count", "Backup Jobs ("},
-		{"guards on backup.available and jobs", "backup.available && backup.jobs && backup.jobs.length > 0"},
+		// Combined-guard pattern after issue #314 — total row count
+		// covers both Borg jobs and Duplicacy entries. Borg-only
+		// installs still hit the empty-state branch on
+		// backup.jobs=[] AND backup.duplicacy=[]/undef, preserving
+		// pre-V1c behaviour.
+		{"guards on totalRows > 0", "backup.available && totalRows > 0"},
 	}
 	for _, tc := range checks {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/api/settings_backup_monitor_duplicacy_collector_wiring_test.go
+++ b/internal/api/settings_backup_monitor_duplicacy_collector_wiring_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/mcdays94/nas-doctor/internal/collector"
+)
+
+// TestApiDuplicacyEntriesToCollector_RoundTripsAllFields pins the
+// api → collector field mapping so a future field rename surfaces
+// at compile time + via test failure rather than silently dropping
+// the value at the api boundary. Mirrors the pattern of
+// TestApiBorgReposToCollector_RoundTripsAllFields. Issue #314.
+func TestApiDuplicacyEntriesToCollector_RoundTripsAllFields(t *testing.T) {
+	in := []DuplicacyEntry{
+		{
+			Enabled:    true,
+			Label:      "  Documents  ", // trim
+			Kind:       "cli-repo",
+			Path:       "  /mnt/user/dup/docs  ",
+			StorageID:  "",
+			StaleAfter: 14,
+		},
+		{
+			Enabled:    false,
+			Label:      "Media",
+			Kind:       "web-cache",
+			Path:       "/mnt/user/duplicacy-web/cache/localhost/0/.duplicacy/cache",
+			StorageID:  "media",
+			StaleAfter: 30,
+		},
+	}
+	got := apiDuplicacyEntriesToCollector(in)
+	if len(got) != 2 {
+		t.Fatalf("got %d entries; want 2", len(got))
+	}
+	want0 := collector.DuplicacyEntry{
+		Enabled:    true,
+		Label:      "Documents",
+		Kind:       "cli-repo",
+		Path:       "/mnt/user/dup/docs",
+		StorageID:  "",
+		StaleAfter: 14,
+	}
+	if got[0] != want0 {
+		t.Errorf("entry 0 mismatch:\n got = %+v\nwant = %+v", got[0], want0)
+	}
+	want1 := collector.DuplicacyEntry{
+		Enabled:    false,
+		Label:      "Media",
+		Kind:       "web-cache",
+		Path:       "/mnt/user/duplicacy-web/cache/localhost/0/.duplicacy/cache",
+		StorageID:  "media",
+		StaleAfter: 30,
+	}
+	if got[1] != want1 {
+		t.Errorf("entry 1 mismatch:\n got = %+v\nwant = %+v", got[1], want1)
+	}
+}
+
+// TestApiDuplicacyEntriesToCollector_NilAndEmptyReturnNil asserts the
+// nil-pass-through semantics required by Collector.SetBackupMonitorDuplicacy
+// (which itself defensively-copies but defaults to clearing on nil).
+func TestApiDuplicacyEntriesToCollector_NilAndEmptyReturnNil(t *testing.T) {
+	if got := apiDuplicacyEntriesToCollector(nil); got != nil {
+		t.Errorf("nil → got %+v; want nil", got)
+	}
+	if got := apiDuplicacyEntriesToCollector([]DuplicacyEntry{}); got != nil {
+		t.Errorf("empty slice → got %+v; want nil (matches apiBorgReposToCollector pattern)", got)
+	}
+}

--- a/internal/api/styles.go
+++ b/internal/api/styles.go
@@ -251,6 +251,24 @@ body.theme-clean .badge-generic { background:rgba(0,0,0,0.06) }
 .pill-speed { background:rgba( 34,211,238,0.14); color:#22d3ee } /* cyan-400    */
 .pill-trace { background:rgba( 45,212,191,0.14); color:#2dd4bf } /* teal-400    */
 
+/* ── Backup row variants (Duplicacy) ──────────────────────────
+   PRD #310 V1c / issue #314. Mirrored verbatim into both dashboard
+   theme templates (midnight.html, clean.html) — they don't link
+   /css/shared.css so any class used on the dashboard MUST be
+   inlined into both themes. Locked by
+   TestStyles_DuplicacyBackupRow_ThreeSourceParity. */
+.backup-card-duplicacy { /* layout inherits from .backup-card */ }
+.duplicacy-kind-tag {
+  font-size:10px; font-weight:600; letter-spacing:0.5px;
+  padding:2px 6px; border-radius:4px;
+  background:rgba(168,85,247,0.15); color:#c084fc; /* purple-400 */
+}
+.duplicacy-running-badge {
+  font-size:10px; font-weight:600; letter-spacing:0.5px;
+  padding:2px 6px; border-radius:4px;
+  background:rgba( 34,211,238,0.15); color:#22d3ee; /* cyan-400 */
+}
+
 /* ── Status Dots ────────────────────────────────────────────── */
 .status-dot.degraded { background:#f59e0b }
 

--- a/internal/api/styles_duplicacy_theme_parity_test.go
+++ b/internal/api/styles_duplicacy_theme_parity_test.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestStyles_DuplicacyBackupRow_ThreeSourceParity locks the Duplicacy
+// row CSS rules across the three CSS sources that must agree on every
+// rule the dashboard JS references:
+//
+//   - SharedCSS (internal/api/styles.go) — served at /css/shared.css,
+//     consumed by every page EXCEPT the dashboard themes.
+//   - midnight.html — dashboard theme template, has its own inline
+//     <style> block and does NOT link shared.css.
+//   - clean.html — same story, second dashboard theme.
+//
+// AGENTS.md §"Theme template parity is critical": v0.9.7 rc4/5/6
+// surfaced this exact class of bug — pill rules existed in shared.css
+// but the dashboard themes didn't load shared.css, so .pill-trace
+// rendered as plain text on the dashboard despite passing every
+// "rule-exists-somewhere" test. The cure is the three-source pin: any
+// new Duplicacy row class added to dashboard.go MUST exist with
+// matching colour values in all three sources before the change is
+// considered safe to ship.
+//
+// Issue #314.
+func TestStyles_DuplicacyBackupRow_ThreeSourceParity(t *testing.T) {
+	// Approved palette for Duplicacy row variants. Both classes use
+	// Tailwind 400-weight shades to match the broader design-system
+	// pattern (purple-400 for the kind tag, cyan-400 for the running
+	// badge — perceptually distinct from every existing pill colour
+	// pinned by TestStyles_ServiceCheckPillPalette).
+	want := map[string]string{
+		"duplicacy-kind-tag":      "#c084fc", // purple-400
+		"duplicacy-running-badge": "#22d3ee", // cyan-400
+	}
+
+	sources := map[string]string{
+		"SharedCSS":     SharedCSS,
+		"midnight.html": DashboardMidnight,
+		"clean.html":    DashboardClean,
+	}
+
+	for sourceName, css := range sources {
+		for className, wantColor := range want {
+			got := extractDuplicacyClassColor(t, css, sourceName, className)
+			if got != wantColor {
+				t.Errorf(".%s in %s: got %q, want %q — update this test AND all three CSS sources together. The dashboard themes do not link /css/shared.css so any Duplicacy row class must be inlined into BOTH theme templates.", className, sourceName, got, wantColor)
+			}
+		}
+		// .backup-card-duplicacy must exist as a rule in each source
+		// (even if its body is empty / inherits from .backup-card) so
+		// the data-provider="duplicacy" + class wiring on the
+		// dashboard rows is honoured by future theme overrides.
+		if !strings.Contains(css, ".backup-card-duplicacy") {
+			t.Errorf("%s missing .backup-card-duplicacy class — needed even with empty body so themes can override the duplicacy variant independently from the borg backup-card", sourceName)
+		}
+	}
+}
+
+// extractDuplicacyClassColor returns the #RRGGBB color value on the
+// .className rule from css. Returns "" and fails the test if the
+// rule is missing or the colour can't be parsed. Mirrors the shape
+// of extractPillColor in styles_pill_palette_test.go.
+func extractDuplicacyClassColor(t *testing.T, css, sourceLabel, className string) string {
+	t.Helper()
+	re := regexp.MustCompile(`\.` + regexp.QuoteMeta(className) + `\b[^{]*\{[^}]*color:\s*(#[0-9a-fA-F]{6})`)
+	m := re.FindStringSubmatch(css)
+	if len(m) < 2 {
+		t.Errorf(".%s: rule or colour not found in %s", className, sourceLabel)
+		return ""
+	}
+	return strings.ToLower(m[1])
+}

--- a/internal/api/templates/clean.html
+++ b/internal/api/templates/clean.html
@@ -65,6 +65,12 @@ body{min-height:100vh;background:#fff}
 .pill-ping  { background:rgba(139, 92,246,0.14); color:#a78bfa }
 .pill-speed { background:rgba( 34,211,238,0.14); color:#22d3ee }
 .pill-trace { background:rgba( 45,212,191,0.14); color:#2dd4bf }
+/* Duplicacy backup row variants (PRD #310 V1c / issue #314).
+   Pinned by TestStyles_DuplicacyBackupRow_ThreeSourceParity. Themes
+   do not link /css/shared.css so this MUST be inlined here. */
+.backup-card-duplicacy { /* layout inherits from .backup-card */ }
+.duplicacy-kind-tag { font-size:10px; font-weight:600; letter-spacing:0.5px; padding:2px 6px; border-radius:4px; background:rgba(168,85,247,0.15); color:#c084fc }
+.duplicacy-running-badge { font-size:10px; font-weight:600; letter-spacing:0.5px; padding:2px 6px; border-radius:4px; background:rgba( 34,211,238,0.15); color:#22d3ee }
 /* Ephemeral /data warning banner (#227). Rendered by util.ephemeralDataBanner
    when /api/v1/status reports data_ephemeral=true. MUST be inlined here
    because dashboard theme templates do not link /css/shared.css — see

--- a/internal/api/templates/midnight.html
+++ b/internal/api/templates/midnight.html
@@ -72,6 +72,12 @@ a:hover{color:var(--hover)}
 .pill-ping  { background:rgba(139, 92,246,0.14); color:#a78bfa }
 .pill-speed { background:rgba( 34,211,238,0.14); color:#22d3ee }
 .pill-trace { background:rgba( 45,212,191,0.14); color:#2dd4bf }
+/* Duplicacy backup row variants (PRD #310 V1c / issue #314).
+   Pinned by TestStyles_DuplicacyBackupRow_ThreeSourceParity. Themes
+   do not link /css/shared.css so this MUST be inlined here. */
+.backup-card-duplicacy { /* layout inherits from .backup-card */ }
+.duplicacy-kind-tag { font-size:10px; font-weight:600; letter-spacing:0.5px; padding:2px 6px; border-radius:4px; background:rgba(168,85,247,0.15); color:#c084fc }
+.duplicacy-running-badge { font-size:10px; font-weight:600; letter-spacing:0.5px; padding:2px 6px; border-radius:4px; background:rgba( 34,211,238,0.15); color:#22d3ee }
 /* Ephemeral /data warning banner (#227). Rendered by util.ephemeralDataBanner
    when /api/v1/status reports data_ephemeral=true. MUST be inlined here
    because dashboard theme templates do not link /css/shared.css — see

--- a/internal/collector/backup.go
+++ b/internal/collector/backup.go
@@ -61,6 +61,15 @@ type CollectBackupsOptions struct {
 	// ReadEnv resolves a named env var — injected so tests don't have
 	// to touch os.Getenv. Defaults to os.Getenv when nil.
 	ReadEnv func(string) string
+	// DuplicacyRunner is the DuplicacyRunner used to read on-disk
+	// state for each enabled Duplicacy entry. Nil → uses
+	// NewDiskDuplicacyRunner() (production default). Issue #314.
+	DuplicacyRunner DuplicacyRunner
+	// Duplicacy is the user-configured list of Duplicacy entries.
+	// Each entry resolves to one DuplicacyJobState in the resulting
+	// BackupInfo.Duplicacy slice. Disabled entries are skipped (no
+	// dashboard row produced). Issue #314.
+	Duplicacy []DuplicacyEntry
 }
 
 // CollectBackups detects and queries backup tools: Borg, Restic, PBS,
@@ -91,10 +100,69 @@ func CollectBackups(opts CollectBackupsOptions) *internal.BackupInfo {
 	info.Jobs = append(info.Jobs, pbsJobs...)
 	info.Jobs = append(info.Jobs, duplicatiJobs...)
 
-	if len(info.Jobs) > 0 {
+	// Duplicacy (PRD #310 / V1c, issue #314). Disk-read by design — no
+	// subprocess invocation. Each enabled entry produces one
+	// DuplicacyJobState; disabled entries are skipped (no dashboard
+	// row). The runner's Read() is total: every classifier outcome
+	// (including filesystem failures) maps to a non-error return with
+	// the corresponding ReasonCode, so we never lose visibility on a
+	// misconfigured entry.
+	dupRunner := opts.DuplicacyRunner
+	if dupRunner == nil {
+		dupRunner = NewDiskDuplicacyRunner()
+	}
+	info.Duplicacy = collectDuplicacyEntries(dupRunner, opts.Duplicacy)
+
+	if len(info.Jobs) > 0 || len(info.Duplicacy) > 0 {
 		info.Available = true
 	}
 	return info
+}
+
+// collectDuplicacyEntries calls DuplicacyRunner.Read for each enabled
+// configured entry and converts the per-entry DuplicacyState into a
+// DuplicacyJobState destined for snapshot.backup.duplicacy. Disabled
+// entries are skipped. Returns nil for an empty/nil input so the
+// snapshot's `duplicacy` JSON key stays absent (omitempty on
+// internal.BackupInfo.Duplicacy) for users without any Duplicacy
+// config — preserves pre-V1c snapshot bytes for upgraders. Issue #314.
+func collectDuplicacyEntries(runner DuplicacyRunner, entries []DuplicacyEntry) []internal.DuplicacyJobState {
+	if len(entries) == 0 || runner == nil {
+		return nil
+	}
+	out := make([]internal.DuplicacyJobState, 0, len(entries))
+	for _, e := range entries {
+		if !e.Enabled {
+			continue
+		}
+		ctx := context.Background()
+		state, err := runner.Read(ctx, e)
+		if err != nil {
+			// Total-function contract: runner SHOULD encode errors as
+			// reason codes, not Go errors. Defense-in-depth: if a
+			// future refactor breaks that contract, surface as
+			// path_unreadable so the user still sees a row with a
+			// recognisable reason rather than a silently-dropped
+			// entry. Better-than-nothing observability.
+			state = DuplicacyState{ReasonCode: DuplicacyReasonPathUnreadable}
+		}
+		out = append(out, internal.DuplicacyJobState{
+			Label:                  e.Label,
+			Kind:                   e.Kind,
+			Path:                   e.Path,
+			StorageID:              e.StorageID,
+			ReasonCode:             string(state.ReasonCode),
+			SnapshotCount:          state.SnapshotCount,
+			LatestBackupAt:         state.LatestBackupAt,
+			LatestBackupSizeBytes:  state.LatestBackupSizeBytes,
+			LatestBackupFiles:      state.LatestBackupFiles,
+			CurrentlyRunning:       state.CurrentlyRunning,
+			LatestSnapshotID:       state.LatestSnapshotID,
+			LatestSnapshotRevision: state.LatestSnapshotRevision,
+			SnapshotIDs:            append([]string(nil), state.SnapshotIDs...),
+		})
+	}
+	return out
 }
 
 // collectBackups is the zero-options shim used by the monolithic

--- a/internal/collector/backup_duplicacy_test.go
+++ b/internal/collector/backup_duplicacy_test.go
@@ -1,0 +1,213 @@
+package collector
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// fakeDupRunner is a recording DuplicacyRunner used to exercise the
+// CollectBackups → collectDuplicacyEntries plumbing without touching
+// the filesystem. Returns canned states keyed by the entry's Label
+// (or kind+path when label is empty).
+type fakeDupRunner struct {
+	calls   []DuplicacyEntry
+	results map[string]DuplicacyState
+	err     error
+}
+
+func (f *fakeDupRunner) Read(ctx context.Context, e DuplicacyEntry) (DuplicacyState, error) {
+	f.calls = append(f.calls, e)
+	if f.err != nil {
+		return DuplicacyState{}, f.err
+	}
+	if r, ok := f.results[e.Label]; ok {
+		return r, nil
+	}
+	return DuplicacyState{ReasonCode: DuplicacyReasonNoSnapshotsYet}, nil
+}
+
+// TestCollectBackups_DuplicacyEntries_PopulatesBackupInfo asserts the
+// scheduler-side wiring: each enabled DuplicacyEntry produces one
+// DuplicacyJobState in BackupInfo.Duplicacy, fields are copied from
+// the runner's DuplicacyState verbatim, and disabled entries are
+// dropped (no row). PRD #310 V1c / issue #314.
+func TestCollectBackups_DuplicacyEntries_PopulatesBackupInfo(t *testing.T) {
+	now := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+	runner := &fakeDupRunner{
+		results: map[string]DuplicacyState{
+			"docs": {
+				ReasonCode:             DuplicacyReasonOK,
+				SnapshotCount:          42,
+				LatestBackupAt:         now.Add(-3 * time.Hour),
+				LatestBackupSizeBytes:  88 * 1024 * 1024 * 1024,
+				LatestBackupFiles:      31000,
+				CurrentlyRunning:       false,
+				LatestSnapshotID:       "documents",
+				LatestSnapshotRevision: 42,
+				SnapshotIDs:            []string{"documents"},
+			},
+			"media": {
+				ReasonCode:    DuplicacyReasonStale,
+				SnapshotCount: 12,
+			},
+		},
+	}
+
+	info := CollectBackups(CollectBackupsOptions{
+		DuplicacyRunner: runner,
+		Duplicacy: []DuplicacyEntry{
+			{Enabled: true, Label: "docs", Kind: DuplicacyKindCLIRepo, Path: "/p/docs"},
+			{Enabled: true, Label: "media", Kind: DuplicacyKindWebCache, Path: "/p/media", StorageID: "main"},
+			{Enabled: false, Label: "skip-me", Kind: DuplicacyKindCLIRepo, Path: "/p/skip"},
+		},
+	})
+
+	if info == nil {
+		t.Fatal("CollectBackups returned nil")
+	}
+	if !info.Available {
+		t.Errorf("BackupInfo.Available = false; want true (Duplicacy entries make backup data available)")
+	}
+	if got := len(info.Duplicacy); got != 2 {
+		t.Fatalf("info.Duplicacy len = %d; want 2 (one disabled entry must be skipped); entries=%+v", got, info.Duplicacy)
+	}
+	// Disabled entries must not even reach the runner.
+	if got := len(runner.calls); got != 2 {
+		t.Errorf("runner.Read called %d times; want 2 (disabled entry must be skipped before Read)", got)
+	}
+	for _, c := range runner.calls {
+		if !c.Enabled {
+			t.Errorf("runner received a disabled entry: %+v", c)
+		}
+	}
+
+	// Field-by-field verification of the docs entry — every field
+	// the dashboard widget + Prometheus exporter consumes must
+	// round-trip from the runner.
+	d0 := info.Duplicacy[0]
+	if d0.Label != "docs" {
+		t.Errorf("entry 0 Label = %q; want docs", d0.Label)
+	}
+	if d0.Kind != DuplicacyKindCLIRepo {
+		t.Errorf("entry 0 Kind = %q; want cli-repo", d0.Kind)
+	}
+	if d0.Path != "/p/docs" {
+		t.Errorf("entry 0 Path = %q; want /p/docs", d0.Path)
+	}
+	if d0.ReasonCode != string(DuplicacyReasonOK) {
+		t.Errorf("entry 0 ReasonCode = %q; want %q", d0.ReasonCode, DuplicacyReasonOK)
+	}
+	if d0.SnapshotCount != 42 {
+		t.Errorf("entry 0 SnapshotCount = %d; want 42", d0.SnapshotCount)
+	}
+	if !d0.LatestBackupAt.Equal(now.Add(-3 * time.Hour)) {
+		t.Errorf("entry 0 LatestBackupAt = %v; want %v", d0.LatestBackupAt, now.Add(-3*time.Hour))
+	}
+	if d0.LatestSnapshotID != "documents" || d0.LatestSnapshotRevision != 42 {
+		t.Errorf("entry 0 latest_snapshot_(id|revision) = %q / %d; want documents / 42", d0.LatestSnapshotID, d0.LatestSnapshotRevision)
+	}
+	if len(d0.SnapshotIDs) != 1 || d0.SnapshotIDs[0] != "documents" {
+		t.Errorf("entry 0 SnapshotIDs = %v; want [documents]", d0.SnapshotIDs)
+	}
+
+	// Web-cache entry round-trips StorageID + carries the per-entry
+	// reason code from the runner.
+	d1 := info.Duplicacy[1]
+	if d1.Kind != DuplicacyKindWebCache || d1.StorageID != "main" {
+		t.Errorf("entry 1 (Kind, StorageID) = (%q, %q); want (web-cache, main)", d1.Kind, d1.StorageID)
+	}
+	if d1.ReasonCode != string(DuplicacyReasonStale) {
+		t.Errorf("entry 1 ReasonCode = %q; want %q", d1.ReasonCode, DuplicacyReasonStale)
+	}
+}
+
+// TestCollectBackups_DuplicacyEntries_NoneSpecified_PreservesPreV1cShape
+// asserts that an install with no Duplicacy entries keeps
+// BackupInfo.Duplicacy nil — the omitempty JSON tag then keeps the
+// `duplicacy` key absent from the snapshot, preserving pre-V1c bytes
+// for upgraders.
+func TestCollectBackups_DuplicacyEntries_NoneSpecified_PreservesPreV1cShape(t *testing.T) {
+	info := CollectBackups(CollectBackupsOptions{})
+	if info == nil {
+		t.Fatal("CollectBackups returned nil")
+	}
+	if info.Duplicacy != nil {
+		t.Errorf("info.Duplicacy = %+v; want nil for an install with no entries (omitempty preserves pre-V1c JSON shape)", info.Duplicacy)
+	}
+}
+
+// TestCollectBackups_DuplicacyEntries_RunnerErrorFallsBackToPathUnreadable
+// asserts the defense-in-depth runner-error fallback. The V1a runner
+// is total (every classifier outcome maps to a ReasonCode), but if a
+// future refactor breaks that contract we surface an entry with the
+// path_unreadable reason rather than silently dropping the row.
+// PRD #310 §10.
+func TestCollectBackups_DuplicacyEntries_RunnerErrorFallsBackToPathUnreadable(t *testing.T) {
+	runner := &fakeDupRunner{err: context.DeadlineExceeded}
+	info := CollectBackups(CollectBackupsOptions{
+		DuplicacyRunner: runner,
+		Duplicacy: []DuplicacyEntry{
+			{Enabled: true, Label: "broken", Kind: DuplicacyKindCLIRepo, Path: "/p"},
+		},
+	})
+	if info == nil || len(info.Duplicacy) != 1 {
+		t.Fatalf("expected one entry surfacing the runner error; got %+v", info)
+	}
+	if info.Duplicacy[0].ReasonCode != string(DuplicacyReasonPathUnreadable) {
+		t.Errorf("runner-error entry ReasonCode = %q; want %q (defense-in-depth fallback)", info.Duplicacy[0].ReasonCode, DuplicacyReasonPathUnreadable)
+	}
+}
+
+// TestCollector_SetBackupMonitorDuplicacy_Roundtrip asserts that the
+// Collector's setter is idempotent + defensively-copies the slice,
+// preventing aliasing bugs where the api layer mutates an entry
+// post-Set.
+func TestCollector_SetBackupMonitorDuplicacy_Roundtrip(t *testing.T) {
+	c := &Collector{}
+	src := []DuplicacyEntry{
+		{Enabled: true, Label: "a", Kind: DuplicacyKindCLIRepo, Path: "/p/a"},
+	}
+	c.SetBackupMonitorDuplicacy(src)
+	src[0].Label = "MUTATED" // caller-side mutation
+	if c.duplicacyEntries[0].Label != "a" {
+		t.Errorf("SetBackupMonitorDuplicacy must defensively copy; got Label=%q after caller mutation", c.duplicacyEntries[0].Label)
+	}
+
+	// Calling again with nil resets to nil/empty (matches Borg pattern).
+	c.SetBackupMonitorDuplicacy(nil)
+	if len(c.duplicacyEntries) != 0 {
+		t.Errorf("SetBackupMonitorDuplicacy(nil) should clear; got %+v", c.duplicacyEntries)
+	}
+}
+
+// TestBackupInfo_DuplicacyJobState_FieldShape is a compile-time pin
+// on the internal.DuplicacyJobState shape. Adds a smoke test so a
+// future field rename is caught at api-boundary update time. Also
+// asserts the JSON tag stability so /api/v1/snapshot/latest's wire
+// shape stays stable for downstream consumers (Grafana, fleet
+// aggregation).
+func TestBackupInfo_DuplicacyJobState_FieldShape(t *testing.T) {
+	// Compile-only: any rename to required fields produces a build
+	// error here.
+	state := internal.DuplicacyJobState{
+		Label:                  "x",
+		Kind:                   "cli-repo",
+		Path:                   "/p",
+		StorageID:              "",
+		ReasonCode:             "ok",
+		SnapshotCount:          1,
+		LatestBackupAt:         time.Now(),
+		LatestBackupSizeBytes:  1,
+		LatestBackupFiles:      1,
+		CurrentlyRunning:       false,
+		LatestSnapshotID:       "x",
+		LatestSnapshotRevision: 1,
+		SnapshotIDs:            []string{"x"},
+	}
+	if state.Kind == "" {
+		t.Fatal("compile guard")
+	}
+}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -27,6 +27,18 @@ type Collector struct {
 	// explicit-config backup probes. Nil → NewExecBorgRunner. Tests
 	// inject a fake to keep Collect() hermetic.
 	borgRunner BorgRunner
+	// duplicacyEntries is the user-configured list of Duplicacy
+	// repos fed in from Settings.BackupMonitor.Duplicacy. Nil/empty
+	// = no Duplicacy monitoring (preserves pre-#314 behaviour).
+	// Updated live via SetBackupMonitorDuplicacy on every Settings
+	// PUT. Issue #314.
+	duplicacyEntries []DuplicacyEntry
+	// duplicacyRunner is the DuplicacyRunner used for all Duplicacy
+	// reads. Nil → NewDiskDuplicacyRunner. Test seam — production
+	// main.go doesn't call SetDuplicacyRunner and the zero value
+	// in collectBackups picks up the disk runner on its own. Issue
+	// #314.
+	duplicacyRunner DuplicacyRunner
 }
 
 // SetProxmoxConfig updates the Proxmox VE API connection settings.
@@ -59,6 +71,23 @@ func (c *Collector) SetBackupMonitorBorg(repos []BorgExternalRepo) {
 // collectBackups-path picks up the exec runner on its own.
 func (c *Collector) SetBorgRunner(r BorgRunner) {
 	c.borgRunner = r
+}
+
+// SetBackupMonitorDuplicacy stores the user-configured Duplicacy
+// entry list. Called from the Settings PUT handler on every save and
+// from main.go at startup once the persisted settings are decoded.
+// Changes take effect on the next backup-collection tick; no
+// restart required. Issue #314 (PRD #310 V1c).
+func (c *Collector) SetBackupMonitorDuplicacy(entries []DuplicacyEntry) {
+	c.duplicacyEntries = append([]DuplicacyEntry(nil), entries...)
+}
+
+// SetDuplicacyRunner injects a DuplicacyRunner used for all
+// Duplicacy reads. Nil = reset to default (NewDiskDuplicacyRunner).
+// Primarily a test seam — production main.go doesn't call this and
+// CollectBackups picks up the disk runner on its own.
+func (c *Collector) SetDuplicacyRunner(r DuplicacyRunner) {
+	c.duplicacyRunner = r
 }
 
 // New creates a new Collector with the given host path mappings.
@@ -182,8 +211,10 @@ func (c *Collector) Collect() (*internal.Snapshot, error) {
 	// reason so operators can correlate dashboard state with logs.
 	c.logger.Info("collecting backup info")
 	backupInfo := CollectBackups(CollectBackupsOptions{
-		Runner:       c.borgRunner,
-		ExternalBorg: c.externalBorg,
+		Runner:          c.borgRunner,
+		ExternalBorg:    c.externalBorg,
+		DuplicacyRunner: c.duplicacyRunner,
+		Duplicacy:       c.duplicacyEntries,
 	})
 	if backupInfo != nil && backupInfo.Available {
 		snap.Backup = backupInfo

--- a/internal/models.go
+++ b/internal/models.go
@@ -327,25 +327,25 @@ type ServiceCheckResult struct {
 // ---------- System ----------
 
 type SystemInfo struct {
-	Hostname     string        `json:"hostname"`
-	OS           string        `json:"os"`
-	Kernel       string        `json:"kernel"`
-	Platform     string        `json:"platform"` // unraid, truenas, synology, linux, etc.
-	PlatformVer  string        `json:"platform_version"`
-	CPUModel     string        `json:"cpu_model"`
-	CPUCores     int           `json:"cpu_cores"`
-	CPUUsage     float64       `json:"cpu_usage_percent"`
-	LoadAvg1     float64       `json:"load_avg_1"`
-	LoadAvg5     float64       `json:"load_avg_5"`
-	LoadAvg15    float64       `json:"load_avg_15"`
-	MemTotalMB   int64         `json:"mem_total_mb"`
-	MemUsedMB    int64         `json:"mem_used_mb"`
-	MemPercent   float64       `json:"mem_percent"`
-	SwapTotalMB  int64         `json:"swap_total_mb"`
-	SwapUsedMB   int64         `json:"swap_used_mb"`
-	IOWait       float64       `json:"io_wait_percent"`
-	UptimeSecs   int64         `json:"uptime_seconds"`
-	Motherboard  string        `json:"motherboard"`
+	Hostname    string  `json:"hostname"`
+	OS          string  `json:"os"`
+	Kernel      string  `json:"kernel"`
+	Platform    string  `json:"platform"` // unraid, truenas, synology, linux, etc.
+	PlatformVer string  `json:"platform_version"`
+	CPUModel    string  `json:"cpu_model"`
+	CPUCores    int     `json:"cpu_cores"`
+	CPUUsage    float64 `json:"cpu_usage_percent"`
+	LoadAvg1    float64 `json:"load_avg_1"`
+	LoadAvg5    float64 `json:"load_avg_5"`
+	LoadAvg15   float64 `json:"load_avg_15"`
+	MemTotalMB  int64   `json:"mem_total_mb"`
+	MemUsedMB   int64   `json:"mem_used_mb"`
+	MemPercent  float64 `json:"mem_percent"`
+	SwapTotalMB int64   `json:"swap_total_mb"`
+	SwapUsedMB  int64   `json:"swap_used_mb"`
+	IOWait      float64 `json:"io_wait_percent"`
+	UptimeSecs  int64   `json:"uptime_seconds"`
+	Motherboard string  `json:"motherboard"`
 	// CPUTempC is the package-level CPU temperature in °C, or 0 when no
 	// reliable sensor is available (e.g. Synology, K8s pods, virtualised
 	// environments without /sys/class/hwmon). Zero values are omitted from
@@ -623,6 +623,71 @@ type GPUDevice struct {
 type BackupInfo struct {
 	Available bool        `json:"available"`
 	Jobs      []BackupJob `json:"jobs"`
+	// Duplicacy is the per-entry state for user-configured Duplicacy
+	// repos (PRD #310 / V1c, issue #314). Sibling to Jobs rather than
+	// merged into it because Duplicacy carries a per-provider reason
+	// type + auxiliary flags (currently_running) that don't fit the
+	// generic BackupJob shape, and per-PRD §4 we deliberately don't
+	// share reason enums across providers. Empty/nil when no
+	// Duplicacy entries are configured — preserves the pre-V1c
+	// snapshot shape exactly.
+	Duplicacy []DuplicacyJobState `json:"duplicacy,omitempty"`
+}
+
+// DuplicacyJobState is the per-entry runtime state surfaced by the
+// dashboard widget, /metrics exporter, and /api/v1/snapshot/latest.
+// Mirrors collector.DuplicacyState in shape but lives in `internal`
+// so callers above the collector layer (api, notifier) can reference
+// the type without an import cycle. Issue #314 (V1c).
+//
+// Field semantics match collector.DuplicacyState verbatim — the
+// scheduler's backup-collection tick copies values across one-for-one.
+// See internal/collector/duplicacy_runner.go for the canonical
+// per-field rationale.
+type DuplicacyJobState struct {
+	// Label is the user-supplied display name from settings; falls
+	// back to the basename of Path on the dashboard widget when empty.
+	Label string `json:"label,omitempty"`
+	// Kind is "cli-repo" or "web-cache". Surfaced as a tag on the
+	// dashboard row + as a Prometheus label so Grafana panels can
+	// group by kind.
+	Kind string `json:"kind"`
+	// Path is echoed back for the dashboard's per-row diagnostic
+	// display (so users can correlate a stale row with its config).
+	Path string `json:"path,omitempty"`
+	// StorageID is echoed back for kind=web-cache rows. Empty for
+	// cli-repo.
+	StorageID string `json:"storage_id,omitempty"`
+	// ReasonCode is one of collector.DuplicacyReason*. Empty string
+	// means "not yet evaluated" (the runner hasn't been called for
+	// this entry yet — should not happen in production but kept
+	// distinct from "ok" so an uninitialised state isn't reported as
+	// healthy).
+	ReasonCode string `json:"reason_code"`
+	// SnapshotCount is the total snapshot-revision count across all
+	// snapshot IDs in the repo.
+	SnapshotCount int `json:"snapshot_count"`
+	// LatestBackupAt is the end_time (or start_time fallback) of the
+	// newest snapshot found.
+	LatestBackupAt time.Time `json:"latest_backup_at,omitempty"`
+	// LatestBackupSizeBytes is the file_size field on the newest
+	// snapshot.
+	LatestBackupSizeBytes int64 `json:"latest_backup_size_bytes"`
+	// LatestBackupFiles is the number_of_files field on the newest
+	// snapshot.
+	LatestBackupFiles int64 `json:"latest_backup_files"`
+	// CurrentlyRunning is the orthogonal aux flag — true when a lock
+	// or incomplete marker is detected on disk. Best-effort.
+	CurrentlyRunning bool `json:"currently_running"`
+	// LatestSnapshotID is the snapshot id (per-repo identifier;
+	// e.g. "documents", "media") that produced LatestBackupAt.
+	LatestSnapshotID string `json:"latest_snapshot_id,omitempty"`
+	// LatestSnapshotRevision is the integer revision number of the
+	// newest snapshot.
+	LatestSnapshotRevision int `json:"latest_snapshot_revision,omitempty"`
+	// SnapshotIDs is the sorted, deduped list of distinct snapshot
+	// ids discovered in the repo.
+	SnapshotIDs []string `json:"snapshot_ids,omitempty"`
 }
 
 type BackupJob struct {

--- a/internal/notifier/prometheus.go
+++ b/internal/notifier/prometheus.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/mcdays94/nas-doctor/internal"
 	"github.com/prometheus/client_golang/prometheus"
@@ -142,6 +143,25 @@ type Metrics struct {
 	backupLastSuccess *prometheus.GaugeVec
 	backupSizeBytes   *prometheus.GaugeVec
 	backupStatus      *prometheus.GaugeVec
+
+	// ── Backup (Duplicacy, PRD #310 V1c / issue #314) ──
+	// Per-entry gauges for Duplicacy repos. Naming + label
+	// conventions parallel nasdoctor_backup_borg_* would have, except
+	// the existing Borg gauges live under `backup` (not
+	// backup_borg). Per the V1c PRD §8 the new gauges go under
+	// `backup_duplicacy` so Grafana panels can group "duplicacy
+	// across all repos" with a single regex on the metric name.
+	// label = entry's user-supplied Label (sanitized to lowercase
+	// alphanumeric + `_` + `-`).
+	//
+	// last_backup_age_seconds is computed at scrape time (now - latest_backup_at)
+	// rather than scan time so the gauge monotonically increases between
+	// scans — matching how the Borg `backup_last_success_timestamp`
+	// gauge gets translated to "age" in Grafana queries.
+	backupDuplicacySnapshotsTotal      *prometheus.GaugeVec
+	backupDuplicacyLastBackupAgeSec    *prometheus.GaugeVec
+	backupDuplicacyLastBackupSizeBytes *prometheus.GaugeVec
+	backupDuplicacyStatus              *prometheus.GaugeVec
 
 	// ── Speed Test ──
 	speedtestDownload prometheus.Gauge
@@ -365,6 +385,14 @@ func NewMetrics() *Metrics {
 	m.backupSizeBytes = gaugeVec(ns, "backup", "size_bytes", "Backup total size in bytes", backupLabels)
 	m.backupStatus = gaugeVec(ns, "backup", "status", "Backup status (1=ok, 0.5=warning, 0=stale/failed)", backupLabels)
 
+	// ── Backup (Duplicacy) ── — PRD #310 V1c / issue #314
+	dupSimpleLabels := []string{"label"}
+	dupStatusLabels := []string{"label", "reason"}
+	m.backupDuplicacySnapshotsTotal = gaugeVec(ns, "backup_duplicacy", "snapshots_total", "Total Duplicacy snapshot revisions across all snapshot IDs in the repo", dupSimpleLabels)
+	m.backupDuplicacyLastBackupAgeSec = gaugeVec(ns, "backup_duplicacy", "last_backup_age_seconds", "Age in seconds of the newest Duplicacy snapshot at scrape time (resolves at scrape, monotonic between scans)", dupSimpleLabels)
+	m.backupDuplicacyLastBackupSizeBytes = gaugeVec(ns, "backup_duplicacy", "last_backup_size_bytes", "file_size of the newest Duplicacy snapshot in bytes", dupSimpleLabels)
+	m.backupDuplicacyStatus = gaugeVec(ns, "backup_duplicacy", "status", "Duplicacy entry status — 1 for the entry's current reason code, 0 for the others (mirrors Borg status convention with reason as a label)", dupStatusLabels)
+
 	// ── Speed Test ──
 	m.speedtestDownload = gauge(ns, "speedtest", "download_mbps", "Latest speed test download in Mbps")
 	m.speedtestUpload = gauge(ns, "speedtest", "upload_mbps", "Latest speed test upload in Mbps")
@@ -419,6 +447,8 @@ func NewMetrics() *Metrics {
 		m.gpuTemperature, m.gpuPowerW, m.gpuPowerMaxW, m.gpuFanPct,
 		m.gpuEncoderPct, m.gpuDecoderPct,
 		m.backupLastSuccess, m.backupSizeBytes, m.backupStatus,
+		m.backupDuplicacySnapshotsTotal, m.backupDuplicacyLastBackupAgeSec,
+		m.backupDuplicacyLastBackupSizeBytes, m.backupDuplicacyStatus,
 		m.speedtestDownload, m.speedtestUpload, m.speedtestLatency, m.speedtestEngine, m.speedtestInProgress, m.speedtestSamplesCount,
 		m.findingsTotal, m.findingsCritical, m.findingsWarning,
 		m.collectionDuration, m.lastCollectionTime, m.updateAvailable,
@@ -727,6 +757,15 @@ func (m *Metrics) Update(snap *internal.Snapshot) {
 	m.backupLastSuccess.Reset()
 	m.backupSizeBytes.Reset()
 	m.backupStatus.Reset()
+	// Duplicacy gauges (#314): reset before re-stamping so removed
+	// entries don't linger. Status family resets first because it
+	// emits one series per (label, reason) pair — without the reset
+	// a renamed/removed entry would leave 8 stale 0-valued series
+	// per old label.
+	m.backupDuplicacySnapshotsTotal.Reset()
+	m.backupDuplicacyLastBackupAgeSec.Reset()
+	m.backupDuplicacyLastBackupSizeBytes.Reset()
+	m.backupDuplicacyStatus.Reset()
 	if snap.Backup != nil && snap.Backup.Available {
 		for _, job := range snap.Backup.Jobs {
 			l := prometheus.Labels{"provider": job.Provider, "name": job.Name}
@@ -741,6 +780,60 @@ func (m *Metrics) Update(snap *internal.Snapshot) {
 				m.backupStatus.With(l).Set(0.5)
 			default: // stale, failed
 				m.backupStatus.With(l).Set(0)
+			}
+		}
+		// Duplicacy: one series-set per entry. Naming + label
+		// conventions match `backup_borg_*` (issue #314 acceptance
+		// criterion). last_backup_age_seconds is computed at scrape
+		// time so it monotonically increases between scans — same
+		// pattern as nasdoctor_speedtest_in_progress.
+		nowUnix := snap.Timestamp.Unix()
+		if snap.Timestamp.IsZero() {
+			nowUnix = time.Now().Unix()
+		}
+		for _, dup := range snap.Backup.Duplicacy {
+			// Duplicacy gauges use a slug-form label (lowercase
+			// alphanumeric + `_` + `-`) so Grafana panels can group
+			// "all duplicacy entries" with stable label values
+			// regardless of casing/whitespace in the user's display
+			// name. PRD #310 §8.
+			label := slugifyDuplicacyLabel(dup.Label)
+			if label == "" {
+				// Empty Label falls back to the basename of Path so
+				// the series doesn't carry an empty label{} pair.
+				label = slugifyDuplicacyLabel(deriveLabelFromPath(dup.Path))
+			}
+			if label == "" {
+				label = "duplicacy"
+			}
+			simple := prometheus.Labels{"label": label}
+			m.backupDuplicacySnapshotsTotal.With(simple).Set(float64(dup.SnapshotCount))
+			m.backupDuplicacyLastBackupSizeBytes.With(simple).Set(float64(dup.LatestBackupSizeBytes))
+			if !dup.LatestBackupAt.IsZero() {
+				age := nowUnix - dup.LatestBackupAt.Unix()
+				if age < 0 {
+					age = 0
+				}
+				m.backupDuplicacyLastBackupAgeSec.With(simple).Set(float64(age))
+			} else {
+				// No snapshots yet — emit 0 so the gauge exists with
+				// the entry's label (vs being absent, which Grafana
+				// queries treat differently).
+				m.backupDuplicacyLastBackupAgeSec.With(simple).Set(0)
+			}
+			// Status family — one series per (label, reason) pair,
+			// 1 for the entry's current reason code and 0 for the
+			// others. Mirrors notifier convention used for
+			// nasdoctor_speedtest_engine{engine=…}.
+			for _, reason := range duplicacyAllReasons {
+				val := 0.0
+				if reason == dup.ReasonCode {
+					val = 1.0
+				}
+				m.backupDuplicacyStatus.With(prometheus.Labels{
+					"label":  label,
+					"reason": reason,
+				}).Set(val)
 			}
 		}
 	}
@@ -818,6 +911,94 @@ func boolToFloat(b bool) float64 {
 		return 1
 	}
 	return 0
+}
+
+// duplicacyAllReasons mirrors collector.DuplicacyReason* values in
+// stable string form. Kept as a package-private slice rather than
+// importing internal/collector to avoid pulling the runner +
+// fixture-machinery into the notifier's dependency graph. The list
+// is locked by TestPrometheus_DuplicacyReasonStability in the
+// collector package's test suite + a notifier-side regression test
+// asserting len(this) == 8 (matches PRD #310 §4 closed set). Issue
+// #314.
+var duplicacyAllReasons = []string{
+	"ok",
+	"path_not_found",
+	"path_unreadable",
+	"not_a_duplicacy_repo",
+	"storage_id_not_found",
+	"no_snapshots_yet",
+	"stale",
+	"corrupt_snapshot",
+}
+
+// slugifyDuplicacyLabel lowercases + replaces non-alphanumeric runs
+// with `_`, trimming leading/trailing underscores. Used for the
+// `label` Prometheus label on the four nasdoctor_backup_duplicacy_*
+// gauge families. The slug form keeps Grafana panel queries stable
+// across user-display-name edits ("Photos Nightly" → "photos_nightly")
+// and across casing differences. Mirrors the slug shape Grafana
+// dashboards typically use for label-pivoted queries. Issue #314.
+func slugifyDuplicacyLabel(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	out := make([]byte, 0, len(s))
+	prevSep := true // collapse leading separators
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'A' && c <= 'Z':
+			out = append(out, c+('a'-'A'))
+			prevSep = false
+		case (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9'):
+			out = append(out, c)
+			prevSep = false
+		case c == '-':
+			// Preserve dashes — mirror Prometheus convention of
+			// allowing `-` in label values; nas-doctor's existing
+			// label conventions accept it.
+			if !prevSep {
+				out = append(out, '-')
+				prevSep = true
+			}
+		default:
+			if !prevSep {
+				out = append(out, '_')
+				prevSep = true
+			}
+		}
+	}
+	// Trim trailing separator.
+	for len(out) > 0 && (out[len(out)-1] == '_' || out[len(out)-1] == '-') {
+		out = out[:len(out)-1]
+	}
+	if len(out) > 128 {
+		out = out[:128]
+	}
+	return string(out)
+}
+
+// deriveLabelFromPath returns the basename of a duplicacy entry path,
+// used as a fallback when the user-supplied Label is empty. Mirrors
+// filepath.Base but avoids that import here (notifier should stay
+// dep-light) — string-split is cheap and the path values are short.
+func deriveLabelFromPath(path string) string {
+	if path == "" {
+		return ""
+	}
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == '/' {
+			if i == len(path)-1 {
+				// Trailing slash — strip and continue.
+				path = path[:i]
+				return deriveLabelFromPath(path)
+			}
+			return path[i+1:]
+		}
+	}
+	return path
 }
 
 func sanitizeLabel(s string) string {

--- a/internal/notifier/prometheus_backup_duplicacy_test.go
+++ b/internal/notifier/prometheus_backup_duplicacy_test.go
@@ -1,0 +1,212 @@
+package notifier
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal"
+)
+
+// TestPrometheus_BackupDuplicacy_FourGaugesPerEntry asserts that after
+// Update() with a snapshot containing one Duplicacy entry, /metrics
+// exports the full 4-gauge family per entry:
+//
+//   - nasdoctor_backup_duplicacy_snapshots_total{label="…"}
+//   - nasdoctor_backup_duplicacy_last_backup_age_seconds{label="…"}
+//   - nasdoctor_backup_duplicacy_last_backup_size_bytes{label="…"}
+//   - nasdoctor_backup_duplicacy_status{label="…",reason="…"}
+//
+// Naming + label conventions match the existing
+// nasdoctor_backup_borg_* would-have. Per PRD #310 §8 the gauges go
+// under the `backup_duplicacy` subsystem so Grafana panels can group
+// "duplicacy across all repos" with a single metric-name regex.
+//
+// Issue #314 (V1c) acceptance criteria 4-5.
+func TestPrometheus_BackupDuplicacy_FourGaugesPerEntry(t *testing.T) {
+	m := NewMetrics()
+	now := time.Now()
+	m.Update(&internal.Snapshot{
+		Timestamp: now,
+		Backup: &internal.BackupInfo{
+			Available: true,
+			Duplicacy: []internal.DuplicacyJobState{
+				{
+					Label:                  "Documents",
+					Kind:                   "cli-repo",
+					Path:                   "/mnt/user/duplicacy/docs",
+					ReasonCode:             "ok",
+					SnapshotCount:          217,
+					LatestBackupAt:         now.Add(-2 * time.Hour),
+					LatestBackupSizeBytes:  44_000_000_000,
+					LatestSnapshotID:       "documents",
+					LatestSnapshotRevision: 217,
+				},
+			},
+		},
+	})
+
+	body := scrapeMetrics(t, m)
+
+	// snapshots_total
+	if !strings.Contains(body, `nasdoctor_backup_duplicacy_snapshots_total{label="documents"} 217`) {
+		t.Errorf("expected nasdoctor_backup_duplicacy_snapshots_total{label=\"documents\"} 217 in /metrics; body:\n%s", body)
+	}
+	// last_backup_size_bytes
+	if !strings.Contains(body, `nasdoctor_backup_duplicacy_last_backup_size_bytes{label="documents"} 4.4e+10`) {
+		t.Errorf("expected nasdoctor_backup_duplicacy_last_backup_size_bytes{label=\"documents\"} 4.4e+10 in /metrics; body:\n%s", body)
+	}
+	// last_backup_age_seconds — 2 hours = 7200s ± 5s of clock slop
+	// between the test's `now` and the gauge's snap.Timestamp delta.
+	// Just match the prefix + label set; numeric proximity is
+	// covered separately below.
+	if !strings.Contains(body, `nasdoctor_backup_duplicacy_last_backup_age_seconds{label="documents"}`) {
+		t.Errorf("expected nasdoctor_backup_duplicacy_last_backup_age_seconds{label=\"documents\"} … in /metrics; body:\n%s", body)
+	}
+	// status — the active reason reads 1, every other reason in the
+	// closed set reads 0. Pin both arms so a future regression
+	// where we forget to zero-out the others is caught.
+	if !strings.Contains(body, `nasdoctor_backup_duplicacy_status{label="documents",reason="ok"} 1`) {
+		t.Errorf("expected nasdoctor_backup_duplicacy_status{label=\"documents\",reason=\"ok\"} 1 in /metrics; body:\n%s", body)
+	}
+	if !strings.Contains(body, `nasdoctor_backup_duplicacy_status{label="documents",reason="stale"} 0`) {
+		t.Errorf("expected nasdoctor_backup_duplicacy_status{label=\"documents\",reason=\"stale\"} 0 in /metrics; body:\n%s", body)
+	}
+	if !strings.Contains(body, `nasdoctor_backup_duplicacy_status{label="documents",reason="path_not_found"} 0`) {
+		t.Errorf("expected nasdoctor_backup_duplicacy_status{label=\"documents\",reason=\"path_not_found\"} 0 in /metrics; body:\n%s", body)
+	}
+}
+
+// TestPrometheus_BackupDuplicacy_StatusFamilyAllReasons asserts that
+// every reason code in the V1a closed set produces a 0-valued series
+// when the entry is in any other state — Grafana queries can build a
+// "current-reason" panel with `nasdoctor_backup_duplicacy_status == 1`.
+// Pinned to 8 reasons matching collector.DuplicacyReason* constants.
+func TestPrometheus_BackupDuplicacy_StatusFamilyAllReasons(t *testing.T) {
+	m := NewMetrics()
+	m.Update(&internal.Snapshot{
+		Timestamp: time.Now(),
+		Backup: &internal.BackupInfo{
+			Available: true,
+			Duplicacy: []internal.DuplicacyJobState{
+				{Label: "media", Kind: "web-cache", ReasonCode: "stale"},
+			},
+		},
+	})
+
+	body := scrapeMetrics(t, m)
+	wantReasons := []string{
+		"ok",
+		"path_not_found",
+		"path_unreadable",
+		"not_a_duplicacy_repo",
+		"storage_id_not_found",
+		"no_snapshots_yet",
+		"stale",
+		"corrupt_snapshot",
+	}
+	for _, r := range wantReasons {
+		expected := r + `"`
+		if !strings.Contains(body, `nasdoctor_backup_duplicacy_status{label="media",reason="`+expected) {
+			t.Errorf("missing series for reason=%q in /metrics body — every reason in the V1a closed set must have a 0/1-valued series so Grafana can `... == 1` filter on the active reason; body excerpt:\n%s", r, body)
+		}
+	}
+	// The active reason reads 1; every other reason reads 0. (The
+	// previous loop only checks presence; this one pins values.)
+	if !strings.Contains(body, `nasdoctor_backup_duplicacy_status{label="media",reason="stale"} 1`) {
+		t.Errorf("expected the active reason (stale) to read 1; body:\n%s", body)
+	}
+	if !strings.Contains(body, `nasdoctor_backup_duplicacy_status{label="media",reason="ok"} 0`) {
+		t.Errorf("expected non-active reason (ok) to read 0; body:\n%s", body)
+	}
+}
+
+// TestPrometheus_BackupDuplicacy_LabelFallback asserts that an entry
+// with an empty Label uses the basename of Path as the gauge label
+// — keeps Prometheus series identifiable even for users who don't
+// fill in the optional Label field.
+func TestPrometheus_BackupDuplicacy_LabelFallback(t *testing.T) {
+	m := NewMetrics()
+	m.Update(&internal.Snapshot{
+		Timestamp: time.Now(),
+		Backup: &internal.BackupInfo{
+			Available: true,
+			Duplicacy: []internal.DuplicacyJobState{
+				{Label: "", Kind: "cli-repo", Path: "/mnt/user/duplicacy/photos", ReasonCode: "ok"},
+			},
+		},
+	})
+
+	body := scrapeMetrics(t, m)
+	if !strings.Contains(body, `nasdoctor_backup_duplicacy_status{label="photos",reason="ok"} 1`) {
+		t.Errorf("expected fallback label to be derived from Path basename; body:\n%s", body)
+	}
+}
+
+// TestPrometheus_BackupDuplicacy_ResetBetweenScans asserts that an
+// entry removed from the configuration disappears from /metrics on
+// the next Update — i.e. the gauges are Reset() before each
+// re-stamp. Without this a renamed entry would leak ghost series
+// forever.
+func TestPrometheus_BackupDuplicacy_ResetBetweenScans(t *testing.T) {
+	m := NewMetrics()
+	now := time.Now()
+	m.Update(&internal.Snapshot{
+		Timestamp: now,
+		Backup: &internal.BackupInfo{
+			Available: true,
+			Duplicacy: []internal.DuplicacyJobState{
+				{Label: "stale-name", Kind: "cli-repo", ReasonCode: "ok"},
+			},
+		},
+	})
+	if body := scrapeMetrics(t, m); !strings.Contains(body, `label="stale-name"`) {
+		t.Fatalf("preconditions: stale-name should be present after first Update; body:\n%s", body)
+	}
+	// Second Update with a different label — first should be gone.
+	m.Update(&internal.Snapshot{
+		Timestamp: now,
+		Backup: &internal.BackupInfo{
+			Available: true,
+			Duplicacy: []internal.DuplicacyJobState{
+				{Label: "fresh-name", Kind: "cli-repo", ReasonCode: "ok"},
+			},
+		},
+	})
+	body := scrapeMetrics(t, m)
+	if strings.Contains(body, `label="stale-name"`) {
+		t.Errorf("expected stale-name series to be dropped after second Update; body:\n%s", body)
+	}
+	if !strings.Contains(body, `label="fresh-name"`) {
+		t.Errorf("expected fresh-name series to be present after second Update; body:\n%s", body)
+	}
+}
+
+// TestPrometheus_BackupDuplicacy_NoEntriesNoSeries asserts that an
+// install with no Duplicacy entries produces no
+// nasdoctor_backup_duplicacy_* series at all. Important for Grafana
+// operators who detect "did the user configure Duplicacy?" via
+// series presence.
+//
+// Note: a GaugeVec with no labelled series produces no `# HELP /
+// # TYPE` headers at all in the Prometheus text exposition format —
+// that's standard Prometheus client behaviour. So we assert on
+// series-line absence only, not on the metric family declaration.
+func TestPrometheus_BackupDuplicacy_NoEntriesNoSeries(t *testing.T) {
+	m := NewMetrics()
+	m.Update(&internal.Snapshot{
+		Timestamp: time.Now(),
+		Backup:    &internal.BackupInfo{Available: false},
+	})
+	body := scrapeMetrics(t, m)
+	for _, line := range strings.Split(body, "\n") {
+		// Skip HELP/TYPE comment lines — those are documentation,
+		// not series. The check is purely on per-entry data lines.
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "nasdoctor_backup_duplicacy_") {
+			t.Errorf("unexpected series with no entries configured: %q", line)
+		}
+	}
+}


### PR DESCRIPTION
Closes #314.

V1c slice of PRD #310. Closes the user-visible loop on Duplicacy backup monitoring: configured entries (V1b) become visible to operators via the dashboard widget, `/metrics` scrape, and the demo site, plus the README documents how to set them up. Builds on V1a's runner + reason classifier; does **not** depend on V1b at runtime — V1c reads `s.latest.Backup.Duplicacy[]` directly from the runner that V1a shipped.

## Design decisions

### Snapshot pipeline shape

`internal.BackupInfo` gains `Duplicacy []DuplicacyJobState` as a sibling field to `Jobs []BackupJob`, **not** merged into `Jobs`. Rationale: Duplicacy carries a per-provider reason-code set + a `currently_running` aux flag that don't fit the generic `BackupJob` shape, and the parent PRD §4 explicitly chose per-provider reason types ("add a per-provider reason type" rather than "extend a god-enum") to set the precedent for Restic/PBS later. `omitempty` preserves pre-V1c JSON bytes for installs with no Duplicacy entries.

### Dashboard rendering — extend the existing loop, don't fork

`sections.backup` was extended to iterate `snapshot.backup.duplicacy[]` alongside the existing `backup.jobs[]` rather than splitting into two parallel render functions. The combined-count title (`Backup Jobs (N)`) covers both groups; mixed Borg+Duplicacy layouts render in one section without forking the surface. Per-row visual rhythm matches Borg (Configured pill, status pill, last-backup-age, snapshot count, error-card on non-OK reason). Distinguished by:
- `.duplicacy-kind-tag` rendering `DUPLICACY:CLI-REPO` / `DUPLICACY:WEB-CACHE` (purple-400)
- Orthogonal `RUNNING` badge surfacing `currently_running` (cyan-400)
- `dupSeverity` helper maps reason_code → ok/info/warning/error per PRD §4

The empty-state copy now mentions Duplicacy + the disk-read approach so visitors with no backup configured discover it without digging into Settings.

### Prometheus naming

The 4 new gauges go under the `backup_duplicacy` subsystem (PRD §8) — chosen so Grafana panels can group "duplicacy across all repos" with a single regex on the metric name (`nasdoctor_backup_duplicacy_.*`). Naming + label conventions parallel the existing Borg gauges:

- `nasdoctor_backup_duplicacy_snapshots_total{label="…"}`
- `nasdoctor_backup_duplicacy_last_backup_age_seconds{label="…"}` — resolves at scrape time, monotonic between scans (same pattern as `nasdoctor_speedtest_in_progress`)
- `nasdoctor_backup_duplicacy_last_backup_size_bytes{label="…"}`
- `nasdoctor_backup_duplicacy_status{label="…",reason="…"}` — 1 for the entry's current reason code, 0 for the others (closed 8-reason set; mirrors `nasdoctor_speedtest_engine{engine=…}` pattern)

`Update()` resets each family before re-stamping so removed entries don't leak ghost series. Label is slug-form (lowercase + `a-z0-9_-`) for stable Grafana queries across user-display-name edits.

### `ensureLatestSnapshot` hydration (v0.9.14 #305)

Existing `/metrics` and `/api/v1/snapshot/latest` both go through `s.ensureLatestSnapshot()`. Because `BackupInfo.Duplicacy` rides on the same `s.latest` that other readers share, the post-restart hydration gap is closed for free — no additional plumbing needed in this PR. Verified by reading the existing helper at `api.go:439`.

### Demo entries

- **Unraid** showcases BOTH `cli-repo` (healthy, Documents) and `web-cache` (stale, Media via duplicacy-web) layouts on the same dashboard so visitors see all V1c severity bands + the orthogonal RUNNING badge in one screenshot. The Media entry has `currently_running=true + reason_code=stale` to demonstrate the dual-state rendering.
- **Synology, TrueNAS, Proxmox** each get one healthy entry (cli-repo or web-cache, varied per platform).
- **Kubernetes** intentionally has none (Velero territory; backup widget hidden).

### Three-source CSS pin

Per AGENTS.md theme-parity discipline (v0.9.7-rc4/5/6 lesson — dashboard themes don't link `/css/shared.css` so any new dashboard class MUST be inlined into both themes), every new Duplicacy CSS class lives in:

1. `internal/api/styles.go` (SharedCSS)
2. `internal/api/templates/midnight.html`
3. `internal/api/templates/clean.html`

Locked by `TestStyles_DuplicacyBackupRow_ThreeSourceParity` — adding a fourth Duplicacy class without updating all three sources fails CI.

## README scour findings

- **Backups feature line** at L121 — added Duplicacy with disk-read note + link to new subsection.
- **New "Duplicacy Monitoring (disk-read, no binary required)" subsection** between External Borg Monitoring and Network Speed Test, covering both layouts, the 8 reason codes, the V1b Settings form layout, and the 4 Prometheus gauges with their label conventions.
- **Prometheus gauge inventory** at L713 — added 4 entries under a new "Backup — Duplicacy" subsection.
- **Demo features inventory** at L832 — backup line now mentions both Duplicacy layouts + the stale+RUNNING showcase on Unraid.
- **Bind-mounts table footnote** at L844 — extended to mention Duplicacy entry bind-mount conventions (RO is safe; no env vars required; no binary mount).
- **Gauge count threshold** at L271, L645, and `unraid-template.xml` L29 stays at "120+" — actual count is 126 (was 122 pre-V1c). `TestReadme_PrometheusCountConsistent` + `TestPrometheus_ActualMetricCount` still green.

## Files touched (LOC delta)

| File | Δ | Purpose |
|---|---|---|
| `internal/models.go` | +89/-14 | `BackupInfo.Duplicacy` + `DuplicacyJobState` |
| `internal/collector/backup.go` | +69/-1 | `CollectBackupsOptions.{DuplicacyRunner, Duplicacy}` + `collectDuplicacyEntries()` |
| `internal/collector/collector.go` | +33/-2 | `SetBackupMonitorDuplicacy / SetDuplicacyRunner` + `Collect()` plumbing |
| `internal/api/api_extended.go` | +14/-2 | PUT handler calls `SetBackupMonitorDuplicacy` |
| `internal/api/backup_monitor.go` | +22/0 | `apiDuplicacyEntriesToCollector()` mapper |
| `internal/api/dashboard.go` | +88/-2 | `sections.backup` extension |
| `internal/api/styles.go` | +18/0 | `.backup-card-duplicacy / .duplicacy-kind-tag / .duplicacy-running-badge` |
| `internal/api/templates/{midnight,clean}.html` | +6/0 each | Theme parity |
| `internal/notifier/prometheus.go` | +179/-2 | 4 gauges + `slugifyDuplicacyLabel()` + `duplicacyAllReasons` |
| `cmd/nas-doctor/main.go` | +21/-1 | Startup wire-up |
| `demo-worker/feeder/src/index.ts` | +185/-12 | Profile entries + `buildDuplicacyEntries()` + `transformSettings` mirror |
| `demo-worker/feeder/src/widget-coverage.test.ts` | +101/0 | 4 new pin tests + EXPECTED_WIDGETS extension |
| `README.md` | +59/-4 | Scour |
| **5 new Go test files** | +675/0 | Dashboard + theme-parity + collector wiring + Prometheus gauges + api mapping |

**Total: 20 files, +1573/-39 LOC.**

## Test counts

- **15 new Go test functions** (50+ subtests) covering dashboard rendering contract, theme parity, collector wiring, Prometheus gauge family, api-collector mapping, and JSON round-trip.
- **4 new feeder vitest cases** (40 of 40 vitest pass).

## §4b pre-push

- `go build ./...` ✓
- `go test ./... -race -count=1` ✓ (all packages green; full suite)
- `go vet ./...` ✓
- `gofmt -w` on changed files ✓ (pre-existing drift in unrelated files out of scope per orchestrator instructions)
- `npm test` in `demo-worker/feeder` ✓ (40/40 vitest pass)

## Scope boundary

Strictly V1c. Does **not** touch:
- Settings UI (`settings.html`'s Duplicacy subsection) — that's V1b
- Test endpoint or Test button JS — that's V1b
- Any new "Duplicacy" config form field — that's V1b

UAT this together with V1b in the same wave; merge as part of v0.10.0 staging.