### PR TITLE
feat(service-checks): SSE live-progress streaming for speedtest Test button (#318)

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -60,6 +60,19 @@ type Server struct {
 	// Tests inject a fake so they don't need a real mtr binary.
 	// Issue #224.
 	streamingTracerouteRunner collector.StreamingTracerouteRunner
+	// streamingSpeedTestRunner is the function invoked by
+	// handleTestServiceCheckStream for type=speed checks. Nil
+	// means the handler will fall back to
+	// collector.RunStreamingSpeedTest. Tests inject a fake so they
+	// don't need a real speedtest tool installed.
+	//
+	// Deliberately separate from the dashboard's livetest.Registry
+	// (handleSpeedtestRun / handleSpeedtestStream): the Test
+	// button is ad-hoc and ephemeral — it must not collapse onto
+	// whatever scheduled or manual run is currently driving the
+	// dashboard's singleton, and it must not write history.
+	// Issue #318.
+	streamingSpeedTestRunner collector.StreamingSpeedTestRunner
 	// borgRunner is the BorgRunner used by the external-Borg Test
 	// endpoint (POST /api/v1/backup-monitor/borg/test) and the
 	// scheduler's external-repo polling. Nil means the handler

--- a/internal/api/service_check_test_stream.go
+++ b/internal/api/service_check_test_stream.go
@@ -1,45 +1,69 @@
 // service_check_test_stream.go — SSE streaming variant of the
-// service-checks Test button (issue #224).
+// service-checks Test button.
 //
-// Scope decision (deliberately narrow): this slice ONLY supports
-// type=traceroute. The dashboard's Speed Test card already has a
-// dedicated SSE live-progress strip (v0.9.11), and adding a second
-// streaming surface for the type=speed Test button is out of scope
-// for #224's first PR. Non-trace requests are rejected with 400 and
-// a hint pointing at the existing synchronous /service-checks/test
-// endpoint, so the JS Test-button wiring can fall back cleanly.
+// Originally introduced for type=traceroute (issue #224, PR #317);
+// extended in issue #318 to also support type=speed so the
+// settings-page Test button for speed-type checks gets the same
+// live-progress UX the dashboard's Speed Test card has had since
+// v0.9.11. Other types continue to use the synchronous /test
+// endpoint and are rejected here with a 400 hint.
 //
-// Wire format mirrors the v0.9.11 speedtest SSE contract:
+// Wire format mirrors the v0.9.11 speedtest SSE contract verbatim
+// where shared:
+//
+// Traceroute:
 //
 //	event: start
 //	data: {"target":"8.8.8.8","cycles":10,"started_at":"..."}
 //
 //	event: hop
-//	data: {"cycle":1,"total_cycles":10,"hops":[{"count":1,"host":"...","Loss%":0,"Avg":...}, ...]}
+//	data: {"cycle":1,"total_cycles":10,"hops":[...]}    // cumulative
 //
 //	event: result
-//	data: <ServiceCheckResult shape — same as POST /test sync endpoint>
+//	data: <ServiceCheckResult — same as POST /test sync endpoint>
 //
 //	event: end
 //	data: {"duration_seconds":12.4}
 //
-// The terminal `result` event's payload is byte-identical to the
-// synchronous /test endpoint's response so the JS renderer can reuse
-// renderServiceCheckDetails verbatim. The `hop` event's `hops` array
-// is cumulative — every event carries the full hop table so far,
-// not a delta — to keep the renderer code path identical for live
-// vs final state.
+// Speed:
+//
+//	event: start
+//	data: {"target":"speedtest","started_at":"..."}
+//
+//	event: phase_change
+//	data: {"phase":"download","phase_index":2,"total_phases":3}
+//
+//	event: sample
+//	data: {"phase":"download","sample_index":7,"ts":"...","mbps":723.4,"latency_ms":0}
+//
+//	event: result
+//	data: <ServiceCheckResult — same as POST /test sync endpoint>
+//
+//	event: error
+//	data: {"message":"engine offline: ..."}             // only on engine error
+//
+//	event: end
+//	data: {"duration_seconds":31.4}
+//
+// In both cases the terminal `result` event's payload is byte-
+// identical to the synchronous /test endpoint's response so the JS
+// renderer can reuse renderServiceCheckDetails verbatim. The
+// per-type live events (`hop` for traceroute, `phase_change` +
+// `sample` for speed) are designed so the JS dispatcher can branch
+// purely on event name without knowing the check type.
 //
 // Process-group SIGKILL on context cancellation (v0.9.14 #304
-// pattern) is delegated to RunStreamingMTR. When the EventSource
-// closes client-side, ctx fires; the streaming runner's goroutine
-// sees ctx.Done(), returns, and the writer goroutine here exits.
+// pattern) is delegated to the underlying runner. When the
+// EventSource closes client-side, ctx fires; the runner sees
+// ctx.Done(), terminates the subprocess (mtr / speedtest), returns,
+// and the writer goroutine here exits.
 
 package api
 
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -56,21 +80,24 @@ import (
 // of network health from both surfaces.
 const streamingTracerouteCycles = 10
 
+// streamingSpeedTotalPhases pins the SSE wire's total_phases value
+// for type=speed runs. Mirrors the dashboard SSE handler's PRD-
+// pinned ordering: latency → download → upload.
+const streamingSpeedTotalPhases = 3
+
 // handleTestServiceCheckStream is the SSE variant of
-// handleTestServiceCheck. POST a ServiceCheckConfig with type=trace,
-// receive a text/event-stream response with one `start` event,
-// per-cycle `hop` events with cumulative hop tables, one terminal
-// `result` event whose body matches the sync endpoint's response,
-// and a final `end` event.
+// handleTestServiceCheck. POST a ServiceCheckConfig with a
+// supported type, receive a text/event-stream response.
 //
-// POST /api/v1/service-checks/test-stream
+// Supported types:
+//   - traceroute — per-cycle hop events
+//   - speed      — phase_change + per-sample events
 //
-// Non-trace types: 400 with a hint pointing at the sync endpoint.
-// Issue #224 narrows this slice to traceroute; speed-type was
-// considered but its streaming surface is already covered by the
-// dashboard's /api/v1/speedtest/run + /stream pair. A future PR can
-// add type=speed support here if the settings-page Test button
-// wants live progress too.
+// All other types return 400 with a hint pointing at the synchronous
+// /api/v1/service-checks/test endpoint. The settings.html JS only
+// opens this stream for traceroute / speed configs, so the 400 is
+// defensive — exercised by direct curl / external tooling that
+// POSTs the wrong shape.
 func (s *Server) handleTestServiceCheckStream(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	if err != nil {
@@ -88,47 +115,55 @@ func (s *Server) handleTestServiceCheckStream(w http.ResponseWriter, r *http.Req
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
-	if cfg.Type != internal.ServiceCheckTraceroute {
-		// Non-trace types: redirect via a 400 with a hint. The
-		// settings.html JS only opens this stream for type=trace
-		// configs, so this path is defensive — exercised by direct
-		// curl / external tooling that POSTs the wrong shape.
-		writeJSON(w, http.StatusBadRequest, map[string]string{
-			"error": fmt.Sprintf("/test-stream only supports type=traceroute (got %q); use POST /api/v1/service-checks/test for synchronous types", cfg.Type),
-		})
-		return
-	}
 
-	// SSE headers — same defensive set as speedtest_sse.go. Explicit
-	// charset prevents content-sniffing proxies from second-guessing
-	// the MIME and re-engaging compression. no-transform discourages
-	// CDN auto-gzip from buffering chunks. X-Accel-Buffering: no is
-	// a hint to nginx-style intermediaries to flush per chunk.
-	// Connection: keep-alive is implied by HTTP/1.1 but stated
-	// explicitly so reviewers reading the headers understand intent.
+	switch cfg.Type {
+	case internal.ServiceCheckTraceroute:
+		s.streamTraceServiceCheck(w, r, cfg)
+	case internal.ServiceCheckSpeed:
+		s.streamSpeedServiceCheck(w, r, cfg)
+	default:
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": fmt.Sprintf("/test-stream supports type=traceroute or type=speed (got %q); use POST /api/v1/service-checks/test for synchronous types", cfg.Type),
+		})
+	}
+}
+
+// writeStreamHeaders applies the SSE defensive header set used by
+// every streaming endpoint in this package — explicit charset, no-
+// cache+no-transform Cache-Control, X-Accel-Buffering hint for
+// nginx-style proxies, explicit keep-alive — and disables the per-
+// connection write deadline so a 30-60s test isn't killed by the
+// router-wide WriteTimeout. Returns the http.Flusher (always
+// non-nil; true if streaming is supported, false otherwise — caller
+// must abort).
+func writeStreamHeaders(w http.ResponseWriter) (http.Flusher, bool) {
 	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache, no-transform")
 	w.Header().Set("X-Accel-Buffering", "no")
 	w.Header().Set("Connection", "keep-alive")
-
-	// Disable per-connection write deadlines — a 10-cycle traceroute
-	// can take 30-60s on slow paths, which would otherwise trip the
-	// http.Server WriteTimeout=30s baseline set in main.go.
 	if rc := http.NewResponseController(w); rc != nil {
 		_ = rc.SetWriteDeadline(time.Time{})
 	}
-
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return nil, false
+	}
+	return flusher, true
+}
+
+// streamTraceServiceCheck handles type=traceroute requests on the
+// /test-stream endpoint. Runs the streaming MTR runner (production
+// or injected fake), emits per-cycle cumulative hop events, and
+// terminates with a canonical ServiceCheckResult built via
+// scheduler.RunCheck so thresholds + Details map are byte-identical
+// to the sync endpoint's response.
+func (s *Server) streamTraceServiceCheck(w http.ResponseWriter, r *http.Request, cfg internal.ServiceCheckConfig) {
+	flusher, ok := writeStreamHeaders(w)
+	if !ok {
 		return
 	}
 
-	// Resolve the streaming runner — production wiring uses
-	// collector.RunStreamingMTR; tests inject a fake via
-	// s.streamingTracerouteRunner so they don't need an actual mtr
-	// binary. Mirrors the existing tracerouteRunner seam used by
-	// the sync /test endpoint.
 	runner := s.streamingTracerouteRunner
 	if runner == nil {
 		runner = collector.RunStreamingMTR
@@ -137,9 +172,6 @@ func (s *Server) handleTestServiceCheckStream(w http.ResponseWriter, r *http.Req
 	target := cfg.Target
 	startedAt := time.Now()
 
-	// Emit the start event before kicking off the runner so the
-	// dashboard sees something immediately (defeats the perceived
-	// "dead spinner" problem #224 was filed to address).
 	if !writeSSEEvent(w, flusher, "start", map[string]any{
 		"target":     target,
 		"cycles":     streamingTracerouteCycles,
@@ -147,11 +179,6 @@ func (s *Server) handleTestServiceCheckStream(w http.ResponseWriter, r *http.Req
 	}) {
 		return
 	}
-
-	// Initial padding to defeat first-N-bytes proxy buffers — same
-	// rationale as speedtest_sse.go (Cloudflare et al. hold the
-	// first chunk until ~2KB has accumulated; without this the
-	// per-cycle hop events stack up invisibly until the test ends).
 	if !writeSSEPadding(w, flusher) {
 		return
 	}
@@ -161,8 +188,6 @@ func (s *Server) handleTestServiceCheckStream(w http.ResponseWriter, r *http.Req
 
 	updates, final := runner(ctx, target, streamingTracerouteCycles)
 
-	// Heartbeat so chunk-coalescing intermediaries keep flushing
-	// between cycles. Same pattern as speedtest_sse.go.
 	heartbeat := time.NewTicker(1 * time.Second)
 	defer heartbeat.Stop()
 
@@ -196,21 +221,12 @@ loop:
 			}
 			lastResult = fin.Result
 			runErr = fin.RunErr
-			// Drain any buffered updates that the runner pushed
-			// before its terminal value — Go's select can
-			// schedule `final` before pending `updates` when
-			// both are ready, and we don't want the SSE
-			// consumer to miss a hop event the runner emitted.
-			//
-			// CRITICAL: guard against `updates == nil`. When the
-			// updates channel closes BEFORE final arrives in the
-			// outer select (a legal ordering when the runner
-			// closes both channels back-to-back via defers and
-			// CI scheduling drains updates first), the
-			// `case u, ok := <-updates: if !ok { updates = nil }`
-			// branch above sets the local var to nil. Ranging
-			// over a nil channel blocks forever — the original
-			// handler bug that caused the v0.9.15-rc1 CI hang.
+			// Drain buffered updates after seeing final — Go's
+			// select can schedule `final` before pending
+			// `updates` when both are ready. CRITICAL: guard
+			// against updates==nil to avoid the v0.9.15-rc1
+			// nil-channel range deadlock (legal channel-close
+			// ordering hits the bad path on CI Linux).
 			if updates != nil {
 				for u := range updates {
 					if !writeSSEEvent(w, flusher, "hop", map[string]any{
@@ -224,24 +240,183 @@ loop:
 			}
 			break loop
 		case <-clientGone:
-			// Browser closed the EventSource — ctx cancellation
-			// will propagate to the runner via the ctx wired into
-			// the runner above; bail without writing terminal
-			// events (the connection is already dead).
 			return
 		}
 	}
 
-	// Build the canonical ServiceCheckResult so the SSE wire's
-	// terminal `result` event matches the sync endpoint's response
-	// shape. We re-use scheduler's RunCheck path with an injected
-	// runner that returns the streamed result — this guarantees
-	// thresholds, MaxLossPct policy, status determination, and
-	// the Details map are computed exactly as on the sync path.
+	// Build the canonical ServiceCheckResult so the terminal
+	// `result` event matches the sync endpoint's shape.
 	checker := scheduler.NewServiceChecker(s.store, s.logger)
 	checker.SetCollectDetails(true)
 	checker.SetTraceRunner(func(_ string, _ int) (*collector.MTRResult, error) {
 		return lastResult, runErr
+	})
+	scResult := checker.RunCheck(cfg, time.Now().UTC())
+
+	_ = writeSSEEvent(w, flusher, "result", scResult)
+	_ = writeSSEEvent(w, flusher, "end", map[string]any{
+		"duration_seconds": time.Since(startedAt).Seconds(),
+	})
+}
+
+// streamSpeedServiceCheck handles type=speed requests on the
+// /test-stream endpoint. Runs the streaming speed-test runner
+// (production composite of speedtest-go primary + Ookla CLI
+// fallback, or an injected fake), forwards per-phase samples as
+// SSE `sample` events with derived `phase_change` events on
+// transitions, and terminates with a canonical ServiceCheckResult
+// built via scheduler.RunCheck so thresholds (ContractedDownMbps
+// / ContractedUpMbps / MarginPct + three-state up/degraded/down
+// logic) are applied identically to the sync endpoint.
+//
+// Engine errors (no speedtest tool available, network-bound
+// failures, etc.) are surfaced as a separate `error` SSE event
+// before the terminal `result` event, mirroring the dashboard
+// speedtest_sse.go contract. The result event still fires (with
+// status=down, error message in Error field) so the JS renderer
+// can produce a coherent toast even on the failure path.
+//
+// Issue #318.
+func (s *Server) streamSpeedServiceCheck(w http.ResponseWriter, r *http.Request, cfg internal.ServiceCheckConfig) {
+	flusher, ok := writeStreamHeaders(w)
+	if !ok {
+		return
+	}
+
+	runner := s.streamingSpeedTestRunner
+	if runner == nil {
+		runner = collector.RunStreamingSpeedTest
+	}
+
+	startedAt := time.Now()
+	// target is decorative for speed checks — most configs ship
+	// with cfg.Target="speedtest" or empty. Echo whatever was
+	// configured so the start event is honest about what the
+	// user submitted.
+	target := cfg.Target
+	if target == "" {
+		target = "speedtest"
+	}
+
+	if !writeSSEEvent(w, flusher, "start", map[string]any{
+		"target":     target,
+		"started_at": startedAt.Format(time.RFC3339Nano),
+	}) {
+		return
+	}
+	if !writeSSEPadding(w, flusher) {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	updates, final := runner(ctx)
+
+	heartbeat := time.NewTicker(1 * time.Second)
+	defer heartbeat.Stop()
+
+	clientGone := r.Context().Done()
+
+	currentPhase := ""
+	phaseIndex := 0
+	sampleIndex := 0
+
+	emitSample := func(s collector.SpeedTestSample) bool {
+		// Derive a phase_change event when the phase transitions —
+		// the runner doesn't emit explicit phase events, the SSE
+		// wire does the derivation. Mirrors speedtest_sse.go.
+		if string(s.Phase) != currentPhase {
+			phaseIndex++
+			currentPhase = string(s.Phase)
+			if !writeSSEEvent(w, flusher, "phase_change", map[string]any{
+				"phase":        currentPhase,
+				"phase_index":  phaseIndex,
+				"total_phases": streamingSpeedTotalPhases,
+			}) {
+				return false
+			}
+		}
+		payload := map[string]any{
+			"phase":        currentPhase,
+			"sample_index": sampleIndex,
+			"ts":           s.At.Format(time.RFC3339Nano),
+			"mbps":         s.Mbps,
+			"latency_ms":   s.LatencyMs,
+		}
+		sampleIndex++
+		return writeSSEEvent(w, flusher, "sample", payload)
+	}
+
+	var resultPtr *internal.SpeedTestResult
+	var runErr error
+
+loop:
+	for {
+		select {
+		case <-heartbeat.C:
+			if !writeSSEHeartbeat(w, flusher) {
+				return
+			}
+		case sample, ok := <-updates:
+			if !ok {
+				updates = nil
+				continue
+			}
+			if !emitSample(sample) {
+				return
+			}
+		case fin, ok := <-final:
+			if !ok {
+				break loop
+			}
+			resultPtr = fin.Result
+			runErr = fin.RunErr
+			// Drain buffered updates after seeing final — same
+			// ordering guard as the trace branch. The nil-
+			// channel guard is critical: a legal channel-close
+			// ordering can leave updates set to nil after the
+			// outer select observed close BEFORE final, and
+			// ranging over a nil channel deadlocks. v0.9.15-
+			// rc1 burn lesson.
+			if updates != nil {
+				for sample := range updates {
+					if !emitSample(sample) {
+						return
+					}
+				}
+			}
+			break loop
+		case <-clientGone:
+			return
+		}
+	}
+
+	// Engine error: emit a dedicated `error` event before the
+	// terminal `result` so JS consumers that want to render an
+	// engine-specific failure message can do so without parsing
+	// ServiceCheckResult.Error. Mirrors speedtest_sse.go.
+	if runErr != nil && !errors.Is(runErr, context.Canceled) && !errors.Is(runErr, context.DeadlineExceeded) {
+		_ = writeSSEEvent(w, flusher, "error", map[string]any{
+			"message": runErr.Error(),
+		})
+	}
+
+	// Build the canonical ServiceCheckResult so the terminal
+	// `result` event matches the sync endpoint's shape exactly.
+	// We re-use scheduler.RunCheck via runSpeedCheckViaRunner —
+	// SetSpeedTestRunner injects a stub that returns the streamed
+	// result. RunCheck applies ContractedDownMbps / ContractedUp
+	// Mbps thresholds + MarginPct + three-state status logic, and
+	// stamps DownloadOK / UploadOK / Details exactly as the sync
+	// endpoint does.
+	checker := scheduler.NewServiceChecker(s.store, s.logger)
+	checker.SetCollectDetails(true)
+	checker.SetSpeedTestRunner(func() *internal.SpeedTestResult {
+		// runSpeedCheckViaRunner treats nil as "no speedtest tool
+		// available". That's the correct semantic when the engine
+		// errored — preserves the sync-endpoint behaviour.
+		return resultPtr
 	})
 	scResult := checker.RunCheck(cfg, time.Now().UTC())
 

--- a/internal/api/service_check_test_stream_test.go
+++ b/internal/api/service_check_test_stream_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mcdays94/nas-doctor/internal"
 	"github.com/mcdays94/nas-doctor/internal/collector"
 )
 
@@ -223,10 +224,15 @@ func TestServiceChecksTestStream_TraceHappyPath(t *testing.T) {
 	}
 }
 
-// TestServiceChecksTestStream_NonTraceReturns400 — type=http (and
-// other non-trace types) must be rejected with 400 + a hint pointing
-// at the synchronous endpoint.
-func TestServiceChecksTestStream_NonTraceReturns400(t *testing.T) {
+// TestServiceChecksTestStream_NonTraceNonSpeedReturns400 — type=http
+// (and other types that are neither traceroute nor speed) must be
+// rejected with 400 + a hint pointing at the synchronous endpoint.
+//
+// The error message MUST now mention BOTH supported streaming
+// types (traceroute, speed) so direct curl / external tooling
+// callers see the full set of streamable types in the rejection
+// reason. Issue #318 — replaces the old _NonTraceReturns400 guard.
+func TestServiceChecksTestStream_NonTraceNonSpeedReturns400(t *testing.T) {
 	srv := newSettingsTestServer()
 	resp := postTestStream(t, srv, map[string]any{
 		"name":   "http-bad",
@@ -244,6 +250,9 @@ func TestServiceChecksTestStream_NonTraceReturns400(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "traceroute") {
 		t.Errorf("expected hint mentioning traceroute, got: %s", body)
+	}
+	if !strings.Contains(string(body), "speed") {
+		t.Errorf("expected hint mentioning speed (issue #318 — both supported types must be enumerated), got: %s", body)
 	}
 }
 
@@ -452,3 +461,407 @@ func TestServiceChecksHTML_TestStreamWiring(t *testing.T) {
 		t.Error("settings.html missing reference to SSE 'hop' event in trace Test button branch")
 	}
 }
+
+// TestServiceChecksHTML_TestStreamSpeedWiring — settings.html JS
+// must also branch type=speed Test buttons through the streaming
+// endpoint, with the speed-specific SSE event names ("sample" /
+// "phase_change") referenced in the dispatcher. Issue #318.
+func TestServiceChecksHTML_TestStreamSpeedWiring(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("templates", "settings.html"))
+	if err != nil {
+		t.Fatalf("read settings.html: %v", err)
+	}
+	data := string(raw)
+	// The speed branch must dispatch via the same /test-stream URL
+	// the trace branch uses (one shared endpoint, switch on type
+	// server-side — see handleTestServiceCheckStream).
+	if !strings.Contains(data, "/api/v1/service-checks/test-stream") {
+		t.Fatal("settings.html missing /test-stream URL — Test button SSE wiring not present at all")
+	}
+	// Speed-branch trigger: the JS must check sc.type === "speed"
+	// and route to a new SSE handler. The exact identifier is
+	// runSpeedTestStream (mirrors the existing runTraceTestStream
+	// for traceroute).
+	if !strings.Contains(data, "runSpeedTestStream") {
+		t.Error("settings.html missing runSpeedTestStream — type=speed Test button branch not wired to SSE")
+	}
+	if !strings.Contains(data, `sc.type === "speed"`) {
+		t.Error("settings.html missing `sc.type === \"speed\"` branch — speed Test button still uses sync /test endpoint")
+	}
+	// Speed-specific SSE events the dispatcher must handle.
+	if !strings.Contains(data, `"sample"`) {
+		t.Error("settings.html missing reference to SSE 'sample' event for speed Test button branch")
+	}
+	if !strings.Contains(data, `"phase_change"`) {
+		t.Error("settings.html missing reference to SSE 'phase_change' event for speed Test button branch")
+	}
+}
+
+// TestServiceChecksTestStream_SpeedHappyPath — type=speed request
+// produces start + per-phase phase_change + sample × N + result +
+// end events with parseable JSON payloads. Phase derivation must
+// produce one phase_change per phase transition, NOT per sample.
+//
+// 5s deadline standard is the v0.9.15-rc1 burn discipline: any test
+// exercising goroutine ordering or channel-close timing must use
+// the helper so a deadlock fails loud-and-fast instead of waiting
+// out the default 10-min go test timeout.
+func TestServiceChecksTestStream_SpeedHappyPath(t *testing.T) {
+	deadline := assertCompletesWithin(t, 5*time.Second)
+	defer deadline()
+
+	srv := newSettingsTestServer()
+
+	// Inject a fake streaming runner that emits 4 samples across 3
+	// phases (latency, download×2, upload) then finalises with a
+	// canonical SpeedTestResult.
+	srv.streamingSpeedTestRunner = func(_ context.Context) (<-chan collector.SpeedTestSample, <-chan collector.StreamingSpeedFinal) {
+		updates := make(chan collector.SpeedTestSample, 8)
+		final := make(chan collector.StreamingSpeedFinal, 1)
+		go func() {
+			defer close(updates)
+			defer close(final)
+			now := time.Now()
+			updates <- collector.SpeedTestSample{Phase: collector.SpeedTestPhaseLatency, At: now, LatencyMs: 5.0}
+			updates <- collector.SpeedTestSample{Phase: collector.SpeedTestPhaseDownload, At: now.Add(time.Second), Mbps: 100.0}
+			updates <- collector.SpeedTestSample{Phase: collector.SpeedTestPhaseDownload, At: now.Add(2 * time.Second), Mbps: 200.0}
+			updates <- collector.SpeedTestSample{Phase: collector.SpeedTestPhaseUpload, At: now.Add(3 * time.Second), Mbps: 50.0}
+			final <- collector.StreamingSpeedFinal{
+				Result: &internal.SpeedTestResult{
+					DownloadMbps: 200.0,
+					UploadMbps:   50.0,
+					LatencyMs:    5.0,
+					Engine:       internal.SpeedTestEngineSpeedTestGo,
+				},
+			}
+		}()
+		return updates, final
+	}
+
+	resp := postTestStream(t, srv, map[string]any{
+		"name":   "speed-stream",
+		"type":   "speed",
+		"target": "speedtest",
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+		t.Fatalf("Content-Type = %q, want text/event-stream prefix", got)
+	}
+	if got := resp.Header.Get("Cache-Control"); !strings.Contains(got, "no-cache") || !strings.Contains(got, "no-transform") {
+		t.Fatalf("Cache-Control = %q, want no-cache + no-transform", got)
+	}
+
+	events, err := parseTraceSSEStream(resp.Body)
+	if err != nil {
+		t.Fatalf("parse SSE: %v", err)
+	}
+
+	gotEvents := make([]string, 0, len(events))
+	for _, e := range events {
+		gotEvents = append(gotEvents, e.Event)
+	}
+	t.Logf("event sequence: %v", gotEvents)
+
+	if gotEvents[0] != "start" {
+		t.Errorf("event[0] = %q, want start", gotEvents[0])
+	}
+
+	phaseCount := 0
+	sampleCount := 0
+	resultIdx := -1
+	endIdx := -1
+	for i, ev := range gotEvents {
+		switch ev {
+		case "phase_change":
+			phaseCount++
+		case "sample":
+			sampleCount++
+		case "result":
+			resultIdx = i
+		case "end":
+			endIdx = i
+		}
+	}
+	if phaseCount != 3 {
+		t.Errorf("expected 3 phase_change events (one per phase transition), got %d", phaseCount)
+	}
+	if sampleCount != 4 {
+		t.Errorf("expected 4 sample events, got %d", sampleCount)
+	}
+	if resultIdx == -1 || endIdx == -1 || resultIdx >= endIdx {
+		t.Errorf("expected result before end, got result=%d end=%d", resultIdx, endIdx)
+	}
+
+	// Per-event payload spot-checks.
+	for _, e := range events {
+		switch e.Event {
+		case "phase_change":
+			var d struct {
+				Phase       string `json:"phase"`
+				PhaseIndex  int    `json:"phase_index"`
+				TotalPhases int    `json:"total_phases"`
+			}
+			if err := json.Unmarshal([]byte(e.Data), &d); err != nil {
+				t.Errorf("phase_change data malformed: %v (data=%s)", err, e.Data)
+			}
+			if d.Phase == "" || d.PhaseIndex <= 0 || d.TotalPhases != 3 {
+				t.Errorf("phase_change fields invalid: %+v", d)
+			}
+		case "sample":
+			var d struct {
+				Phase       string  `json:"phase"`
+				SampleIndex int     `json:"sample_index"`
+				Mbps        float64 `json:"mbps"`
+				LatencyMs   float64 `json:"latency_ms"`
+			}
+			if err := json.Unmarshal([]byte(e.Data), &d); err != nil {
+				t.Errorf("sample data malformed: %v (data=%s)", err, e.Data)
+			}
+			if d.Phase == "" {
+				t.Errorf("sample missing phase: data=%s", e.Data)
+			}
+		case "result":
+			// Canonical ServiceCheckResult shape — same fields the sync
+			// /test endpoint produces. The speed runner with no
+			// contracted thresholds should land status=up.
+			var d map[string]any
+			if err := json.Unmarshal([]byte(e.Data), &d); err != nil {
+				t.Errorf("result data malformed: %v (data=%s)", err, e.Data)
+			}
+			if _, ok := d["status"]; !ok {
+				t.Errorf("result missing status field; data=%s", e.Data)
+			}
+			// download_mbps and upload_mbps must be propagated from
+			// the streamed engine result so the JS toast can show
+			// real numbers.
+			if dl, ok := d["download_mbps"].(float64); !ok || dl <= 0 {
+				t.Errorf("result.download_mbps missing or zero: %v", d["download_mbps"])
+			}
+			if ul, ok := d["upload_mbps"].(float64); !ok || ul <= 0 {
+				t.Errorf("result.upload_mbps missing or zero: %v", d["upload_mbps"])
+			}
+		case "end":
+			var d struct {
+				DurationSeconds float64 `json:"duration_seconds"`
+			}
+			if err := json.Unmarshal([]byte(e.Data), &d); err != nil {
+				t.Errorf("end data malformed: %v", err)
+			}
+		}
+	}
+}
+
+// TestServiceChecksTestStream_SpeedCtxCancelKillsRunner — closing the
+// EventSource client-side must promptly cancel the runner ctx for
+// type=speed checks too. We assert by injecting a runner that blocks
+// on ctx.Done() and verifying the function returns within a small
+// budget after the client closes the connection.
+func TestServiceChecksTestStream_SpeedCtxCancelKillsRunner(t *testing.T) {
+	deadline := assertCompletesWithin(t, 8*time.Second)
+	defer deadline()
+
+	srv := newSettingsTestServer()
+
+	runnerExited := make(chan struct{})
+	srv.streamingSpeedTestRunner = func(ctx context.Context) (<-chan collector.SpeedTestSample, <-chan collector.StreamingSpeedFinal) {
+		updates := make(chan collector.SpeedTestSample)
+		final := make(chan collector.StreamingSpeedFinal, 1)
+		go func() {
+			defer close(updates)
+			defer close(final)
+			defer close(runnerExited)
+			<-ctx.Done()
+			final <- collector.StreamingSpeedFinal{RunErr: ctx.Err()}
+		}()
+		return updates, final
+	}
+
+	ts := httptest.NewServer(srv.Router())
+	defer ts.Close()
+
+	body, _ := json.Marshal(map[string]any{
+		"name":   "speed-cancel",
+		"type":   "speed",
+		"target": "speedtest",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+"/api/v1/service-checks/test-stream", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+
+	br := bufio.NewReader(resp.Body)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				return
+			}
+			if strings.Contains(line, "event: start") {
+				return
+			}
+		}
+	}()
+	wg.Wait()
+
+	cancel()
+	resp.Body.Close()
+
+	select {
+	case <-runnerExited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("speed runner did not exit within 2s of client cancel — ctx cancellation not propagating")
+	}
+}
+
+// TestServiceChecksTestStream_SpeedUpdatesCloseBeforeFinal pins the
+// nil-channel range edge case for the speed branch. Same shape as
+// the trace counterpart: forces the runner to close `updates`
+// BEFORE emitting `final` so the handler's outer select observes
+// the close-of-updates first, then final. Without the nil guard,
+// the post-final drain ranges over nil and deadlocks.
+func TestServiceChecksTestStream_SpeedUpdatesCloseBeforeFinal(t *testing.T) {
+	deadline := assertCompletesWithin(t, 5*time.Second)
+	defer deadline()
+
+	srv := newSettingsTestServer()
+	srv.streamingSpeedTestRunner = func(_ context.Context) (<-chan collector.SpeedTestSample, <-chan collector.StreamingSpeedFinal) {
+		updates := make(chan collector.SpeedTestSample, 1)
+		final := make(chan collector.StreamingSpeedFinal)
+		updates <- collector.SpeedTestSample{Phase: collector.SpeedTestPhaseDownload, Mbps: 50.0}
+		close(updates)
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			final <- collector.StreamingSpeedFinal{Result: &internal.SpeedTestResult{
+				DownloadMbps: 50.0,
+				UploadMbps:   10.0,
+				LatencyMs:    5.0,
+			}}
+			close(final)
+		}()
+		return updates, final
+	}
+
+	resp := postTestStream(t, srv, map[string]any{
+		"name":   "speed-ordering",
+		"type":   "speed",
+		"target": "speedtest",
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	events, err := parseTraceSSEStream(resp.Body)
+	if err != nil {
+		t.Fatalf("parse SSE: %v", err)
+	}
+	gotEnd := false
+	for _, e := range events {
+		if e.Event == "end" {
+			gotEnd = true
+			break
+		}
+	}
+	if !gotEnd {
+		t.Fatalf("expected terminal end event; sequence: %v", eventNames(events))
+	}
+}
+
+// TestServiceChecksTestStream_SpeedEngineErrorEmitsErrorEvent — when
+// the runner fails before any samples (e.g. no speedtest tool
+// available), the SSE stream must still emit a coherent event
+// sequence: start → error → result (status=down) → end. The dedicated
+// `error` event is what gives JS consumers a hook to render an
+// engine-specific failure message before the canonical result event
+// fires.
+func TestServiceChecksTestStream_SpeedEngineErrorEmitsErrorEvent(t *testing.T) {
+	deadline := assertCompletesWithin(t, 5*time.Second)
+	defer deadline()
+
+	srv := newSettingsTestServer()
+	srv.streamingSpeedTestRunner = func(_ context.Context) (<-chan collector.SpeedTestSample, <-chan collector.StreamingSpeedFinal) {
+		updates := make(chan collector.SpeedTestSample)
+		final := make(chan collector.StreamingSpeedFinal, 1)
+		go func() {
+			defer close(updates)
+			defer close(final)
+			final <- collector.StreamingSpeedFinal{
+				RunErr: errSpeedEngineUnavailable,
+			}
+		}()
+		return updates, final
+	}
+
+	resp := postTestStream(t, srv, map[string]any{
+		"name":   "speed-engine-fail",
+		"type":   "speed",
+		"target": "speedtest",
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	events, err := parseTraceSSEStream(resp.Body)
+	if err != nil {
+		t.Fatalf("parse SSE: %v", err)
+	}
+
+	gotError := false
+	gotResult := false
+	gotEnd := false
+	for _, e := range events {
+		switch e.Event {
+		case "error":
+			gotError = true
+			if !strings.Contains(e.Data, "speedtest engine unavailable") {
+				t.Errorf("error event message did not surface engine error: %s", e.Data)
+			}
+		case "result":
+			gotResult = true
+			// Result must reflect the failure — status != "up" and
+			// an error message present.
+			var d map[string]any
+			_ = json.Unmarshal([]byte(e.Data), &d)
+			if d["status"] == "up" {
+				t.Errorf("result.status = up despite engine error; data=%s", e.Data)
+			}
+		case "end":
+			gotEnd = true
+		}
+	}
+	if !gotError {
+		t.Errorf("expected error event after engine failure; sequence: %v", eventNames(events))
+	}
+	if !gotResult {
+		t.Errorf("expected result event after engine error (not a stream abort); sequence: %v", eventNames(events))
+	}
+	if !gotEnd {
+		t.Errorf("expected terminal end event; sequence: %v", eventNames(events))
+	}
+}
+
+// errSpeedEngineUnavailable is a static error fixture used by the
+// engine-error test above so the assertion can grep for a stable
+// substring without scraping a wrapped errors.Is chain.
+var errSpeedEngineUnavailable = errSpeedTestSentinel("speedtest engine unavailable: both engines offline")
+
+type errSpeedTestSentinel string
+
+func (e errSpeedTestSentinel) Error() string { return string(e) }

--- a/internal/api/templates/settings.html
+++ b/internal/api/templates/settings.html
@@ -2800,13 +2800,18 @@ function renderServiceCheckDetails(type, details, result) {
 // (Ookla CLI), so we warn the user up-front and disable the button for
 // the duration of the request. See issue #154.
 //
-// Traceroute checks use the SSE streaming variant
-// (POST /api/v1/service-checks/test-stream) so the user sees per-cycle
-// hop progress in the toast — closes the "dead spinner" UX surfaced
-// in v0.9.7 UAT of #189 (issue #224). All other types use the
-// synchronous /test endpoint unchanged. ReadableStream + the SSE
-// wire format is hand-parsed because EventSource is GET-only and
-// the Test button has to POST the form payload.
+// Traceroute and speed checks use the SSE streaming variant
+// (POST /api/v1/service-checks/test-stream) so the user sees
+// per-cycle hop progress (traceroute) or per-phase live samples
+// (speed) in the toast. Closes the "dead spinner" UX surfaced in
+// v0.9.7 UAT of #189 (issue #224, traceroute slice in v0.9.15) and
+// the same problem for the long-running Ookla CLI invocation
+// (issue #318, speed slice). All other types use the synchronous
+// /test endpoint unchanged.
+//
+// ReadableStream + the SSE wire format is hand-parsed because
+// EventSource is GET-only and the Test button has to POST the
+// form payload.
 function testServiceCheck() {
   var sc = readServiceCheckForm();
   if (!sc) return;
@@ -2818,6 +2823,15 @@ function testServiceCheck() {
   // Traceroute → live-progress SSE branch.
   if (sc.type === "traceroute" && typeof window.ReadableStream !== "undefined") {
     runTraceTestStream(sc, btn, originalLabel);
+    return;
+  }
+
+  // Speed → live-progress SSE branch (issue #318). Falls back to
+  // the synchronous path on browsers without ReadableStream
+  // (essentially nobody in practice but the guard mirrors the
+  // traceroute branch above).
+  if (sc.type === "speed" && typeof window.ReadableStream !== "undefined") {
+    runSpeedTestStream(sc, btn, originalLabel);
     return;
   }
 
@@ -2999,6 +3013,159 @@ function handleTraceEvent(ev, data, sc) {
   // Other events (start, end, error) are passive — nothing to
   // render. Heartbeat comments never reach the dispatcher because
   // they have no `event:` line.
+}
+
+// runSpeedTestStream consumes the SSE response from
+// POST /api/v1/service-checks/test-stream for a type=speed Test.
+// Renders incremental progress via toast — each `phase_change`
+// event refreshes the toast headline with the current phase, and
+// each `sample` event updates the live throughput readout. The
+// terminal `result` event finalises with the same shape as the
+// sync endpoint so the existing renderServiceCheckDetails helper
+// can be reused (issue #318).
+//
+// Cancellation: AbortController wires the fetch to the page
+// lifecycle, so navigating away or closing the page promptly
+// aborts the HTTP request. The server-side runner sees ctx.Done()
+// and kills the speedtest subprocess via the v0.9.14 #304
+// process-group SIGKILL plumbing in collector.runOoklaSpeedtestCtx.
+//
+// Anti-pattern guards (AGENTS.md): no backticks anywhere in this
+// function (Go raw-string DashboardJS/SharedCSS unaffected). All
+// comments are line comments — no `/* */` block comments contain
+// `*/` substrings that would close the block early and break the
+// entire <script> parse (the v0.9.9-rc1 trap).
+function runSpeedTestStream(sc, btn, originalLabel) {
+  showToast("Running speed test (live, 30-60s)…", "info");
+
+  var controller = (typeof AbortController !== "undefined") ? new AbortController() : null;
+  var signal = controller ? controller.signal : undefined;
+
+  fetch("/api/v1/service-checks/test-stream", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "Accept": "text/event-stream" },
+    body: JSON.stringify(sc),
+    signal: signal
+  })
+    .then(function(resp) {
+      if (!resp.ok) {
+        return resp.json().then(function(d) {
+          throw new Error((d && d.error) ? d.error : ("HTTP " + resp.status));
+        }).catch(function() {
+          throw new Error("HTTP " + resp.status);
+        });
+      }
+      var reader = resp.body.getReader();
+      var decoder = new TextDecoder("utf-8");
+      var buf = "";
+      // Tracks live progress so the toast update on each `sample`
+      // event has the latest phase + Mbps headline available.
+      var liveState = { phase: "", phaseIndex: 0, totalPhases: 3, lastMbps: 0, lastLatencyMs: 0 };
+
+      function pump() {
+        return reader.read().then(function(chunk) {
+          if (chunk.done) return;
+          buf += decoder.decode(chunk.value, { stream: true });
+          // Frames are terminated by a blank line. Split on the
+          // SSE "\n\n" frame separator.
+          var frames = buf.split("\n\n");
+          buf = frames.pop(); // tail may be partial
+          for (var i = 0; i < frames.length; i++) {
+            var frame = frames[i];
+            if (!frame) continue;
+            var ev = "", data = "";
+            var lines = frame.split("\n");
+            for (var j = 0; j < lines.length; j++) {
+              var line = lines[j];
+              if (line.indexOf("event: ") === 0) ev = line.substring(7);
+              else if (line.indexOf("data: ") === 0) data = line.substring(6);
+            }
+            if (!ev) continue;
+            handleSpeedEvent(ev, data, sc, liveState);
+          }
+          return pump();
+        });
+      }
+      return pump();
+    })
+    .catch(function(e) {
+      if (e && e.name === "AbortError") return;
+      showToast("Test failed: " + (e && e.message ? e.message : "network error"), "error");
+    })
+    .finally(function() {
+      if (btn) { btn.disabled = false; btn.textContent = originalLabel; }
+    });
+}
+
+// handleSpeedEvent dispatches a parsed speed-test SSE event to
+// the appropriate rendering path. `phase_change` updates the
+// liveState's current phase + headline; `sample` refreshes the
+// toast with the live throughput readout; `result` produces the
+// canonical pass/fail summary using the existing per-type
+// renderer; `error` surfaces engine-specific failures (e.g.
+// "no speedtest tool available").
+function handleSpeedEvent(ev, data, sc, liveState) {
+  if (ev === "phase_change") {
+    var p = null;
+    try { p = JSON.parse(data); } catch (e) { return; }
+    if (!p) return;
+    liveState.phase = p.phase || "";
+    liveState.phaseIndex = p.phase_index || 0;
+    liveState.totalPhases = p.total_phases || 3;
+    var headline = "Speed test — phase " + liveState.phaseIndex + "/" + liveState.totalPhases + ": " + (liveState.phase || "?");
+    showToast(headline, "info");
+    return;
+  }
+  if (ev === "sample") {
+    var s = null;
+    try { s = JSON.parse(data); } catch (e) { return; }
+    if (!s) return;
+    if (typeof s.mbps === "number") liveState.lastMbps = s.mbps;
+    if (typeof s.latency_ms === "number") liveState.lastLatencyMs = s.latency_ms;
+    var lines = ["Speed test — phase " + liveState.phaseIndex + "/" + liveState.totalPhases + ": " + (liveState.phase || "?")];
+    if (s.phase === "latency") {
+      lines.push("  latency " + (typeof s.latency_ms === "number" ? s.latency_ms.toFixed(1) + " ms" : "—"));
+    } else {
+      lines.push("  " + (s.phase || "?") + " " + (typeof s.mbps === "number" ? s.mbps.toFixed(1) + " Mbps" : "—"));
+    }
+    showToast(lines.join("\n"), "info");
+    return;
+  }
+  if (ev === "error") {
+    var err = null;
+    try { err = JSON.parse(data); } catch (e) { return; }
+    var msg = (err && err.message) ? err.message : "speed test engine error";
+    showToast("Speed test engine error: " + msg, "error");
+    return;
+  }
+  if (ev === "result") {
+    var r = null;
+    try { r = JSON.parse(data); } catch (e) { return; }
+    if (!r) return;
+    var status = r.status || "unknown";
+    var ms = r.response_ms;
+    var headline;
+    var toastKind = "info";
+    if (status === "up") {
+      headline = "✓ Check is UP" + (typeof ms === "number" ? " (" + ms + " ms)" : "");
+      toastKind = "success";
+    } else if (status === "degraded") {
+      headline = "△ Degraded";
+      toastKind = "warning";
+    } else {
+      headline = "✗ Check is DOWN";
+      toastKind = "error";
+    }
+    var msg = headline;
+    var detailsText = renderServiceCheckDetails(sc.type, r.details, r);
+    if (detailsText) msg += "\n" + detailsText;
+    if (r.error) msg += "\n" + r.error;
+    showToast(msg, toastKind);
+    return;
+  }
+  // Other events (start, end) are passive. Heartbeat comments
+  // never reach the dispatcher because they have no `event:`
+  // line.
 }
 
 function removeServiceCheck(idx) {

--- a/internal/collector/speedtest_stream.go
+++ b/internal/collector/speedtest_stream.go
@@ -1,0 +1,184 @@
+// Streaming speed-test runner — issue #318.
+//
+// PR #317 introduced /api/v1/service-checks/test-stream as an SSE
+// endpoint that streams per-cycle hop progress for type=traceroute
+// Test invocations. Issue #318 extends the same endpoint to support
+// type=speed, replacing the dashboard Test button's "dead spinner"
+// during a 30-60s Ookla run with live phase + sample feedback.
+//
+// Why a NEW abstraction rather than reusing livetest.Registry:
+//
+//   - livetest.Registry is the dashboard speed-test card's singleton
+//     state machine: one in-flight test at a time, multi-subscriber
+//     fan-out for replay-on-attach across browser tabs, history-row
+//     persistence on completion via registered completion handlers,
+//     Prometheus in-progress gauge management. None of those are
+//     desirable on the Test button path — Test invocations are
+//     ephemeral, don't compete with the dashboard's own scheduled
+//     run, and don't write history.
+//
+//   - Mixing Test-button traffic into the singleton would mean
+//     clicking Test on the settings page collapses onto whatever
+//     test is currently running on the dashboard (or the next
+//     scheduled cron tick) instead of running its own throwaway
+//     measurement. That breaks the existing UX expectation from
+//     #170 (Test = run now, ad hoc).
+//
+// What we DO reuse: the underlying SpeedTestRunner engine (composite
+// of speedtest-go primary + Ookla CLI fallback, defined in
+// speedtest_runner.go). The streaming wrapper just calls Run(ctx),
+// forwards samples to a channel, and emits a single terminal
+// SpeedTestResult. Process-group SIGKILL on cancellation is handled
+// inside the engine's Ookla path (v0.9.14 #304); cancelling the ctx
+// passed in here propagates through to the subprocess.
+
+package collector
+
+import (
+	"context"
+
+	internal "github.com/mcdays94/nas-doctor/internal"
+)
+
+// StreamingSpeedFinal is the terminal value emitted by a streaming
+// speed-test run. Exactly one is sent on the final channel before
+// it's closed.
+type StreamingSpeedFinal struct {
+	// Result is the canonical SpeedTestResult assembled by the
+	// underlying engine. Nil when RunErr is non-nil.
+	Result *internal.SpeedTestResult
+	// RunErr is the underlying error from the engine, if any.
+	// nil on the happy path. Cancellation surfaces here as
+	// context.Canceled / context.DeadlineExceeded.
+	RunErr error
+}
+
+// StreamingSpeedTestRunner is the function signature the streaming
+// /test-stream endpoint depends on for type=speed checks.
+// Implementations push samples onto the returned `updates` channel
+// and a single terminal value onto the returned `final` channel
+// before closing both.
+//
+// Contract — mirrors StreamingTracerouteRunner verbatim:
+//   - Samples are emitted in phase order (latency → download →
+//     upload). The Phase field on each sample drives SSE-side
+//     phase_change derivation.
+//   - When ctx is cancelled, both channels are closed promptly.
+//     final may emit a value carrying ctx.Err() as RunErr or close
+//     without emitting if cancellation races with completion.
+//   - On engine error, final emits a StreamingSpeedFinal with
+//     RunErr non-nil and Result nil; callers should treat any
+//     non-nil RunErr as "down".
+//
+// The production implementation is RunStreamingSpeedTest. Tests
+// inject a stub via Server.streamingSpeedTestRunner so they don't
+// need an actual speedtest tool installed. Issue #318.
+type StreamingSpeedTestRunner func(ctx context.Context) (updates <-chan SpeedTestSample, final <-chan StreamingSpeedFinal)
+
+// RunStreamingSpeedTest is the production StreamingSpeedTestRunner.
+// Adapts the existing composite SpeedTestRunner (speedtest-go primary
+// + Ookla CLI fallback) to the streaming channel-pair shape used by
+// the /test-stream SSE handler.
+//
+// Behaviour:
+//   - Latches the engine result + samples channel from Run(ctx).
+//   - Forwards each sample onto `updates` until the engine's
+//     samples channel closes.
+//   - Emits one StreamingSpeedFinal carrying the engine result OR
+//     the engine error onto `final`, then closes both channels.
+//
+// Cancellation propagates through the ctx wired into engine.Run; the
+// Ookla CLI path uses process-group SIGKILL (v0.9.14 #304) so a
+// browser closing the EventSource promptly kills the subprocess
+// instead of letting it run its full 30-60s window.
+func RunStreamingSpeedTest(ctx context.Context) (<-chan SpeedTestSample, <-chan StreamingSpeedFinal) {
+	return runStreamingSpeedTestWithRunner(ctx, defaultStreamingSpeedTestRunner())
+}
+
+// runStreamingSpeedTestWithRunner is the seam that lets tests inject
+// a fake SpeedTestRunner without exposing the channel-pair shape.
+// Production wiring goes through RunStreamingSpeedTest which builds
+// the composite at first call.
+func runStreamingSpeedTestWithRunner(ctx context.Context, runner SpeedTestRunner) (<-chan SpeedTestSample, <-chan StreamingSpeedFinal) {
+	// Buffered enough so a fast-emitting engine doesn't block on
+	// our forwarder; sized to match livetest.SubscribeBufferSize
+	// for parity with the dashboard SSE consumer.
+	updates := make(chan SpeedTestSample, 64)
+	final := make(chan StreamingSpeedFinal, 1)
+
+	go func() {
+		defer close(updates)
+		defer close(final)
+
+		if runner == nil {
+			final <- StreamingSpeedFinal{
+				RunErr: errStreamingSpeedNoRunner,
+			}
+			return
+		}
+
+		res, samples, err := runner.Run(ctx)
+		if err != nil {
+			final <- StreamingSpeedFinal{RunErr: err}
+			return
+		}
+
+		// Forward samples until the engine closes the channel.
+		// Defensive against a runner that returns nil samples
+		// despite the contract — treat as "no live samples,
+		// straight to final" rather than blocking forever.
+		if samples != nil {
+			for {
+				select {
+				case s, ok := <-samples:
+					if !ok {
+						samples = nil
+						break
+					}
+					select {
+					case updates <- s:
+					case <-ctx.Done():
+						// Best-effort emit final with
+						// ctx.Err() so SSE consumers see
+						// a clean error event. We still
+						// drain the engine's samples
+						// channel implicitly when this
+						// goroutine returns and the GC
+						// reclaims it.
+						final <- StreamingSpeedFinal{RunErr: ctx.Err()}
+						return
+					}
+				case <-ctx.Done():
+					final <- StreamingSpeedFinal{RunErr: ctx.Err()}
+					return
+				}
+				if samples == nil {
+					break
+				}
+			}
+		}
+
+		final <- StreamingSpeedFinal{Result: res}
+	}()
+
+	return updates, final
+}
+
+// errStreamingSpeedNoRunner is the sentinel emitted when no engine is
+// configured — defensive guard so a misconfigured server returns a
+// clean error event instead of hanging the EventSource indefinitely.
+var errStreamingSpeedNoRunner = streamingSpeedErr("streaming speed runner: no engine configured")
+
+type streamingSpeedErr string
+
+func (e streamingSpeedErr) Error() string { return string(e) }
+
+// defaultStreamingSpeedTestRunner constructs the production composite
+// runner used by RunStreamingSpeedTest. Lazily built so tests that
+// inject their own runner via runStreamingSpeedTestWithRunner do not
+// pay the cost of probing for the upstream speedtest-go library.
+func defaultStreamingSpeedTestRunner() SpeedTestRunner {
+	primary := NewSpeedTestGoRunner()
+	fallback := NewOoklaCLIRunner()
+	return NewCompositeSpeedTestRunner(primary, fallback)
+}

--- a/internal/collector/speedtest_stream_test.go
+++ b/internal/collector/speedtest_stream_test.go
@@ -1,0 +1,283 @@
+package collector
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	internal "github.com/mcdays94/nas-doctor/internal"
+)
+
+// fakeStreamingSpeedRunner is a hand-rolled SpeedTestRunner for the
+// streaming-wrapper tests. The runner emits the configured samples
+// (in order, with ~no delay) onto the channel returned from Run,
+// closes the channel, and returns the configured result/err.
+type fakeStreamingSpeedRunner struct {
+	samples []SpeedTestSample
+	result  *internal.SpeedTestResult
+	err     error
+	// blockUntil, if non-nil, is closed by the test to signal
+	// "now drain samples and return" — useful for cancellation
+	// races.
+	blockUntil <-chan struct{}
+}
+
+func (f *fakeStreamingSpeedRunner) Run(ctx context.Context) (*internal.SpeedTestResult, <-chan SpeedTestSample, error) {
+	if f.err != nil {
+		return nil, nil, f.err
+	}
+	out := make(chan SpeedTestSample, len(f.samples)+1)
+	go func() {
+		defer close(out)
+		if f.blockUntil != nil {
+			select {
+			case <-f.blockUntil:
+			case <-ctx.Done():
+				return
+			}
+		}
+		for _, s := range f.samples {
+			select {
+			case out <- s:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return f.result, out, nil
+}
+
+// streamAssertCompletesWithin enforces the 5s deadline standard so a
+// channel-ordering deadlock is loud-and-fast instead of silent-and-
+// slow under the default `go test` 10-minute timeout. Mirrors the
+// helper in the api package's service_check_test_stream_test.go.
+func streamAssertCompletesWithin(t *testing.T, d time.Duration) func() {
+	t.Helper()
+	timer := time.AfterFunc(d, func() {
+		buf := make([]byte, 1<<20)
+		n := runtime.Stack(buf, true)
+		panic("test exceeded " + d.String() + " deadline; goroutine dump:\n" + string(buf[:n]))
+	})
+	return func() { timer.Stop() }
+}
+
+func TestRunStreamingSpeedTest_ForwardsSamplesThenFinal(t *testing.T) {
+	stop := streamAssertCompletesWithin(t, 5*time.Second)
+	defer stop()
+
+	want := []SpeedTestSample{
+		{Phase: SpeedTestPhaseLatency, At: time.Now(), LatencyMs: 5.0},
+		{Phase: SpeedTestPhaseDownload, At: time.Now(), Mbps: 100.0},
+		{Phase: SpeedTestPhaseDownload, At: time.Now(), Mbps: 200.0},
+		{Phase: SpeedTestPhaseUpload, At: time.Now(), Mbps: 50.0},
+	}
+	wantResult := &internal.SpeedTestResult{
+		DownloadMbps: 200.0,
+		UploadMbps:   50.0,
+		LatencyMs:    5.0,
+		Engine:       internal.SpeedTestEngineSpeedTestGo,
+	}
+	runner := &fakeStreamingSpeedRunner{samples: want, result: wantResult}
+
+	updates, final := runStreamingSpeedTestWithRunner(context.Background(), runner)
+
+	var got []SpeedTestSample
+	for s := range updates {
+		got = append(got, s)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d samples, want %d", len(got), len(want))
+	}
+	for i, s := range got {
+		if s.Phase != want[i].Phase {
+			t.Errorf("sample[%d].Phase = %v, want %v", i, s.Phase, want[i].Phase)
+		}
+	}
+
+	fin, ok := <-final
+	if !ok {
+		t.Fatalf("final channel closed without emitting")
+	}
+	if fin.RunErr != nil {
+		t.Fatalf("RunErr = %v, want nil", fin.RunErr)
+	}
+	if fin.Result == nil || fin.Result.DownloadMbps != wantResult.DownloadMbps {
+		t.Fatalf("Result mismatch: %+v", fin.Result)
+	}
+
+	// final must close after the value is emitted so SSE handler's
+	// for-range terminates cleanly.
+	if _, ok := <-final; ok {
+		t.Errorf("final channel did not close after emit")
+	}
+}
+
+func TestRunStreamingSpeedTest_RunnerErrorSurfacesInFinal(t *testing.T) {
+	stop := streamAssertCompletesWithin(t, 5*time.Second)
+	defer stop()
+
+	wantErr := errors.New("engine offline")
+	runner := &fakeStreamingSpeedRunner{err: wantErr}
+
+	updates, final := runStreamingSpeedTestWithRunner(context.Background(), runner)
+
+	// Updates channel must close empty when the engine errors
+	// before the first sample.
+	var samples []SpeedTestSample
+	for s := range updates {
+		samples = append(samples, s)
+	}
+	if len(samples) != 0 {
+		t.Errorf("got %d samples, want 0 on engine error", len(samples))
+	}
+
+	fin, ok := <-final
+	if !ok {
+		t.Fatalf("final channel closed without emitting")
+	}
+	if !errors.Is(fin.RunErr, wantErr) {
+		t.Errorf("RunErr = %v, want wraps %v", fin.RunErr, wantErr)
+	}
+	if fin.Result != nil {
+		t.Errorf("Result = %+v, want nil on error", fin.Result)
+	}
+}
+
+func TestRunStreamingSpeedTest_CtxCancelClosesPromptly(t *testing.T) {
+	stop := streamAssertCompletesWithin(t, 5*time.Second)
+	defer stop()
+
+	// Block the runner until cancellation so the wrapper's select
+	// observes ctx.Done() rather than samples-channel-close.
+	gate := make(chan struct{})
+	runner := &fakeStreamingSpeedRunner{
+		blockUntil: gate,
+		samples: []SpeedTestSample{
+			{Phase: SpeedTestPhaseDownload, Mbps: 1.0},
+		},
+		result: &internal.SpeedTestResult{DownloadMbps: 1.0},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	updates, final := runStreamingSpeedTestWithRunner(ctx, runner)
+
+	cancel()
+
+	// Both channels must close within 2s of cancellation. We don't
+	// assert anything about the contents — the engine may have
+	// returned context.Canceled OR the wrapper may have caught
+	// ctx.Done() first and emitted ctx.Err() into final. Either
+	// path is correct; what matters is no deadlock.
+	doneUpdates := make(chan struct{})
+	doneFinal := make(chan struct{})
+	go func() {
+		for range updates {
+		}
+		close(doneUpdates)
+	}()
+	go func() {
+		for range final {
+		}
+		close(doneFinal)
+	}()
+
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	select {
+	case <-doneUpdates:
+	case <-deadline.C:
+		t.Fatal("updates channel did not close within 2s of ctx cancel")
+	}
+	select {
+	case <-doneFinal:
+	case <-deadline.C:
+		t.Fatal("final channel did not close within 2s of ctx cancel")
+	}
+	close(gate) // release the gated runner goroutine
+}
+
+func TestRunStreamingSpeedTest_NilRunnerYieldsCleanError(t *testing.T) {
+	stop := streamAssertCompletesWithin(t, 5*time.Second)
+	defer stop()
+
+	updates, final := runStreamingSpeedTestWithRunner(context.Background(), nil)
+
+	for range updates {
+	}
+	fin, ok := <-final
+	if !ok {
+		t.Fatalf("final channel closed without emitting")
+	}
+	if fin.RunErr == nil {
+		t.Fatal("expected RunErr on nil-runner path, got nil")
+	}
+	if fin.Result != nil {
+		t.Errorf("Result = %+v, want nil on nil-runner path", fin.Result)
+	}
+}
+
+// TestRunStreamingSpeedTest_NilSamplesChannel — defensive guard
+// against a runner that violates the contract by returning (result,
+// nil-channel, nil-err). The wrapper must not panic and must still
+// emit a terminal value onto final. Mirrors the StreamingTraceFinal
+// equivalent in traceroute_stream_test.go.
+func TestRunStreamingSpeedTest_NilSamplesChannel(t *testing.T) {
+	stop := streamAssertCompletesWithin(t, 5*time.Second)
+	defer stop()
+
+	runner := &nilSamplesRunner{result: &internal.SpeedTestResult{DownloadMbps: 1.0}}
+	updates, final := runStreamingSpeedTestWithRunner(context.Background(), runner)
+	for range updates {
+	}
+	fin, ok := <-final
+	if !ok {
+		t.Fatalf("final channel closed without emitting")
+	}
+	if fin.Result == nil {
+		t.Errorf("Result missing despite engine returning non-nil result; fin=%+v", fin)
+	}
+}
+
+type nilSamplesRunner struct {
+	result *internal.SpeedTestResult
+}
+
+func (n *nilSamplesRunner) Run(_ context.Context) (*internal.SpeedTestResult, <-chan SpeedTestSample, error) {
+	return n.result, nil, nil
+}
+
+// TestStreamingSpeedTestRunnerType_Compatibility — type-check that
+// RunStreamingSpeedTest matches the StreamingSpeedTestRunner alias.
+// If a future refactor changes the return shape, this fails cleanly
+// with a compile-time error rather than a confusing runtime mismatch
+// in service_check_test_stream.go.
+func TestStreamingSpeedTestRunnerType_Compatibility(t *testing.T) {
+	var _ StreamingSpeedTestRunner = RunStreamingSpeedTest
+}
+
+// regression guard for race-detector flake: the wrapper must not
+// emit duplicate finals if the engine errors AND ctx is cancelled
+// concurrently.
+func TestRunStreamingSpeedTest_FinalEmittedExactlyOnce(t *testing.T) {
+	stop := streamAssertCompletesWithin(t, 5*time.Second)
+	defer stop()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		runner := &fakeStreamingSpeedRunner{err: errors.New("boom")}
+		_, final := runStreamingSpeedTestWithRunner(context.Background(), runner)
+		count := 0
+		for range final {
+			count++
+		}
+		if count != 1 {
+			t.Errorf("final emitted %d times, want exactly 1", count)
+		}
+	}()
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Extends `/api/v1/service-checks/test-stream` (introduced for `type=traceroute` in v0.9.15 / PR #317) to also support `type=speed`. The Settings page Test button for speed-type service checks now streams phase + sample events via SSE instead of blocking the user on a 30-60s Ookla CLI invocation. Same defensive SSE measures inherited from #317 (charset, no-transform, X-Accel-Buffering, padding, 1Hz keepalive).

Closes #318. Refs #224 (speed half deferred from the v0.9.15 traceroute slice).

## Scope

One shared endpoint, switch on `cfg.Type` server-side:

- `traceroute` → existing per-cycle hop event path (unchanged from PR #317).
- `speed` → new path: phase_change + sample events derived from a streaming speed-test runner.
- everything else → 400 with hint pointing at the synchronous `/test` endpoint. Hint message updated to enumerate **both** supported streaming types.

The dashboard speedtest card's `/api/v1/speedtest/run` + `/stream/{id}` pair (v0.9.11) is untouched. Test-button traffic is deliberately separate from that singleton — Test invocations are ephemeral, don't collapse onto the dashboard's in-flight test, and don't write history.

The synchronous `POST /api/v1/service-checks/test` endpoint is unchanged for external callers.

## Backend changes

### `internal/collector/speedtest_stream.go` (new)

- `StreamingSpeedTestRunner` function type + `StreamingSpeedFinal` value type, mirror-shape of the existing `StreamingTracerouteRunner` / `StreamingTraceFinal` from PR #317.
- `RunStreamingSpeedTest(ctx)` — production runner. Wraps the existing composite `SpeedTestRunner` (speedtest-go primary + Ookla CLI fallback) and forwards per-phase samples onto a channel. Deliberately reuses `SpeedTestRunner` so process-group SIGKILL semantics from v0.9.14 #304 are inherited end-to-end.
- `runStreamingSpeedTestWithRunner` — internal seam letting tests inject a fake runner without going through the production composite construction.
- Defensive guards: nil runner → clean error event, nil samples channel → still emits terminal value, ctx-cancel during sample forwarding → ctx.Err() emitted into final.

### Why a new abstraction rather than reusing `livetest.Registry`

`livetest.Registry` is the dashboard speed-test card's singleton state machine: one in-flight test at a time, multi-subscriber fan-out, history-row persistence on completion, Prometheus in-progress gauge management. None of those are desirable on the Test button path:

- Mixing Test traffic into the singleton would make the settings Test button collapse onto whatever scheduled or manual run is currently driving the dashboard, breaking the existing "Test = run now, ad hoc" UX from #170.
- Test invocations are ephemeral by design (existing convention from the sync `/test` flow), so no completion-handler persistence wiring is appropriate here.

The new `StreamingSpeedTestRunner` is a thin channel-pair wrapper around the engine; ~150 LOC, no shared state.

### `internal/api/api.go`

- New `streamingSpeedTestRunner collector.StreamingSpeedTestRunner` test seam on `*Server`.

### `internal/api/service_check_test_stream.go`

- `handleTestServiceCheckStream` now switches on `cfg.Type` and dispatches to `streamTraceServiceCheck` (existing) or `streamSpeedServiceCheck` (new). Default branch returns 400 with updated hint enumerating both types.
- Shared `writeStreamHeaders` helper so both paths use identical defensive headers and write-deadline handling.
- Speed branch wire format mirrors v0.9.11 dashboard speedtest contract verbatim:
  - `start` → `{target, started_at}` (target echoes whatever the user submitted; defaults to `"speedtest"` when empty for honesty)
  - `phase_change` → `{phase, phase_index, total_phases:3}` — derived server-side from sample-phase transitions (one event per phase, NOT per sample)
  - `sample` → `{phase, sample_index, ts, mbps, latency_ms}`
  - `error` → `{message}` (only on engine error, before result; matches dashboard contract)
  - `result` → canonical `ServiceCheckResult` built via `scheduler.RunCheck` with `SetSpeedTestRunner` injecting a stub returning the streamed engine result. Thresholds (`ContractedDownMbps` / `ContractedUpMbps` / `MarginPct` / three-state up/degraded/down logic) applied identically to the sync path so JS reuses `renderServiceCheckDetails` verbatim.
  - `end` → `{duration_seconds}`
- Same nil-channel range guard as the trace branch (v0.9.15-rc1 lesson).

## Frontend changes

### `internal/api/templates/settings.html`

- `testServiceCheck` branches `sc.type === "speed"` → `runSpeedTestStream` instead of the sync `fetch`.
- `runSpeedTestStream` consumes the SSE response via `fetch` + `ReadableStream` + `TextDecoder`, hand-parses SSE wire frames, and dispatches via `handleSpeedEvent`. `AbortController` wires the fetch to cancellation.
- `handleSpeedEvent` updates a `liveState` object on each event and refreshes the toast:
  - `phase_change` → headline like `"Speed test — phase 2/3: download"`.
  - `sample` → headline + per-phase live readout (`"latency 5.3 ms"` for latency phase, `"download 723.4 Mbps"` for throughput phases).
  - `error` → `"Speed test engine error: <message>"` toast (so users see the engine-specific reason before the canonical result event fires).
  - `result` → reuses `renderServiceCheckDetails` per-type renderer for final pass/fail summary.
- Anti-pattern guards (AGENTS.md): all new JS uses `//` line comments only, no `/* */` block comments → safe from the v0.9.9-rc1 trap. settings.html is embedded via `embed.FS`, not a Go raw-string literal, so backticks in line comments are harmless (DashboardJS / SharedCSS not affected).

## Tests

### New (collector layer)

`internal/collector/speedtest_stream_test.go` — 7 tests:
- `TestRunStreamingSpeedTest_ForwardsSamplesThenFinal` — happy path, samples in order, terminal value emitted, channels close after.
- `TestRunStreamingSpeedTest_RunnerErrorSurfacesInFinal` — engine error → empty updates channel + RunErr in final.
- `TestRunStreamingSpeedTest_CtxCancelClosesPromptly` — both channels close within 2s of ctx cancel.
- `TestRunStreamingSpeedTest_NilRunnerYieldsCleanError` — defensive guard, no panic, error event emitted.
- `TestRunStreamingSpeedTest_NilSamplesChannel` — defensive guard for runner contract violation.
- `TestStreamingSpeedTestRunnerType_Compatibility` — compile-time guard the production `RunStreamingSpeedTest` matches the function-type alias.
- `TestRunStreamingSpeedTest_FinalEmittedExactlyOnce` — race-detector regression guard.

All use the 5s deadline helper (mirrored from #317's `assertCompletesWithin`) so a goroutine-ordering deadlock fails loud-and-fast instead of waiting out the default 10-min timeout.

### New (handler layer)

`internal/api/service_check_test_stream_test.go`:
- `TestServiceChecksTestStream_SpeedHappyPath` — full `start → phase_change×3 → sample×4 → result → end` event sequence, parseable JSON payloads, phase derivation produces exactly one `phase_change` per phase transition (NOT per sample), `download_mbps` and `upload_mbps` propagated through the canonical result event.
- `TestServiceChecksTestStream_SpeedCtxCancelKillsRunner` — closes response body client-side, asserts injected runner exits within 2s of cancellation.
- `TestServiceChecksTestStream_SpeedUpdatesCloseBeforeFinal` — pins the nil-channel range edge case for the speed branch (v0.9.15-rc1 burn lesson).
- `TestServiceChecksTestStream_SpeedEngineErrorEmitsErrorEvent` — engine error before any samples → SSE stream still produces coherent `start → error → result(status≠up) → end` sequence.

### Updated

- `TestServiceChecksTestStream_NonTraceReturns400` → renamed `TestServiceChecksTestStream_NonTraceNonSpeedReturns400`. Asserts the updated 400 hint mentions BOTH `traceroute` and `speed` so direct-curl callers see the full enumerated set.
- `TestServiceChecksTestStream_TraceHappyPath` from #317 still passes — regression guard for the original slice.

### New (frontend wiring guard)

- `TestServiceChecksHTML_TestStreamSpeedWiring` — string-match guard that settings.html contains `runSpeedTestStream`, `sc.type === \"speed\"` branch, and references the SSE `\"sample\"` + `\"phase_change\"` event names.

## Pre-push checks (§4b)

- ✅ `go build ./...`
- ✅ `go test ./... -race -count=1` — green
- ✅ `go test ./internal/api/ ./internal/collector/ ./internal/livetest/ -race -count=3` — race-clean
- ✅ `go vet ./...` — clean
- ✅ `gofmt -l` — no drift in files I touched
- ✅ `TestSettingsTemplate_JSBlocksParse` still passes — confirms my settings.html JS additions don't break the script parse (no `*/`-inside-block-comments, no backticks-in-comments anti-patterns).

## Acceptance criteria (issue #318)

- [x] `POST /api/v1/service-checks/test-stream` accepts `type=speed` (in addition to existing `type=traceroute`).
- [x] Speed Test button in Settings UI streams phase + sample events, then a final result, instead of blocking until completion.
- [x] Cancellation honoured: closing the EventSource client-side terminates the speedtest subprocess (process-group kill from v0.9.14 inherited via the engine layer).
- [x] Reuses (does not duplicate) the SpeedTestRunner abstraction from v0.9.11; new `StreamingSpeedTestRunner` is a thin channel-pair wrapper specifically scoped to the ad-hoc Test path so it doesn't collapse onto the dashboard's `livetest.Registry` singleton.
- [x] Per-type Settings JS branching extends cleanly: `type=traceroute` → existing path, `type=speed` → new path, others → existing synchronous endpoint.
- [x] Same defensive SSE measures (charset, no-transform, X-Accel-Buffering, padding, keepalive) inherited from #317.

## Notes for UAT

- On a machine without an Ookla CLI installed AND without the showwin/speedtest-go primary working, the `/test-stream` endpoint emits an `error` SSE event before the terminal `result` event with status=down. The Alpine container has the bundled binary so production + UAT have at least the fallback engine.
- CF Tunnel + Access content-aware buffering caveat from v0.9.12 still applies — direct LAN streaming works; through-proxy may hold per-sample events until end-of-stream. The dashboard speedtest card already documents this in the README's Network Speed Test section; the same caveat applies here unchanged.
- Test runs from the Settings page do NOT write a `speedtest_history` row, do NOT update `LastSpeedTestAttempt`, and do NOT touch the `nasdoctor_speedtest_in_progress` Prometheus gauge — Test is ephemeral by convention. The dashboard card and scheduled cron path remain the sole writers.