### PR TITLE
fix(scheduler): recover from panics in all four scheduler goroutines (#325)

### DIFF
--- a/internal/scheduler/panic_recovery.go
+++ b/internal/scheduler/panic_recovery.go
@@ -1,0 +1,61 @@
+package scheduler
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+// runWithRecover wraps a single tick's work in a panic recovery so a
+// panic in one cycle does not kill the goroutine and silently stop
+// collection (issue #325, surfaced by #323).
+//
+// Background: prior to this fix, every goroutine started by
+// Scheduler.Start had the pattern
+//
+//	go func() {
+//	    for {
+//	        select {
+//	        case <-ticker.C:
+//	            s.RunOnce() // ← if this panics, the goroutine dies
+//	        case <-s.stop:
+//	            return
+//	        }
+//	    }
+//	}()
+//
+// with no recover() anywhere. A panic in any sub-collector (a stale
+// row in smart_history referencing a vanished device path, an unexpected
+// JSON shape in a settings field, etc.) would kill the loop. The HTTP
+// server stayed up, the dashboard rendered off the last cached
+// snapshot, but new collection silently stopped. From the user's
+// perspective the only signal was "trend chart flat-lines on date X" —
+// hence #162 and #323.
+//
+// After this fix, every per-tick invocation is wrapped:
+//
+//	case <-ticker.C:
+//	    s.runWithRecover("main-scan", s.RunOnce)
+//
+// A panic is logged at Error level with the panic value, the loop name,
+// and the full stack trace. The wrapper returns normally so the outer
+// select loop continues on the next tick. The underlying bug isn't
+// fixed, but the failure mode is now visible-and-self-recovering
+// instead of invisible-and-permanent.
+//
+// The helper is defensive against a nil logger so it's safe to call
+// from any code path, including future ones that might construct a
+// bare Scheduler in a test harness.
+func (s *Scheduler) runWithRecover(loop string, fn func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			if s.logger != nil {
+				s.logger.Error("scheduler goroutine recovered from panic",
+					"loop", loop,
+					"panic", fmt.Sprint(r),
+					"stack", string(debug.Stack()),
+				)
+			}
+		}
+	}()
+	fn()
+}

--- a/internal/scheduler/panic_recovery_test.go
+++ b/internal/scheduler/panic_recovery_test.go
@@ -1,0 +1,126 @@
+package scheduler
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// newTestSchedulerForPanicRecovery builds a minimal *Scheduler that's
+// only valid for exercising runWithRecover. The helper only reads
+// s.logger, so we leave the other fields zero.
+func newTestSchedulerForPanicRecovery(buf *bytes.Buffer) *Scheduler {
+	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	return &Scheduler{logger: logger}
+}
+
+// TestScheduler_RunWithRecover_RecoversFromPanic verifies the panic-recovery
+// helper introduced for #325: a panic inside the wrapped function must not
+// propagate out, so the caller's outer goroutine loop continues across
+// panics instead of silently dying.
+//
+// Surfaced by #323 / #325 audit, and originally hypothesised in #162's
+// first comment back in April: prior to this fix, a panic in any of the
+// scheduler goroutines killed it permanently because none of them had
+// recover() coverage. The HTTP server stayed up and the dashboard
+// rendered off the last cached snapshot, but new collection silently
+// stopped. The fix here converts that failure mode from invisible-and-
+// permanent to visible-and-self-recovering.
+func TestScheduler_RunWithRecover_RecoversFromPanic(t *testing.T) {
+	var buf bytes.Buffer
+	s := newTestSchedulerForPanicRecovery(&buf)
+
+	didPanic := func() (panicked bool) {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		s.runWithRecover("test-loop", func() {
+			panic("deliberate test panic")
+		})
+		return false
+	}()
+	if didPanic {
+		t.Fatal("runWithRecover let the panic propagate out; the goroutine would have died")
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "deliberate test panic") {
+		t.Errorf("log output missing panic value:\n%s", logged)
+	}
+	if !strings.Contains(logged, "test-loop") {
+		t.Errorf("log output missing loop name (so operators can identify which scheduler subsystem panicked):\n%s", logged)
+	}
+	if !strings.Contains(logged, "level=ERROR") {
+		t.Errorf("expected ERROR-level log entry; panic recovery is severe enough to warrant ERROR not WARN:\n%s", logged)
+	}
+	if !strings.Contains(logged, "stack") {
+		t.Errorf("log output missing stack-trace key; without it operators can't tell which call site panicked:\n%s", logged)
+	}
+}
+
+// TestScheduler_RunWithRecover_PassthroughOnNormalReturn verifies that
+// the wrapper is transparent when the wrapped function completes
+// normally (no panic). No log entry, no side effects.
+func TestScheduler_RunWithRecover_PassthroughOnNormalReturn(t *testing.T) {
+	var buf bytes.Buffer
+	s := newTestSchedulerForPanicRecovery(&buf)
+
+	called := false
+	s.runWithRecover("test-loop", func() {
+		called = true
+	})
+
+	if !called {
+		t.Fatal("runWithRecover did not invoke the wrapped function on the normal path")
+	}
+	if buf.Len() > 0 {
+		t.Errorf("runWithRecover wrote to the logger on the normal (no-panic) path:\n%s", buf.String())
+	}
+}
+
+// TestScheduler_RunWithRecover_SurvivesMultiplePanics verifies that the
+// wrapper can be invoked repeatedly across multiple panic events, which
+// is the actual property the scheduler relies on (one bad tick must not
+// poison subsequent ticks).
+func TestScheduler_RunWithRecover_SurvivesMultiplePanics(t *testing.T) {
+	var buf bytes.Buffer
+	s := newTestSchedulerForPanicRecovery(&buf)
+
+	for i := 0; i < 5; i++ {
+		s.runWithRecover("test-loop", func() {
+			panic("tick panic")
+		})
+	}
+
+	// All 5 panics should be logged as separate ERROR entries.
+	logged := buf.String()
+	count := strings.Count(logged, "scheduler goroutine recovered from panic")
+	if count != 5 {
+		t.Errorf("expected 5 separate panic-recovery log entries, got %d:\n%s", count, logged)
+	}
+}
+
+// TestScheduler_RunWithRecover_HandlesNilLogger ensures the helper
+// does not itself panic if Scheduler.logger is nil. Production always
+// wires a logger via New(), but defensive code should not assume it.
+func TestScheduler_RunWithRecover_HandlesNilLogger(t *testing.T) {
+	s := &Scheduler{} // logger left nil intentionally
+
+	didPanic := func() (panicked bool) {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		s.runWithRecover("test-loop", func() {
+			panic("with nil logger")
+		})
+		return false
+	}()
+	if didPanic {
+		t.Fatal("runWithRecover with nil logger should silently swallow the panic, not propagate it")
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -228,15 +228,17 @@ func (s *Scheduler) Start() {
 		"global_interval", s.interval,
 		"tick_interval", tickInterval,
 	)
-	// Main diagnostic collection loop
+	// Main diagnostic collection loop. Per-tick work is wrapped in
+	// runWithRecover (#325) so a panic in any sub-collector doesn't
+	// silently kill the goroutine and stop collection forever.
 	go func() {
-		s.RunOnce()
+		s.runWithRecover("main-scan", s.RunOnce)
 		ticker := time.NewTicker(tickInterval)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
-				s.RunOnce()
+				s.runWithRecover("main-scan", s.RunOnce)
 			case newInterval := <-s.restart:
 				ticker.Stop()
 				// The `restart` channel carries a GLOBAL scan_interval
@@ -269,14 +271,15 @@ func (s *Scheduler) Start() {
 			}
 		}
 	}()
-	// Independent service check loop — ticks every 30s, runs due checks
+	// Independent service check loop — ticks every 30s, runs due checks.
+	// Wrapped in runWithRecover (#325).
 	go func() {
 		ticker := time.NewTicker(30 * time.Second)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
-				s.runDueServiceChecks()
+				s.runWithRecover("service-checks", s.runDueServiceChecks)
 			case <-s.stop:
 				return
 			}
@@ -286,6 +289,8 @@ func (s *Scheduler) Start() {
 	// Independent container & process stats loop — collects Docker metrics and
 	// top processes every 5 minutes for chart history (full scans happen at the
 	// configured interval which is too infrequent for granular charts).
+	// Wrapped in runWithRecover (#325); both calls share one recovery so a
+	// panic in either keeps the loop alive for the next tick.
 	go func() {
 		time.Sleep(30 * time.Second) // let first scan finish
 		ticker := time.NewTicker(5 * time.Minute)
@@ -293,58 +298,65 @@ func (s *Scheduler) Start() {
 		for {
 			select {
 			case <-ticker.C:
-				s.collectContainerStats()
-				s.collectProcessStats()
+				s.runWithRecover("container-process-stats", func() {
+					s.collectContainerStats()
+					s.collectProcessStats()
+				})
 			case <-s.stop:
 				return
 			}
 		}
 	}()
 
-	// Independent speed test loop — runs on interval or at scheduled times
+	// Independent speed test loop — runs on interval or at scheduled times.
+	// Wrapped in runWithRecover (#325); the entire tick body (timing logic
+	// plus runSpeedTest invocations) is one recovery unit because any panic
+	// inside is equally fatal to subsequent ticks.
 	go func() {
 		time.Sleep(2 * time.Minute)
-		s.runSpeedTest()
+		s.runWithRecover("speed-test-initial", s.runSpeedTest)
 		ticker := time.NewTicker(1 * time.Minute) // check every minute for schedule hits
 		defer ticker.Stop()
 		lastRun := time.Now()
 		for {
 			select {
 			case <-ticker.C:
-				s.mu.RLock()
-				schedule := s.speedTestSchedule
-				interval := s.speedTestInterval
-				s.mu.RUnlock()
-				now := time.Now()
-				if len(schedule) > 0 {
+				s.runWithRecover("speed-test", func() {
 					s.mu.RLock()
-					day := s.speedTestDay
-					freq := s.speedTestFreq
+					schedule := s.speedTestSchedule
+					interval := s.speedTestInterval
 					s.mu.RUnlock()
-					// Check if today matches the schedule day
-					dayMatch := true
-					if freq == "weekly" && day != "" {
-						dayMatch = strings.EqualFold(now.Weekday().String(), day)
-					} else if freq == "monthly" && day != "" {
-						dayNum, _ := strconv.Atoi(day)
-						dayMatch = dayNum > 0 && now.Day() == dayNum
-					}
-					// Scheduled mode: run at specific HH:MM times on matching days
-					nowHHMM := now.Format("15:04")
-					for _, t := range schedule {
-						if dayMatch && nowHHMM == t && now.Sub(lastRun) > 5*time.Minute {
+					now := time.Now()
+					if len(schedule) > 0 {
+						s.mu.RLock()
+						day := s.speedTestDay
+						freq := s.speedTestFreq
+						s.mu.RUnlock()
+						// Check if today matches the schedule day
+						dayMatch := true
+						if freq == "weekly" && day != "" {
+							dayMatch = strings.EqualFold(now.Weekday().String(), day)
+						} else if freq == "monthly" && day != "" {
+							dayNum, _ := strconv.Atoi(day)
+							dayMatch = dayNum > 0 && now.Day() == dayNum
+						}
+						// Scheduled mode: run at specific HH:MM times on matching days
+						nowHHMM := now.Format("15:04")
+						for _, t := range schedule {
+							if dayMatch && nowHHMM == t && now.Sub(lastRun) > 5*time.Minute {
+								s.runSpeedTest()
+								lastRun = now
+								break
+							}
+						}
+					} else {
+						// Interval mode
+						if now.Sub(lastRun) >= interval {
 							s.runSpeedTest()
 							lastRun = now
-							break
 						}
 					}
-				} else {
-					// Interval mode
-					if now.Sub(lastRun) >= interval {
-						s.runSpeedTest()
-						lastRun = now
-					}
-				}
+				})
 			case <-s.stop:
 				return
 			}


### PR DESCRIPTION
Closes #325. Surfaced by #323 and originally hypothesised in #162's first-comment audit.

## Why

Prior to this PR, every goroutine started by `Scheduler.Start` had the pattern:

\`\`\`go
go func() {
  for {
    select {
    case <-ticker.C:
      s.RunOnce()  // ← if this panics, the goroutine dies permanently
    case <-s.stop:
      return
    }
  }
}()
\`\`\`

with **zero** `recover()` coverage. A panic in any sub-collector (stale row in `smart_history` referencing a vanished device path, unexpected JSON shape in a settings field, malformed kernel-log entry, etc.) would kill the loop. The HTTP server stayed up, the dashboard rendered off the last cached snapshot, but new collection silently stopped. From the user's perspective the only signal was "trend chart flat-lines on date X".

This is the exact failure mode behind #162 (resolved by CA reinstall) and #323 (required appdata wipe). The actual panic source is still unknown for #323 (their pre-wipe DB is gone), but with this fix the symptom won't recur silently again: a panic now logs at ERROR level with the loop name and full stack trace, and the goroutine continues on the next tick.

## What changes

- `internal/scheduler/panic_recovery.go` (new file): `Scheduler.runWithRecover(loop, fn)` helper. Defers a `recover()`, logs Error with `loop`, `panic`, and `stack` keys, returns normally. Defensive against `nil` logger so the helper is safe from any code path.

- `internal/scheduler/scheduler.go` `Start()`: every per-tick call wrapped:
  | Loop | Wrapped function |
  |---|---|
  | `main-scan` | initial + ticker call to `s.RunOnce` |
  | `service-checks` | `s.runDueServiceChecks` (every 30s) |
  | `container-process-stats` | `s.collectContainerStats` + `s.collectProcessStats` (every 5m) |
  | `speed-test-initial` | initial `s.runSpeedTest` |
  | `speed-test` | entire tick body (timing logic + runSpeedTest invocations) |

## Tests

| Test | Pins |
|---|---|
| `TestScheduler_RunWithRecover_RecoversFromPanic` | log entry contains panic value, loop name, ERROR level, and stack-trace key |
| `TestScheduler_RunWithRecover_PassthroughOnNormalReturn` | no log spam on the normal path |
| `TestScheduler_RunWithRecover_SurvivesMultiplePanics` | 5 successive panics each produce their own log entry; no state pollution |
| `TestScheduler_RunWithRecover_HandlesNilLogger` | defensive nil-guard so the helper itself never panics on a misconfigured Scheduler |

Full repo `go test ./...` green.

## What this does NOT do

- **Fix the underlying panic source for #323.** Without @adriendecombe's pre-wipe DB we can't reproduce the specific data shape that wedged their install. The audit on #325 hypothesises stale `smart_history` rows referencing vanished device paths, or settings JSON in an unexpected shape, but it's untestable without a repro. This PR converts that failure mode from invisible-and-permanent to visible-and-self-recovering: the next time it happens, the operator gets a stack trace they can act on.
- **Add metrics for recovery counts.** Could be a follow-up if observability around "how often is this firing in the wild" becomes valuable. For now the structured log entry is enough; operators grep for `scheduler goroutine recovered from panic` if they suspect the failure mode.
- **Change any behaviour.** No new settings, no API change, no schema bump. Pure defensive hardening.

## Recommended merge path

- Independent from PR #326 (#324 dashboard fix). Either can merge first.
- Sanity-check after merge: load `wrangler tail` (or equivalent) on the UAT instance and confirm no `recovered from panic` entries appear under normal operation (none expected; the log line is opt-in, fires only when a panic actually happens).
- Could bundle both #326 and this into a v0.10.1 release once you confirm everything green on UAT, or ship them individually. Up to you.

## References

- #325 — issue body + audit findings
- #323 — original symptom that surfaced this
- #162 — earlier occurrence + the original "no recover() anywhere" hypothesis from your own first-comment investigation
- `internal/scheduler/scheduler.go:225-352` — the four goroutines that were unprotected