### PR TITLE
fix(dashboard): polish backup cold-start and disk detail history (#328)

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -346,6 +346,22 @@ type statusResponse struct {
 	// (omitempty) on the happy path so unrelated consumers of the status
 	// endpoint don't need to care. Issue #227.
 	DataEphemeral bool `json:"data_ephemeral,omitempty"`
+	// BackupMonitor surfaces the count of enabled external Borg and
+	// Duplicacy repos configured via Settings → Backup Monitors. The
+	// dashboard JS reads these counts to detect the "configured but
+	// awaiting first scan" window and render the "Initial scan pending"
+	// placeholder instead of the misleading "No backup provider detected"
+	// copy. Paths and credentials are intentionally NOT exposed — counts
+	// are sufficient signal for the render-branch decision. Absent via
+	// omitempty when both counts are zero. Issue #328.
+	BackupMonitor *backupMonitorStatus `json:"backup_monitor,omitempty"`
+}
+
+// backupMonitorStatus carries the per-provider count of enabled external
+// repos from settings. Issue #328.
+type backupMonitorStatus struct {
+	BorgCount      int `json:"borg_count"`
+	DuplicacyCount int `json:"duplicacy_count"`
 }
 
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
@@ -405,6 +421,29 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	resp.SectionHeights = settings.SectionHeights
 	resp.SectionOrder = settings.SectionOrder
 	resp.DismissedFindings = settings.DismissedFindings
+
+	// Surface enabled-only external-backup-repo counts so the dashboard
+	// JS can render the "Initial scan pending" placeholder during the
+	// post-deploy window before snap.Backup is populated (issue #328).
+	// Disabled entries are intentionally skipped — a user who has set
+	// Enabled=false should not see the awaiting placeholder forever.
+	var borgEnabled, duplicacyEnabled int
+	for _, r := range settings.BackupMonitor.Borg {
+		if r.Enabled {
+			borgEnabled++
+		}
+	}
+	for _, d := range settings.BackupMonitor.Duplicacy {
+		if d.Enabled {
+			duplicacyEnabled++
+		}
+	}
+	if borgEnabled > 0 || duplicacyEnabled > 0 {
+		resp.BackupMonitor = &backupMonitorStatus{
+			BorgCount:      borgEnabled,
+			DuplicacyCount: duplicacyEnabled,
+		}
+	}
 
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/api/api_disk_history_window_test.go
+++ b/internal/api/api_disk_history_window_test.go
@@ -61,6 +61,10 @@ func newTestServerForDiskHistory(store storage.Store) (*Server, http.Handler) {
 //
 // Issue #166.
 func TestHandleGetDisk_HoursParamUsesTimeWindow(t *testing.T) {
+	rangePoints := []storage.DiskHistoryPoint{
+		{Timestamp: time.Now().Add(-2 * time.Hour), Temperature: 31},
+		{Timestamp: time.Now().Add(-1 * time.Hour), Temperature: 32},
+	}
 	cases := []struct {
 		label string
 		hours int
@@ -73,7 +77,7 @@ func TestHandleGetDisk_HoursParamUsesTimeWindow(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.label, func(t *testing.T) {
-			spy := &spyStore{FakeStore: storage.NewFakeStore()}
+			spy := &spyStore{FakeStore: storage.NewFakeStore(), historyInRangeResp: rangePoints}
 			_, handler := newTestServerForDiskHistory(spy)
 
 			req := httptest.NewRequest("GET", "/api/v1/disks/SN1?hours="+itoa(tc.hours), nil)
@@ -94,6 +98,61 @@ func TestHandleGetDisk_HoursParamUsesTimeWindow(t *testing.T) {
 				t.Errorf("window: expected %v, got %v", wantWindow, spy.lastWindow)
 			}
 		})
+	}
+}
+
+// TestHandleGetDisk_HoursParamFallsBackToLatestSamplesWhenWindowTooSparse pins
+// the /disk/<serial> behaviour after the v0.10.2-rc1 UAT finding: the Stats
+// page showed useful temperature history for a drive via /api/v1/sparklines,
+// but /disk/<serial> defaulted to the 1D window and showed "Not enough history
+// data" because only one SMART row existed in the last 24 hours. If the chosen
+// range has fewer than two points, the API falls back to the legacy latest-N
+// history query so the disk detail page can render the same useful chart shape
+// as /stats instead of a false empty-state.
+func TestHandleGetDisk_HoursParamFallsBackToLatestSamplesWhenWindowTooSparse(t *testing.T) {
+	latestSamples := []storage.DiskHistoryPoint{
+		{Timestamp: time.Now().Add(-72 * time.Hour), Temperature: 34},
+		{Timestamp: time.Now().Add(-48 * time.Hour), Temperature: 33},
+		{Timestamp: time.Now().Add(-1 * time.Hour), Temperature: 30},
+	}
+	spy := &spyStore{
+		FakeStore:          storage.NewFakeStore(),
+		historyInRangeResp: []storage.DiskHistoryPoint{{Timestamp: time.Now().Add(-1 * time.Hour), Temperature: 30}},
+		historyResp:        latestSamples,
+	}
+	_, handler := newTestServerForDiskHistory(spy)
+
+	req := httptest.NewRequest("GET", "/api/v1/disks/5PK9RPTB?hours=24", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if spy.rangeCalls != 1 {
+		t.Errorf("expected GetDiskHistoryInRange called once, got %d", spy.rangeCalls)
+	}
+	if spy.legacyCalls != 1 {
+		t.Errorf("expected fallback GetDiskHistory called once when range has <2 points, got %d", spy.legacyCalls)
+	}
+	if spy.lastLegacyLimit != 500 {
+		t.Errorf("expected fallback latest-samples limit 500, got %d", spy.lastLegacyLimit)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	history, ok := resp["history"].([]any)
+	if !ok {
+		t.Fatalf("response history missing/wrong type: %v", resp["history"])
+	}
+	if len(history) != len(latestSamples) {
+		t.Fatalf("history len = %d; want fallback latest samples len %d", len(history), len(latestSamples))
+	}
+	last := history[len(history)-1].(map[string]any)
+	if got := int(last["temperature"].(float64)); got != 30 {
+		t.Errorf("last fallback temperature = %d; want 30", got)
 	}
 }
 

--- a/internal/api/api_extended.go
+++ b/internal/api/api_extended.go
@@ -1684,6 +1684,15 @@ func (s *Server) handleGetDisk(w http.ResponseWriter, r *http.Request) {
 			hours = 8760
 		}
 		history, err = s.store.GetDiskHistoryInRange(serial, time.Duration(hours)*time.Hour)
+		// If the chosen time window is too sparse to render a chart, fall
+		// back to the latest samples for this drive. This mirrors the /stats
+		// page's sparkline behaviour (latest N points regardless of age) and
+		// avoids a false "Not enough history data" state for drives that are
+		// polled infrequently or spend long periods in standby. See the
+		// v0.10.2-rc1 UAT finding on /disk/5PK9RPTB.
+		if err == nil && len(history) < 2 {
+			history, err = s.store.GetDiskHistory(serial, 500)
+		}
 	} else {
 		history, err = s.store.GetDiskHistory(serial, 500)
 	}

--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -774,12 +774,24 @@ sections.ups = function(sn) {
 };
 
 /* ── Section: Backup ─────────────────────────────────────────── */
-sections.backup = function(sn) {
+sections.backup = function(sn, st) {
   var esc = util.esc;
   var fmtBytes = util.fmtBytes;
   var h = '';
   h += '<div class="section-block" data-section="backup">';
   var backup = sn ? sn.backup : null;
+  /* Awaiting-first-scan detection (issue #328). When the user has
+     configured external Borg or Duplicacy repos via Settings →
+     Backup Monitors, but the first scan post-deploy hasn't landed
+     yet, the existing empty-state copy ("No backup provider
+     detected or configured") reads as a failure. Detect this
+     window via st.backup_monitor.{borg_count,duplicacy_count}
+     (set server-side in handleStatus from
+     settings.BackupMonitor.{Borg,Duplicacy}) and render a distinct
+     "Initial scan pending" placeholder. */
+  var borgConfigured = (st && st.backup_monitor && st.backup_monitor.borg_count) || 0;
+  var duplicacyConfigured = (st && st.backup_monitor && st.backup_monitor.duplicacy_count) || 0;
+  var anyConfigured = (borgConfigured + duplicacyConfigured) > 0;
   /* Duplicacy reason → severity mapping (PRD #310 §4 / issue #314).
      Mirrors the dashboard widget contract for the new per-provider
      reason set. ok=success, no_snapshots_yet=info, stale=warning,
@@ -912,6 +924,26 @@ sections.backup = function(sn) {
       h += '</div>';
     }
     h += '</div>';
+  } else if (anyConfigured) {
+    /* Awaiting-first-scan placeholder (#328). Visually distinct from a
+       failure: no red, no error pill, uses the same neutral panel
+       background as the empty state. The SYNCING badge mirrors the
+       Borg/Duplicacy "CONFIGURED" pill family so users see the
+       relationship between the placeholder and the configured-repos
+       state. */
+    var configuredParts = [];
+    if (borgConfigured > 0) configuredParts.push(borgConfigured + ' Borg repo' + (borgConfigured === 1 ? '' : 's'));
+    if (duplicacyConfigured > 0) configuredParts.push(duplicacyConfigured + ' Duplicacy repo' + (duplicacyConfigured === 1 ? '' : 's'));
+    var configuredSummary = configuredParts.join(' + ');
+    h += '<div>';
+    h += '<div class="section-title">Initial scan pending</div>';
+    h += '<div style="background:var(--bg-panel);border:1px solid var(--border);border-radius:calc(var(--radius)*1.5);padding:14px;font-size:12px;color:var(--text-tertiary);line-height:1.5">';
+    h += '<div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">';
+    h += '<span style="font-size:10px;padding:2px 6px;border-radius:4px;background:rgba(34,211,238,0.15);color:#22d3ee;font-weight:600;letter-spacing:0.5px">SYNCING</span>';
+    h += '<span style="color:var(--text-secondary)">' + esc(configuredSummary) + ' configured</span>';
+    h += '</div>';
+    h += 'First scan in progress. This message will disappear once the initial probe completes — typically within a few seconds. Configure additional repos in <a href="/settings#backup-monitors" style="color:var(--brand)">Settings &rarr; Backup Monitors</a>.';
+    h += '</div></div>';
   } else {
     h += '<div>';
     h += '<div class="section-title">Backup Monitoring</div>';

--- a/internal/api/dashboard_backup_awaiting_test.go
+++ b/internal/api/dashboard_backup_awaiting_test.go
@@ -1,0 +1,267 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mcdays94/nas-doctor/internal/storage"
+)
+
+// Issue #328 — Dashboard Backup widget renders "Initial scan pending" placeholder
+// instead of "no backup provider detected" copy when the user has configured
+// external Borg/Duplicacy repos via Settings but no scan has completed yet.
+//
+// Three cross-layer invariants are pinned here so a future refactor cannot
+// silently regress the user-visible polish:
+//
+//  1. /api/v1/status exposes backup_monitor.{borg_count,duplicacy_count} so
+//     the dashboard JS knows how many external repos are configured WITHOUT
+//     leaking paths or credentials.
+//  2. Only ENABLED entries are counted — disabled repos must not contribute
+//     to the placeholder render or the user sees "Initial scan pending"
+//     forever when they have all repos disabled.
+//  3. DashboardJS renders the "Initial scan pending" copy when the counts
+//     are non-zero AND snap.backup has no rows; the existing data-path and
+//     "no backup provider detected" empty state are preserved unchanged.
+
+// TestDashboardJS_BackupSection_RendersAwaitingFirstScan verifies the Backup
+// dashboard section renders a distinct "Initial scan pending" placeholder
+// when the user has configured external Borg/Duplicacy repos but no snapshot
+// data has landed yet (see issue #328).
+//
+// This is the post-fresh-deploy window @adriendecombe observed in the #323
+// debug thread — before #328, the dashboard rendered configured-but-no-data
+// repos with the same "No backup provider detected or configured" copy used
+// for actually-empty installs, which read as a failure. The fix introduces
+// a third rendering branch keyed on _statusData.backup_monitor counts.
+func TestDashboardJS_BackupSection_RendersAwaitingFirstScan(t *testing.T) {
+	js := DashboardJS
+
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		{"headline copy", "Initial scan pending"},
+		{"reads borg count from statusData", "backup_monitor.borg_count"},
+		{"reads duplicacy count from statusData", "backup_monitor.duplicacy_count"},
+		{"explains first-scan-in-progress state", "First scan in progress"},
+		{"links user to Backup Monitors settings", "/settings#backup-monitors"},
+	}
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(js, tc.substr) {
+				t.Errorf("DashboardJS missing %q (expected substring: %q) — required for issue #328 awaiting-first-scan placeholder", tc.name, tc.substr)
+			}
+		})
+	}
+}
+
+// TestDashboardJS_BackupSection_AwaitingPlaceholder_DistinctFromFailure pins
+// the requirement that the "Initial scan pending" state is VISUALLY distinct
+// from a real failure render. Specifically: a SYNCING pill must be present
+// (the explicit non-error cue), and the awaiting copy must not be styled
+// with the same red colour used for failed Borg/Duplicacy probes.
+//
+// This is the polish guard for #328: the bug was that configured-but-no-data
+// repos rendered as "failing" — a future refactor that conflates the
+// awaiting branch with the failure branch (or strips the SYNCING pill)
+// would regress the fix. The check covers BOTH the explicit positive cue
+// (SYNCING pill string + cyan colour) AND the absence of the red colour
+// near the "Initial scan pending" headline.
+func TestDashboardJS_BackupSection_AwaitingPlaceholder_DistinctFromFailure(t *testing.T) {
+	js := DashboardJS
+
+	// Positive cues.
+	if !strings.Contains(js, "SYNCING") {
+		t.Error(`DashboardJS missing "SYNCING" pill — the explicit "this is not a failure" visual cue must be present in the awaiting-first-scan placeholder`)
+	}
+	// Cyan colour token used by the SYNCING badge. Mirrors the
+	// "currently_running" badge from the Duplicacy renderer for visual
+	// consistency. If a future refactor changes the colour family
+	// (e.g. to amber or to red), this test catches it.
+	if !strings.Contains(js, "rgba(34,211,238,0.15)") {
+		t.Error(`DashboardJS missing cyan colour token rgba(34,211,238,0.15) used by the SYNCING badge background — the awaiting placeholder must remain visually distinct from a failure state`)
+	}
+
+	// Negative cue: no red colouring in the immediate vicinity of the
+	// "Initial scan pending" headline. The window is generous (1000
+	// chars in each direction) to catch a future refactor that re-uses
+	// the existing error-card colour palette inside the awaiting branch.
+	idx := strings.Index(js, "Initial scan pending")
+	if idx < 0 {
+		t.Fatal(`"Initial scan pending" not present at all — the headline copy regression already caught upstream; this test is a follow-on guard`)
+	}
+	start := idx - 1000
+	if start < 0 {
+		start = 0
+	}
+	end := idx + 1000
+	if end > len(js) {
+		end = len(js)
+	}
+	window := js[start:end]
+	for _, redToken := range []string{"var(--red", "#dc2626"} {
+		if strings.Contains(window, redToken) {
+			t.Errorf(`red colour token %q appears within 1000 chars of "Initial scan pending" — the awaiting placeholder must NOT look like a failure (issue #328)`, redToken)
+		}
+	}
+}
+
+// newBackupAwaitingTestServer builds a minimal Server for exercising
+// /api/v1/status with the backup-monitor settings exposure path.
+func newBackupAwaitingTestServer() *Server {
+	return &Server{
+		store:     storage.NewFakeStore(),
+		logger:    slog.Default(),
+		version:   "test",
+		startTime: time.Now(),
+	}
+}
+
+// seedSettings writes a Settings blob to the FakeStore so getSettings()
+// returns the requested shape. Mirrors the production flow that loads
+// settings from store.GetConfig(settingsConfigKey).
+func seedSettings(t *testing.T, srv *Server, s Settings) {
+	t.Helper()
+	raw, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal settings: %v", err)
+	}
+	if err := srv.store.SetConfig(settingsConfigKey, string(raw)); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+}
+
+// TestStatusEndpoint_BackupMonitorCounts_OnlyEnabled verifies that disabled
+// external Borg / Duplicacy entries do NOT contribute to the counts surfaced
+// in /api/v1/status. Without this guard, a user who toggled a repo off in
+// Settings would still see "Initial scan pending" forever — the placeholder
+// only makes sense when there's a configured-AND-enabled repo that the
+// scheduler will actually probe.
+func TestStatusEndpoint_BackupMonitorCounts_OnlyEnabled(t *testing.T) {
+	srv := newBackupAwaitingTestServer()
+	seedSettings(t, srv, Settings{
+		SettingsVersion: currentSettingsVersion,
+		BackupMonitor: BackupMonitorSettings{
+			Borg: []BorgExternalRepo{
+				{Enabled: true, RepoPath: "/mnt/borg/main"},
+				{Enabled: false, RepoPath: "/mnt/borg/disabled-a"},
+				{Enabled: false, RepoPath: "/mnt/borg/disabled-b"},
+			},
+			Duplicacy: []DuplicacyEntry{
+				{Enabled: false, Path: "/mnt/dup/disabled", Kind: "cli-repo"},
+				{Enabled: true, Path: "/mnt/dup/photos", Kind: "cli-repo"},
+			},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	rec := httptest.NewRecorder()
+	srv.handleStatus(rec, req)
+	body, _ := io.ReadAll(rec.Body)
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	bm, ok := parsed["backup_monitor"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("backup_monitor missing (would have made the awaiting placeholder unreachable): %v", parsed)
+	}
+	if got, _ := bm["borg_count"].(float64); int(got) != 1 {
+		t.Errorf("borg_count = %v; want 1 (only one Enabled=true Borg entry); disabled entries must not be counted", bm["borg_count"])
+	}
+	if got, _ := bm["duplicacy_count"].(float64); int(got) != 1 {
+		t.Errorf("duplicacy_count = %v; want 1 (only one Enabled=true Duplicacy entry); disabled entries must not be counted", bm["duplicacy_count"])
+	}
+}
+
+// TestStatusEndpoint_BackupMonitorAbsent_WhenNothingConfigured locks in
+// omitempty behavior: when neither Borg nor Duplicacy entries exist (or
+// all are disabled), the backup_monitor key is absent from the response
+// entirely. This is what allows the dashboard JS to fall through to the
+// "No backup provider detected" empty-state branch unchanged. Without
+// this, the JS would have to also count the values, duplicating the
+// truth check in two places.
+func TestStatusEndpoint_BackupMonitorAbsent_WhenNothingConfigured(t *testing.T) {
+	srv := newBackupAwaitingTestServer()
+	seedSettings(t, srv, Settings{
+		SettingsVersion: currentSettingsVersion,
+		BackupMonitor: BackupMonitorSettings{
+			Borg: []BorgExternalRepo{
+				{Enabled: false, RepoPath: "/mnt/borg/disabled"},
+			},
+			Duplicacy: []DuplicacyEntry{},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	rec := httptest.NewRecorder()
+	srv.handleStatus(rec, req)
+	body, _ := io.ReadAll(rec.Body)
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if _, present := parsed["backup_monitor"]; present {
+		t.Errorf("backup_monitor must be absent (omitempty) when nothing is enabled; got %v", parsed["backup_monitor"])
+	}
+}
+
+// TestStatusEndpoint_ExposesBackupMonitorCounts verifies /api/v1/status surfaces
+// the count of enabled Borg and Duplicacy external repos from
+// settings.BackupMonitor.{Borg,Duplicacy}. The dashboard JS reads these to
+// detect the "configured-but-not-yet-scanned" state and render the
+// "Initial scan pending" placeholder (see issue #328 + the matching
+// DashboardJS test above).
+//
+// Surface is intentionally a flat pair of integer counts. No paths, no
+// credentials — just enough signal for the JS to pick the right render
+// branch. Mirrors the data_ephemeral pattern: the server already knows
+// from settings, surface a derived flag/count for the browser to react.
+func TestStatusEndpoint_ExposesBackupMonitorCounts(t *testing.T) {
+	srv := newBackupAwaitingTestServer()
+	seedSettings(t, srv, Settings{
+		SettingsVersion: currentSettingsVersion,
+		BackupMonitor: BackupMonitorSettings{
+			Borg: []BorgExternalRepo{
+				{Enabled: true, RepoPath: "/mnt/borg/main"},
+				{Enabled: true, RepoPath: "/mnt/borg/offsite"},
+			},
+			Duplicacy: []DuplicacyEntry{
+				{Enabled: true, Path: "/mnt/dup/photos", Kind: "cli-repo"},
+			},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	rec := httptest.NewRecorder()
+	srv.handleStatus(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/status returned %d: %s", rec.Code, rec.Body.String())
+	}
+
+	body, _ := io.ReadAll(rec.Body)
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	bm, ok := parsed["backup_monitor"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("backup_monitor missing from /api/v1/status response: keys=%v", keysOf(parsed))
+	}
+	if got, _ := bm["borg_count"].(float64); int(got) != 2 {
+		t.Errorf("backup_monitor.borg_count = %v; want 2", bm["borg_count"])
+	}
+	if got, _ := bm["duplicacy_count"].(float64); int(got) != 1 {
+		t.Errorf("backup_monitor.duplicacy_count = %v; want 1", bm["duplicacy_count"])
+	}
+}
+
+

--- a/internal/api/dashboard_backup_test.go
+++ b/internal/api/dashboard_backup_test.go
@@ -62,7 +62,7 @@ func TestDashboardJS_BackupSection_PreservesExistingBehavior(t *testing.T) {
 		name   string
 		substr string
 	}{
-		{"sections.backup defined", "sections.backup = function(sn)"},
+		{"sections.backup defined", "sections.backup = function(sn, st)"},
 		{"data-section attribute", `data-section="backup"`},
 		{"renders backup jobs count", "Backup Jobs ("},
 		// Combined-guard pattern after issue #314 — total row count

--- a/internal/api/disk_detail_range_selector_test.go
+++ b/internal/api/disk_detail_range_selector_test.go
@@ -86,3 +86,28 @@ func TestDiskDetailHTMLRangeSelectorDefaultIs1D(t *testing.T) {
 		}
 	}
 }
+
+// TestDiskDetailHTMLRelatedFindingsRendersDetectedAt verifies the Related
+// Findings section on /disk/<serial> surfaces the timestamp already returned by
+// the API as finding.detected_at. UAT for v0.10.2-rc1 showed disk-specific
+// findings rendering without dates even though the JSON payload included
+// detected_at; this pins the template-side reference.
+func TestDiskDetailHTMLRelatedFindingsRendersDetectedAt(t *testing.T) {
+	tmpl := DiskDetailPage
+
+	checks := []struct {
+		name   string
+		substr string
+	}{
+		{"reads detected_at", "f.detected_at"},
+		{"renders Detected label", "Detected:"},
+		{"formats detected_at as local string", "new Date(f.detected_at).toLocaleString()"},
+	}
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(tmpl, tc.substr) {
+				t.Errorf("DiskDetailPage missing %q — expected substring: %q", tc.name, tc.substr)
+			}
+		})
+	}
+}

--- a/internal/api/templates/clean.html
+++ b/internal/api/templates/clean.html
@@ -467,7 +467,7 @@ tbody tr:hover{background:rgba(0,0,0,0.03)}
     h += sec.zfs(sn);
     h += sec.gpu(sn);
     h += sec.ups(sn);
-    h += sec.backup(sn);
+    h += sec.backup(sn, st);
     h += sec.network(sn);
     h += sec.speedtest(sn);
     h += sec.serviceChecks(sn);

--- a/internal/api/templates/disk_detail.html
+++ b/internal/api/templates/disk_detail.html
@@ -534,6 +534,7 @@ fetch("/api/v1/status").then(function(r){return r.json()}).then(function(d){if(d
         html += "<span class=\"finding-title\">" + escHtml(f.title || "") + "</span>";
         html += "<span class=\"" + tagCls + "\">" + escHtml(sev) + "</span>";
         html += "</div>";
+        if (f.detected_at) html += "<div class=\"finding-meta\"><span><strong>Detected:</strong> " + new Date(f.detected_at).toLocaleString() + "</span></div>";
         if (f.description) html += "<div class=\"finding-desc\">" + escHtml(f.description) + "</div>";
         if (f.action) html += "<div class=\"finding-action-text\">" + escHtml(f.action) + "</div>";
         html += "</div>";

--- a/internal/api/templates/midnight.html
+++ b/internal/api/templates/midnight.html
@@ -413,7 +413,7 @@ tbody tr:hover{background:rgba(255,255,255,0.03)}
     h += sec.zfs(sn);
     h += sec.gpu(sn);
     h += sec.ups(sn);
-    h += sec.backup(sn);
+    h += sec.backup(sn, st);
     h += sec.network(sn);
     h += sec.speedtest(sn);
     h += sec.serviceChecks(sn);


### PR DESCRIPTION
## Summary

Closes #328 — Dashboard Backup widget no longer renders configured Borg/Duplicacy repos as "No backup provider detected" during the cold-start window between container start and first scan completion.

Also includes two v0.10.2-rc1 UAT fixes found on `/disk/5PK9RPTB`:

- `/disk/<serial>` temperature charts now fall back to latest SMART samples when the selected time window has fewer than two points, matching the useful chart shape users already see on `/stats` via `/api/v1/sparklines`.
- Disk detail Related Findings now render the existing `detected_at` timestamp already present in the API payload.

## What changed

### Backup cold-start placeholder

1. **`/api/v1/status` exposes `backup_monitor.{borg_count,duplicacy_count}`** — new fields, `omitempty` when nothing enabled, enabled-only. Paths and credentials are intentionally NOT exposed; counts are sufficient signal for the render-branch decision.
2. **`sections.backup` gains a third rendering branch** keyed on those counts. When user has configured external repos AND `snap.backup` has no rows yet, the dashboard renders **"Initial scan pending"** with a SYNCING badge in cyan — visually distinct from the red failure state.
3. **Both theme templates pass `st`** into `sec.backup(sn, st)`, mirroring the `sec.drives(sn, st)` convention from #324.

### Disk detail UAT fixes

4. **Sparse range fallback** — `GET /api/v1/disks/{serial}?hours=N` still tries the selected time-window query first, but if it returns fewer than two points it falls back to the latest 500 SMART history rows for that disk. This avoids false "Not enough history data" states when 1D has one row but older useful history exists.
5. **Related Finding timestamps** — `/disk/<serial>` now renders `Detected: <local time>` from `f.detected_at` in each related finding card.

## Test coverage

New / updated coverage includes:

- `TestDashboardJS_BackupSection_RendersAwaitingFirstScan`
- `TestDashboardJS_BackupSection_AwaitingPlaceholder_DistinctFromFailure`
- `TestStatusEndpoint_ExposesBackupMonitorCounts`
- `TestStatusEndpoint_BackupMonitorCounts_OnlyEnabled`
- `TestStatusEndpoint_BackupMonitorAbsent_WhenNothingConfigured`
- `TestHandleGetDisk_HoursParamFallsBackToLatestSamplesWhenWindowTooSparse`
- `TestDiskDetailHTMLRelatedFindingsRendersDetectedAt`
- existing signature / data-path / empty-state regression guards updated or preserved

Local checks:

- `go test ./internal/api -count=1` ✅
- `go test ./... -count=1` ✅
- `go vet ./...` ✅

## UAT status

- `v0.10.2-rc1` built and was deployed to UAT.
- rc1 surfaced the disk detail issues above.
- `v0.10.2-rc2` is being built from commit `4bd984a` and should be deployed to UAT next.

## Important release gate

Do **not** tag stable `v0.10.2`, retag `:latest`, create GitHub release notes, or trigger demo-deploy until Miguel has tested the RC in UAT and explicitly says to proceed.