### PR TITLE
feat(dashboard): render standby drives as placeholder rows (#324)

### DIFF
--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -404,7 +404,13 @@ sections.drives = function(sn, st) {
   h += '<div class="section-block" data-section="drives">';
   var smart = sn ? (sn.smart || []) : [];
   var disks = sn ? (sn.disks || []) : [];
-  if (smart.length > 0 || disks.length > 0) {
+  /* Issue #324: drives that were in standby during the most recent SMART
+     scan are reported in snap.smart_standby_devices but NOT included in
+     snap.smart (since we have no SMART data for them). Render them as
+     placeholder rows below the active drives so the user sees the full
+     drive count and an explanation of why no SMART data is shown. */
+  var standbyDevices = sn ? (sn.smart_standby_devices || []) : [];
+  if (smart.length > 0 || disks.length > 0 || standbyDevices.length > 0) {
     h += '<div>';
     var healthOk = 0, healthWarn = 0, healthCrit = 0;
     for (var hc = 0; hc < smart.length; hc++) {
@@ -413,7 +419,7 @@ sections.drives = function(sn, st) {
       else if ((smart[hc].temperature_c || 0) >= 50 || smart[hc].reallocated_sectors > 0 || smart[hc].pending_sectors > 0) healthWarn++;
       else healthOk++;
     }
-    h += '<div class="section-title" style="display:flex;align-items:center;gap:12px">Drives (' + (smart.length || disks.length) + ')';
+    h += '<div class="section-title" style="display:flex;align-items:center;gap:12px">Drives (' + ((smart.length + standbyDevices.length) || disks.length) + ')';
     h += '<span class="health-summary" style="display:inline-flex;gap:8px;font-size:11px;color:var(--text-quaternary);font-weight:400;text-transform:none;letter-spacing:0">';
     if (healthOk > 0) h += '<span style="display:flex;align-items:center;gap:3px"><span style="width:6px;height:6px;border-radius:50%;background:var(--green)"></span>' + healthOk + ' ok</span>';
     if (healthWarn > 0) h += '<span style="display:flex;align-items:center;gap:3px"><span style="width:6px;height:6px;border-radius:50%;background:var(--amber)"></span>' + healthWarn + ' warn</span>';
@@ -490,6 +496,23 @@ sections.drives = function(sn, st) {
 
         h += '</div>';
       }
+    }
+
+    /* Issue #324: render placeholder rows for drives currently in standby.
+       Below the active-drive rows but above the storage list, since
+       standby drives are physical drives without SMART data, not storage
+       mount points. Visually de-emphasised (opacity, no temp/sparkline)
+       so users can scan past them when triaging real-drive issues. */
+    for (var stbI = 0; stbI < standbyDevices.length; stbI++) {
+      var stbDev = standbyDevices[stbI];
+      h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:10px 12px;margin-bottom:6px;opacity:0.65">';
+      h += '<div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">';
+      h += '<span class="status-dot unknown"></span>';
+      h += '<span style="font-weight:600;font-size:13px;min-width:55px">' + esc(stbDev) + '</span>';
+      h += '<span style="font-size:11px;color:var(--text-quaternary);background:var(--bg-elevated);padding:1px 6px;border-radius:4px">standby</span>';
+      h += '<span style="font-size:12px;color:var(--text-tertiary);flex:1">No SMART data: drive is in standby and <a href="/settings#card-advanced" style="color:var(--accent)">Wake drives for SMART check</a> is off.</span>';
+      h += '</div>';
+      h += '</div>';
     }
 
     var usedInMerge = {};

--- a/internal/api/dashboard_drives_standby_test.go
+++ b/internal/api/dashboard_drives_standby_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDashboardJS_DrivesSection_RendersStandbyPlaceholders verifies that drives
+// reported in snap.SMARTStandbyDevices are surfaced as placeholder rows in the
+// DRIVES section, instead of being silently omitted.
+//
+// Surfaced by issue #323 / fix tracked in #324: after an appdata wipe, spun-down
+// drives appear "missing" from the dashboard because the SMART snapshot only
+// contains drives actively read this cycle. The StaleSMARTChecker won't
+// force-wake them (PRD #236 user story 7 carve-out at stale_smart.go:108-111)
+// until smart_history has rows for them, so the visibility gap can persist
+// indefinitely. Pure UX fix here: honors smart.wake_drives=false as the user
+// has it set, just makes the gap visible with an explanatory message.
+func TestDashboardJS_DrivesSection_RendersStandbyPlaceholders(t *testing.T) {
+	js := DashboardJS
+
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		{"reads smart_standby_devices from snapshot", "smart_standby_devices"},
+		{"explains the in-standby state", "in standby"},
+		{"explains the wake_drives setting", "Wake drives for SMART check"},
+		{"links to advanced scan settings", "/settings#card-advanced"},
+	}
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(js, tc.substr) {
+				t.Errorf("DashboardJS missing %q (expected substring: %q)", tc.name, tc.substr)
+			}
+		})
+	}
+}
+
+// TestDashboardJS_DrivesSection_StandbyCountedInHeader pins the requirement
+// that the "Drives (N)" header in the DRIVES section counts standby drives
+// alongside actively-read ones. Without this, a user with 4 awake + 4
+// standby drives sees "Drives (4)" and reasonably concludes 4 are missing.
+//
+// The check is a substring on the count expression rather than the exact
+// formatting, so a refactor that preserves the behavior (e.g. extracting
+// the count to a helper) doesn't false-positive.
+func TestDashboardJS_DrivesSection_StandbyCountedInHeader(t *testing.T) {
+	js := DashboardJS
+
+	if !strings.Contains(js, "standbyDevices.length") {
+		t.Error("DRIVES (N) header count expression must reference standbyDevices.length so standby drives contribute to the visible count")
+	}
+}
+
+// TestDashboardJS_DrivesSection_PreservesExistingBehavior is a regression
+// guard for the active-drive render path. The standby additions must not
+// break the existing handling of awake drives with full SMART data, slot
+// labels, merged-view storage rows, or the section's outer scaffolding.
+func TestDashboardJS_DrivesSection_PreservesExistingBehavior(t *testing.T) {
+	js := DashboardJS
+
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		{"sections.drives defined", "sections.drives = function(sn, st)"},
+		{"data-section attribute", `data-section="drives"`},
+		{"reads sn.smart", "sn.smart || []"},
+		{"reads sn.disks", "sn.disks || []"},
+		{"iterates active smart array", "for (var si = 0; si < smart.length; si++)"},
+		{"renders slot label from array_slot", "s.array_slot"},
+		{"renders NO DATA badge for data_available=false drives", ">NO DATA<"},
+		{"renders merged-view storage rows for unmatched disks", "unmatchedDisks"},
+	}
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(js, tc.substr) {
+				t.Errorf("DashboardJS regression: existing behavior %q lost (expected substring: %q)", tc.name, tc.substr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #324. Surfaced by #323.

## Why

After an appdata wipe, spun-down drives appear "missing" from the dashboard DRIVES section because the SMART snapshot only includes drives actually read this cycle. The `StaleSMARTChecker` won't force-wake them (PRD #236 user story 7 carve-out at `stale_smart.go:108-111`) until `smart_history` has rows, so the visibility gap can persist indefinitely.

Pure UX fix: honor `smart.wake_drives=false` as the user has it set, just make the gap visible with an explanation that connects cause and fix.

## What changes

- `sections.drives` in `DashboardJS` reads `snap.smart_standby_devices` alongside `snap.smart` and `snap.disks`.
- The `Drives (N)` header count now includes standby drives. Users with 4 active + 4 standby no longer see `Drives (4)` and conclude 4 are missing.
- Each standby drive renders as a minimal placeholder row below the active-drive list: device path, "standby" pill, and the message _"No SMART data: drive is in standby and **Wake drives for SMART check** is off."_ with a link to `/settings#card-advanced`.
- Standby rows are rendered at `opacity: 0.65` and lack the temp / sparkline / health badges, so users can visually scan past them when triaging real-drive issues.

## What does NOT change

- Default scan behaviour. `smart.wake_drives=false` stays.
- The PRD #236 user story 7 carve-out in `stale_smart.go` stays.
- Existing active-drive render path is unchanged (regression guard test pins it).

## Tests (3 new functions, 13 sub-asserts)

| Test | Pins |
|---|---|
| `TestDashboardJS_DrivesSection_RendersStandbyPlaceholders` | 4 sub-asserts: reads `smart_standby_devices`, "in standby" copy, "Wake drives for SMART check" copy, `/settings#card-advanced` link |
| `TestDashboardJS_DrivesSection_StandbyCountedInHeader` | Count expression references `standbyDevices.length` |
| `TestDashboardJS_DrivesSection_PreservesExistingBehavior` | 8 sub-asserts: existing render path scaffolding, slot labels, NO DATA badge, merged-view storage rows |

Full repo `go test ./...` green. Manual visual UAT recommended on real Unraid hardware with a spun-down drive (`hdparm -y /dev/sdX` on a non-array drive can simulate).

## Recommended merge path

- Single-PR scope, no schema change, no API change, no behaviour change.
- Suggested: `gh pr merge <N> --squash --admin` after sanity-checking the JS renders correctly (load `/` on UAT instance, look at DRIVES section).
- Or bundle with #325 (if that lands as a code change) into a v0.10.1 release. Up to you.

## References

- #323 — user report that surfaced this
- #324 — issue body with full investigation trail
- `internal/collector/smart.go:81-94` — where standby drives are dropped from `results`
- `internal/scheduler/stale_smart.go:108-111` — the new-drive carve-out